### PR TITLE
Use cmdliner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /reasonfmt_merlin_impl.sh
 /refmt_merlin_impl.sh
 *.byte
+*.cmt
 *.docdir
 _build
 *.install

--- a/.merlin
+++ b/.merlin
@@ -1,3 +1,3 @@
-PKG utop str merlin_extend
+PKG utop str merlin_extend cmdliner
 B _build/src
 S src

--- a/.merlin
+++ b/.merlin
@@ -1,3 +1,3 @@
-PKG utop str merlin_extend cmdliner
+PKG utop str merlin_extend cmdliner compiler-libs
 B _build/src
 S src

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ build:
 
 install:
 	opam pin add reason . -y
+	./refmt_impl.native --help=groff > $(shell opam config var man)/man1/refmt.1
 
 run: build
 	rlwrap ocaml \

--- a/_tags
+++ b/_tags
@@ -3,7 +3,7 @@ true: warn(@5@8@10@11@12@14@23-24@26@29@40), bin_annot, safe_string, debug
 <editorSupport/**>: -traverse
 "formatTest": -traverse
 "src": include
-<src/*>: package(menhirLib unix compiler-libs.common ocamlbuild findlib easy-format str BetterErrors merlin_extend)
+<src/*>: package(menhirLib unix compiler-libs.common ocamlbuild findlib easy-format str BetterErrors merlin_extend cmdliner)
 <src/reason_utop.*>: package(menhirLib utop str)
 
 <src_gen/*>: package(sedlex str)

--- a/formatTest/test.sh
+++ b/formatTest/test.sh
@@ -83,16 +83,16 @@ function unit_test() {
         else
           REFILE="$(basename $FILE .mli).rei"
         fi
-        debug "$REFMT -heuristics-file $INPUT/arity.txt -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE"
-        $REFMT -heuristics-file $INPUT/arity.txt -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE
+        debug "$REFMT --heuristics-file $INPUT/arity.txt --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE"
+        $REFMT --heuristics-file $INPUT/arity.txt --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE
         if ! [[ $? -eq 0 ]]; then
             warning "  ⊘ TEST FAILED CONVERTING ML TO RE\n"
             return 1
         fi
         FILE=$REFILE
     else
-      debug "  '$REFMT -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE'"
-      $REFMT -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE
+      debug "  '$REFMT --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE'"
+      $REFMT --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE
     fi
 
     debug "  Comparing results:  diff $OUTPUT/$FILE $EXPECTED_OUTPUT/$FILE"
@@ -126,21 +126,21 @@ function idempotent_test() {
         fi
         debug "  Converting $FILE to $REFILE:"
 
-        debug "  Formatting Once: $REFMT -heuristics-file $INPUT/arity.txt -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE"
-        $REFMT -heuristics-file $INPUT/arity.txt -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE
+        debug "  Formatting Once: $REFMT --heuristics-file $INPUT/arity.txt --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE"
+        $REFMT --heuristics-file $INPUT/arity.txt --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE
         if ! [[ $? -eq 0 ]]; then
             warning "⊘ FAILED\n"
             return 1
         fi
         FILE=$REFILE
         debug "  Generating output again: $REFMT -print-width 50 -print re $OUTPUT/$FILE 2>&1 > $OUTPUT/$FILE.formatted"
-        $REFMT -print-width 50 -print re $OUTPUT/$FILE 2>&1 > $OUTPUT/$FILE.formatted
+        $REFMT --print-width 50 --print re $OUTPUT/$FILE 2>&1 > $OUTPUT/$FILE.formatted
     else
       debug "  Formatting Once: '$REFMT -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE'"
-      $REFMT -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE
+      $REFMT --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE
 
       debug "  Generating output again: $REFMT -print-width 50 -print re $OUTPUT/$FILE 2>&1 > $OUTPUT/$FILE.formatted"
-      $REFMT -print-width 50 -print re $OUTPUT/$FILE 2>&1 > $OUTPUT/$FILE.formatted
+      $REFMT --print-width 50 --print re $OUTPUT/$FILE 2>&1 > $OUTPUT/$FILE.formatted
     fi
 
     diff --unchanged-line-format="" --new-line-format=":%dn: %L" --old-line-format=":%dn: %L" $OUTPUT/$FILE $OUTPUT/$FILE.formatted
@@ -169,25 +169,25 @@ function typecheck_test() {
           REFILE="$(basename $FILE .mli).rei"
         fi
         debug "  Converting $FILE to $REFILE:"
-        debug "$REFMT -heuristics-file $INPUT/arity.txt -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE"
-        $REFMT -heuristics-file $INPUT/arity.txt -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE
+        debug "$REFMT --heuristics-file $INPUT/arity.txt --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE"
+        $REFMT --heuristics-file $INPUT/arity.txt --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE
         if ! [[ $? -eq 0 ]]; then
             warning "  ⊘ FAILED\n"
             return 1
         fi
         FILE=$REFILE
     else
-        debug "  Formatting: $REFMT -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE"
-        $REFMT -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE
+        debug "  Formatting: $REFMT --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE"
+        $REFMT --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE
         if ! [[ $? -eq 0 ]]; then
             warning "  ⊘ FAILED\n"
             return 1
         fi
     fi
     if [ "$(basename $FILE)" != "$(basename $FILE .re)" ]; then
-      COMPILE_FLAGS="-intf-suffix .rei -impl"
+      COMPILE_FLAGS="--intf-suffix .rei -impl"
     else
-      COMPILE_FLAGS="-intf"
+      COMPILE_FLAGS="--intf"
     fi
 
     debug "  Compiling: ocamlc -c -pp $REFMT $COMPILE_FLAGS $OUTPUT/$FILE"

--- a/formatTest/test.sh
+++ b/formatTest/test.sh
@@ -185,9 +185,9 @@ function typecheck_test() {
         fi
     fi
     if [ "$(basename $FILE)" != "$(basename $FILE .re)" ]; then
-      COMPILE_FLAGS="--intf-suffix .rei -impl"
+      COMPILE_FLAGS="-intf-suffix .rei -impl"
     else
-      COMPILE_FLAGS="--intf"
+      COMPILE_FLAGS="-intf"
     fi
 
     debug "  Compiling: ocamlc -c -pp $REFMT $COMPILE_FLAGS $OUTPUT/$FILE"

--- a/opam
+++ b/opam
@@ -22,6 +22,7 @@ depends: [
   "easy-format"  {>= "1.2.0"}
   "ocamlfind"    {build}
   "ounit"        {test}
+  "cmdliner"     {>= "0.9.8"}
   "utop"         {>= "1.17"}
   "BetterErrors" {>= "0.0.1"}
   "menhir"       {>= "20160303"}

--- a/src/refmt_args.ml
+++ b/src/refmt_args.ml
@@ -1,0 +1,52 @@
+open Cmdliner
+
+let is_interface_pp =
+  let doc = "parse AST as interface" in
+  Arg.(value & flag & info ["i"; "interface"] ~doc)
+
+let use_stdin =
+  let doc = "parse AST from stdin" in
+  Arg.(value & flag & info ["s"; "stdin"] ~doc)
+
+let recoverable =
+  let doc = "enable recoverable parser" in
+  Arg.(value & flag & info ["r"; "recoverable"] ~doc)
+
+let explicit_arity =
+  let doc =
+    "If a constructor's argument is a tuple, always interpret \
+     it as multiple arguments"
+  in
+  Arg.(value & flag & info ["e"; "explicit_arity"] ~doc)
+
+let parse_ast =
+  let doc =
+    "parse AST as 'ml', 're', 'binary_reason(for \
+     interchange between Reason versions')"
+  in
+  Arg.(value  & opt (some string) None & info ["parse"] ~doc)
+
+let print =
+  let doc =
+    "print AST in <print> (either 'ml', 're', 'binary(default - \
+     for compiler input)', \
+     'binary_reason(for interchange between Reason versions)', \
+     'ast (print human readable directly)', 'none')"
+  in
+  Arg.(value & opt (some string) None & info ["p"; "print"] ~doc)
+
+let print_width =
+  let doc = "wrapping width for printing the AST" in
+  Arg.(value & opt (some int) (Some 90) & info ["w"; "print_width"] ~doc)
+
+let heuristics_file =
+  let doc =
+    "load path as a heuristics file to specify which constructors are defined with \
+     multi-arguments. Mostly used in removing [@implicit_arity] introduced from \
+     OCaml conversion.\n\t\texample.txt:\n\t\tConstructor1\n\t\tConstructor2"
+  in
+  Arg.(value & opt (some file) None & info ["h"; "heuristic"] ~doc)
+
+let input =
+  let doc = "input files" in
+  Arg.(required & pos ~rev:true 0 (some file) None & info [] ~doc)

--- a/src/refmt_args.ml
+++ b/src/refmt_args.ml
@@ -2,7 +2,7 @@ open Cmdliner
 
 let is_interface_pp =
   let doc = "parse AST as interface" in
-  Arg.(value & flag & info ["i"; "is-interface-pp"] ~doc)
+  Arg.(value & opt (some bool) None & info ["i"; "is-interface-pp"] ~doc)
 
 let use_stdin =
   let doc = "parse AST from stdin" in

--- a/src/refmt_args.ml
+++ b/src/refmt_args.ml
@@ -2,11 +2,11 @@ open Cmdliner
 
 let is_interface_pp =
   let doc = "parse AST as interface" in
-  Arg.(value & flag & info ["i"; "interface"] ~doc)
+  Arg.(value & flag & info ["i"; "is-interface-pp"] ~doc)
 
 let use_stdin =
   let doc = "parse AST from stdin" in
-  Arg.(value & flag & info ["s"; "stdin"] ~doc)
+  Arg.(value & flag & info ["s"; "use-stdin"] ~doc)
 
 let recoverable =
   let doc = "enable recoverable parser" in
@@ -17,7 +17,7 @@ let explicit_arity =
     "If a constructor's argument is a tuple, always interpret \
      it as multiple arguments"
   in
-  Arg.(value & flag & info ["e"; "explicit_arity"] ~doc)
+  Arg.(value & flag & info ["e"; "assume-explicit-arity"] ~doc)
 
 let parse_ast =
   let doc =
@@ -37,7 +37,7 @@ let print =
 
 let print_width =
   let doc = "wrapping width for printing the AST" in
-  Arg.(value & opt (some int) (Some 90) & info ["w"; "print_width"] ~doc)
+  Arg.(value & opt (some int) (Some 90) & info ["w"; "print-width"] ~doc)
 
 let heuristics_file =
   let doc =
@@ -45,7 +45,7 @@ let heuristics_file =
      multi-arguments. Mostly used in removing [@implicit_arity] introduced from \
      OCaml conversion.\n\t\texample.txt:\n\t\tConstructor1\n\t\tConstructor2"
   in
-  Arg.(value & opt (some file) None & info ["h"; "heuristic"] ~doc)
+  Arg.(value & opt (some file) None & info ["h"; "heuristics-file"] ~doc)
 
 let input =
   let doc = "input files" in

--- a/src/refmt_impl.ml
+++ b/src/refmt_impl.ml
@@ -207,7 +207,7 @@ let top_level_info =
 
 let () =
   match Cmdliner.Term.eval (entry_point, top_level_info) with
-  | `Error _ ->
-    "This is unexpected, please report to github.com/facebook/Reason"
+  | `Error `Exn ->
+    "This is unexpected, please report to http://github.com/facebook/Reason"
     |> prerr_endline
   | _ -> ()

--- a/src/refmt_impl.ml
+++ b/src/refmt_impl.ml
@@ -8,29 +8,34 @@ exception Invalid_config of string
 let default_print_width = 90
 
 (* Note: filename should only be used with .ml files. See reason_toolchain. *)
-let defaultImplementationParserFor use_stdin filename =
-  if Filename.check_suffix filename ".re" then (Reason_toolchain.JS.canonical_implementation_with_comments (Reason_toolchain.setup_lexbuf use_stdin filename), false, false)
-  else if Filename.check_suffix filename ".ml" then (Reason_toolchain.ML.canonical_implementation_with_comments (Reason_toolchain.setup_lexbuf use_stdin filename), true, false)
-  else (
-    raise (Invalid_config ("Cannot determine default implementation parser for filename '" ^ filename ^ "'."))
+let defaultImplementationParserFor use_stdin filename = Reason_toolchain.(
+    if Filename.check_suffix filename ".re"
+    then (JS.canonical_implementation_with_comments (setup_lexbuf use_stdin filename), false, false)
+    else if Filename.check_suffix filename ".ml"
+    then (ML.canonical_implementation_with_comments (setup_lexbuf use_stdin filename), true, false)
+    else
+      (Invalid_config ("Cannot determine default implementation parser for filename '" ^ filename ^ "'."))
+      |> raise
   )
 
 (* Note: filename should only be used with .mli files. See reason_toolchain. *)
-let defaultInterfaceParserFor use_stdin filename =
-  if Filename.check_suffix filename ".rei" then (Reason_toolchain.JS.canonical_interface_with_comments (Reason_toolchain.setup_lexbuf use_stdin filename) , false, true)
-  else if Filename.check_suffix filename ".mli" then (Reason_toolchain.ML.canonical_interface_with_comments (Reason_toolchain.setup_lexbuf use_stdin filename), true, true)
-  else (
-    raise (Invalid_config ("Cannot determine default interface parser for filename '" ^ filename ^ "'."))
+let defaultInterfaceParserFor use_stdin filename = Reason_toolchain.(
+    if Filename.check_suffix filename ".rei"
+    then (JS.canonical_interface_with_comments (setup_lexbuf use_stdin filename) , false, true)
+    else if Filename.check_suffix filename ".mli"
+    then (ML.canonical_interface_with_comments (setup_lexbuf use_stdin filename), true, true)
+    else
+      (Invalid_config ("Cannot determine default interface parser for filename '" ^ filename ^ "'."))
+      |> raise
   )
 
 let reasonBinaryParser use_stdin filename =
   let chan =
-    match use_stdin with
-      | true -> stdin
-      | false ->
-          let file_chan = open_in filename in
-          seek_in file_chan 0;
-          file_chan
+    if use_stdin then stdin
+    else
+      let file_chan = open_in filename in
+      seek_in file_chan 0;
+      file_chan
   in
   let (magic_number, filename, ast, comments, parsedAsML, parsedAsInterface) = input_value chan in
   ((ast, comments), parsedAsML, parsedAsInterface)

--- a/src/refmt_impl.ml
+++ b/src/refmt_impl.ml
@@ -2,10 +2,21 @@
 
 open Lexing
 
+module P = Printf
+
 exception Invalid_config of string
 
-
-let default_print_width = 90
+let read_lines file =
+  let list = ref [] in
+  let chan = open_in file in
+  try
+    while true do
+      list := input_line chan :: !list
+    done;
+    []
+  with End_of_file ->
+    close_in chan;
+    List.rev !list
 
 (* Note: filename should only be used with .ml files. See reason_toolchain. *)
 let defaultImplementationParserFor use_stdin filename = Reason_toolchain.(
@@ -44,166 +55,159 @@ let reasonBinaryParser use_stdin filename =
  * As soon as m17n vends comments, this should be replaced with what is
  * effectively m17n's parser.
  *)
-let () =
-  let filename = ref "" in
-  let prnt = ref None in
-  let prse = ref None in
-  let use_stdin = ref false in
-  let intf = ref None in
-  let recoverable = ref false in
-  let assumeExplicitArity = ref false in
-  let heuristics_file = ref None in
-  let print_width = ref None in
-  let () = Arg.parse [
-    "-ignore", Arg.Unit ignore, "ignored";
-    "-is-interface-pp", Arg.Bool (fun x -> intf := Some x), "<interface>, parse AST as <interface> (either true or false)";
-    "-use-stdin", Arg.Bool (fun x -> use_stdin := x), "<use_stdin>, parse AST from <use_stdin> (either true, false). You still must provide a file name even if using stdin for errors to be reported";
-    "-recoverable", Arg.Bool (fun x -> recoverable := x), "Enable recoverable parser";
-    "-assume-explicit-arity", Arg.Unit (fun () -> assumeExplicitArity := true), "If a constructor's argument is a tuple, always interpret it as multiple arguments";
-    "-parse", Arg.String (fun x -> prse := Some x), "<parse>, parse AST as <parse> (either 'ml', 're', 'binary_reason(for interchange between Reason versions')";
-    (* Use a print option of "none" to simply perform a parsing validation -
-     * useful for IDE error messages etc.*)
-    "-print", Arg.String (fun x -> prnt := Some x), "<print>, print AST in <print> (either 'ml', 're', 'binary(default - for compiler input)', 'binary_reason(for interchange between Reason versions)', 'ast (print human readable directly)', 'none')";
-    "-print-width", Arg.Int (fun x -> print_width := Some x), "<print-width>, wrapping width for printing the AST";
-    "-heuristics-file", Arg.String (fun x -> heuristics_file := Some x),
-    "<path>, load path as a heuristics file to specify whtich constructors are defined with multi-arguments. Mostly used in removing [@implicit_arity] introduced from OCaml conversion.\n\t\texample.txt:\n\t\tConstructor1\n\t\tConstructor2";
-  ]
-  (fun arg -> filename := arg)
-  "Reason: Meta Language Utility"
+
+let begin_reason
+    is_interface_pp
+    use_stdin
+    is_recoverable
+    explicit_arity
+    parse_ast
+    print
+    print_width
+    h_file
+    input_file
+  =
+  Reason_config.configure is_recoverable;
+  Location.input_name := input_file;
+  let constructorLists = match h_file with
+      None -> [] | Some f_name -> read_lines f_name
   in
-  let filename = !filename in
-  let use_stdin = !use_stdin in
-  let print_width = match !print_width with
-    | None -> default_print_width
-    | Some x -> x
-  in
-  let constructorLists = match !heuristics_file with
-    | None -> []
-    | Some file ->
-      let list = ref [] in
-      let chan = open_in file in
-      try
-        while true; do
-          list := input_line chan :: !list
-        done; []
-      with End_of_file ->
-        close_in chan;
-        List.rev !list
-  in
-  let _ = if !recoverable then
-    Reason_config.configure ~r:true
-  in
-  Location.input_name := filename;
-  let intf = match !intf with
-    | None when (Filename.check_suffix filename ".rei" || Filename.check_suffix filename ".mli") -> true
-    | None -> 
-      if use_stdin then
-        raise (Invalid_config ("Unable to determine if stdin input is an interface file. Invalid -is-interface-pp setting."))
-      else
-        false
+  let intf =
+    let is_suffix = String.lowercase input_file |> Filename.check_suffix in
+    match is_interface_pp with
+    | None when (is_suffix ".rei" || is_suffix ".mli") -> true
+    | None -> if use_stdin then
+        Invalid_config "Unable to determine if stdin input is an \
+                        interface file. Invalid --is-interface-pp setting."
+        |> raise
+      else false
     | Some b -> b
   in
   try
     if intf then (
-      let ((ast, comments), parsedAsML, parsedAsInterface) = match !prse with
-        | None -> (defaultInterfaceParserFor use_stdin filename)
-        | Some "binary_reason" -> reasonBinaryParser use_stdin filename
-        | Some "ml" -> ((Reason_toolchain.ML.canonical_interface_with_comments (Reason_toolchain.setup_lexbuf use_stdin filename)), true, true)
-        | Some "re" -> ((Reason_toolchain.JS.canonical_interface_with_comments (Reason_toolchain.setup_lexbuf use_stdin filename)), false, true)
-        | Some s -> (
-          raise (Invalid_config ("Invalid -parse setting for interface '" ^ s ^ "'."))
-        )
+      let ((ast, comments), parsedAsML, parsedAsInterface) = Reason_toolchain.(match parse_ast with
+          | None -> (defaultInterfaceParserFor use_stdin input_file)
+          | Some "binary_reason" -> reasonBinaryParser use_stdin input_file
+          | Some "ml" -> ((ML.canonical_interface_with_comments (setup_lexbuf use_stdin input_file)), true, true)
+          | Some "re" -> ((JS.canonical_interface_with_comments (setup_lexbuf use_stdin input_file)), false, true)
+          | Some s -> (
+              Invalid_config (P.sprintf "Invalid --parse setting for interface ' %s'." s)
+              |> raise
+            ))
       in
       let _ =
         if not parsedAsInterface then
           raise (Invalid_config ("The file parsed does not appear to be an interface file.")) in
-      let _ = Reason_pprint_ast.configure
-          ~width: print_width
-          ~assumeExplicitArity: !assumeExplicitArity
-          ~constructorLists
-      in
-      let thePrinter = match !prnt with
-        | Some "binary_reason" -> fun (ast, comments) -> (
+      Reason_pprint_ast.configure
+        ~width: (match print_width with None -> 90 | Some i -> i)
+        ~assumeExplicitArity:explicit_arity
+        ~constructorLists;
+      let thePrinter = match print with
+        | Some "binary_reason" -> fun (ast, comments) ->
           (* Our special format for interchange between reason should keep the
            * comments separate.  This is not compatible for input into the
            * ocaml compiler - only for input into another version of Reason. We
            * also store whether or not the binary was originally *parsed* as an
            * interface file.
-           *)
-          output_value stdout (
-            Config.ast_intf_magic_number, filename, ast, comments, parsedAsML, true
-          );
-        )
+          *)
+          (Config.ast_intf_magic_number, input_file, ast, comments, parsedAsML, true)
+          |> output_value stdout
         | Some "binary"
         | None -> fun (ast, comments) -> (
-          output_string stdout Config.ast_intf_magic_number;
-          output_value  stdout filename;
-          output_value  stdout ast
-        )
-        | Some "ast" -> fun (ast, comments) -> (
-          Printast.interface Format.std_formatter ast
-        )
+            output_string stdout Config.ast_intf_magic_number;
+            output_value  stdout input_file;
+            output_value  stdout ast
+          )
+        | Some "ast" -> fun (ast, comments) -> Printast.interface Format.std_formatter ast
         (* If you don't wrap the function in parens, it's a totally different
          * meaning #thanksOCaml *)
         | Some "none" -> (fun (ast, comments) -> ())
         | Some "ml" -> Reason_toolchain.ML.print_canonical_interface_with_comments
         | Some "re" -> Reason_toolchain.JS.print_canonical_interface_with_comments
-        | Some s -> (
-          raise (Invalid_config ("Invalid -print setting for interface '" ^ s ^ "'."))
-        )
+        | Some s ->
+          Invalid_config (P.sprintf "Invalid --print setting for interface '%s'." s)
+          |> raise
       in
       thePrinter (ast, comments)
     ) else (
       (*    Printf.fprintf stderr "syntax error: %s\n" (Reason_error_report.report checkpoint); [] in *)
-      let ((ast, comments), parsedAsML, parsedAsInterface) = match !prse with
-        | None -> (defaultImplementationParserFor use_stdin filename)
-        | Some "binary_reason" -> reasonBinaryParser use_stdin filename
-        | Some "ml" -> (Reason_toolchain.ML.canonical_implementation_with_comments (Reason_toolchain.setup_lexbuf use_stdin filename), true, false)
-        | Some "re" -> (Reason_toolchain.JS.canonical_implementation_with_comments (Reason_toolchain.setup_lexbuf use_stdin filename), false, false)
-        | Some s -> (
-          raise (Invalid_config ("Invalid -parse setting for interface '" ^ s ^ "'."))
+      let ((ast, comments), parsedAsML, parsedAsInterface) = Reason_toolchain.(match parse_ast with
+          | None -> (defaultImplementationParserFor use_stdin input_file)
+          | Some "binary_reason" -> reasonBinaryParser use_stdin input_file
+          | Some "ml" -> (ML.canonical_implementation_with_comments (setup_lexbuf use_stdin input_file), true, false)
+          | Some "re" -> (JS.canonical_implementation_with_comments (setup_lexbuf use_stdin input_file), false, false)
+          | Some s ->
+            Invalid_config (P.sprintf "Invalid --parse setting for interface '%s'." s)
+            |> raise
         )
       in
+
       let _ = if parsedAsInterface then
           raise (Invalid_config ("The file parsed does not appear to be an implementation file.")) in
-      let _ = Reason_pprint_ast.configure
-          ~width: print_width
-          ~assumeExplicitArity: !assumeExplicitArity
-          ~constructorLists
-      in
-      let thePrinter = match !prnt with
-        | Some "binary_reason" -> fun (ast, comments) -> (
+      Reason_pprint_ast.configure
+        ~width: (match print_width with None -> 90 | Some i -> i)
+        ~assumeExplicitArity: explicit_arity
+        ~constructorLists;
+      let thePrinter = match print with
+        | Some "binary_reason" -> fun (ast, comments) ->
           (* Our special format for interchange between reason should keep the
            * comments separate.  This is not compatible for input into the
            * ocaml compiler - only for input into another version of Reason. We
            * also store whether or not the binary was originally *parsed* as an
            * interface file.
-           *)
-          output_value stdout (
-            Config.ast_impl_magic_number, filename, ast, comments, parsedAsML, false
-          );
-        )
+          *)
+          (Config.ast_impl_magic_number, input_file, ast, comments, parsedAsML, false)
+          |> output_value stdout
         | Some "binary"
         | None -> fun (ast, comments) -> (
-          output_string stdout Config.ast_impl_magic_number;
-          output_value stdout filename;
-          output_value stdout ast
-        )
-        | Some "ast" -> fun (ast, comments) -> (
+            output_string stdout Config.ast_impl_magic_number;
+            output_value stdout input_file;
+            output_value stdout ast
+          )
+        | Some "ast" -> fun (ast, comments) ->
           Printast.implementation Format.std_formatter ast
-        )
         (* If you don't wrap the function in parens, it's a totally different
          * meaning #thanksOCaml *)
         | Some "none" -> (fun (ast, comments) -> ())
         | Some "ml" -> Reason_toolchain.ML.print_canonical_implementation_with_comments
         | Some "re" -> Reason_toolchain.JS.print_canonical_implementation_with_comments
-        | Some s -> (
-          raise (Invalid_config ("Invalid -print setting for implementation '" ^ s ^ "'."))
-        )
+        | Some s ->
+          Invalid_config (P.sprintf "Invalid --print setting for implementation '%s'." s)
+          |> raise
       in
       thePrinter (ast, comments)
     )
+
   with
   | exn ->
     Location.report_exception Format.err_formatter exn;
     exit 1
+
+
+let entry_point =
+  Refmt_args.(Cmdliner.Term.(pure
+                               begin_reason
+                             $ is_interface_pp
+                             $ use_stdin
+                             $ recoverable
+                             $ explicit_arity
+                             $ parse_ast
+                             $ print
+                             $ print_width
+                             $ heuristics_file
+                             $ input
+                            ))
+
+let top_level_info =
+  let doc = "Meta language utility" in
+  let man = [`S "DESCRIPTION";
+             `P "Something something"]
+  in
+  Cmdliner.Term.info "refmt" ~version:"0.0.2" ~doc ~man
+
+let () =
+  match Cmdliner.Term.eval (entry_point, top_level_info) with
+  | `Error _ ->
+    "This is unexpected, please report to github.com/facebook/Reason"
+    |> prerr_endline
+  | _ -> ()


### PR DESCRIPTION
Implement replacement of Arg with cmdliner while passing all tests for `refmt_imp` along with some style changes.

@jordwalke You'll probably want to commit on top of this to replace the proper description in the man page's main `DESCRIPTION`.