### PR TITLE
Fix symlink for atom plugin

### DIFF
--- a/editorSupport/NuclideReason/compiledSrc/jsBuild
+++ b/editorSupport/NuclideReason/compiledSrc/jsBuild
@@ -1,1 +1,1 @@
-/Users/jwalke/github/Reason/editorSupport/NuclideReason/_build_byte_debug_js
+../_build_byte_debug_js


### PR DESCRIPTION
I'll have to modify the `CommonML` to make sure these symlinks are always relative. For now fixing this one.
