### PR TITLE
[Docs] Fix typos, change "top level" -> "REPL"

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@ A new, approachable interface to the ML language.
 
 </table>
 
-`Reason` is a new "interface" to the ML langauge - a toolchain for writing, building,
+`Reason` is a new "interface" to the ML language - a toolchain for writing, building,
 and sharing code that targets the OCaml compiler. Reason's completely new syntax
 works well with your existing tools and build systems. It is possible to use all
 of `Reason` or just a portion, while gradually upgrading one file at a time.
@@ -81,7 +81,7 @@ Install
 Install `OPAM` so that you can easily switch compiler versions (using
 [Homebrew](http://brew.sh/)). Then switch to a supported compiler version
 (`4.02.1` or `4.02.3` will work). Finally have `OPAM` install `Reason` from
-Github by "pinning" it.
+GitHub by "pinning" it.
 
 ```sh
 brew install opam --HEAD
@@ -829,7 +829,7 @@ new versions of functions that are the same as the old ones, but with _some_ of
 the argument data filled in. Here, `addFour` is like a specialized version of `add`
 with the first argument "filled in".
 
-Instead of having a function accept a tuple as an argument, you might chose to
+Instead of having a function accept a tuple as an argument, you might choose to
 make that function curried instead. Currying accomplishes the same goal, but
 allows you to supply the set of input data one at a time, potentially "pausing"
 when you've only supplied a portion of the argument data. Compare this to
@@ -1116,7 +1116,7 @@ let sumsToZero = fun {first, second} => first + second == 0;
 ```
 
 
-Advanced 
+Advanced
 =======
 
 With the basic constructs covered, here are more advanced features.
@@ -1162,7 +1162,7 @@ several technologies that make the `Reason` developer
 experience possible.
 
 - `OCaml` itself.
-- `utop` - highly customizable top level.
+- `utop` - highly customizable repl.
 - `Merlin` - assistant for editing OCaml code that The Merlin team has extensively
 refactored to support `Reason`.
 
@@ -1187,7 +1187,7 @@ opam pin remove reason
 
 **2. `pin` the `master` versions of everything:**
 This updates all your globally installed packages to their respective master
-branches. It also makes `reasonfmt` and other programs available in your
+branches. It also makes `refmt` and other programs available in your
 `PATH`.
 ```sh
 opam pin add -y merlin git@github.com:the-lambda-church/merlin.git

--- a/mlCompared.html
+++ b/mlCompared.html
@@ -66,13 +66,13 @@ Reason also supports line comments, which are not supported in OCaml.
   </tr>
 </table>
 
-###Top Level
+###REPL ([Read-Eval-Print-Loop](https://en.wikipedia.org/wiki/Read–eval–print_loop))
 
-In `Reason`'s top level `rtop` (a customized `utop`), each input is submitted via
-a single `;` semicolon. `OCaml`'s top level requires two semicolons `;;`.
+In `Reason`'s repl `rtop` (a customized `utop`), each input is submitted via
+a single `;` semicolon. `OCaml`'s repl requires two semicolons `;;`.
 
 > <table>
-  <thead><tr> <th scope="col"><p >OCaml Top Level</p></th> <th scope="col"><p>Reason Top Level</p></th></tr></thead>
+  <thead><tr> <th scope="col"><p >OCaml REPL</p></th> <th scope="col"><p>Reason REPL</p></th></tr></thead>
   <tr>
     <td>
       <pre>;;</pre>
@@ -89,7 +89,7 @@ a single `;` semicolon. `OCaml`'s top level requires two semicolons `;;`.
 are *expressed* differently.
 In `Reason`, structural equality is written as `==`, and reference equality
 (physical equality)
-is written as `===` (so just remember to add an extra equals to what `OCaml`
+is written as `===` (so just remember to add an extra `=` to what `OCaml`
 requires). In `Reason`, to achieve the corresponding *inequality*,
 simply swap the first character with a `!` character. (`!=` for structural
 inequality, and `!==` for reference inequality). `Reason`'s
@@ -320,8 +320,8 @@ to be wrapped in *additional* parentheses.
     </td>
   </tr>
 </table>
-  
-In `Reason`, records resemble JavaScript , using `:` instead of `=`. Because
+
+In `Reason`, records resemble JavaScript, using `:` instead of `=`. Because
 `Reason` tuples always require wrapping parens, records may contain lambdas as values
 without needing extra parens.
 > <table>
@@ -1132,7 +1132,7 @@ operators must be written differently.  The rules for prefix/infix operators
 are the same as in OCaml syntax, but with the following exceptions:
 
 Specifically, if any character except the first in an prefix/infix operator is
-a star or forward slash, that must be first excaped with a backslash. These will
+a star or forward slash, that must be first escaped with a backslash. These will
 be parsed *without* the backslash when added to the AST. When reprinted, the
 escape backslashes are added back in automatically.
 
@@ -1152,7 +1152,7 @@ escape backslashes are added back in automatically.
 ###### Operator Renaming
 If `Reason` uses `==` to represent `OCaml`'s `=`, and
 uses `===` to represent `OCaml`'s `==`, then how would `Reason` represent `OCaml`'s
-`===` symbol (if it were defined)? `Reason` provides a way! "Escape" the triple 
+`===` symbol (if it were defined)? `Reason` provides a way! "Escape" the triple
 equals symbol!
 
 > <table>
@@ -1231,6 +1231,3 @@ x \=== y</pre>
 
 </body>
 </html>
-
-
-

--- a/modules.html
+++ b/modules.html
@@ -26,7 +26,7 @@
 Modules
 ===========
 The section below demonstrates the syntax for advanced language constructs such
-as modules. 
+as modules.
 
 
 > *Note: This documentation on modules is just a rough sketch, and will be improved*
@@ -124,7 +124,7 @@ to record type definitions, with the following differences:
   instead of describing *values* (which are runtime constructs).
 - They describe values being inside of modules via the following syntax: `let q: s;` (as opposed to
   `key:keyType,`).
-- Signatures can include entries for `type` fields - which is admitedly
+- Signatures can include entries for `type` fields - which is admittedly
   difficult to wrap your head around.
 - Identifiers that refer to signatures must begin with a capital letter.
 - The rules for satisfying signatures are based on "subtyping", whereas records
@@ -376,4 +376,3 @@ let module Pairify: ParifyT = functor (X:HasT) => {
 
 </body>
 </html>
-

--- a/projects.html
+++ b/projects.html
@@ -40,13 +40,13 @@ no additional configuration. This allows you to add `Reason` files to your exist
 
 We will update this document with instructions for integrating with `clang/gcc`.
 
-If your build system executes explicit build commands then the easiest way to
+If your build system executes explicit build commands, then the easiest way to
 use `Reason` with `ocamlopt/ocamlc` is by adding the following flags to each
 compilation step:
 ```sh
 # intf-suffix tells the compiler where to look for corresponding interface files
-ocamlopt -pp reasonfmt -intf-suffix rei -impl myFile.re
-ocamlopt -pp reasonfmt -intf myFile.rei
+ocamlopt -pp refmt -intf-suffix rei -impl myFile.re
+ocamlopt -pp refmt -intf myFile.rei
 
 ```
 
@@ -208,4 +208,3 @@ new artifact.
 
 </body>
 </html>
-

--- a/tools.html
+++ b/tools.html
@@ -58,7 +58,7 @@ Those other plugins include `NuclideReason` (IDE features), and `language-reason
 
 #### Features/Configuration
 The `Reason` IDE experience is powered by `refmt`, the `Reason` AST formatting tool, and
-even moreso by the excellent [merlin](https://github.com/the-lambda-church/merlin) project.
+even more so by the excellent [merlin](https://github.com/the-lambda-church/merlin) project.
 `refmt` provides source code beautifying/printing, and Merlin provides type information, autocompletion,
 and professional IDE features even in the face of partially invalid files/projects.
 


### PR DESCRIPTION
Literally pasted everything into Word and fixed the red and green
squiggly lines. That's how I started contributing on React!

Changing the term top level to REPL where appropriate (discussed
offline). "REPL" is used everywhere and "top level" is probably better
off abiding by its non-technical usage of "this declaration is at the
top level of the file".
