### PR TITLE
[rtop] force bash interpreter

### DIFF
--- a/src/rtop.sh
+++ b/src/rtop.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # 0. Touches .utoprc (otherwise utop will fail).
 # 1. Avoids "#use"ing ~/.ocamlinit before reason is required.


### PR DESCRIPTION
`rtop` needs bash to execute properly due to the use of `BASH_SOURCE` in the script.
