### PR TITLE
add tests for M.{} and M.({}), for #132

### DIFF
--- a/formatTest/formatOutput.re
+++ b/formatTest/formatOutput.re
@@ -1413,7 +1413,9 @@ let module N = {
     34;
     35
   };
-  let z = M.({});
+  let z = M.{};
+  let z = M.{};
+  let z = M.{};
   let z = M.{x: 10};
   let z = M.[foo, bar];
   let z = M.[foo, bar];

--- a/formatTest/modules.re
+++ b/formatTest/modules.re
@@ -417,6 +417,8 @@ open M;
 let z = { let open M; 34; };
 let z = { let open M; 34; 35; };
 let z = { let open M; {} };
+let z = M.{};
+let z = M.({});
 let z = { let open M; {x:10} };
 let z = { let open M; [foo, bar] };
 let z = { let open M; ([foo, bar]) };


### PR DESCRIPTION
Tests for #132, associated ReasonSyntax PR here: facebook/ReasonSyntax#38