### PR TITLE
Fix opam-version in opam file.

### DIFF
--- a/opam
+++ b/opam
@@ -1,4 +1,4 @@
-opam-version: "0.0.2"
+opam-version: "1.2"
 name: "reason"
 version: "0.0.2"
 maintainer: "Jordan Walke <jordojw@gmail.com>"


### PR DESCRIPTION
From the opam manual: opam-version specifies the file format version, it
should be the current Opam version in the format MAJOR.MINOR (i.e. with
patch version omitted)
