### PR TITLE
Fix parsing issues in object

### DIFF
--- a/formatTest/formatOutput.re
+++ b/formatTest/formatOutput.re
@@ -6202,6 +6202,12 @@ and secondRecursiveClass init => {
 /**
  * Anonymous objects.
  */
+type closedObj = <>;
+
+let (<..>) a b => a + b;
+
+let five = 2 <..> 3;
+
 type typeDefForClosedObj = <x : int, y : int>;
 
 type typeDefForOpenObj 'a =

--- a/formatTest/object.re
+++ b/formatTest/object.re
@@ -1,0 +1,20 @@
+type t = <>;
+
+type t = <
+  u: int,
+  v: int,
+>;
+
+type t = <u: int, ..>;
+
+type t = <u: int
+, ..>;
+
+type t = <
+  ..
+>;
+
+type t = <..>;
+
+let (<..>) a b => a + b;
+let five = 2 <..> 3;

--- a/formatTest/typeCheckedTests/oo.re
+++ b/formatTest/typeCheckedTests/oo.re
@@ -34,7 +34,7 @@ let tmp = {
 /**
  * Comment on stackWithAttributes.
  */
-class virtual stackWithAttributes 'a init => 
+class virtual stackWithAttributes 'a init =>
 /* Before class */
 {
 
@@ -111,6 +111,12 @@ and secondRecursiveClass init => {
 /**
  * Anonymous objects.
  */
+
+type closedObj = <>;
+
+let (<..>) a b => a + b;
+let five = 2 <..> 3;
+
 type typeDefForClosedObj = <x: int, y:int>;
 type typeDefForOpenObj 'a = <x:int, y:int, ..> as 'a;
 let anonClosedObject: <x:int, y:int> = {
@@ -276,4 +282,3 @@ class addablePoint2 = (fun init => {
   method x => (init : int);
   method y => init;
 } : int => new addablePointClassType);
-

--- a/src/reason_lexer.mll
+++ b/src/reason_lexer.mll
@@ -478,7 +478,8 @@ rule token = parse
   | "+=" { PLUSEQ }
   | "-"  { MINUS }
   | "-." { MINUSDOT }
-
+  | "<>" { LESSGREATER }
+  | "<..>" { LESSDOTDOTGREATER }
   | "!" appropriate_operator_suffix_chars +
             { PREFIXOP(unescape_stars_slashes (Lexing.lexeme lexbuf)) }
   | ['~' '?'] appropriate_operator_suffix_chars +

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -716,6 +716,8 @@ let class_of_let_bindings lbs body =
 %token LBRACKETPERCENT
 %token LBRACKETPERCENTPERCENT
 %token LESS
+%token LESSGREATER
+%token LESSDOTDOTGREATER
 %token LESSMINUS
 %token EQUALGREATER
 %token LET
@@ -2247,6 +2249,10 @@ expr:
       { mkinfix $1 "-" $3 }
   | expr MINUSDOT expr
       { mkinfix $1 "-." $3 }
+  | expr LESSDOTDOTGREATER expr
+      { mkinfix $1 "<..>" $3 }
+  | expr LESSGREATER expr
+      { mkinfix $1 "<>" $3 }
   | expr STAR expr
       { mkinfix $1 "*" $3 }
   | expr PERCENT expr
@@ -3477,7 +3483,9 @@ non_arrowed_simple_core_type:
       { mktyp(Ptyp_constr(mkrhs $1 1, [])) }
   | LESS meth_list GREATER
       { let (f, c) = $2 in mktyp(Ptyp_object (f, c)) }
-  | LESS GREATER
+  | LESSDOTDOTGREATER
+      { mktyp(Ptyp_object ([], Open)) }
+  | LESSGREATER
       { mktyp(Ptyp_object ([], Closed)) }
   | LBRACKET tag_field RBRACKET
       { mktyp(Ptyp_variant([$2], Closed, None)) }
@@ -3549,11 +3557,13 @@ non_arrowed_simple_core_type_list:
     non_arrowed_simple_core_type %prec below_LBRACKETAT     { [$1] }
   | non_arrowed_simple_core_type_list non_arrowed_simple_core_type  %prec below_LBRACKETAT     { $2 :: $1 }
 ;
+
 meth_list:
     field COMMA meth_list                     { let (f, c) = $3 in ($1 :: f, c) }
   | field opt_comma                              { [$1], Closed }
   | DOTDOT                                      { [], Open }
 ;
+
 field:
     label COLON poly_type attributes           { ($1, $4, $3) }
 ;
@@ -3592,10 +3602,12 @@ ident:
     UIDENT                                      { $1 }
   | LIDENT                                      { $1 }
 ;
+
 val_ident:
     LIDENT                                      { $1 }
   | LPAREN operator RPAREN                      { $2 }
 ;
+
 operator:
     PREFIXOP                                    { $1 }
   | INFIXOP0                                    { $1 }
@@ -3619,6 +3631,8 @@ operator:
   | COLONEQUAL                                  { ":=" }
   | PLUSEQ                                      { "+=" }
   | PERCENT                                     { "%" }
+  | LESSGREATER                                 { "<>" }
+  | LESSDOTDOTGREATER                           { "<..>" }
 ;
 constr_ident:
     UIDENT                                      { $1 }


### PR DESCRIPTION
Previously `type t = <>;` and `type t = <..>;`
were not parsable since "<>" and "<..>" were parsed
as user defined operations. (see #78 )

This patch fixes that.
