### PR TITLE
Add an option in reasonfmt: "-heuristics-file"

### DIFF
--- a/formatTest/formatOutput.re
+++ b/formatTest/formatOutput.re
@@ -6674,14 +6674,11 @@ let result =
 let nested_match =
   fun | A (B | C | D | E) => 3;
 
-let some = Some 1 2 3 [@implicit_arity];
+let some = Some (1, 2, 3);
 
-let nestedSome =
-  Some 1 2 (Some 1 2 3 [@implicit_arity])
-  [@implicit_arity];
+let nestedSome = Some (1, 2, Some (1, 2, 3));
 
-let nestedSomeSimple =
-  Some (Some 1 2 3 [@implicit_arity]);
+let nestedSomeSimple = Some (Some (1, 2, 3));
 
 let module EM = {exception E of int int;};
 

--- a/formatTest/test.sh
+++ b/formatTest/test.sh
@@ -42,13 +42,14 @@ touch ./customMLFormatOutput.re
 
 echo "" > ./customMLFormatOutput.re
 
-shopt -s nullglob # prevent file from being set to "./customMLFiles/*.ml"
+shopt -s nullglob # prevent the variable 'file' from being set to "./customMLFiles/*.ml"
 for file in ./customMLFiles/*.ml
 do
   ../reasonfmt_impl.native -print-width 50 -parse ml -print re "$file" 2>&1 >> ./customMLFormatOutput.re
 done
 
 idempotent_test ./customMLFormatOutput.re
+
 
 for file in ./typeCheckedTests/*.re
 do
@@ -64,6 +65,10 @@ done
 ocamlc -c -pp ../reasonfmt_impl.native -intf-suffix .rei -impl ./typeCheckedTests/mlSyntax.re
 ../reasonfmt_impl.native -parse ml -print re ./typeCheckedTests/mlVariants.ml > ./typeCheckedTests/mlVariants.re
 ocamlc -c -pp ../reasonfmt_impl.native -intf-suffix .rei -impl ./typeCheckedTests/mlVariants.re
+
+../reasonfmt_impl.native -heuristics-file ./typeCheckedTests/arity.txt -assume-explicit-arity -parse ml -print re ./typeCheckedTests/arityConversion.ml > ./typeCheckedTests/arityConversion.re
+ocamlc -c -pp ../reasonfmt_impl.native -intf-suffix .rei -impl ./typeCheckedTests/arityConversion.re 2>&1 | ../reason_error_reporter.native
+
 # Remove the generated .re version too
 rm ./typeCheckedTests/mlSyntax.re
 rm ./typeCheckedTests/mlVariants.re

--- a/formatTest/typeCheckedTests/arity.txt
+++ b/formatTest/typeCheckedTests/arity.txt
@@ -1,0 +1,3 @@
+And
+TupleConstructor
+Or

--- a/formatTest/typeCheckedTests/arityConversion.ml
+++ b/formatTest/typeCheckedTests/arityConversion.ml
@@ -1,0 +1,14 @@
+Some (1, 2, 3)
+
+type bcd = TupleConstructor of (int * int) | MultiArgumentsConstructor of int * int
+
+let a = TupleConstructor(1, 2)
+let b = MultiArgumentsConstructor(1, 2)
+
+module Test = struct
+  type a = | And of (int * int) | Or of (int * int)
+end;;
+
+let _ = Test.And (1, 2)
+let _ = Test.Or (1, 2)
+let _ = Some 1

--- a/formatTest/typeCheckedTests/arityConversion.re
+++ b/formatTest/typeCheckedTests/arityConversion.re
@@ -1,0 +1,15 @@
+Some (1, 2, 3);
+
+type tm = | TupleConstructor of (int, int) | MultiArgumentsConstructor of int int;
+
+let a = TupleConstructor (1, 2);
+
+let b = MultiArgumentsConstructor 1 2;
+
+let module Test = {type a = | And of (int, int) | Or of (int, int);};
+
+Test.And (1, 2);
+
+Test.Or (1, 2);
+
+Some (1, 2);


### PR DESCRIPTION
See updated README in the diff for details.

(Depending on https://github.com/facebook/ReasonSyntax/pull/18)

Usage: 

```
reasonfmt -heuristics-file ./heuristics.txt -assume-explicit-arity -parse ml -print re test.ml
```

Example:

```
> cat heuristics.txt
TupleConstructor
And
Or
```

```
> cat test.ml
type tm = TupleConstructor of (int * int) | MultiArgumentsConstructor of int * int

let _ = TupleConstructor(1, 2)
let _ = MultiArgumentsConstructor(1, 2)

module Test = struct
  type a = | And of (int * int) | Or of (int * int)
end;;

let _ = Test.And (1, 2)
let _ = Test.Or (1, 2)
let _ = Some (1, 2)
```

```
> reasonfmt -heuristics-file ./heuristics.txt -assume-explicit-arity -parse ml -print re test.ml
type tm = | TupleConstructor of (int, int) | MultiArgumentsConstructor of int int;

let a = TupleConstructor (1, 2);

let b = MultiArgumentsConstructor 1 2;

let module Test = {type a = | And of (int, int) | Or of (int, int);};

Test.And (1, 2);

Test.Or (1, 2);

Some (1, 2);

```
