### PR TITLE
Add enough OPAM metadata to build mechanically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ src_test/_tags
 .DS_Store
 formatTest/customMLFiles/*.ml
 formatTest/customMLFormatOutput.re
+.dopam/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ opam pin add -y reason git@github.com:facebook/reason.git#b105ecd2b6728e3f62f11f
 
 ```
 
+Quick Start with Docker
+-----------------------
+
+You can try Reason without any developer tools being installed by using Docker for Mac.
+Install the [dopam](https://github.com/avsm/dopam) helper and:
+
+``sh
+dopam init reason <src>
+# list the other options such as distro/arch/compiler
+dopam help
+```
+
+All of the tools below will be installed in the container, and your source code directory
+`<src>` will be mounted in `/home/opam/src`.
+
 Get Started Now
 ---------------
 Download the up-to-date [docs](https://github.com/facebook/Reason/archive/docs.zip) which guide you through the basic syntax and toolchain features.

--- a/opam
+++ b/opam
@@ -19,12 +19,13 @@ build-test: [
   "ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_reason.byte" "--"
 ]
 depends: [
-  "easy-format"  {>= "1.2.0"}
-  "ocamlfind"    {build}
-  "ounit"        {test}
-  "utop"         {>= "1.17"}
-  "BetterErrors" {>= "0.0.1"}
-  "menhir"       {>= "20160303"}
+  "easy-format"   {>= "1.2.0"}
+  "ocamlfind"     {build}
+  "ounit"         {test}
+  "utop"          {>= "1.17"}
+  "BetterErrors"  {>= "0.0.1"}
+  "menhir"        {>= "20160303"}
+  "merlin_extend" {> "0.2"}
 ]
 depopts: [
 ]

--- a/repo/packages/merlin.dev/descr
+++ b/repo/packages/merlin.dev/descr
@@ -1,0 +1,3 @@
+Editor helper, provides completion, typing and source browsing in Vim and Emacs
+
+Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more.

--- a/repo/packages/merlin.dev/opam
+++ b/repo/packages/merlin.dev/opam
@@ -1,0 +1,49 @@
+opam-version: "1.2"
+maintainer: "defree@gmail.com"
+authors: "The Merlin team"
+homepage: "https://github.com/the-lambda-church/merlin"
+bug-reports: "https://github.com/the-lambda-church/merlin/issues"
+dev-repo: "https://github.com/the-lambda-church/merlin.git"
+build: [
+  ["./configure" "--prefix" prefix]
+  ["rm" "-rf" "%{prefix}%/share/ocamlmerlin"]
+  [make "-j" jobs]
+]
+depends: [
+  "ocamlfind" {>= "1.5.2"}
+  "yojson"
+]
+available: [ocaml-version >= "4.00.0"]
+post-messages: [
+  "
+merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam config var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  ;; Add opam emacs directory to the load-path
+  (setq opam-share (substring (shell-command-to-string \"opam config var share 2> /dev/null\") 0 -1))
+  (add-to-list 'load-path (concat opam-share \"/emacs/site-lisp\"))
+  ;; Load merlin-mode
+  (require 'merlin)
+  ;; Start merlin on ocaml files
+  (add-hook 'tuareg-mode-hook 'merlin-mode t)
+  (add-hook 'caml-mode-hook 'merlin-mode t)
+  ;; Enable auto-complete
+  (setq merlin-use-auto-complete-mode 'easy)
+  ;; Use opam switch to lookup ocamlmerlin binary
+  (setq merlin-command 'opam)
+
+Take a look at https://github.com/the-lambda-church/merlin for more information
+  "
+    {success}
+]

--- a/repo/packages/merlin.dev/url
+++ b/repo/packages/merlin.dev/url
@@ -1,0 +1,1 @@
+git: "git://github.com/the-lambda-church/merlin.git#df48da122f02e2276b14bcab58490350749215fa"

--- a/repo/packages/merlin_extend/merlin_extend.dev/opam
+++ b/repo/packages/merlin_extend/merlin_extend.dev/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+name: "merlin_extend"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/def-lkb/merlin-extend"
+bug-reports: "https://github.com/def-lkb/merlin-extend"
+license: "MIT"
+dev-repo: "https://github.com/def-lkb/merlin-extend.git"
+build: [
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "merlin_extend"]
+depends: [
+  "ocamlfind" {build}
+]

--- a/repo/packages/merlin_extend/merlin_extend.dev/url
+++ b/repo/packages/merlin_extend/merlin_extend.dev/url
@@ -1,0 +1,1 @@
+git: "git://github.com/def-lkb/merlin-extend.git#ef634252a793542b05ec00a90f3c17de8fe0a357"


### PR DESCRIPTION
This introduces an OPAM repository under `repo/` which can be used
by automated tooling to get all the pins required.

To see it in action, you can install [dopam](https://github.com/avsm/dopam)
on a Mac without any development tools.  Reason can be built by running:

```
dopam init reason
make
```

A number of other distributions and compiler versions can also be
experimented with by passing options to `dopam init` or doing:

```
dopam bulk-compilers
dopam bulk-distros
```

`dopam` works by initialising a Docker container per combination
of OS/distro, and running OPAM inside the container.  The source
tree is mapped in from the Mac host, so normal editors can be used.

If this PR is useful, I will also update the `README` and documentation to provide the Docker option as a quick install mechanism.
