### PR TITLE
Remove linking unix.cmxa

### DIFF
--- a/pkg/META.in
+++ b/pkg/META.in
@@ -8,7 +8,7 @@ archive(syntax, preprocessor, utf8) = "-ignore"
 preprocessor = "ocamlreason_preprocessor_where_does_this_end_up"
 
 # Toplevel
-archive(byte, toploop) = "@compiler-libs/ocamlcommon.cma @unix/unix.cmxa @str/str.cma"
+archive(byte, toploop) = "@compiler-libs/ocamlcommon.cma @str/str.cma"
 archive(byte, toploop) += "@easy-format/easy_format.cmo reason.cma"
 archive(byte, toploop, -pkg_utop) += "reason_toploop.cmo"
 archive(byte, toploop, pkg_utop) += "reason_utop.cmo"


### PR DESCRIPTION
reason.cma is already linked with unix.cma, no need for double linking
