### PR TITLE
Add support for line comments of the form `//`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ formatTest/customMLFiles/*.ml
 formatTest/customMLFormatOutput.re
 .jenga
 src/reason_parser.messages.bak
+*~

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Portions Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
 
-SHELL=/bin/bash -o pipefail
+SHELL=bash -o pipefail
 
 default: build test
 

--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,12 @@ clean:
 
 # Compile error messages into ml file, checks if the error messages are complete and not redundent
 compile_error: update_error
-	menhir --strict --unused-tokens src/reason_parser.mly --compile-errors src/reason_parser.messages > src/reason_parser_message.ml
+	menhir --explain --strict --unused-tokens src/reason_parser.mly --compile-errors src/reason_parser.messages > src/reason_parser_message.ml
 
 # Update error messages based on new grammar
 update_error:
 	@ cp -f src/reason_parser.messages src/reason_parser.messages.bak
-	@ if ! menhir --strict --unused-tokens src/reason_parser.mly --update-errors src/reason_parser.messages.bak | sed -e 's/[[:space:]]*$$//g' > src/reason_parser.messages ; then \
+	@ if ! menhir --explain --strict --unused-tokens src/reason_parser.mly --update-errors src/reason_parser.messages.bak | sed -e 's/[[:space:]]*$$//g' > src/reason_parser.messages ; then \
 		cp src/reason_parser.messages.bak src/reason_parser.messages ; \
 		exit 1 ; \
 	fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM ocaml/opam:debian
+RUN sudo -u opam sh -c "opam depext -u merlin utop"
+RUN opam remote add main https://opam.ocaml.org && \
+    opam pin add -y merlin https://github.com/the-lambda-church/merlin.git#reason-0.0.1 && \
+    opam pin add -y merlin_extend https://github.com/let-def/merlin-extend.git#reason-0.0.1 && \
+    opam pin add -y reason https://github.com/facebook/reason.git#0.0.6

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,41 @@
+# Dockerfile for Reason
+
+A Docker file for Reason development.
+
+## Build
+
+* Ensure that you have docker [installed](https://docs.docker.com/engine/installation/).
+* Build the image: `docker build -t reason .`
+
+All set!
+
+## Running
+
+### Reason interactive top-level
+
+Start the Reason interactive top-level with:
+
+    $ docker run -it reason rtop
+
+### Build native apps
+
+Assuming that you have a reason project directory called `hello_reason` with a
+single file `hello.re`:
+
+```
+$ cat hello.re
+print_string "Hello, Reason!\n"
+```
+
+To build the `hello` native app:
+
+    $ cd hello_reason
+    $ docker run -it -v `pwd`:/src reason
+    $ cd /src
+    $ rebuild hello.native
+    $ ./hello.native
+    Hello, Reason!
+
+You can further edit your source file from the host machine and rebuild the
+native app from your docker container. The build artefacts are found in your
+host machins `hello_reason` directory.

--- a/docker/README.md
+++ b/docker/README.md
@@ -37,5 +37,5 @@ To build the `hello` native app:
     Hello, Reason!
 
 You can further edit your source file from the host machine and rebuild the
-native app from your docker container. The build artefacts are found in your
-host machins `hello_reason` directory.
+native app from your docker container. The build artifacts are found in your
+host machines `hello_reason` directory.

--- a/formatTest/unit_tests/expected_output/comments.re
+++ b/formatTest/unit_tests/expected_output/comments.re
@@ -1,38 +1,46 @@
 /*
  * Multiline comment
  */
+// Empty comments, or comments with whitespaces:
+//
+//
+//
+//a
+/*inlinecommentwithnospaces*/
+/*
+
+
+ */
 /*
  * Multiline comment with a // single line comment
  */
 // Single line comment
-// Single line comment with a multiline /* starting
+
 let testPostComment = "";
 
 // let commentedCode = "";
-// Test inter-code comments
+// Test: inter-code comments
 let testMultiline a =>
   switch a {
   //  single line comment
-  | `Thingy x => {
-      print_string
-        // multiline comment should be fine
-        "matched thingy x";
-      let zz = 10;
-      // post line single line comment
-      zz
-    }
-  | `Other x => {
-      //  single line comment above
-      print_string "matched other x";
-      x
-    }
-  };
+  | `Thingy x =>
+    print_string
+      /* multiline comment should be fine */
+      "matched thingy x";
+    let zz = 10;
+    // post line single line comment
+    zz
+  | `Other x =>
+    //  single line comment above
+    print_string "matched other x";
+    x
+  }
+//  single line comment below;
 
-//  single line comment below
-// short comment
+/* short comment */
 let x = ["test"];
 
-// short comment
+/* short comment */
 let x = {
   // /* */
   let y = "";
@@ -40,11 +48,13 @@ let x = {
 };
 
 // /* this is a valid nested comment*/ this is a valid comment
-// valid /* this is a valid comment
+// valid /* this is also a valid nested comment */
 let z = 10;
 
+///////////////////////////////////////////////////////////////////////////////////
 // The following tests will test the conversion of /* */ to single line
 // comments as well as the wrapping of interleaved comments within short sequences.
+///////////////////////////////////////////////////////////////////////////////////
 /*
  * Test wrapping every form of named arguments where various parts are
  * commented.
@@ -53,41 +63,61 @@ let a = 10;
 
 let b = 20;
 
-//A
-let named /* a::a */ a::a /* b::b */ b::b => /* a + b */ a + b;
+/*A*/
+let named /* a::a */ a::a /* b::b */ b::b =>
+  /* a + b */
+  a + b;
 
-//B
-let namedAlias /* a::aa */ a::aa /* b::bb */ b::bb => /* aa + bb */ aa + bb;
+/*B*/
+let namedAlias
+    /* a::aa */
+    a::aa
+    /* b::bb */
+    b::bb =>
+  /* aa + bb */
+  aa + bb;
 
-//C
+/*C*/
 let namedAnnot
     /* a::(a: option int) */
     a::(a: option int)
     /* b::(b: option int) */
     b::(b: option int) =>
-  // 20
+  /* 20 */
   20;
 
-//D
+/*D*/
 let namedAliasAnnot
     /* a::(aa: option int) */
     a::(aa: option int)
     /* b::(bb: option int) */
     b::(bb: option int) =>
-  // 20
+  /* 20 */
   20;
 
-//E
-let optional /* a::a=? */ a::a=? /* b::b=? */ b::b=? /* () */ () =>
-  // 10
+/*E*/
+let optional
+    /* a::a=? */
+    a::a=?
+    /* b::b=? */
+    b::b=?
+    /* () */
+    () =>
+  /* 10 */
   10;
 
-//F
-let optionalAlias /* a::aa */ a::aa=? /* ?b:bb */ b::bb=? /* () */ () =>
-  // 10
+/*F*/
+let optionalAlias
+    /* a::aa */
+    a::aa=?
+    /* ?b:bb */
+    b::bb=?
+    /* () */
+    () =>
+  /* 10 */
   10;
 
-//G
+/*G*/
 let optionalAnnot
     /* a::(a: option int)=? */
     a::(a: option int)=?
@@ -95,10 +125,10 @@ let optionalAnnot
     b::(b: option int)=?
     /* () */
     () =>
-  // 10
+  /* 10 */
   10;
 
-//H
+/*H*/
 let optionalAliasAnnot
     /* a::(aa: option int)=? */
     a::(aa: option int)=?
@@ -106,20 +136,32 @@ let optionalAliasAnnot
     b::(bb: option int)=?
     /* () => */
     () =>
-  // 10
+  /* 10 */
   10;
 
-//I: This one is really annoying? Where's the visual label?
-let defOptional /* a::a=10 */ a::a=10 /* b::b=10 */ b::b=10 /* () => */ () =>
-  // 10
+/*I: This one is really annoying? Where's the visual label?*/
+let defOptional
+    /* a::a=10 */
+    a::a=10
+    /* b::b=10 */
+    b::b=10
+    /* () => */
+    () =>
+  /* 10 */
   10;
 
-//J
-let defOptionalAlias /* a::aa=10 */ a::aa=10 /* b::bb=10 */ b::bb=10 /* () => */ () =>
-  // 10;
+/*J*/
+let defOptionalAlias
+    /* a::aa=10 */
+    a::aa=10
+    /* b::bb=10 */
+    b::bb=10
+    /* () => */
+    () =>
+  /* 10; */
   10;
 
-//K
+/*K*/
 let defOptionalAnnot
     /* a::(a:int)=10 */
     a::(a: int)=10
@@ -127,5 +169,14 @@ let defOptionalAnnot
     b::(b: int)=10
     /* () => */
     () =>
-  // 10;
+  /* 10; */
   10;
+
+// This tests a short inline comment that should retain it's inline properties when formatted
+let x = [/* sh */ "te"];
+
+// This tests an empty /* */ nested comment
+// This tests a line comment that should be converted to an inline comment when formatted
+let x = [/* sh*/ "te"];
+
+// File ends with a comment

--- a/formatTest/unit_tests/expected_output/comments.re
+++ b/formatTest/unit_tests/expected_output/comments.re
@@ -1,0 +1,131 @@
+/*
+ * Multiline comment
+ */
+/*
+ * Multiline comment with a // single line comment
+ */
+// Single line comment
+// Single line comment with a multiline /* starting
+let testPostComment = "";
+
+// let commentedCode = "";
+// Test inter-code comments
+let testMultiline a =>
+  switch a {
+  //  single line comment
+  | `Thingy x => {
+      print_string
+        // multiline comment should be fine
+        "matched thingy x";
+      let zz = 10;
+      // post line single line comment
+      zz
+    }
+  | `Other x => {
+      //  single line comment above
+      print_string "matched other x";
+      x
+    }
+  };
+
+//  single line comment below
+// short comment
+let x = ["test"];
+
+// short comment
+let x = {
+  // /* */
+  let y = "";
+  ()
+};
+
+// /* this is a valid nested comment*/ this is a valid comment
+// valid /* this is a valid comment
+let z = 10;
+
+// The following tests will test the conversion of /* */ to single line
+// comments as well as the wrapping of interleaved comments within short sequences.
+/*
+ * Test wrapping every form of named arguments where various parts are
+ * commented.
+ */
+let a = 10;
+
+let b = 20;
+
+//A
+let named /* a::a */ a::a /* b::b */ b::b => /* a + b */ a + b;
+
+//B
+let namedAlias /* a::aa */ a::aa /* b::bb */ b::bb => /* aa + bb */ aa + bb;
+
+//C
+let namedAnnot
+    /* a::(a: option int) */
+    a::(a: option int)
+    /* b::(b: option int) */
+    b::(b: option int) =>
+  // 20
+  20;
+
+//D
+let namedAliasAnnot
+    /* a::(aa: option int) */
+    a::(aa: option int)
+    /* b::(bb: option int) */
+    b::(bb: option int) =>
+  // 20
+  20;
+
+//E
+let optional /* a::a=? */ a::a=? /* b::b=? */ b::b=? /* () */ () =>
+  // 10
+  10;
+
+//F
+let optionalAlias /* a::aa */ a::aa=? /* ?b:bb */ b::bb=? /* () */ () =>
+  // 10
+  10;
+
+//G
+let optionalAnnot
+    /* a::(a: option int)=? */
+    a::(a: option int)=?
+    /* ?b:(b: option int) */
+    b::(b: option int)=?
+    /* () */
+    () =>
+  // 10
+  10;
+
+//H
+let optionalAliasAnnot
+    /* a::(aa: option int)=? */
+    a::(aa: option int)=?
+    /* b::(bb: option int)=? */
+    b::(bb: option int)=?
+    /* () => */
+    () =>
+  // 10
+  10;
+
+//I: This one is really annoying? Where's the visual label?
+let defOptional /* a::a=10 */ a::a=10 /* b::b=10 */ b::b=10 /* () => */ () =>
+  // 10
+  10;
+
+//J
+let defOptionalAlias /* a::aa=10 */ a::aa=10 /* b::bb=10 */ b::bb=10 /* () => */ () =>
+  // 10;
+  10;
+
+//K
+let defOptionalAnnot
+    /* a::(a:int)=10 */
+    a::(a: int)=10
+    /* b::(b:int)=10 */
+    b::(b: int)=10
+    /* () => */
+    () =>
+  // 10;
+  10;

--- a/formatTest/unit_tests/input/comments.re
+++ b/formatTest/unit_tests/input/comments.re
@@ -1,7 +1,6 @@
 /*
  * Multiline comment
  */
-
 /*
 
 
@@ -10,11 +9,12 @@
 /*
  * Multiline comment with a // single line comment
  */
+
 // Single line comment
 let testPostComment = "";
 // let commentedCode = "";
 
-// Test inter-code comments
+// Test: inter-code comments
 let testMultiline a => switch a {
   //  single line comment
   | `Thingy x => {
@@ -30,12 +30,10 @@ let testMultiline a => switch a {
   //  single line comment below
 };
 
-
 /* short comment */
 let x = [
     "test",
 ];
-
 
 /* short comment */
 let x = {
@@ -45,15 +43,14 @@ let x = {
 
 // /* this is a valid nested comment*/ this is a valid comment
 
-
-// valid /* this is a valid comment */
+// valid /* this is also a valid nested comment */
 
 let z = 10;
 
-
-
+///////////////////////////////////////////////////////////////////////////////////
 // The following tests will test the conversion of /* */ to single line
 // comments as well as the wrapping of interleaved comments within short sequences.
+///////////////////////////////////////////////////////////////////////////////////
 
 /*
  * Test wrapping every form of named arguments where various parts are
@@ -172,5 +169,21 @@ let defOptionalAnnot
     () =>
   /* 10; */
   10;
+
+// This tests a short inline comment that should retain it's inline properties when formatted
+let x = [
+  /* sh */
+  "te",
+];
+
+// This tests an empty /* */ nested comment
+
+// This tests a line comment that should be converted to an inline comment when formatted
+let x = [
+  // sh
+  "te",
+];
+
+
 
 

--- a/formatTest/unit_tests/input/comments.re
+++ b/formatTest/unit_tests/input/comments.re
@@ -1,0 +1,172 @@
+/*
+ * Multiline comment
+ */
+
+/*
+ * Multiline comment with a // single line comment
+ */
+// Single line comment
+// Single line comment with a multiline /* starting
+let testPostComment = "";
+// let commentedCode = "";
+
+// Test inter-code comments
+let testMultiline a => switch a {
+  //  single line comment
+  | `Thingy x => {
+    print_string /* multiline comment should be fine */ "matched thingy x";
+    let zz = 10; // post line single line comment
+    zz;
+  }
+  | `Other x => {
+    //  single line comment above
+    print_string "matched other x";
+    x;
+  }
+  //  single line comment below
+};
+
+
+/* short comment */
+let x = [
+    "test",
+];
+
+
+/* short comment */
+let x = {
+  // /* */
+    let y = ""
+};
+
+// /* this is a valid nested comment*/ this is a valid comment
+
+
+// valid /* this is a valid comment
+
+let z = 10;
+
+
+
+// The following tests will test the conversion of /* */ to single line
+// comments as well as the wrapping of interleaved comments within short sequences.
+
+/*
+ * Test wrapping every form of named arguments where various parts are
+ * commented.
+ */
+let a = 10;
+let b = 20;
+/*A*/
+let named
+    /* a::a */
+    a::a
+    /* b::b */
+    b::b =>
+  /* a + b */
+  a + b;
+
+/*B*/
+let namedAlias
+    /* a::aa */
+    a::aa
+    /* b::bb */
+    b::bb =>
+  /* aa + bb */
+  aa + bb;
+
+/*C*/
+let namedAnnot
+    /* a::(a: option int) */
+    a::(a: option int)
+    /* b::(b: option int) */
+    b::(b: option int) =>
+  /* 20 */
+  20;
+
+/*D*/
+let namedAliasAnnot
+    /* a::(aa: option int) */
+    a::(aa: option int)
+    /* b::(bb: option int) */
+    b::(bb: option int) =>
+  /* 20 */
+  20;
+
+/*E*/
+let optional
+    /* a::a=? */
+    a::a=?
+    /* b::b=? */
+    b::b=?
+    /* () */
+    () =>
+  /* 10 */
+  10;
+
+/*F*/
+let optionalAlias
+    /* a::aa */
+    a::aa=?
+    /* ?b:bb */
+    b::bb=?
+    /* () */
+    () =>
+  /* 10 */
+  10;
+
+/*G*/
+let optionalAnnot
+    /* a::(a: option int)=? */
+    a::(a: option int)=?
+    /* ?b:(b: option int) */
+    b::(b: option int)=?
+    /* () */
+    () =>
+  /* 10 */
+  10;
+
+/*H*/
+let optionalAliasAnnot
+    /* a::(aa: option int)=? */
+    a::(aa: option int)=?
+    /* b::(bb: option int)=? */
+    b::(bb: option int)=?
+    /* () => */
+    () =>
+  /* 10 */
+  10;
+/*I: This one is really annoying? Where's the visual label?*/
+let defOptional
+    /* a::a=10 */
+    a::a=10
+    /* b::b=10 */
+    b::b=10
+    /* () => */
+    () =>
+  /* 10 */
+  10;
+
+/*J*/
+let defOptionalAlias
+    /* a::aa=10 */
+    a::aa=10
+    /* b::bb=10 */
+    b::bb=10
+    /* () => */
+    () =>
+  /* 10; */
+  10;
+
+/*K*/
+let defOptionalAnnot
+    /* a::(a:int)=10 */
+    a::(a:int)=10
+    /* b::(b:int)=10 */
+    b::(b:int)=10
+    /* () => */
+    () =>
+  /* 10; */
+  10;
+
+

--- a/formatTest/unit_tests/input/comments.re
+++ b/formatTest/unit_tests/input/comments.re
@@ -3,10 +3,14 @@
  */
 
 /*
+
+
+ */
+
+/*
  * Multiline comment with a // single line comment
  */
 // Single line comment
-// Single line comment with a multiline /* starting
 let testPostComment = "";
 // let commentedCode = "";
 
@@ -42,7 +46,7 @@ let x = {
 // /* this is a valid nested comment*/ this is a valid comment
 
 
-// valid /* this is a valid comment
+// valid /* this is a valid comment */
 
 let z = 10;
 

--- a/formatTest/unit_tests/input/comments.re
+++ b/formatTest/unit_tests/input/comments.re
@@ -1,6 +1,14 @@
 /*
  * Multiline comment
  */
+
+// Empty comments, or comments with whitespaces:
+//
+// 
+// 
+//a
+/*inlinecommentwithnospaces*/
+
 /*
 
 
@@ -185,5 +193,4 @@ let x = [
 ];
 
 
-
-
+// File ends with a comment

--- a/opam
+++ b/opam
@@ -32,4 +32,4 @@ depopts: [
 conflicts: [
   "utop" {< "1.17"}
 ]
-available: [ ocaml-version >= "4.02.3" ]
+available: [ ocaml-version = "4.02.3" ]

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -915,7 +915,7 @@ let built_in_explicit_arity_constructors = ["Some"; "Assert_failure"; "Match_fai
 %token WHEN
 %token WHILE
 %token WITH
-%token <string * Location.t> COMMENT
+%token <string * bool * Location.t> COMMENT
 
 %token EOL
 

--- a/src/reasonbuild.ml
+++ b/src/reasonbuild.ml
@@ -64,14 +64,17 @@ let compile_ocaml_interf rei cmi env build =
 let ocamldep_command ~impl arg out env _build =
   let out = List.map env out in
   let out = List.map (fun n -> Px n) out in
-  let teeout = [Sh "|"; P "tee"] @ out in
+  let out =
+    match List.rev out with
+    | ([] | [_]) as out -> out
+    | last :: rev_prefix -> [Sh "|"; P "tee"] @ List.rev_append rev_prefix [Sh ">"; last] in
   let arg = env arg in
   let tags = tags_of_pathname arg in
   let specs =
     [ ocamldep_command' tags;
       A "-pp"; P refmt ]
     @ impl_intf ~impl arg
-    @ teeout in
+    @ out in
   Cmd (S specs)
 
 ;;

--- a/src/refmt_merlin_impl.sh
+++ b/src/refmt_merlin_impl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/src/reopt.sh
+++ b/src/reopt.sh
@@ -7,7 +7,6 @@
 
 MY_OCAML_BUILD="-o myocamlbuild"
 
-echo "$REASON_BUILD_DIR"
 if [ -z "$REASON_BUILD_DIR" ];
 then
     REASON_BUILD_DIR=$(ocamlfind query reason)
@@ -59,7 +58,6 @@ then
     # Link reason build rules
     set -- "${@:1:$#-3}" "$REASON_BUILD_DIR/reasonbuild.cmx" "${@: -3}"
 fi
-echo $OCAMLOPT $@
 
 # use OCAMLOPT that's passed in by rebuild
 $OCAMLOPT "$@"


### PR DESCRIPTION
This adds support for line comments of the form `// comment`.
1. It updates the lexer to recognize `//`, by maintaining a `single_line_comment` `bool` indicating whether we're currently parsing a single line comment. this differentiation prevents cases like `// */ let x = 10` from executing, so that the `*/` does not get parsed as an end of comment. It also maintains a separate `line_comment_start_loc` to keep track of the line comment locations to separate the logic for checking for unmatched comments, so that newlines and nested `*/` comment endings can be differentiated. It also updates the pretty printer to handle these cases accordingly.
2. There is an edge case with regards to interleaved comments having to maintain their "multiline" status.

For example, in the `wrappingTest.re` cases in facebook/Reason,

```
/*A*/
let named
    /* a::a */
    a::a
    /* b::b */
    b::b =>
  /* a + b */
  a + b;

/*B*/
let namedAlias
    /* a::aa */
    a::aa
    /* b::bb */
    b::bb =>
  /* aa + bb */
  aa + bb;
```

must be compiled into 

```
//A
let named /* a::a */ a::a /* b::b */ b::b => /* a + b */ a + b;

//B
let namedAlias
    /* a::aa */
    a::aa
    /* b::bb */
    b::bb => /* aa + bb */ aa + bb;
```

as opposed to 

```
//A
let named // a::a  a::a // b::b  b::b => // a + b  a + b;

//B
let namedAlias
    // a::aa 
    a::aa
    // b::bb 
    b::bb => // aa + bb  aa + bb;
```

to fix this, I check if the listConfig every defines its `break` attribute to be `Never` or `IfNeed`, it will force a multiline comment. 
1. As per the discussion on facebook/ReasonSyntax#41, there is also the edge case of nested inline comments within a line comment. To handle this, there is a new error within the lexer, `Unterminated_nested_comments` that get thrown when a nested comment is detected to not have been matched.

There are a few open questions that aren't answered by this pull request, both of which can be found in greater detail in the discussion on facebook/reasonsyntax#41:
1. How should we handle line breaking? Should it be handled through easy_format (which is causing the current edge cases)? 
2. Converting from ML <-> reason, you could potentially run into problems with nested comments - for example, if you had strings of either `/*` or `(*` converting from one to the other, it could potentially cause issues. 
