### PR TITLE
correctly pretty print constraints

### DIFF
--- a/formatTest/formatOutput.re
+++ b/formatTest/formatOutput.re
@@ -4569,8 +4569,10 @@ type semiLongWrappingTypeWithConstraint =
   M_ReactKit__Gesture.Types.instance
     'a 
     TapGestureRecognizerFinal.tapGestureFields 
-    TapGestureRecognizerFinal.tapGestureMethods
+    TapGestureRecognizerFinal.tapGestureMethods 
 constraint 'a = (unit, unit);
+
+type onelineConstrain = 'a constraint 'a = int;
 
 /* This must be in trunk but not in this branch of OCaml */
 /* type withNestedRecords = MyConstructor of {myField: int} */

--- a/formatTest/ocpFormatOutput.re
+++ b/formatTest/ocpFormatOutput.re
@@ -2637,7 +2637,7 @@ let module Utils: {
 /* HACK: tmp until we merge it into TRAVERSE_CORE for TraverseInterface,
    and rename it into TRAVERSE */
 module type OLD_TRAVERSE = {
-  type t 'pconstraint 'p = (_, _, _); 
+  type t 'p constraint 'p = (_, _, _); 
   let traverse_iter:
     ((t 'p => unit) => t 'p => unit) => 
     t 'p => 
@@ -3184,15 +3184,15 @@ type t = {
   f4: 'a 'b .t2
 };
 
-type t 'aconstraint 'a = tconstraint 'b = 'a;
+type t 'a constraint 'a = t constraint 'b = 'a;
 
 type t 'a +'b -'c -'d = {
   f1: t1, 
   f2: 'a, 
   mutable f3: t2, 
   f4: (t1, t2)
-}
-constraint 'a = t
+} 
+constraint 'a = t 
 constraint 'b = 'a;
 
 exception E;

--- a/formatTest/syntax.re
+++ b/formatTest/syntax.re
@@ -128,7 +128,7 @@ type semiLongWrappingTypeWithConstraint =
     constraint 'a = (unit, unit)
   ;
 
-
+type onelineConstrain = 'a constraint 'a = int;
 
 /* This must be in trunk but not in this branch of OCaml */
 /* type withNestedRecords = MyConstructor of {myField: int} */
@@ -647,7 +647,7 @@ L: let defOptionalAliasAnnot ?a:(aa:int=10) ?b:(bb:int=10)      = 10 in
 
 let a = 10;
 let b = 20;
-  
+
 /*A*/
 let named                 a::a      b::b             => a + b;
 type named =              a::int => b::int => int;
@@ -777,7 +777,7 @@ let something = (thisIsANamedArg: thing blah);
 
 let something = (aTypeAnnotation: thing blah);
 
-  
+
 
 let something = (thisIsANamedArg thing:blah);
 let something = (typeAnnotation thing : blah);

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -1673,7 +1673,7 @@ class printer  ()= object(self:'self)
     let everything =
       match constraints with
         | [] -> everythingButConstraints
-        | hd::tl -> makeList ~break:IfNeed ~indent:0 ~inline:(true, true) (everythingButConstraints::hd::tl)
+        | hd::tl -> makeList ~break:IfNeed ~postSpace:true ~indent:0 ~inline:(true, true) (everythingButConstraints::hd::tl)
     in
     (SourceMap (break, ptype_loc, everything))
 
@@ -4094,7 +4094,7 @@ class printer  ()= object(self:'self)
 
   (* TODO: TODOATTRIBUTES. *)
   method class_field x =
-    let itm = 
+    let itm =
       match x.pcf_desc with
       | Pcf_inherit (ovf, ce, so) ->
         let inheritText = ("inherit" ^ override ovf) in


### PR DESCRIPTION
#85

```
type 'a t constraint 'a = t
```

is now pretty printed as 

```
type t 'a constraint 'a = t;
```
