### PR TITLE
Correctly support '-pkgs unix'

### DIFF
--- a/src/reopt.sh
+++ b/src/reopt.sh
@@ -19,11 +19,38 @@ then
     exit 1
 fi
 
+
 # Expand special subtitions like '~'
 eval REASON_BUILD_DIR=$REASON_BUILD_DIR
 
 if [[ "${@: -2}" = "${MY_OCAML_BUILD}" ]];
 then
+    #
+    # Remove "unix.cmxa" as myocamlbuild is already linked
+    # with the library
+    #
+    # See https://github.com/facebook/Reason/issues/133
+    #
+    UNIXIDX=-1
+    i=1
+    for var in "$@"
+    do
+        if [[ $var =~ "unix.cmxa" ]];
+        then
+            #
+            # If there is already an unix.cmxa linked, remove the second one
+            #
+            if [[ $UNIXIDX -ne -1 ]];
+            then
+                set -- "${@:1:i-1}" "${@: i+1}"
+            fi
+            UNIXIDX=$i
+        fi
+        i=$i+1
+    done
+
+
+
     # Link reason build rules
     set -- "${@:1:$#-3}" "$REASON_BUILD_DIR/reasonbuild.cmx" "${@: -3}"
 fi


### PR DESCRIPTION
Problem: When unix is used in ocamlbuild, as with Infer,
building myocamlbuild fails as it uses both unix.cmxa and path_to_opam/unix.cmxa

(Hacky) Solution: Ask reopt to remove the second option of "unix.cmxa"
when building myocamlbuild.
#133
