### PR TITLE
[Type formatter] Parse module signature

### DIFF
--- a/src/reason_type_of_ocaml_type.ml
+++ b/src/reason_type_of_ocaml_type.ml
@@ -9,17 +9,41 @@ let () = Reason_pprint_ast.configure
 
 let reasonFormatter = Reason_pprint_ast.createFormatter ()
 
+(* "Why would you ever pass in some of these to print into Reason?"
+"Because Merlin returns these as type signature sometimes" *)
+
+(* int list *)
+let parseAsCoreType str formatter =
+  Lexing.from_string str
+  |> Reason_toolchain.ML.canonical_core_type
+  |> reasonFormatter#core_type formatter
+
+(* type a = int list *)
+let parseAsImplementation str formatter =
+  Lexing.from_string str
+  |> Reason_toolchain.ML.canonical_implementation
+  |> reasonFormatter#structure [] formatter
+
+(* val a: int list *)
+let parseAsInterface str formatter =
+  Lexing.from_string str
+  |> Reason_toolchain.ML.canonical_interface
+  |> reasonFormatter#signature [] formatter
+
+(* sig val a: int list end *)
+(* This one is a hack; we should have our own parser entry point to module_type.
+But that'd require modifying compiler-libs, which we'll refrain from doing. *)
+let parseAsCoreModuleType str formatter =
+  Lexing.from_string ("module X: " ^ str)
+  |> Reason_toolchain.ML.canonical_interface
+  |> reasonFormatter#signature [] formatter
+
 let convert str =
-  try
-    (* we'll first assume the input is a type, e.g. "int list" *)
-    Lexing.from_string str
-    |> Reason_toolchain.ML.canonical_core_type
-    |> reasonFormatter#core_type Format.str_formatter;
-    Format.flush_str_formatter ()
-  with Syntaxerr.Error a ->
-    (* if the above parsing failed, we re-try, assuming that we're being
-    passed a syntaxically valid input, e.g. type a = A | B *)
-    Lexing.from_string str
-    |> Reason_toolchain.ML.canonical_implementation
-    |> reasonFormatter#structure [] Format.str_formatter;
-    Format.flush_str_formatter ()
+  let formatter = Format.str_formatter in
+  try (parseAsCoreType str formatter; Format.flush_str_formatter ())
+  with Syntaxerr.Error _ ->
+  try (parseAsImplementation str formatter; Format.flush_str_formatter ())
+  with Syntaxerr.Error _ ->
+  try (parseAsInterface str formatter; Format.flush_str_formatter ())
+  with Syntaxerr.Error _ ->
+  (parseAsCoreModuleType str formatter; Format.flush_str_formatter ())


### PR DESCRIPTION
Merlin returns e.g. `sig val x:int end` when, say, we query the type of
`List`. We need to introduce a new entry point to compiler-libs's parser
which starts with module_type. But since that means we need to copy
compiler-libs over and patch it, I'm bailing out by just appending
"module X: " in front of a type.

Also refactored the code to be more streamlined.

@jordwalke @yunxing 
