### PR TITLE
better rebuild

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -2,6 +2,19 @@ open Ocamlbuild_plugin
 
 let () = dispatch (
   function
+  | Before_rules ->
+    rule "myocamlbuild"
+      ~prod:"_reasonbuild/_build/myocamlbuild"
+      ~deps:["src/reasonbuild.cmx"; "src/reopt.sh"]
+      begin fun env build ->
+        Cmd(S[Sh"mkdir -p _reasonbuild;";
+              Sh"cd _reasonbuild;";
+              Sh"pwd;";
+              Sh"touch myocamlbuild.ml;";
+              Sh"chmod +x ../src/reopt.sh;";
+              A"ocamlbuild"; A"-just-plugin"; A"-ocamlopt";
+              A"env REASON_BUILD_DIR=../../src ../../src/reopt.sh"])
+      end;
   | After_rules ->
     flag ["ocaml"; "pp"; "pp_byte"; "reason"] &
       A"src/reason_pp.byte";

--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -17,6 +17,7 @@ let () =
     Pkg.bin  "src/rebuild.sh" ~dst:"rebuild";
     Pkg.bin  "src/rtop.sh" ~dst:"rtop";
     Pkg.bin  "src/rtop_init.ml" ~dst:"rtop_init.ml";
+    Pkg.bin "_reasonbuild/_build/myocamlbuild" ~dst:"reasonbuild";
     Pkg.bin  ~auto:true "src/reason_error_reporter" ~dst:"refmterr";
     Pkg.bin  ~auto:true "src/reason_format_type" ~dst:"refmttype";
     Pkg.doc "README.md";

--- a/src/rebuild.sh
+++ b/src/rebuild.sh
@@ -54,16 +54,5 @@ then
     set -- "${@:1:OCAMLOPTIDX-1}" "${@: VALUEIDX+1}"
 fi
 
-MYOCAMLBUILD="$(pwd)/myocamlbuild.ml"
-
-if [ -f MYOCAMLBUILD ];
-then
-    # pass OCAMLOPT as an environment variable
-    ocamlbuild -ocamlopt "env OCAMLOPT=\"$OCAMLOPT\" $REOPT" "$@"
-else
-    # create a temperate myocamlbuild so that reasonbuild rules can be triggered
-    touch $MYOCAMLBUILD
-    # pass OCAMLOPT as an environment variable
-    ocamlbuild -ocamlopt "env OCAMLOPT=\"$OCAMLOPT\" $REOPT" "$@"
-    rm $MYOCAMLBUILD
-fi
+# pass OCAMLOPT as an environment variable
+reasonbuild -ocamlopt "env OCAMLOPT=\"$OCAMLOPT\" $REOPT" "$@"

--- a/src/reopt.sh
+++ b/src/reopt.sh
@@ -19,6 +19,11 @@ then
     exit 1
 fi
 
+if [ -z "$OCAMLOPT" ];
+then
+    OCAMLOPT="ocamlopt"
+fi
+
 
 # Expand special subtitions like '~'
 eval REASON_BUILD_DIR=$REASON_BUILD_DIR


### PR DESCRIPTION
This is a better version of rebuild that doesn't rely on the hack which creates and removes
myocamlbuild.ml, thus supports parallel build.

How it works:
- A special rule is added to myocamlbuild.ml which bootstraps a binary called myocamlbuild
- The bootstraped binary is linked with our ocamlbuild rules (src/reasonbuild.ml) via `src/reopt.sh` to be able to handle reason files
- In pkg/build.ml, the binary is installed as `reasonbuild`
- The script `rebuild` invokes `reasonbuild` directly instead of ocamlbuild. Since `reasonbuild` is already linked with our custom rules, rebuild can always `build` reason files.
