### PR TITLE
[Reason] Add String descriptions of syntax errors.

### DIFF
--- a/src/reason_toolchain.ml
+++ b/src/reason_toolchain.ml
@@ -23,20 +23,18 @@
 open Ast_helper
 open Location
 
-let syntax_error_extension loc descriptions =
-  let suffix = String.concat "." ("SyntaxError" :: descriptions)
-  in ((mkloc suffix loc), Parsetree.PStr [])
-
 let invalidLex = "invalidCharacter.orComment.orString"
 let syntax_error_str err loc =
   if !Reason_config.recoverable then
-    [Str.mk ~loc:loc (Parsetree.Pstr_extension (syntax_error_extension loc [invalidLex], []))]
+    [
+      Str.mk ~loc:loc (Parsetree.Pstr_extension (Reason_utils.syntax_error_extension_node loc invalidLex, []))
+    ]
   else
     raise err
 
 let syntax_error_sig err loc =
   if !Reason_config.recoverable then
-    [Sig.mk ~loc:loc (Parsetree.Psig_extension (syntax_error_extension loc [invalidLex], []))]
+    [Sig.mk ~loc:loc (Parsetree.Psig_extension (Reason_utils.syntax_error_extension_node loc invalidLex, []))]
   else
     raise err
 


### PR DESCRIPTION
(This is the second diff - the first diff for `ReasonSyntax` that
implements the `Reason_utils` function is here: )

Summary:Per Frederic's request, we will form the extension nodes with a
richer structure (creates a string identifier for convenient display).

Test Plan: Ran in Atom+Merlin, though it does not yet render
the new string descriptions. Should we still continue and expect
support of rendering these strings in the editors will be arriving soon?

Reviewers:

CC:
