### PR TITLE
[Reason] Attribute end-of-line comments to correct node.

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/comments.re
+++ b/formatTest/typeCheckedTests/expected_output/comments.re
@@ -1,4 +1,3 @@
-
 /* **** comment */
 /*** comment */
 /** docstring */
@@ -31,3 +30,20 @@
 /**
  **
  */
+let testingEndOfLineComments = [
+  /* Comment For First Item */
+  "Item 1",
+  /* Comment For Second Item */
+  "Item 2",
+  /* Comment For Third Item */
+  "Item 3",
+  "Item 4"
+  /* Comment For Fourth Item - but before semi */
+  /* Comment after last item in list. */
+  /* Comment after list bracket */
+];
+
+/* This time no space between bracket and comment */
+let testingEndOfLineComments = [];
+
+/* Comment after list bracket */

--- a/formatTest/typeCheckedTests/input/comments.ml
+++ b/formatTest/typeCheckedTests/input/comments.ml
@@ -40,3 +40,15 @@
 (**
   **
   *)
+
+let testingEndOfLineComments = [
+  "Item 1";(* Comment For First Item *)  
+  "Item 2"; (* Comment For Second Item *)
+  "Item 3";  (* Comment For Third Item *)
+  "Item 4" (* Comment For Fourth Item - but before semi *);
+  (* Comment after last item in list. *)
+] (* Comment after list bracket *)
+
+(* This time no space between bracket and comment *)
+let testingEndOfLineComments = [
+](* Comment after list bracket *)

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -446,9 +446,9 @@ arrayWithTwo.(1) = 300;
  */
 let myString = "asdf";
 
+/* Replacing a character: I could do without this sugar */
 myString.[2] = '9';
 
-/* Replacing a character: I could do without this sugar */
 /*                           FUNCTIONS
  *=============================================================================
  */

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -271,8 +271,8 @@ let point2D = {x: 20, y: 30};
 let point3D: point3D = {
   x: 10,
   y: 11,
-  z: 80
   /* Optional Comma */
+  z: 80
 };
 
 let printPoint (p: point) => {
@@ -341,18 +341,18 @@ let printPerson (p: person) => {
 
 /* let dontParseMeBro x y:int = x = y;*/
 /* With this unification, anywhere eyou see `= fun` you can just ommit it */
-let blah a => a;
-
 /* Done */
 let blah a => a;
 
 /* Done (almost) */
-let blah a b => a;
+let blah a => a;
 
 /* Done */
 let blah a b => a;
 
 /* Done (almost) */
+let blah a b => a;
+
 /* More than one consecutive pattern must have a single case */
 type blah = {blahBlah: int};
 
@@ -380,21 +380,21 @@ let
   onlyDoingThisTopLevelLetToBypassTopLevelSequence = {
   let x = {
     print_int 1;
-    print_int 20
     /* Missing trailing SEMI */
+    print_int 20
   };
   let x = {
     print_int 1;
-    print_int 20;
     /* Ensure missing middle SEMI reported well */
+    print_int 20;
     print_int 20
   };
   let x = {
     print_int 1;
     print_int 20;
     10
+    /* Missing final SEMI */
   };
-  /* Missing final SEMI */
   x + x
 };
 
@@ -445,17 +445,17 @@ let blah =
       let blah x | Red _ => 1 | Black _ => 0;
       Theres no sugar rule for dropping => fun, only = fun
    */
+/* See, nothing says we can drop the => fun */
 let blahCurriedX x =>
-  fun /* See, nothing says we can drop the => fun */
+  fun /* With some effort, we can ammend the sugar rule that would */
       | Red x
       | Black x
       | Green x => 1
-      /* With some effort, we can ammend the sugar rule that would */
-      | Black x => 0
       /* Allow us to drop any => fun.. Just need to make pattern matching */
+      | Black x => 0
+      /* Support that */
       | Green x => 0;
 
-/* Support that */
 /* This should be parsed/printed exactly as the previous */
 let blahCurriedX x =>
   fun | Red x
@@ -467,9 +467,9 @@ let blahCurriedX x =>
 /* Any time there are multiple match cases we require a leading BAR */
 let v = Red 10;
 
+/* So this NON-function still parses */
 let Black x | Red x | Green x = v;
 
-/* So this NON-function still parses */
 /* This doesn't parse, however (and it doesn't in OCaml either):
      let | Black x | Red x | Green x = v;
    */

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -281,7 +281,7 @@ let myList = [
 let myList = [
   1,
   2,
-  3,
+  3
   /*CommentAfterThreeBeforeCons */
 ];
 
@@ -1707,9 +1707,9 @@ let someResult: (
   int,
   int,
   int
+  /* This shouldn't be broken onto its own newline: @see ensureSingleTokenSticksToLabel */
 ) = someResult;
 
-/* This shouldn't be broken onto its own newline: @see ensureSingleTokenSticksToLabel */
 type sevenStrings = (
   string,
   string,
@@ -1814,9 +1814,9 @@ let df_locallyAbstractFunc
     (type b)
     (input: a) => {
   inputIs: input
+  /* With setting ReturnValOnSameLine */
 };
 
-/* With setting ReturnValOnSameLine */
 let df_locallyAbstractFuncNotSugared
     (type a)
     (type b)


### PR DESCRIPTION
Summary: This diff does not print end of line comments, but
it correctly attributes them to the right node

Test Plan:

Reviewers:

CC:
