### PR TITLE
Print nonrec keyword in Reason type declarations

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/mlVariants.re
+++ b/formatTest/typeCheckedTests/expected_output/mlVariants.re
@@ -12,3 +12,5 @@ let sumThem =
   fun
   | `IntTuple (x, y) => x + y
   | `StillAnIntTuple (a, b) => a + b;
+
+type nonrec t = | A of int | B of bool;

--- a/formatTest/typeCheckedTests/input/mlVariants.ml
+++ b/formatTest/typeCheckedTests/input/mlVariants.ml
@@ -12,3 +12,5 @@ let stillAnIntTuple = `StillAnIntTuple (4, 5)
 let sumThem = function
   | `IntTuple (x, y) -> x + y
   | `StillAnIntTuple (a, b) -> a + b
+
+type nonrec t = A of int | B of bool


### PR DESCRIPTION
pretty prints `nonrec` keyword in type declarations. 
