### PR TITLE
Fix printing nullary gadt constructors

### DIFF
--- a/src/reason_oprint.ml
+++ b/src/reason_oprint.ml
@@ -578,11 +578,11 @@ and print_out_constr ppf (name, tyl,ret_type_opt) =
   | Some ret_type ->
       begin match tyl with
       | [] ->
-          fprintf ppf "@[<2>%s of@ %a@]" name print_simple_out_type  ret_type
+          fprintf ppf "@[<2>%s :@ %a@]" name print_simple_out_type ret_type
       | _ ->
           fprintf ppf "@[<2>%s of@ %a :%a@]" name
-            (print_typlist print_simple_out_type "")
-            tyl print_simple_out_type ret_type
+            (print_typlist print_simple_out_type "") tyl
+            print_simple_out_type ret_type
       end
 
 


### PR DESCRIPTION
Fix a bug with printing nullary gadt constructors. Earlier, the following gadt:

```
type t 'a = Nil : t unit | Int of int : t int
```

was printed as 

```
type t 'a = Nil of t unit | Int of int : t int
```

instead of the correct output

```
type t 'a = Nil : t unit | Int of int : t int
```
