### PR TITLE
Add a merlin-extend frontend

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,0 +1,3 @@
+PKG utop str reasonsyntax.lib merlin_extend
+B _build/src
+S src

--- a/_tags
+++ b/_tags
@@ -3,7 +3,7 @@ true: warn(@5@8@10@11@12@14@23-24@26@29@40), bin_annot, safe_string, debug
 <editorSupport/**>: -traverse
 "formatTest": -traverse
 "src": include
-<src/*>: package(menhirLib unix compiler-libs.common ocamlbuild findlib easy-format str BetterErrors)
+<src/*>: package(menhirLib unix compiler-libs.common ocamlbuild findlib easy-format str BetterErrors merlin_extend)
 <src/reason_utop.*>: package(menhirLib utop str)
 
 <src_gen/*>: package(sedlex str)

--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -24,6 +24,7 @@ let () =
     Pkg.lib ~exts:[`Ext ".cmx"; `Ext ".o"] "src/reasonbuild";
     Pkg.lib ~cond:(Env.bool "utop") ~exts:[`Ext ".cmo"] "src/reason_utop";
     Pkg.bin ~auto:true "src/reasonfmt_impl" ~dst:"reasonfmt";
+    Pkg.bin ~auto:true "src/ocamlmerlin_reason" ~dst:"ocamlmerlin-reason";
     Pkg.bin  "src/reasonfmt_merlin_impl.sh" ~dst:"reasonfmt_merlin";
     Pkg.bin  "src/reopt.sh" ~dst:"reopt";
     Pkg.bin  "src/rebuild.sh" ~dst:"rebuild";

--- a/src/ocamlmerlin_reason.ml
+++ b/src/ocamlmerlin_reason.ml
@@ -1,0 +1,44 @@
+open Extend_protocol.Reader
+
+let () =
+  Reason_config.recoverable := true
+
+module Reason_reader = struct
+  type t = buffer
+
+  let load buffer = buffer
+
+  let parse {text; path} =
+    let l = String.length path in
+    let buf = Lexing.from_string text in
+    if l > 0 && path.[l - 1] = 'i' then
+      Signature (Reason_toolchain.JS.canonical_interface buf)
+    else
+      Structure (Reason_toolchain.JS.canonical_implementation buf)
+
+  let for_completion t _ =
+    ({complete_labels = true}, parse t)
+
+  let parse_line t pos line =
+    let buf = Lexing.from_string line in
+    Structure (Reason_toolchain.JS.canonical_implementation buf)
+
+  let ident_at t _ = []
+
+  let print_outcome ppf =
+    let open Reason_oprint in function
+    | Out_value          x -> print_out_value          ppf x
+    | Out_type           x -> print_out_type           ppf x
+    | Out_class_type     x -> print_out_class_type     ppf x
+    | Out_module_type    x -> print_out_module_type    ppf x
+    | Out_sig_item       x -> print_out_sig_item       ppf x
+    | Out_signature      x -> print_out_signature      ppf x
+    | Out_type_extension x -> print_out_type_extension ppf x
+    | Out_phrase         x -> print_out_phrase         ppf x
+end
+
+let () =
+  let open Extend_main in
+  extension_main
+    ~reader:(Reader.make_v0 (module Reason_reader : V0))
+    (Description.make_v0 ~name:"reason" ~version:"0.1")


### PR DESCRIPTION
This patch produces a new binary, `ocamlmerlin-reason`, which implements [merlin-extend](https://github.com/def-lkb/merlin-extend) protocol.

This protocol allows to customize Merlin's frontend by providing custom parsers and pretty-printers.
