### PR TITLE
[Reason][Request For Comments] Better indentation for switch cases.

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/mutation.re
+++ b/formatTest/typeCheckedTests/expected_output/mutation.re
@@ -38,13 +38,13 @@ switch numberToSwitchOn {
 | 0 => holdsAUnit.contents = ()
 | 1 => holdsAUnit.contents = holdsAnInt := 0
 | 2 =>
-    true ?
-      holdsAUnit.contents = () :
-      holdsABool.contents ? () : ()
+  true ?
+    holdsAUnit.contents = () :
+    holdsABool.contents ? () : ()
 | 3 =>
-    true ?
-      holdsAUnit := () :
-      holdsABool.contents ? () : ()
+  true ?
+    holdsAUnit := () :
+    holdsABool.contents ? () : ()
 | 4 => true ? holdsAnInt := 40 : ()
 | 5 => holdsAnInt := 40
 | _ => ()

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -8,10 +8,9 @@ class virtual stack 'a init => {
   method virtual implementMe: int => int;
   method pop =
     switch v {
-    | [hd, ...tl] => {
-        v = tl;
-        Some hd
-      }
+    | [hd, ...tl] =>
+      v = tl;
+      Some hd
     | [] => None
     };
   method push hd => v = [hd, ...v];
@@ -42,10 +41,9 @@ class virtual stackWithAttributes 'a init =>
     method virtual implementMe: int => int;
     method pop =
       switch v {
-      | [hd, ...tl] => {
-          v = tl;
-          Some hd
-        }
+      | [hd, ...tl] =>
+        v = tl;
+        Some hd
       | [] => None
       };
     method push hd => v = [hd, ...v];

--- a/formatTest/typeCheckedTests/expected_output/patternMatching.re
+++ b/formatTest/typeCheckedTests/expected_output/patternMatching.re
@@ -1,0 +1,119 @@
+type point = {x: int, y: int};
+
+let id x => x;
+
+type myVariant =
+  | TwoCombos of inner inner
+  | Short
+  | AlsoHasARecord of int int point
+and inner =
+  | Unused
+  | HeresTwoConstructorArguments of int int;
+
+let computeTuple a b c d e f g h => (
+  a + b,
+  c + d,
+  e + f,
+  g + h
+);
+
+let res =
+  switch (TwoCombos Unused Unused) {
+  | TwoCombos
+      (HeresTwoConstructorArguments x y)
+      (HeresTwoConstructorArguments a b) => (
+      x,
+      y,
+      a,
+      b
+    )
+  | TwoCombos _ _ => (0, 0, 0, 0)
+  | Short
+  | AlsoHasARecord 300 _ _ => (
+      100000,
+      100000,
+      100000,
+      100000
+    )
+  | AlsoHasARecord firstItem two {x, y} =>
+    computeTuple
+      firstItem
+      firstItem
+      firstItem
+      firstItem
+      firstItem
+      two
+      two
+      two
+  };
+
+/**
+ * Match bodies may include sequence expressions, but without the `{}`
+ * braces required.
+ */
+let res =
+  switch (TwoCombos Unused Unused) {
+  | TwoCombos
+      (HeresTwoConstructorArguments x y)
+      (HeresTwoConstructorArguments a b) =>
+    let ret = (x, y, a, b);
+    ret
+  | TwoCombos _ _ =>
+    /**
+     * See, no braces required - saves indentation as well!
+     */
+    let ret = (0, 0, 0, 0);
+    ret
+  | Short
+  | AlsoHasARecord 300 _ _ =>
+    /**
+     * And no final semicolon is required.
+     */
+    let ret = (100000, 100000, 100000, 100000);
+    ret
+  | AlsoHasARecord firstItem two {x, y} =>
+    computeTuple
+      firstItem
+      firstItem
+      firstItem
+      firstItem
+      firstItem
+      two
+      two
+      two
+  };
+
+/**
+ * Ensure that nested Pexp_functions are correctly wrapped in parens.
+ *
+ */
+let res =
+  switch (TwoCombos Unused Unused) {
+  | TwoCombos
+      (HeresTwoConstructorArguments x y)
+      (HeresTwoConstructorArguments a b) => (
+      fun
+      | Some x => x + 1
+      | None => 0
+    )
+  | TwoCombos _ _ =>
+    let x = (
+      fun
+      | Some x => x + 1
+      | None => 0
+    );
+    x
+  | Short
+  | AlsoHasARecord 300 _ _ =>
+    id (
+      fun
+      | Some x => x + 1
+      | None => 0
+    )
+  | AlsoHasARecord firstItem two {x, y} =>
+    id (
+      fun
+      | Some x => x + 1
+      | None => 0
+    )
+  };

--- a/formatTest/typeCheckedTests/input/patternMatching.re
+++ b/formatTest/typeCheckedTests/input/patternMatching.re
@@ -1,0 +1,106 @@
+type point = {x: int, y: int};
+
+let id x => x;
+
+type myVariant =
+  | TwoCombos of inner inner
+  | Short
+  | AlsoHasARecord of int int point
+and inner =
+  | Unused
+  | HeresTwoConstructorArguments of int int;
+
+let computeTuple a b c d e f g h => (
+  a + b,
+  c + d,
+  e + f,
+  g + h
+);
+
+let res =
+  switch (TwoCombos Unused Unused) {
+  | TwoCombos
+      (HeresTwoConstructorArguments x y)
+      (HeresTwoConstructorArguments a b) =>
+      (x, y, a, b)
+  | TwoCombos
+      _
+      _ => (0, 0, 0, 0)
+  | Short
+  | AlsoHasARecord 300 _ _ => (
+      100000,
+      100000,
+      100000,
+      100000
+    )
+  | AlsoHasARecord firstItem two {x, y} =>
+    computeTuple firstItem firstItem firstItem firstItem firstItem two two two
+  };
+
+/**
+ * Match bodies may include sequence expressions, but without the `{}`
+ * braces required.
+ */
+let res =
+  switch (TwoCombos Unused Unused) {
+  | TwoCombos
+      (HeresTwoConstructorArguments x y)
+      (HeresTwoConstructorArguments a b) => {
+      let ret = (x, y, a, b);
+      ret;
+    }
+  | TwoCombos _ _ =>
+    /**
+     * See, no braces required - saves indentation as well!
+     */
+    let ret = (0, 0, 0, 0);
+    ret;
+  | Short
+  | AlsoHasARecord 300 _ _ =>
+    /**
+     * And no final semicolon is required.
+     */
+    let ret = (
+      100000,
+      100000,
+      100000,
+      100000
+    );
+    ret
+  | AlsoHasARecord firstItem two {x, y} =>
+    computeTuple firstItem firstItem firstItem firstItem firstItem two two two
+  };
+
+
+
+/**
+ * Ensure that nested Pexp_functions are correctly wrapped in parens.
+ * 
+ */
+let res =
+  switch (TwoCombos Unused Unused) {
+  | TwoCombos
+      (HeresTwoConstructorArguments x y)
+      (HeresTwoConstructorArguments a b) =>
+    (fun
+      | Some x => x + 1
+      | None => 0)
+  | TwoCombos
+      _
+      _ =>
+    let x =
+      (fun
+        | Some x => x + 1
+        | None => 0);
+    x;
+  | Short
+  | AlsoHasARecord 300 _ _ => id ((fun
+        | Some x => x + 1
+        | None => 0))
+  | AlsoHasARecord firstItem two {x, y} =>
+    id ((fun
+            | Some x => x + 1
+            | None => 0));
+  };
+
+

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -359,10 +359,10 @@ let nestedMatch lstLst =>
   switch lstLst {
   | [hd, ...tl] when false => 10
   | [hd, ...tl] =>
-      switch tl {
-      | [] => 0 + 0
-      | [tlHd, ...tlTl] => 0 + 1
-      }
+    switch tl {
+    | [] => 0 + 0
+    | [tlHd, ...tlTl] => 0 + 1
+    }
   | [] => 0
   };
 
@@ -370,11 +370,11 @@ let nestedMatchWithWhen lstLst =>
   switch lstLst {
   | [hd, ...tl] when false => 10
   | [hd, ...tl] when true =>
-      switch tl {
-      | [] when false => 0 + 0
-      | [] when true => 0 + 0
-      | [tlHd, ...tlTl] => 0 + 1
-      }
+    switch tl {
+    | [] when false => 0 + 0
+    | [] when true => 0 + 0
+    | [tlHd, ...tlTl] => 0 + 1
+    }
   | [] => 0
   };
 

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -384,7 +384,7 @@ let module rec A: {
   let compare t1 t2 =>
     switch (t1, t2) {
     | (Leaf s1, Leaf s2) =>
-        Pervasives.compare s1 s2
+      Pervasives.compare s1 s2
     | (Leaf _, Node _) => 1
     | (Node _, Leaf _) => (-1)
     | (Node n1, Node n2) => ASet.compare n1 n2

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -21,15 +21,13 @@ TestUtils.printSection "General Syntax";
 /*  */
 let matchingFunc a =>
   switch a {
-  | `Thingy x => {
-      print_string "matched thingy x";
-      let zz = 10;
-      zz
-    }
-  | `Other x => {
-      print_string "matched other x";
-      x
-    }
+  | `Thingy x =>
+    print_string "matched thingy x";
+    let zz = 10;
+    zz
+  | `Other x =>
+    print_string "matched other x";
+    x
   };
 
 type firstTwoShouldBeGroupedInParens =

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -132,31 +132,31 @@ let accessDeeplyWithArg x =>
   | LocalModule.AccessedThroughModuleWith (
       x as retVal
     ) =>
-      retVal + 1
+    retVal + 1
   | LocalModule.AccessedThroughModuleWithTwo
       (x as retVal1) (y as retVal2) =>
-      retVal1 + retVal2 + 1
+    retVal1 + retVal2 + 1
   };
 
 /* Just to show that by default `as` captures much less aggresively */
 let rec accessDeeplyWithArgRecursive x count =>
   switch x {
   | LocalModule.AccessedThroughModuleWith x as entirePattern =>
-      /* It captures the whole pattern */
-      if (count > 0) {
-        0
-      } else {
-        accessDeeplyWithArgRecursive
-          entirePattern (count - 1)
-      }
+    /* It captures the whole pattern */
+    if (count > 0) {
+      0
+    } else {
+      accessDeeplyWithArgRecursive
+        entirePattern (count - 1)
+    }
   | LocalModule.AccessedThroughModuleWithTwo x y as entirePattern =>
-      /* It captures the whole pattern */
-      if (count > 0) {
-        0
-      } else {
-        accessDeeplyWithArgRecursive
-          entirePattern (count - 1)
-      }
+    /* It captures the whole pattern */
+    if (count > 0) {
+      0
+    } else {
+      accessDeeplyWithArgRecursive
+        entirePattern (count - 1)
+    }
   };
 
 accessDeeplyWithArgRecursive
@@ -188,7 +188,7 @@ let matchingTwoCurriedConstructorsInTuple x =>
       HeresTwoConstructorArguments x y,
       HeresTwoConstructorArguments a b
     ) =>
-      x + y + a + b
+    x + y + a + b
   };
 
 type twoCurriedConstructors =
@@ -200,7 +200,7 @@ let matchingTwoCurriedConstructorInConstructor x =>
   | TwoCombos
       (HeresTwoConstructorArguments x y)
       (HeresTwoConstructorArguments a b) =>
-      a + b + x + y
+    a + b + x + y
   };
 
 type twoCurriedConstructorsPolyMorphic 'a =
@@ -294,15 +294,15 @@ let myTuple = OneTuple (20, 30);
 let res =
   switch myTuple {
   | Two x y =>
-      try (Two x y) {
-      | One => "hi"
-      | Two => "bye"
-      }
+    try (Two x y) {
+    | One => "hi"
+    | Two => "bye"
+    }
   | One =>
-      switch One {
-      | One => "hi"
-      | _ => "bye"
-      }
+    switch One {
+    | One => "hi"
+    | _ => "bye"
+    }
   };
 
 /* FIXME type somePolyVariant = [ `Purple of int | `Yellow of int]; */
@@ -313,13 +313,13 @@ let prp = `Purple (101, 100);
 let res =
   switch (ylw, prp) {
   | (`Yellow (y, y2), `Purple (p, p2)) =>
-      `Yellow (p + y, 0)
+    `Yellow (p + y, 0)
   | (`Purple (p, p2), `Yellow (y, y2)) =>
-      `Purple (y + p, 0)
+    `Purple (y + p, 0)
   | (`Purple (p, p2), `Purple (y, y2)) =>
-      `Yellow (y + p, 0)
+    `Yellow (y + p, 0)
   | (`Yellow (p, p2), `Yellow (y, y2)) =>
-      `Purple (y + p, 0)
+    `Purple (y + p, 0)
   };
 
 let ylw = `Yellow 100;
@@ -359,13 +359,13 @@ let prp = `Purple (101, 101);
 let res =
   switch (ylw, prp) {
   | (`Yellow (y, y2), `Purple (p, p2)) =>
-      `Yellow (p + y, 0)
+    `Yellow (p + y, 0)
   | (`Purple (p, p2), `Yellow (y, y2)) =>
-      `Purple (y + p, 0)
+    `Purple (y + p, 0)
   | (`Purple (p, p2), `Purple (y, y2)) =>
-      `Yellow (y + p, 0)
+    `Yellow (y + p, 0)
   | (`Yellow (p, p2), `Yellow (y, y2)) =>
-      `Purple (y + p, 0)
+    `Purple (y + p, 0)
   };
 
 let rec atLeastOneFlushableChildAndNoWipNoPending
@@ -374,42 +374,40 @@ let rec atLeastOneFlushableChildAndNoWipNoPending
   switch composition {
   | [] => false
   | [hd, ...tl] =>
-      switch hd {
-      | OpaqueGraph {
-          lifecycle: Reconciled (_, [])
-        } =>
-          atLeastOneFlushableChildAndNoWipNoPending
-            tl atPriority
-      | OpaqueGraph {
-          lifecycle:
-            ReconciledFlushable (
-              priority,
-              _,
-              _,
-              _,
-              _,
-              _
-            )
-        }
-      | OpaqueGraph {
-          lifecycle:
-            NeverReconciledFlushable (
-              priority,
-              _,
-              _,
-              _,
-              _
-            )
-        }
-          when priority == AtPriority =>
-          noWipNoPending tl atPriority
-      | SuperLongNameThatWontBreakByItselfSoWhenWillHaveToBreak
-          when
-            priority ==
-              AtPrasldkfjalsdfjasdlfalsdkf =>
-          noWipNoPending tl atPriority
-      | _ => false
+    switch hd {
+    | OpaqueGraph {lifecycle: Reconciled (_, [])} =>
+      atLeastOneFlushableChildAndNoWipNoPending
+        tl atPriority
+    | OpaqueGraph {
+        lifecycle:
+          ReconciledFlushable (
+            priority,
+            _,
+            _,
+            _,
+            _,
+            _
+          )
       }
+    | OpaqueGraph {
+        lifecycle:
+          NeverReconciledFlushable (
+            priority,
+            _,
+            _,
+            _,
+            _
+          )
+      }
+        when priority == AtPriority =>
+      noWipNoPending tl atPriority
+    | SuperLongNameThatWontBreakByItselfSoWhenWillHaveToBreak
+        when
+          priority ==
+            AtPrasldkfjalsdfjasdlfalsdkf =>
+      noWipNoPending tl atPriority
+    | _ => false
+    }
   };
 
 /*
@@ -430,9 +428,9 @@ let rec map f =>
   fun
   | Node None m => Node None (M.map (map f) m)
   | Node LongModule.Path.None m =>
-      Node None (M.map (map f) m)
+    Node None (M.map (map f) m)
   | Node (LongModule.Path.Some v) m =>
-      Node (Some (f v)) (M.map (map f) m);
+    Node (Some (f v)) (M.map (map f) m);
 
 let myFunc x y None => "asdf";
 
@@ -440,12 +438,12 @@ let rec map f =>
   fun
   | Node None m => Node None (M.map (map f) m)
   | Node LongModule.Path.None m =>
-      LongModule.Path.Node
-        LongModule.Path.None (M.map (map f) m)
+    LongModule.Path.Node
+      LongModule.Path.None (M.map (map f) m)
   | Node (LongModule.Path.Some v) m =>
-      LongModule.Path.Node
-        (LongModule.Path.Some (f v))
-        (M.map (map f) m);
+    LongModule.Path.Node
+      (LongModule.Path.Some (f v))
+      (M.map (map f) m);
 
 let myFunc x y LongModule.Path.None => "asdf";
 
@@ -474,6 +472,6 @@ let listPatternMayEvenIncludeAliases x =>
       Foo a b as head2,
       ...Something x as tail
     ] =>
-      ()
+    ()
   | _ => ()
   };

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -2494,9 +2494,9 @@ _expr:
    */
   | FUN BAR no_leading_bar_match_cases %prec below_BAR
       { mkexp (Pexp_function(List.rev $3)) }
-  | SWITCH simple_expr LBRACE BAR no_leading_bar_match_cases RBRACE
+  | SWITCH simple_expr LBRACE BAR no_leading_bar_match_cases_to_sequence_body RBRACE
       { mkexp (Pexp_match($2, List.rev $5)) }
-  | TRY simple_expr LBRACE BAR no_leading_bar_match_cases RBRACE
+  | TRY simple_expr LBRACE BAR no_leading_bar_match_cases_to_sequence_body RBRACE
       { mkexp (Pexp_try($2, List.rev $5)) }
   | TRY simple_expr WITH error
       { syntax_error_exp (rhs_loc 4) "Invalid try with"}
@@ -3038,10 +3038,22 @@ no_leading_bar_match_cases:
   | no_leading_bar_match_cases BAR match_case { $3 :: $1 }
 ;
 
+no_leading_bar_match_cases_to_sequence_body:
+  | match_case_to_sequence_body { [$1] }
+  | no_leading_bar_match_cases_to_sequence_body BAR match_case_to_sequence_body { $3 :: $1 }
+;
+
 or_pattern: mark_position_pat(_or_pattern) {$1}
 _or_pattern:
   | pattern BAR pattern
     { mkpat(Ppat_or($1, $3)) }
+
+match_case_to_sequence_body:
+  | pattern EQUALGREATER semi_terminated_seq_expr
+      { Exp.case $1 $3 }
+  | pattern WHEN expr EQUALGREATER semi_terminated_seq_expr
+      { Exp.case $1 ~guard:$3 $5 }
+;
 
 
 match_case:


### PR DESCRIPTION
Summary:This diff relaxes the requirement that the right hand side of an
`=>` in `switch` cases must be parsable as an expression in any other
context. Instead, we say that the right hand side of `=>` in a `switch`
case must either be parsable as an expression, or parsable as the
contents of a "sequence(block) expression". This is basically saying that
there are "implicit" sequence braces wrapping the right hand side of the
`=>` so you don't need to add them there.

This saves considerable indentation (two spaces for every level of
`switch` nesting). (On my own library I'm authoring, it saved about 10-20% vertical real estate in addition to horizontal "condensed"-ness).

Test Plan:

Reviewers:

CC:
