### PR TITLE
Add ocaml-better-errors error reporter to reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ opam init
 
 opam switch 4.02.1
 opam install utop
+opam pin add -y BetterErrors git@github.com:chenglou/ocaml-better-errors.git
 opam pin add -y reasonsyntax git@github.com:facebook/ReasonSyntax.git
 opam pin add -y reason git@github.com:facebook/Reason.git
 ```
@@ -124,4 +125,3 @@ projects are under their original licenses.
 
 Editor plugins (which have also been forked) in the `editorSupport/` directory
 include their own licenses.
-

--- a/_tags
+++ b/_tags
@@ -2,7 +2,7 @@ true: warn(@5@8@10@11@12@14@23-24@26@29@40), bin_annot, safe_string, debug
 
 "editorSupport": -traverse
 "src": include
-<src/*>: package(unix compiler-libs.common ocamlbuild findlib easy-format str reasonsyntax.lib)
+<src/*>: package(unix compiler-libs.common ocamlbuild findlib easy-format str reasonsyntax.lib BetterErrors)
 <src/reason_utop.*>: package(utop str reasonsyntax.lib)
 
 <src_gen/*>: package(sedlex str)

--- a/opam
+++ b/opam
@@ -23,6 +23,7 @@ depends: [
   "ocamlfind"    {build}
   "ounit"        {test}
   "utop"         {>= "1.17"}
+  "BetterErrors" {>= "0.0.1"}
 ]
 depopts: [
 ]

--- a/pkg/META.in
+++ b/pkg/META.in
@@ -18,7 +18,7 @@ archive(byte, toploop, pkg_utop) += "reason_utop.cmo"
 package "lib" (
   version = "%{version}%"
   description = "Library version of reason"
-  requires = "compiler-libs.common reasonsyntax easy-format"
+  requires = "compiler-libs.common reasonsyntax easy-format BetterErrors"
 
   archive(byte) = "reason.cma"
   archive(native) = "reason.cmxa"

--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -17,6 +17,7 @@ let () =
     Pkg.bin  "src/rebuild.sh" ~dst:"rebuild";
     Pkg.bin  "src/rtop.sh" ~dst:"rtop";
     Pkg.bin  "src/rtop_init.ml" ~dst:"rtop_init.ml";
+    Pkg.bin  ~auto:true "src/reason_error_reporter" ~dst:"refmterr";
     Pkg.doc "README.md";
     Pkg.doc "LICENSE.txt";
     Pkg.doc "CHANGELOG.md";

--- a/src/reason_error_reporter.ml
+++ b/src/reason_error_reporter.ml
@@ -1,0 +1,39 @@
+(* Portions Copyright (c) 2015-present, Facebook, Inc. All rights reserved. *)
+
+let reasonFormatter = Reason_pprint_ast.createFormatter ()
+
+let reasonTypesOfOcamlTypes str =
+  let lexbuf = Lexing.from_string str in
+  let parsedTree = Reason_toolchain.ML.canonical_core_type lexbuf in
+  (* will print the resulting string to the string formatter buffer *)
+  reasonFormatter#core_type Format.str_formatter parsedTree;
+  (* will return the formatted string *)
+  Format.flush_str_formatter ()
+
+let customIncompatibleTypeForReason errorBody cachedContent range =
+  let open BetterErrorsTypes in
+  match BetterErrorsParseError.type_IncompatibleType errorBody cachedContent range with
+  | Type_IncompatibleType {actual; expected; actualEquivalentType; expectedEquivalentType; extra} ->
+    let actual = reasonTypesOfOcamlTypes actual in
+    let expected = reasonTypesOfOcamlTypes expected in
+    Type_IncompatibleType {
+      actual;
+      expected;
+      (* we're using the error reporter's typeDiff logic temporarily. That diff
+      is semantic, aka knows about module boundaries from dot, and function
+      argument boundaries from ->. But since reason uses => as function
+      delimiter we'll need to customize the diff function soon *)
+      differingPortion = BetterErrorsParseError.typeDiff actual expected;
+      actualEquivalentType;
+      expectedEquivalentType;
+      extra;
+    }
+  (* currently the error reporter logic asks you to throw in order to pass onto
+  the next parser that tries to parse the error. This branch, however, will
+  never be reached because type_IncompatibleType always returns the
+  `Type_IncompatibleType blaRecord` variant *)
+  | _ -> raise Not_found
+
+let () =
+  BetterErrorsMain.parseFromStdin
+    ~customErrorParsers:[customIncompatibleTypeForReason]


### PR DESCRIPTION
Uses the better error output from
https://github.com/chenglou/ocaml-better-errors

I've made a few modifications to that repo so that it can accept custom
parsers, which, in this case, is a type incompatible error parser that
delegates to BetterError's type incompatible parser, but does some
post-processing to make the type output use the reason syntax rather
than the OCaml one.

This exposes a new terminal command called `rerr` (name temporary). Try
it with `ocamlc someFileWithCompilerError.ml |& rerr`. See that repo for
more details.

**BetterErrors currently isn't submitted to OPAM yet, so please do `opam
pin add BetterErrors` first to make sure this works.**

The names casing in this file are inconsistent, partially because I'm
also confused as to whether we're using snake_case, camelCase or
kebab-case.
