### PR TITLE
Update gh-pages 

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@ computed.
 let three = {
   let one = 1;
   let two = 2;
-  one + two;
+  one + two
 };
 /* one and two not accessible here! */
 ```
@@ -190,7 +190,7 @@ evaluating to the expression on the right side of the `=>`.
 let longerFunc = fun argOne argTwo => {
   let tmp = 2 * argOne;
   let next = 3 * argTwo;
-  tmp * next;
+  tmp * next
 };
 ```
 
@@ -202,7 +202,7 @@ let longerFunc = fun argOne argTwo => {
   let tmp = 2 * argOne;
   let next = 3 * argTwo;
   print_string "Returning from the function";
-  tmp * next;
+  tmp * next
 };
 ```
 
@@ -362,7 +362,7 @@ Notice how this resembles `C`/`JavaScript` style argument syntax.
 ```reason
 
 let addTupleFields = fun (first, second) => {
-  first + second;
+  first + second
 };
 let five = addTupleFields (4, 1);
 ```
@@ -373,7 +373,7 @@ always, record type definitions must be in scope when records are used.
 ```reason
 let isOverThirty = fun {name: n, age: a} => {
   let ret = a > 30;
-  ret;
+  ret
 };
 let overThirty = isOverThirty {name: "Jay", age: 31};
 ```
@@ -384,11 +384,11 @@ let (ten: int, twenty: int) = someInts;
 let {name: n:string, age: a:int} = somePerson;
 
 let addTupleFields = fun (first:int, second:int) => {
-  first + second;
+  first + second
 };
 let isOverThirty = fun {name: n:int, age: a:int} => {
   let ret = a > 30;
-  ret;
+  ret
 };
 ```
 
@@ -646,7 +646,7 @@ let module Login = {
 let module RepeatedLogin = {
   include Login;
   let loginTwice = fun auth => {
-    (login auth, login auth);
+    (login auth, login auth)
   };
 };
 ```

--- a/javaScriptCompared.html
+++ b/javaScriptCompared.html
@@ -39,15 +39,15 @@ JavaScript is the closest thing to Reason `let`).
 
 JavaScript                |   Reason
 --------------------------|--------------------------------
-<pre>3</pre>                       |  <pre>3</pre>                
-<pre> 3.1415 </pre>                |  <pre> 3.1415 </pre>                              
-<pre> "Hello world!" </pre>        |  <pre> "Hello world!" </pre>                      
-<pre> 'Hello world!' </pre>        |  Strings must use "  
-Characters are strings    |  <pre> 'a'  </pre>                                
-<pre>true</pre>                    |  <pre>true </pre>                      
-<pre> [1,2,3] </pre>               |  <pre>[1,2,3] </pre>                          
-<pre>null</pre>                    |  <pre>()</pre>                      
-<pre> const x = y;</pre>           |  <pre>let x = y;</pre>                          
+<pre>3</pre>                       |  <pre>3</pre>
+<pre> 3.1415 </pre>                |  <pre> 3.1415 </pre>
+<pre> "Hello world!" </pre>        |  <pre> "Hello world!" </pre>
+<pre> 'Hello world!' </pre>        |  Strings must use "
+Characters are strings    |  <pre> 'a'  </pre>
+<pre>true</pre>                    |  <pre>true </pre>
+<pre> [1,2,3] </pre>               |  <pre>[1,2,3] </pre>
+<pre>null</pre>                    |  <pre>()</pre>
+<pre> const x = y;</pre>           |  <pre>let x = y;</pre>
 <pre> var x = y;</pre>             |  No equivalent for this terrible abomination.
 
 
@@ -55,9 +55,9 @@ Characters are strings    |  <pre> 'a'  </pre>
 
 JavaScript                         |   Reason
 -----------------------------------|--------------------------------
-<pre>1 + 2</pre>                   |  <pre>1 + 2</pre>                
-<pre> 1.0 + 2.0 </pre>             |  <pre> 1.0 +. 2.0 </pre>                              
-<pre> "hello " + "world" </pre>    |  <pre> "hello " ^ "world" </pre>                      
+<pre>1 + 2</pre>                   |  <pre>1 + 2</pre>
+<pre> 1.0 + 2.0 </pre>             |  <pre> 1.0 +. 2.0 </pre>
+<pre> "hello " + "world" </pre>    |  <pre> "hello " ^ "world" </pre>
 
 ### Objects and Records
 JavaScript                |   Reason
@@ -102,7 +102,7 @@ let res = undefined;
 let res = {
   let x = 23;
   let y = 34;
-  x + y;
+  x + y
 };
       </pre>
     </td>
@@ -144,7 +144,7 @@ sequence.
 const myFun = (x, y) => {
   const doubleX = x + x;
   const doubleY = y + y;
-  return doubleX + doubleY;
+  return doubleX + doubleY
 };
       </pre>
     </td>
@@ -153,7 +153,7 @@ const myFun = (x, y) => {
 let myFun = fun x y => {
   let doubleX = x + x;
   let doubleY = y + y;
-  doubleX + doubleY;
+  doubleX + doubleY
 };
       </pre>
     </td>

--- a/mlCompared.html
+++ b/mlCompared.html
@@ -69,7 +69,7 @@ time, and in OCaml, nested `(* *)` are validated at parse time.
   let msg =  "Hello";
   print\_string msg;
   let msg2 = "Goodbye";
-  print\_string msg2;
+  print\_string msg2
 };
       </pre>
     </td>


### PR DESCRIPTION
This fixes issue [13](https://github.com/facebook/Reason/issues/13):
- Fix github link
- Copy paste error in mlCompared.html#Various_Improvements session
- Remove trailing semicolons in block syntax

Note that trailing semicolons in 'let module = ' blocks still exists due to syntax constrain: 

```
let module MyModule: MySig = {
  type t = int;
  let x = 10;
};
```

You can preview these changes at: http://yunxing.github.io/Reason
