### PR TITLE
Stop passing `stdin` to utop directly

### DIFF
--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -1097,6 +1097,8 @@ interface:
 
 toplevel_phrase:
     structure_item SEMI                 { Ptop_def [$1]}
+  | structure_item EOF                  { Ptop_def []}
+  | EOF                                 { raise End_of_file}
   | toplevel_directive SEMISEMI         { $1 }
 ;
 

--- a/src/rtop.sh
+++ b/src/rtop.sh
@@ -16,4 +16,8 @@
 touch $HOME/.utoprc
 touch $HOME/.utop-history
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-utop -init $DIR/rtop_init.ml -I $HOME "$@"
+if [[ $@ =~ "stdin" ]]; then
+   export stdin=1
+fi
+
+utop -init $DIR/rtop_init.ml -I $HOME

--- a/src/rtop_init.ml
+++ b/src/rtop_init.ml
@@ -3,6 +3,8 @@
 #require "menhirLib";;
 #require "reason";;
 
+let interactive = try let _ = Sys.getenv "stdin" in false with | Not_found -> true in
+if interactive then
 print_string
 "
                    ___  _______   ________  _  __


### PR DESCRIPTION
- Stop passing `stdin` to utop directly -- when stdin is presented, --init is silently ignored.
- Mimic `stdin`'s behavior (ending ';' is optional) in Reason parser itself.
- In rtop_init, detects if `stdin` is presented and slient the Reason logo.

This patch allows rtop -stdin to provide a relatively similar behavior as utop -stdin, except for that it has some extra prints*, but I think it is good for now.

*: 
![image](https://cloud.githubusercontent.com/assets/1017689/14577156/ecdfb194-03a2-11e6-9ec7-5b174fe093c2.png)
