### PR TITLE
Fix conflicts in usefile

### DIFF
--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -1105,20 +1105,11 @@ _toplevel_phrase:
 
 use_file: _use_file {apply_mapper_chain_to_use_file $1 default_mapper_chain}
 _use_file:
-    use_file_tail                        { $1 }
-  | expr post_item_attributes use_file_tail
-                                         { Ptop_def[mkstrexp $1 $2] :: $3 }
-;
-
-use_file_tail:
-    EOF                                       { [] }
-  | SEMI EOF                                  { [] }
-  | SEMI expr post_item_attributes use_file_tail
-                                              { Ptop_def[mkstrexp $2 $3] :: $4 }
-  | SEMI structure_item use_file_tail         { Ptop_def[$2] :: $3 }
-  | SEMI toplevel_directive use_file_tail     { $2 :: $3 }
-  | structure_item use_file_tail              { Ptop_def[$1] :: $2 }
-  | toplevel_directive use_file_tail          { $1 :: $2 }
+    EOF                                            { [] }
+  | structure_item SEMI use_file                   { Ptop_def[$1] :: $3 }
+  | toplevel_directive SEMI use_file               { $1 :: $3 }
+  | structure_item EOF                             { [Ptop_def[$1]] }
+  | toplevel_directive EOF                         { [$1] }
 ;
 
 parse_core_type:


### PR DESCRIPTION
There were 2 issues:
- Reason already have the syntax sugar of `expr post_item_attributes` as a structure item (so we don't need to write `let _ = blah`), this is conflicting with `expr post_item_attributes` in use_file.
- There was nothing marking an end of WHILE loop (in ocaml, we have the `DONE` keyworld). If a while loop ends with `SHARP label`, the parser would be confused (is the `SHARP label` part of the while loop, or is it the beginning for a `toplevel_directive` )?

This patch fixes the first issue by removing the `expr post_item_attributes` syntax sugar in use file (since we already have it in `structure_item`). It also fixes the second issue by forcing an SEMI colon after each use_file (so that we don't we hit the end of a WHILE statement).
