### PR TITLE
[Reason] Properly parse single underscore pattern.

### DIFF
--- a/formatTest/formatOutput.re
+++ b/formatTest/formatOutput.re
@@ -5925,6 +5925,38 @@ module type HasAttrs = {
   [@@sigItem]; 
   class fooBar : int => new foo [@@sigItem];
 };
+type reasonXyz =
+  | X | Y of int int int | Z of int int | Q | R;
+
+let reasonDoubleBar =
+  fun | X
+      | Y _ _ _
+      | Z _ _
+      | Q => true 
+      | _ => false;
+
+let reasonDoubleBarNested =
+  fun | X
+      | Y _ _ _
+      | Z _ _
+      | Q => true 
+      | _ => false;
+
+/* Liberal use of the Any pattern being compatible with multiple
+  arguments  */
+let reasonDoubleBarAnyPatterns =
+  fun | X
+      | Y _
+      | Z _
+      | Q => true 
+      | _ => false;
+
+let reasonDoubleBarNestedAnyPatterns =
+  fun | X
+      | Y _
+      | Z _
+      | Q => true 
+      | _ => false;
 /*
  * Syntax and fallback syntax.
 
@@ -6178,6 +6210,21 @@ let doubleBarNested =
   fun | X
       | Y _ _ _
       | Z _ _
+      | Q => true 
+      | _ => false;
+
+/* Liberal use of the Any pattern being compatible with multiple arguments  */
+let doubleBarAnyPatterns =
+  fun | X
+      | Y _
+      | Z _
+      | Q => true 
+      | _ => false;
+
+let doubleBarNestedAnyPatterns =
+  fun | X
+      | Y _
+      | Z _
       | Q => true 
       | _ => false;
 

--- a/formatTest/typeCheckedTests/basics.re
+++ b/formatTest/typeCheckedTests/basics.re
@@ -1,0 +1,25 @@
+type reasonXyz =
+  | X
+  | Y of int int int
+  | Z of int int
+  | Q
+  | R;
+
+let reasonDoubleBar = fun
+  | X | Y _ _ _ | Z _ _ | Q => true
+  | _ => false;
+
+let reasonDoubleBarNested = fun
+  | X | Y _ _ _ | (Z _ _ | Q)  => true
+  | _ => false;
+
+
+/* Liberal use of the Any pattern being compatible with multiple
+  arguments  */
+let reasonDoubleBarAnyPatterns = fun
+  | X | Y _ | Z _ | Q => true
+  | _ => false;
+
+let reasonDoubleBarNestedAnyPatterns = fun
+  | X | Y _ | (Z _ | Q)  => true
+  | _ => false;

--- a/formatTest/typeCheckedTests/mlSyntax.ml
+++ b/formatTest/typeCheckedTests/mlSyntax.ml
@@ -18,6 +18,16 @@ let doubleBarNested = function
   | X | Y (_, _, _) | (Z (_, _) | Q)  -> true
   | _ -> false
 
+
+(* Liberal use of the Any pattern being compatible with multiple arguments  *)
+let doubleBarAnyPatterns = function
+  | X | Y  _ | Z  _ | Q -> true
+  | _ -> false
+
+let doubleBarNestedAnyPatterns = function
+  | X | Y  _ | (Z  _ | Q)  -> true
+  | _ -> false
+
 type bcd = B | C | D | E
 type a = A of bcd
 let result = match B with


### PR DESCRIPTION
Summary:
We need to properly parse the underscore as being _potentiall_ a pattern
for _all_ arguments of a constructor. That means in the case of a single
underscore, we need to stop putting the "explicit_arity" attribute on
patterns (normally that "explicit_arity" attribute is awesome, but in
this case we just need to relax things a bit).

Test Plan:See test cases.

Reviewers:yunxing, cristiano

Fixes: https://github.com/facebook/Reason/issues/46
