### PR TITLE
[AtomReason] Fix cringy empty lines after formatting

### DIFF
--- a/editorSupport/AtomReason/src/AtomReasonFormat.re
+++ b/editorSupport/AtomReason/src/AtomReasonFormat.re
@@ -52,7 +52,7 @@ let characterIndexForPositionInString stdOutLines (curCursorRow, curCursorColumn
   };
   {
     Nuclide.FileFormat.newCursor: finalCharCount.contents,
-    Nuclide.FileFormat.formatted: String.concat "\n" (List.rev result.contents)
+    Nuclide.FileFormat.formatted: String.concat "" (List.rev result.contents)
   }
 };
 
@@ -108,8 +108,8 @@ let formatImpl editor subText isInterface onComplete onFailure => {
   let handleError error handle => {
     NotificationManager.addError options::{...NotificationManager.defaultOptions, detail: error} errorTitle;
     /* TODO: this doesn't type check, but sits across the border of js <-> reason so it passes. onFailure (the
-    promise `onFailure`) takes in a reason string, when it reality it should take in a Js.string like the other
-    locations in this file where we do `onFailure stdErr` */
+       promise `onFailure`) takes in a reason string, when it reality it should take in a Js.string like the other
+       locations in this file where we do `onFailure stdErr` */
     onFailure "Failure!";
     handle ()
   };
@@ -130,7 +130,6 @@ let formatImpl editor subText isInterface onComplete onFailure => {
  * - If text before cursor changed in ways beyond "whitespace" changes, fall
  * back to current behavior.
  */
-
 let getEntireFormatting editor range notifySuccess notifyInvalid notifyInfo resolve reject => {
   let buffer = Editor.getBuffer editor;
   let text = Buffer.getText buffer;

--- a/editorSupport/AtomReason/src/Index.re
+++ b/editorSupport/AtomReason/src/Index.re
@@ -156,7 +156,7 @@ export
       fun jsEditor position => {
         /* TODO: make selection work in conjunction with expansion */
         /* TODO: currently gets the first type hint. The rest are the types of the expanded scope. Will use
-        them one day. */
+           them one day. */
         let position = Atom.Point.fromJs position;
         let text = Atom.Buffer.getText (Atom.Editor.getBuffer jsEditor);
         Atom.Promise.createFakePromise (

--- a/editorSupport/AtomReason/src/NuclideJs.re
+++ b/editorSupport/AtomReason/src/NuclideJs.re
@@ -6,7 +6,7 @@
  * vim: set ft=reason:
  */
 /* This exposes the modules (e.g. autocomplete, diagnostic) that do the conversion from reason data structures
-(with the help of types from nuclide.re) to js ones */
+   (with the help of types from nuclide.re) to js ones */
 let def x d =>
   switch x {
   | None => d

--- a/editorSupport/AtomReason/src/SuperMerlin.re
+++ b/editorSupport/AtomReason/src/SuperMerlin.re
@@ -257,7 +257,6 @@ let locate path::path text::text extension::extension position::position resolve
     query::(
       Js.array [|
         Js.Unsafe.inject (Js.string "locate"),
-
         Js.Unsafe.inject (Js.string ""),
         Js.Unsafe.inject (Js.string extension),
         Js.Unsafe.inject (Js.string "at"),


### PR DESCRIPTION
Fixes #291. It was a regression I introduced while fixing another bug (2b42f91e0fbd60c789746c58869a3e195681e20d). We already have line breaks included in each line in the array of lines; simply concat with an empty string.
