### PR TITLE
Add tests for expected errors

### DIFF
--- a/formatTest/errorTests/expected_output/comments1.re
+++ b/formatTest/errorTests/expected_output/comments1.re
@@ -1,0 +1,2 @@
+File "comments1.re", line 1, characters 0-2:
+Error: Comment not terminated

--- a/formatTest/errorTests/input/comments1.re
+++ b/formatTest/errorTests/input/comments1.re
@@ -1,0 +1,1 @@
+/* this is an unterminated comment


### PR DESCRIPTION
This is a simple extension of how our current tests are structured to address #305. It adds a set of tests that check the output of stderr to ensure certain errors are being thrown.
