### PR TITLE
Correctly passthrough commandline options from rtop to utop

### DIFF
--- a/src/rtop.sh
+++ b/src/rtop.sh
@@ -16,4 +16,4 @@
 touch $HOME/.utoprc
 touch $HOME/.utop-history
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-utop -init $DIR/rtop_init.ml -I $HOME
+utop -init $DIR/rtop_init.ml -I $HOME "$@"


### PR DESCRIPTION
I figured out this is the correct way to get `-stdin` to work.
