### PR TITLE
[Syntax] Convert poly variant from using ` to #

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/mlVariants.re
+++ b/formatTest/typeCheckedTests/expected_output/mlVariants.re
@@ -1,13 +1,13 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 type polyVariantsInMl = [
-  | `IntTuple of (int, int)
-  | `StillAnIntTuple of (int, int)
+  | #IntTuple of (int, int)
+  | #StillAnIntTuple of (int, int)
 ];
 
-let intTuple = `IntTuple (1, 2);
+let intTuple = #IntTuple (1, 2);
 
-let stillAnIntTuple = `StillAnIntTuple (4, 5);
+let stillAnIntTuple = #StillAnIntTuple (4, 5);
 
 let sumThem =
-  fun | `IntTuple (x, y) => x + y
-      | `StillAnIntTuple (a, b) => a + b;
+  fun | #IntTuple (x, y) => x + y
+      | #StillAnIntTuple (a, b) => a + b;

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -16,17 +16,17 @@ TestUtils.printSection "General Syntax";
 
 /* Won't work! */
 /* let matchingFunc a = match a with */
-/*   `Thingy x => (print_string "matched thingy x"); x */
-/*   | `Other x => (print_string "matched other x"); x;; */
+/*   #Thingy x => (print_string "matched thingy x"); x */
+/*   | #Other x => (print_string "matched other x"); x;; */
 /*  */
 let matchingFunc a =>
   switch a {
-  | `Thingy x => {
+  | #Thingy x => {
       print_string "matched thingy x";
       let zz = 10;
       zz
     }
-  | `Other x => {
+  | #Other x => {
       print_string "matched other x";
       x
     }
@@ -556,7 +556,7 @@ let matchesWithWhen =
       | Black x => 10
       | Green x => 10;
 
-let matchesOne (`Red x) => 10;
+let matchesOne (#Red x) => 10;
 
 /*
  Typical OCaml would make you *wrap the functions in parens*! This is because it
@@ -655,22 +655,22 @@ type yourThing = myOtherThing int int;
 
 /* Conveniently - this parses exactly how you would intend! No *need* to wrap
    in an extra [], but it doesn't hurt */
-/* FIXME type lookAtThesePolyVariants = list [`Red] ; */
-/* FIXME type bracketsGroupMultipleParamsAndPrecedence = list (list (list [`Red])); */
-/* FIXME type youCanWrapExtraIfYouWant = (list [`Red]); */
-/* FIXME type hereAreMultiplePolyVariants = list [`Red | `Black]; */
-/* FIXME type hereAreMultiplePolyVariantsWithOptionalWrapping = list ([`Red | `Black]); */
+/* FIXME type lookAtThesePolyVariants = list [#Red] ; */
+/* FIXME type bracketsGroupMultipleParamsAndPrecedence = list (list (list [#Red])); */
+/* FIXME type youCanWrapExtraIfYouWant = (list [#Red]); */
+/* FIXME type hereAreMultiplePolyVariants = list [#Red | #Black]; */
+/* FIXME type hereAreMultiplePolyVariantsWithOptionalWrapping = list ([#Red | #Black]); */
 /*
    /* Proposal: ES6 style lambdas: */
 
    /* Currying */
-   let lookES6Style = (`Red x) (`Black y) => { };
-   let lookES6Style (`Red x) (`Black y) => { };
+   let lookES6Style = (#Red x) (#Black y) => { };
+   let lookES6Style (#Red x) (#Black y) => { };
 
    /* Matching the single argument */
    let lookES6Style = oneArg => match oneArg with
-     | `Red x => x
-     | `Black x => x;
+     | #Red x => x
+     | #Black x => x;
 
    /* The "trick" to currying that we already have is basically the same - we just
     * have to reword it a bit:
@@ -680,8 +680,8 @@ type yourThing = myOtherThing int int;
     * "Any time you see [let x = ... => ] just replace it with [let x ... => ]"
     */
    let lookES6Style oneArg => match oneArg with
-     | `Red x => x
-     | `Black x => x;
+     | #Red x => x
+     | #Black x => x;
 
  */
 /** Current OCaml Named Arguments. Any aliasing is more than just aliasing!

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -73,15 +73,15 @@ let doesntCareWhichFormAs x =>
 
 type colorList1 = [
   otherThingInheritedFrom
-  | `Red
-  | `Black
+  | #Red
+  | #Black
 ];
 
 type colorList = [<
-  | `Red of (int, int) &int
-  | `Black of &(int, int) &int
-  | `Blue
-  > `Red `Black
+  | #Red of (int, int) &int
+  | #Black of &(int, int) &int
+  | #Blue
+  > #Red #Black
 ];
 
 1 + doesntCareWhichForm (FormOne 10);
@@ -302,33 +302,33 @@ let res =
       }
   };
 
-/* FIXME type somePolyVariant = [ `Purple of int | `Yellow of int]; */
-let ylw = `Yellow (100, 100);
+/* FIXME type somePolyVariant = [ #Purple of int | #Yellow of int]; */
+let ylw = #Yellow (100, 100);
 
-let prp = `Purple (101, 100);
+let prp = #Purple (101, 100);
 
 let res =
   switch (ylw, prp) {
-  | (`Yellow (y, y2), `Purple (p, p2)) =>
-      `Yellow (p + y, 0)
-  | (`Purple (p, p2), `Yellow (y, y2)) =>
-      `Purple (y + p, 0)
-  | (`Purple (p, p2), `Purple (y, y2)) =>
-      `Yellow (y + p, 0)
-  | (`Yellow (p, p2), `Yellow (y, y2)) =>
-      `Purple (y + p, 0)
+  | (#Yellow (y, y2), #Purple (p, p2)) =>
+      #Yellow (p + y, 0)
+  | (#Purple (p, p2), #Yellow (y, y2)) =>
+      #Purple (y + p, 0)
+  | (#Purple (p, p2), #Purple (y, y2)) =>
+      #Yellow (y + p, 0)
+  | (#Yellow (p, p2), #Yellow (y, y2)) =>
+      #Purple (y + p, 0)
   };
 
-let ylw = `Yellow 100;
+let ylw = #Yellow 100;
 
-let prp = `Purple 101;
+let prp = #Purple 101;
 
 let res =
   switch (ylw, prp) {
-  | (`Yellow y, `Purple p) => `Yellow (p + y)
-  | (`Purple p, `Yellow y) => `Purple (y + p)
-  | (`Purple p, `Purple y) => `Yellow (y + p)
-  | (`Yellow p, `Yellow y) => `Purple (y + p)
+  | (#Yellow y, #Purple p) => #Yellow (p + y)
+  | (#Purple p, #Yellow y) => #Purple (y + p)
+  | (#Purple p, #Purple y) => #Yellow (y + p)
+  | (#Yellow p, #Yellow y) => #Purple (y + p)
   };
 
 /*
@@ -349,20 +349,20 @@ let res =
  *
  * Though, I'm not sure this will even work.
  */
-let ylw = `Yellow (100, 100);
+let ylw = #Yellow (100, 100);
 
-let prp = `Purple (101, 101);
+let prp = #Purple (101, 101);
 
 let res =
   switch (ylw, prp) {
-  | (`Yellow (y, y2), `Purple (p, p2)) =>
-      `Yellow (p + y, 0)
-  | (`Purple (p, p2), `Yellow (y, y2)) =>
-      `Purple (y + p, 0)
-  | (`Purple (p, p2), `Purple (y, y2)) =>
-      `Yellow (y + p, 0)
-  | (`Yellow (p, p2), `Yellow (y, y2)) =>
-      `Purple (y + p, 0)
+  | (#Yellow (y, y2), #Purple (p, p2)) =>
+      #Yellow (p + y, 0)
+  | (#Purple (p, p2), #Yellow (y, y2)) =>
+      #Purple (y + p, 0)
+  | (#Purple (p, p2), #Purple (y, y2)) =>
+      #Yellow (y + p, 0)
+  | (#Yellow (p, p2), #Yellow (y, y2)) =>
+      #Purple (y + p, 0)
   };
 
 let rec atLeastOneFlushableChildAndNoWipNoPending
@@ -412,12 +412,12 @@ let rec atLeastOneFlushableChildAndNoWipNoPending
 /*
  * When pretty printed, this appears to be multi-argument constructors.
  */
-let prp = `Purple (101, 101);
+let prp = #Purple (101, 101);
 
 let res =
   switch prp {
-  | `Yellow (y, y2) => `Yellow (y2 + y, 0)
-  | `Purple (p, p2) => `Purple (p2 + p, 0)
+  | #Yellow (y, y2) => #Yellow (y2 + y, 0)
+  | #Purple (p, p2) => #Purple (p2 + p, 0)
   };
 
 /*

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -9,16 +9,16 @@ BasicStructures.run();
 TestUtils.printSection "General Syntax";
 /* Won't work! */
 /* let matchingFunc a = match a with */
-/*   `Thingy x => (print_string "matched thingy x"); x */
-/*   | `Other x => (print_string "matched other x"); x;; */
+/*   #Thingy x => (print_string "matched thingy x"); x */
+/*   | #Other x => (print_string "matched other x"); x;; */
 /*  */
 let matchingFunc a => switch a {
-  | `Thingy x => {
+  | #Thingy x => {
     print_string "matched thingy x";
     let zz = 10;
     zz;
   }
-  | `Other x => {
+  | #Other x => {
     print_string "matched other x";
     x;
   }
@@ -492,7 +492,7 @@ let matchesWithWhen = fun
   | Green x => 10;
 
 
-let matchesOne (`Red x) => 10;
+let matchesOne (#Red x) => 10;
 
 
 /*
@@ -578,14 +578,14 @@ type yourThing = myOtherThing int int;
 
 /* Conveniently - this parses exactly how you would intend! No *need* to wrap
 in an extra [], but it doesn't hurt */
-/* FIXME type lookAtThesePolyVariants = list [`Red] ; */
+/* FIXME type lookAtThesePolyVariants = list [#Red] ; */
 
-/* FIXME type bracketsGroupMultipleParamsAndPrecedence = list (list (list [`Red])); */
+/* FIXME type bracketsGroupMultipleParamsAndPrecedence = list (list (list [#Red])); */
 
-/* FIXME type youCanWrapExtraIfYouWant = (list [`Red]); */
+/* FIXME type youCanWrapExtraIfYouWant = (list [#Red]); */
 
-/* FIXME type hereAreMultiplePolyVariants = list [`Red | `Black]; */
-/* FIXME type hereAreMultiplePolyVariantsWithOptionalWrapping = list ([`Red | `Black]); */
+/* FIXME type hereAreMultiplePolyVariants = list [#Red | #Black]; */
+/* FIXME type hereAreMultiplePolyVariantsWithOptionalWrapping = list ([#Red | #Black]); */
 
 
 
@@ -593,13 +593,13 @@ in an extra [], but it doesn't hurt */
   /* Proposal: ES6 style lambdas: */
 
   /* Currying */
-  let lookES6Style = (`Red x) (`Black y) => { };
-  let lookES6Style (`Red x) (`Black y) => { };
+  let lookES6Style = (#Red x) (#Black y) => { };
+  let lookES6Style (#Red x) (#Black y) => { };
 
   /* Matching the single argument */
   let lookES6Style = oneArg => match oneArg with
-    | `Red x => x
-    | `Black x => x;
+    | #Red x => x
+    | #Black x => x;
 
   /* The "trick" to currying that we already have is basically the same - we just
    * have to reword it a bit:
@@ -609,8 +609,8 @@ in an extra [], but it doesn't hurt */
    * "Any time you see [let x = ... => ] just replace it with [let x ... => ]"
    */
   let lookES6Style oneArg => match oneArg with
-    | `Red x => x
-    | `Black x => x;
+    | #Red x => x
+    | #Black x => x;
 
 */
 

--- a/formatTest/unit_tests/input/variants.re
+++ b/formatTest/unit_tests/input/variants.re
@@ -57,15 +57,15 @@ let doesntCareWhichFormAs x => switch x {
 
 type colorList1 = [
   otherThingInheritedFrom
-  | `Red
-  | `Black
+  | #Red
+  | #Black
 ];
 
 type colorList = [<
-  | `Red of (int, int) &int
-  | `Black of &(int, int) &int
-  | `Blue
-  > `Red `Black
+  | #Red of (int, int) &int
+  | #Black of &(int, int) &int
+  | #Blue
+  > #Red #Black
 ];
 
 1 + doesntCareWhichForm (FormOne 10);
@@ -221,28 +221,28 @@ let res = switch myTuple {
            }
 };
 
-/* FIXME type somePolyVariant = [ `Purple of int | `Yellow of int]; */
+/* FIXME type somePolyVariant = [ #Purple of int | #Yellow of int]; */
 
-let ylw = `Yellow (100, 100);
+let ylw = #Yellow (100, 100);
 
-let prp = `Purple (101, 100);
+let prp = #Purple (101, 100);
 
 let res = switch (ylw, prp) {
-  | (`Yellow (y, y2), `Purple (p, p2)) => `Yellow (p + y, 0)
-  | (`Purple (p, p2), `Yellow (y, y2)) => `Purple (y + p, 0)
-  | (`Purple (p, p2), `Purple (y, y2)) => `Yellow (y + p, 0)
-  | (`Yellow (p, p2), `Yellow (y, y2)) => `Purple (y + p, 0)
+  | (#Yellow (y, y2), #Purple (p, p2)) => #Yellow (p + y, 0)
+  | (#Purple (p, p2), #Yellow (y, y2)) => #Purple (y + p, 0)
+  | (#Purple (p, p2), #Purple (y, y2)) => #Yellow (y + p, 0)
+  | (#Yellow (p, p2), #Yellow (y, y2)) => #Purple (y + p, 0)
 };
 
-let ylw = `Yellow 100;
+let ylw = #Yellow 100;
 
-let prp = `Purple 101;
+let prp = #Purple 101;
 
 let res = switch (ylw, prp) {
-  | (`Yellow y, `Purple p) => `Yellow (p + y)
-  | (`Purple p, `Yellow y) => `Purple (y + p)
-  | (`Purple p, `Purple y) => `Yellow (y + p)
-  | (`Yellow p, `Yellow y) => `Purple (y + p)
+  | (#Yellow y, #Purple p) => #Yellow (p + y)
+  | (#Purple p, #Yellow y) => #Purple (y + p)
+  | (#Purple p, #Purple y) => #Yellow (y + p)
+  | (#Yellow p, #Yellow y) => #Purple (y + p)
 };
 
 /*
@@ -263,15 +263,15 @@ let res = switch (ylw, prp) {
  *
  * Though, I'm not sure this will even work.
  */
-let ylw = `Yellow (100, 100);
+let ylw = #Yellow (100, 100);
 
-let prp = `Purple (101, 101);
+let prp = #Purple (101, 101);
 
 let res = switch (ylw, prp) {
-  | (`Yellow (y, y2), `Purple (p, p2)) => `Yellow (p + y, 0)
-  | (`Purple (p, p2), `Yellow (y, y2)) => `Purple (y + p, 0)
-  | (`Purple (p, p2), `Purple (y, y2)) => `Yellow (y + p, 0)
-  | (`Yellow (p, p2), `Yellow (y, y2)) => `Purple (y + p, 0)
+  | (#Yellow (y, y2), #Purple (p, p2)) => #Yellow (p + y, 0)
+  | (#Purple (p, p2), #Yellow (y, y2)) => #Purple (y + p, 0)
+  | (#Purple (p, p2), #Purple (y, y2)) => #Yellow (y + p, 0)
+  | (#Yellow (p, p2), #Yellow (y, y2)) => #Purple (y + p, 0)
 };
 
 let rec atLeastOneFlushableChildAndNoWipNoPending composition atPriority => switch composition {
@@ -294,11 +294,11 @@ let rec atLeastOneFlushableChildAndNoWipNoPending composition atPriority => swit
 /*
  * When pretty printed, this appears to be multi-argument constructors.
  */
-let prp = `Purple (101, 101);
+let prp = #Purple (101, 101);
 
 let res = switch prp {
-  | `Yellow (y, y2) => `Yellow (y2 + y, 0)
-  | `Purple (p, p2) => `Purple (p2 + p, 0)
+  | #Yellow (y, y2) => #Yellow (y2 + y, 0)
+  | #Purple (p, p2) => #Purple (p2 + p, 0)
 };
 
 /*

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -4111,7 +4111,7 @@ toplevel_directive:
 /* Miscellaneous */
 
 name_tag:
-    BACKQUOTE ident                             { $2 }
+    SHARP ident                             { $2 }
 ;
 rec_flag:
     /* empty */                                 { Nonrecursive }

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -1769,7 +1769,7 @@ class printer  ()= object(self:'self)
   method type_variant_leaf1 opt_ampersand polymorphic print_bar x =
     let {pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes} = x in
     let (arityAttrs, docAtrs, stdAttrs) = partitionAttributes pcd_attributes in
-    let prefix = if polymorphic then "`" else "" in
+    let prefix = if polymorphic then "#" else "" in
     let sourceMappedName = SourceMap (break, pcd_name.loc, atom (prefix ^ pcd_name.txt)) in
     let nameOf = makeList ~postSpace:true [sourceMappedName; atom "of"] in
     let barNameOf =
@@ -2088,7 +2088,7 @@ class printer  ()= object(self:'self)
               | (Closed,Some tl) -> ("<", tl)
               | (Open,_) -> (">", []) in
           let node_list = List.map variant_helper l in
-          let ll = (List.map (fun t -> atom ("`" ^ t)) tl) in
+          let ll = (List.map (fun t -> atom ("#" ^ t)) tl) in
           let tag_list = makeList ~postSpace:true ~break:IfNeed ((atom ">")::ll) in
           let type_list = if List.length tl != 0 then node_list@[tag_list] else node_list in
           makeList ~wrap:("[" ^ designator,"]") ~pad:(true, false) ~postSpace:true ~break:IfNeed type_list
@@ -2184,7 +2184,7 @@ class printer  ()= object(self:'self)
           if arityAttrs != [] then
             raise (NotPossible "Should never see embedded attributes on poly variant")
           else
-            let layout = (self#constructor_pattern ~polyVariant:true ~arityIsClear:true (atom ("`" ^ l)) p) in
+            let layout = (self#constructor_pattern ~polyVariant:true ~arityIsClear:true (atom ("#" ^ l)) p) in
             SourceMap (break, x.ppat_loc, layout)
       | Ppat_lazy p -> label ~space:true (atom "lazy") (self#simple_pattern p)
       | Ppat_construct (({txt} as li), po) when not (txt = Lident "::")-> (* FIXME The third field always false *)
@@ -2302,7 +2302,7 @@ class printer  ()= object(self:'self)
               makeList ~wrap:("(", ")") ~sep:"," ~postSpace:true ~break:IfNeed (List.map (self#potentiallyConstrainedPattern1) l)
           | Ppat_constant (c) -> (self#constant c)
           | Ppat_interval (c1, c2) -> makeList [self#constant c1; atom ".."; self#constant c2]
-          | Ppat_variant (l, None) -> makeList[atom "`"; atom l]
+          | Ppat_variant (l, None) -> makeList[atom "#"; atom l]
           | Ppat_constraint (p, ct) ->
               formatPrecedence (formatTypeConstraint (self#pattern p) (self#core_type ct))
           | Ppat_lazy p ->formatPrecedence (label ~space:true (atom "lazy") (self#simple_pattern p))
@@ -3717,7 +3717,7 @@ class printer  ()= object(self:'self)
             if arityAttrs != [] then
               raise (NotPossible "Should never see embedded attributes on poly variant")
             else
-              self#constructor_expression ~polyVariant:true ~arityIsClear:true stdAttrs (atom ("`" ^ l)) eo
+              self#constructor_expression ~polyVariant:true ~arityIsClear:true stdAttrs (atom ("#" ^ l)) eo
         | _ -> self#simple_expression x
       in
       SourceMap (break, x.pexp_loc, itm)
@@ -3888,7 +3888,7 @@ class printer  ()= object(self:'self)
               ~wrap:("(", ")")
               [formatCoerce (self#expression e) optFormattedType (self#core_type ct)]
         | Pexp_variant (l, None) ->
-            ensureSingleTokenSticksToLabel (atom ("`" ^ l))
+            ensureSingleTokenSticksToLabel (atom ("#" ^ l))
         | Pexp_record (l, eo) ->
             let makeRow (li, e) appendComma shouldPun =
               let comma = atom "," in


### PR DESCRIPTION
This is a stepping stone to turning interpolated string from {|bla|} to
`bla`. Which is more familiar to JS devs and frees the weird syntax
error of switch bla {|lol => 1}

Test plan: `make test`
