### PR TITLE
Add support for nonrec flag in type declarations

### DIFF
--- a/src/reason_lexer.mll
+++ b/src/reason_lexer.mll
@@ -101,6 +101,7 @@ let keyword_table =
     "module", MODULE;
     "mutable", MUTABLE;
     "new", NEW;
+    "nonrec", NONREC;
     "object", OBJECT;
     "of", OF;
     "open", OPEN;


### PR DESCRIPTION
```
$ cat test.re
type nonrec t = A of t
$ ocamlc -pp refmt -impl test.re
```

will raise the expected error since the type `t` is non-recursive.

```
File "test.re", line 1, characters 21-22:
Error: Unbound type constructor t
```

During conversion to OCaml, the 4.02.3 pretty-printer produces code that does not compile. This is one more pretty-printing bug fixed in 4.03.

```
$ cat test.re
type nonrec t = A
$ refmt -parse re -print ml test.re
type nonrec t =
  | A[@@nonrec ]
```

The above OCaml code doesn't compile under 4.02.3, but does under 4.03.
