### PR TITLE
force check for -is-interface-pp when using stdin

### DIFF
--- a/src/refmt_impl.ml
+++ b/src/refmt_impl.ml
@@ -92,15 +92,10 @@ let () =
   let intf = match !intf with
     | None when (Filename.check_suffix filename ".rei" || Filename.check_suffix filename ".mli") -> true
     | None -> 
-      begin match (use_stdin, !prse) with
-        (* If binary_reason, whether or not it's an interface will be parsed in reasonBinaryParser *)
-        | (_, Some "binary_reason") ->
-          false
-        | (true, _) ->
-          raise (Invalid_config ("Unable to determine if stdin input is an interface file. Invalid -is-interface-pp setting."))
-        | (_, _) ->
-          false
-      end
+      if use_stdin then
+        raise (Invalid_config ("Unable to determine if stdin input is an interface file. Invalid -is-interface-pp setting."))
+      else
+        false
     | Some b -> b
   in
   try


### PR DESCRIPTION
following up on a comment by @cristianoc on #353. When using stdin, if you don't specify -is-interface-pp, it will default to reading it as an implementation. I'm not sure if this is the best of addressing this, but this PR forces a check on -is-interface-pp when using stdin by raising an error.
