### PR TITLE
    [Reason] Minimum Viable End Of Line Support

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/comments.re
+++ b/formatTest/typeCheckedTests/expected_output/comments.re
@@ -30,20 +30,48 @@
 /**
  **
  */
-let testingEndOfLineComments = [
-  /* Comment For First Item */
+let testingNotQuiteEndOfLineComments = [
   "Item 1",
-  /* Comment For Second Item */
+  /* Comment For First Item */
   "Item 2",
-  /* Comment For Third Item */
+  /* Comment For Second Item */
   "Item 3",
+  /* Comment For Third Item */
+  "Item 4"  /* Comment For Fourth Item - but no semi */
+  /* Comment after last item in list. */
+];
+
+/* Comment after list bracket */
+let testingEndOfLineComments = [
+  "Item 1",  /* Comment For First Item */
+  "Item 2",  /* Comment For Second Item */
+  "Item 3",  /* Comment For Third Item */
   "Item 4"
   /* Comment For Fourth Item - but before semi */
   /* Comment after last item in list. */
-  /* Comment after list bracket */
 ];
 
+/* Comment after list bracket */
 /* This time no space between bracket and comment */
 let testingEndOfLineComments = [];
 
 /* Comment after list bracket */
+type t = (int, int); /* End of line on t */
+
+/* End of line on int * int */
+type t2 = (int, int);
+
+/* End of line on Y */
+type variant =
+  /* Comment above X */
+  | X of int int  /* End of line on X */
+  /* Comment above Y */
+  | Y of int int;
+
+/* attached *above* x */
+type x = {fieldOne: int}
+/* Attached end of line after x */
+/* attached *above* y */
+and y = {fieldTwo: int};
+
+/* Attached end of line after y */

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -1,0 +1,217 @@
+/*-*/
+3;
+
+/*-*/
+3;
+
+3 /*-*/;
+
+/* **** comment */
+/*** comment */
+/** docstring */
+/* comment */
+/** docstring */
+/*** comment */
+/**** comment */
+/***** comment */
+/** */
+/*** */
+/**** */
+/**/
+/***/
+/****/
+/** (** comment *) */
+/** (*** comment *) */
+/* (** comment *) */
+/* (*** comment *) */
+/* *(*** comment *) */
+/* comment **/
+/* comment ***/
+/* comment ****/
+/* comment *****/
+/**
+ * Multiline
+ */
+/** Multiline
+ *
+ */
+/**
+ **
+ */
+let testingEndOfLineComments = [
+  "Item 1",
+  /* Comment For First Item */
+  "Item 2",
+  /* Comment For Second Item */
+  "Item 3",
+  /* Comment For Third Item */
+  "Item 4"
+  /* Comment For Fourth Item - but before trailing comma */
+  /* Comment after last item in list. */
+]
+/* Comment after rbracket */;
+
+/* But if you place them after the comma at eol, they're preserved as such */
+let testingEndOfLineComments = [
+  "Item 1",  /* Comment For First Item */
+  "Item 2",  /* Comment For Second Item */
+  "Item 3",  /* Comment For Third Item */
+  "Item 4"
+  /* Comment For Fourth Item - but before trailing comma */
+  /* Comment after last item in list. */
+]
+/* Comment after rbracket */;
+
+/* The space between ; and comment shoudn't matter */
+/* Comment after semi */
+let testPlacementOfTrailingComment = [
+  "Item 0"  /* */
+  /* Comment after last item in list. */
+];
+
+/* The space between ; and comment shoudn't matter */
+/* Comment after semi */
+let testPlacementOfTrailingComment = [
+  "Item 0"  /* */
+  /* Comment after last item in list. */
+];
+
+/* Try again but without other things in the list */
+/* Comment after semi */
+let testPlacementOfTrailingComment = [
+  "Item 0" /* */
+];
+
+/* The space between ; and comment shoudn't matter */
+/* Comment after semi */
+let testPlacementOfTrailingComment = [
+  "Item 0"  /* */
+  /* Comment after last item in list. */
+];
+
+let testingEndOfLineComments = []; /* Comment after entire let binding */
+
+/* The following is not yet idempotent */
+/* let myFunction */
+/*     withFirstArg  /* First arg */ */
+/*     andSecondArg  => { /* Second Arg */ */
+/*   withFirstArg + andSecondArg /* before semi */ ; */
+/* }; */
+/* After Semi */
+let myFunction
+    /* First arg */
+    withFirstArg
+    /* Second Arg */
+    andSecondArg => withFirstArg + andSecondArg;
+
+type point = {
+  x: string,  /* x field */
+  y: string /* y field */
+};
+
+/* The way the last row comment is formatted is suboptimal becuase
+ * record type definitions do not include enough location information */
+type anotherpoint = {
+  x: string,  /* x field */
+  y: string /* y field */
+}
+/* comment as last row of record */;
+
+type t = (int, int); /* End of line on t */
+
+/* End of line on (int, int) */
+type t2 = (int, int);
+
+/* End of line on (int, int) */
+type t3 = (int, int);
+
+/* On the entire type */
+type variant =
+  | X of (int, int)  /* End of line on X */
+  | Y of (int, int);
+
+let res =
+  switch (X (2, 3)) {
+  /* Above X line */
+  | X _ => "result of X" /* End of X line */
+  /* Above Y line */
+  | Y _ => "result of Y" /* End of Y line */
+  };
+
+/* On entire type */
+type variant2 =
+  /* Comment above X */
+  | X of (int, int)  /* End of line on X */
+  /* Comment above Y */
+  | Y of (int, int);
+
+/* End of line on Y  */
+type variant3 =
+  /* Comment above X */
+  | X of (int, int)  /* End of line on X */
+  /* Comment above Y */
+  | Y of (int, int);
+
+/* On entire type */
+/* attached *above* x */
+type x = {fieldOne: int}
+/* Attached end of line after x */
+/* attached *above* y */
+and y = {fieldTwo: int}
+/* Attached end of line after y */;
+
+/* attached *above* x2 */
+/* Attached to entire set of bindings */
+type x2 = {fieldOne: int}
+/* Attached end of line after x2 */
+/* attached *above* y2 */
+and y2 = {fieldTwo: int};
+
+type optionalTuple =
+  | OptTup of (
+      option
+        (
+          int,  /* First int */
+          int /* Second int */
+        )
+    );
+
+type optionTuple =
+  option
+    (
+      int,  /* First int */
+      int /* Second int */
+    );
+
+type intPair = (
+  int,  /* First int */
+  int /* Second int */
+);
+
+type intPair2 = (
+  /* First int */
+  int,
+  /* Second int */
+  int
+);
+
+let result =
+  /**/
+  2 + 3;
+
+/* This is not yet idempotent */
+/* { */
+/*   /**/ */
+/*   (+) 2 3 */
+/* }; */
+let a = ();
+
+for i in 0 to 10 {
+  a
+  /* bla  */
+};
+
+if true {
+  ()
+}
+/* hello */;

--- a/formatTest/typeCheckedTests/input/comments.ml
+++ b/formatTest/typeCheckedTests/input/comments.ml
@@ -41,6 +41,14 @@
   **
   *)
 
+let testingNotQuiteEndOfLineComments = [
+  "Item 1"(* Comment For First Item *);  
+  "Item 2" (* Comment For Second Item *);
+  "Item 3" (* Comment For Third Item *);
+  "Item 4" (* Comment For Fourth Item - but no semi *)
+  (* Comment after last item in list. *)
+] (* Comment after list bracket *)
+
 let testingEndOfLineComments = [
   "Item 1";(* Comment For First Item *)  
   "Item 2"; (* Comment For Second Item *)
@@ -52,3 +60,23 @@ let testingEndOfLineComments = [
 (* This time no space between bracket and comment *)
 let testingEndOfLineComments = [
 ](* Comment after list bracket *)
+
+
+type t = int * int (* End of line on t *)
+type t2 =
+  int * int (* End of line on int * int *)
+
+
+type variant =
+  (* Comment above X *)
+  | X of int * int (* End of line on X *)
+  (* Comment above Y *)
+  | Y of int * int (* End of line on Y *)
+
+
+type x = { (* attached *above* x *)
+  fieldOne : int
+} (* Attached end of line after x *)
+and y = { (* attached *above* y *)
+  fieldTwo : int
+} (* Attached end of line after y *)

--- a/formatTest/typeCheckedTests/input/reasonComments.re
+++ b/formatTest/typeCheckedTests/input/reasonComments.re
@@ -1,0 +1,207 @@
+3 /*-*/
+;
+3/*-*/
+;
+3/*-*/;
+/* **** comment */
+/*** comment */
+/** docstring */
+/* comment */
+/** docstring */
+/*** comment */
+/**** comment */
+/***** comment */
+/** */
+/*** */
+/**** */
+/**/
+/***/
+/****/
+/** (** comment *) */
+/** (*** comment *) */
+/* (** comment *) */
+/* (*** comment *) */
+/* *(*** comment *) */
+/* comment **/
+/* comment ***/
+/* comment ****/
+/* comment *****/
+/**
+ * Multiline
+ */
+/** Multiline
+ *
+ */
+/**
+ **
+ */
+let testingEndOfLineComments =
+  [
+    "Item 1" /* Comment For First Item */,
+    "Item 2" /* Comment For Second Item */,
+    "Item 3" /* Comment For Third Item */,
+    "Item 4" /* Comment For Fourth Item - but before trailing comma */,
+    /* Comment after last item in list. */
+  ] /* Comment after rbracket */;
+
+/* But if you place them after the comma at eol, they're preserved as such */
+let testingEndOfLineComments =
+  [
+    "Item 1", /* Comment For First Item */
+    "Item 2", /* Comment For Second Item */
+    "Item 3", /* Comment For Third Item */
+    "Item 4" /* Comment For Fourth Item - but before trailing comma */,
+    /* Comment after last item in list. */
+  ] /* Comment after rbracket */ ;
+
+
+/* The space between ; and comment shoudn't matter */
+let testPlacementOfTrailingComment = [
+  "Item 0" /* */
+  /* Comment after last item in list. */
+]; /* Comment after semi */
+
+/* The space between ; and comment shoudn't matter */
+let testPlacementOfTrailingComment = [
+  "Item 0" /* */
+  /* Comment after last item in list. */
+];/* Comment after semi */
+
+/* Try again but without other things in the list */
+let testPlacementOfTrailingComment = [
+  "Item 0" /* */
+]; /* Comment after semi */
+
+/* The space between ; and comment shoudn't matter */
+let testPlacementOfTrailingComment = [
+  "Item 0" /* */
+  /* Comment after last item in list. */
+];/* Comment after semi */
+
+let testingEndOfLineComments = [];/* Comment after entire let binding */
+
+
+/* The following is not yet idempotent */
+/* let myFunction */
+/*     withFirstArg  /* First arg */ */
+/*     andSecondArg  => { /* Second Arg */ */
+/*   withFirstArg + andSecondArg /* before semi */ ; */
+/* }; */
+
+let myFunction
+    /* First arg */
+    withFirstArg
+    /* Second Arg */
+    andSecondArg  => {
+  withFirstArg + andSecondArg
+}; /* After Semi */
+
+type point = {
+  x: string, /* x field */
+  y: string, /* y field */
+};
+
+/* The way the last row comment is formatted is suboptimal becuase
+ * record type definitions do not include enough location information */
+type anotherpoint = {
+  x: string, /* x field */
+  y: string, /* y field */
+  /* comment as last row of record */
+};
+
+type t = (int, int); /* End of line on t */
+type t2 =
+  (int, int) /* End of line on (int, int) */
+  ;
+
+type t3 =
+  (int, int); /* End of line on (int, int) */
+
+
+type variant =
+  | X of (int, int) /* End of line on X */
+  | Y of (int, int); /* On the entire type */
+
+let res =
+  switch (X (2, 3)) {
+    /* Above X line */
+    | X _ => "result of X"  /* End of X line */
+    /* Above Y line */
+    | Y _ => "result of Y"  /* End of Y line */
+  };
+
+type variant2 =
+  /* Comment above X */
+  | X of (int, int) /* End of line on X */
+  /* Comment above Y */
+  | Y of (int, int); /* On entire type */
+
+type variant3 =
+  /* Comment above X */
+  | X of (int, int) /* End of line on X */
+  /* Comment above Y */
+  | Y of (int, int) /* End of line on Y  */
+; /* On entire type */
+
+
+type x = { /* attached *above* x */
+  fieldOne : int
+} /* Attached end of line after x */
+and y = { /* attached *above* y */
+  fieldTwo : int
+} /* Attached end of line after y */
+;
+
+type x2 = { /* attached *above* x2 */
+  fieldOne : int
+} /* Attached end of line after x2 */
+and y2 = { /* attached *above* y2 */
+  fieldTwo : int
+}; /* Attached to entire set of bindings */
+
+type optionalTuple =
+  | OptTup of (
+      option (
+        int, /* First int */
+        int /* Second int */
+      )
+    );
+
+type optionTuple =
+  option (
+    int, /* First int */
+    int /* Second int */
+  );
+
+type intPair = (
+  int, /* First int */
+  int /* Second int */
+);
+type intPair2 = (
+  /* First int */
+  int,
+  /* Second int */
+  int
+);
+
+let result = {
+  /**/
+  (+) 2 3
+};
+
+/* This is not yet idempotent */
+/* { */
+/*   /**/ */
+/*   (+) 2 3 */
+/* }; */
+
+let a = ();
+for i in 0 to 10 {
+  /* bla  */
+  a
+};
+
+if true {
+  /* hello */
+  ()
+};

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -447,8 +447,7 @@ arrayWithTwo.(1) = 300;
  */
 let myString = "asdf";
 
-/* Replacing a character: I could do without this sugar */
-myString.[2] = '9';
+myString.[2] = '9'; /* Replacing a character: I could do without this sugar */
 
 /*                           FUNCTIONS
  *=============================================================================

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -269,8 +269,7 @@ let point2D = {x: 20, y: 30};
 let point3D: point3D = {
   x: 10,
   y: 11,
-  /* Optional Comma */
-  z: 80
+  z: 80 /* Optional Comma */
 };
 
 let printPoint (p: point) => {
@@ -339,17 +338,13 @@ let printPerson (p: person) => {
 
 /* let dontParseMeBro x y:int = x = y;*/
 /* With this unification, anywhere eyou see `= fun` you can just ommit it */
-/* Done */
-let blah a => a;
+let blah a => a; /* Done */
 
-/* Done (almost) */
-let blah a => a;
+let blah a => a; /* Done (almost) */
 
-/* Done */
-let blah a b => a;
+let blah a b => a; /* Done */
 
-/* Done (almost) */
-let blah a b => a;
+let blah a b => a; /* Done (almost) */
 
 /* More than one consecutive pattern must have a single case */
 type blah = {blahBlah: int};
@@ -378,21 +373,20 @@ let
   onlyDoingThisTopLevelLetToBypassTopLevelSequence = {
   let x = {
     print_int 1;
-    /* Missing trailing SEMI */
-    print_int 20
+    print_int 20 /* Missing trailing SEMI */
   };
   let x = {
     print_int 1;
-    /* Ensure missing middle SEMI reported well */
-    print_int 20;
+    print_int 20; /* Ensure missing middle SEMI reported well */
     print_int 20
   };
   let x = {
     print_int 1;
     print_int 20;
     10
-    /* Missing final SEMI */
+    /* Comment in final position */
   };
+  /* Missing final SEMI */
   x + x
 };
 
@@ -444,17 +438,34 @@ let blah =
       let blah x | Red _ => 1 | Black _ => 0;
       Theres no sugar rule for dropping => fun, only = fun
    */
-/* See, nothing says we can drop the => fun */
+/* Not idempotent! */
+/* let blahCurriedX x => fun  /* See, nothing says we can drop the => fun */ */
+/*   |(Red x | Black x | Green x) => 1     /* With some effort, we can ammend the sugar rule that would */ */
+/*   | Black x => 0                       /* Allow us to drop any => fun.. Just need to make pattern matching */ */
+/*   | Green x => 0;                      /* Support that */ */
+/*  */
+/* Support that */
 let blahCurriedX x =>
   fun
   /* With some effort, we can ammend the sugar rule that would */
   | Red x
   | Black x
   | Green x => 1
-  /* Allow us to drop any => fun.. Just need to make pattern matching */
-  | Black x => 0
-  /* Support that */
+  | Black x => 0  /* Allow us to drop any => fun.. Just need to make pattern matching */
   | Green x => 0;
+
+let sameThingInLocal = {
+  /* Support that */
+  let blahCurriedX x =>
+    fun
+    /* With some effort, we can ammend the sugar rule that would */
+    | Red x
+    | Black x
+    | Green x => 1
+    | Black x => 0  /* Allow us to drop any => fun.. Just need to make pattern matching */
+    | Green x => 0;
+  blahCurriedX
+};
 
 /* This should be parsed/printed exactly as the previous */
 let blahCurriedX x =>
@@ -468,8 +479,7 @@ let blahCurriedX x =>
 /* Any time there are multiple match cases we require a leading BAR */
 let v = Red 10;
 
-/* So this NON-function still parses */
-let Black x | Red x | Green x = v;
+let Black x | Red x | Green x = v; /* So this NON-function still parses */
 
 /* This doesn't parse, however (and it doesn't in OCaml either):
      let | Black x | Red x | Green x = v;

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -286,7 +286,91 @@ let myList = [
   1,
   2,
   3
-  /*CommentAfterThreeBeforeCons */
+  /*CommentAfterThreeBeforeCons*/
+];
+
+let myList = [
+  1,
+  2,
+  3
+  /*same w space after three    */
+];
+
+let myList = [
+  1,
+  2,
+  3
+  /*same w space before rbracket*/
+];
+
+let myList = [
+  1,
+  2,
+  3
+  /*same w both                 */
+];
+
+/* End of line comments */
+let myList = [
+  1,
+  2,
+  3 /*no space after three    */
+];
+
+let myList = [
+  1,
+  2,
+  3 /*same w space after three    */
+];
+
+let myList = [
+  1,
+  2,  /*no space after two comma    */
+  3
+];
+
+let myList = [
+  1,
+  2,  /*same w space after two comma    */
+  3
+];
+
+/* End of line comments */
+let myList = [
+  1,
+  2,  /*no space after two comma    */
+  3
+];
+
+let myList = [
+  1,
+  2,  /*same w space after two comma    */
+  3
+];
+
+let myRec = {
+  x: 1,
+  y: 2,  /*no space after two    */
+  z: 3
+};
+
+let myRec = {
+  x: 1,
+  y: 2,  /*same w space after two    */
+  z: 3
+};
+
+/* Ensure end of line comments force breaks */
+let myList = [
+  1,
+  2,
+  3 /* */
+];
+
+let myList = [
+  1,
+  2,  /**/
+  3
 ];
 
 let myList = [
@@ -318,9 +402,9 @@ type hasABunch = {
   fieldtwo: list int,
   fieldThree: list string,
   fieldFour: nameAge
-};
+}
+/* Comment at bottom of record type def */;
 
-/* Comment at bottom of record type def */
 type functionsInARecord = {
   adder: int => int,
   minuser: int => int
@@ -1694,6 +1778,7 @@ let someResult: (
   10
 );
 
+/* The rhs of = shouldn't be broken onto its own newline: @see ensureSingleTokenSticksToLabel */
 let someResult: (
   int,
   int,
@@ -1711,7 +1796,6 @@ let someResult: (
   int,
   int,
   int
-  /* This shouldn't be broken onto its own newline: @see ensureSingleTokenSticksToLabel */
 ) = someResult;
 
 type sevenStrings = (
@@ -1813,12 +1897,12 @@ let myFunc
 
 type inputEchoRecord 'a = {inputIs: 'a};
 
+/* With setting ReturnValOnSameLine */
 let df_locallyAbstractFunc
     (type a)
     (type b)
     (input: a) => {
   inputIs: input
-  /* With setting ReturnValOnSameLine */
 };
 
 let df_locallyAbstractFuncNotSugared
@@ -2608,3 +2692,45 @@ let x =
     a
     a
     alskdjfalskdjfalsdf + reallyReallyLongName;
+
+let
+  onlyDoingThisTopLevelLetToBypassTopLevelSequence = {
+  let x = {
+    print_int 1;
+    print_int 20 /* Missing trailing SEMI */
+  };
+  let x = {
+    print_int 1;
+    print_int 20; /* Ensure missing middle SEMI reported well */
+    print_int 20
+  };
+  let x = {
+    print_int 1;
+    print_int 20;
+    10
+  };
+  /* Missing final SEMI */
+  let x = {
+    print_int 1;
+    print_int 20;
+    10
+  };
+  x + x /* Final item */
+};
+
+/* With this unification, anywhere eyou see `= fun` you can just ommit it */
+let blah a => a; /* Done */
+
+let blah a => a; /* Done (almost) */
+
+let blah a b => a; /* Done */
+
+let blah a b => a; /* Done (almost) */
+
+let tryingTheSameInLocalScope = {
+  let blah a => a; /* Done */
+  let blah a => a; /* Done (almost) */
+  let blah a b => a; /* Done */
+  let blah a b => a; /* Done (almost) */
+  ()
+};

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -346,6 +346,7 @@ let onlyDoingThisTopLevelLetToBypassTopLevelSequence = {
       print_int 1;
       print_int 20;
       10;
+      /* Comment in final position */
     };  /* Missing final SEMI */
     x + x;
 };
@@ -389,10 +390,32 @@ let blah = fun
    Theres no sugar rule for dropping => fun, only = fun
 */
 
-let blahCurriedX x => fun  /* See, nothing says we can drop the => fun */
-  |(Red x | Black x | Green x) => 1     /* With some effort, we can ammend the sugar rule that would */
-  | Black x => 0                       /* Allow us to drop any => fun.. Just need to make pattern matching */
-  | Green x => 0;                      /* Support that */
+/* Not idempotent! */
+/* let blahCurriedX x => fun  /* See, nothing says we can drop the => fun */ */
+/*   |(Red x | Black x | Green x) => 1     /* With some effort, we can ammend the sugar rule that would */ */
+/*   | Black x => 0                       /* Allow us to drop any => fun.. Just need to make pattern matching */ */
+/*   | Green x => 0;                      /* Support that */ */
+/*  */
+
+let blahCurriedX x =>
+  fun
+  | Red x
+  | Black x
+  | Green x => 1  /* With some effort, we can ammend the sugar rule that would */
+  | Black x => 0  /* Allow us to drop any => fun.. Just need to make pattern matching */
+  | Green x => 0; /* Support that */
+
+let sameThingInLocal = {
+  let blahCurriedX x =>
+    fun
+    | Red x
+    | Black x
+    | Green x => 1  /* With some effort, we can ammend the sugar rule that would */
+    | Black x => 0  /* Allow us to drop any => fun.. Just need to make pattern matching */
+    | Green x => 0; /* Support that */
+  blahCurriedX;
+
+};
 
 /* This should be parsed/printed exactly as the previous */
 let blahCurriedX x => fun

--- a/formatTest/unit_tests/input/wrappingTest.re
+++ b/formatTest/unit_tests/input/wrappingTest.re
@@ -268,7 +268,69 @@ let myList = [/*CommentAfterEqualBefore1 */1, 2, 3];
 let myList = [1 /*CommentAfterOneBeforeCons */, 2, 3];
 let myList = [1, 2 /*CommentAfterTwoBeforeCons */, 3, ];
 let myList = [1, 2, /*CommentAfterConsBeforeThree */3 ];
-let myList = [1, 2, 3/*CommentAfterThreeBeforeCons */];
+let myList = [1, 2, 3/*CommentAfterThreeBeforeCons*/];
+
+let myList = [1, 2, 3 /*same w space after three    */];
+let myList = [1, 2, 3/*same w space before rbracket*/ ];
+let myList = [1, 2, 3 /*same w both                 */ ];
+
+/* End of line comments */
+let myList = [
+  1,
+  2,
+  3/*no space after three    */
+];
+let myList = [
+  1,
+  2,
+  3 /*same w space after three    */
+];
+let myList = [
+  1,
+  2,/*no space after two comma    */
+  3
+];
+let myList = [
+  1,
+  2, /*same w space after two comma    */
+  3
+];
+
+
+/* End of line comments */
+let myList = [
+  1,
+  2,/*no space after two comma    */
+  3
+];
+let myList = [
+  1,
+  2, /*same w space after two comma    */
+  3
+];
+let myRec = {
+  x:1,
+  y:2,/*no space after two    */
+  z:3
+};
+let myRec = {
+  x:1,
+  y:2, /*same w space after two    */
+  z:3
+};
+
+/* Ensure end of line comments force breaks */
+let myList = [
+  1,
+  2,
+  3/* */
+];
+let myList = [
+  1,
+  2,/**/
+  3
+];
+
 let myList = [1, 2, 3, /*CommentAfterConsBeforeAppendedTo */...myList];
 let myList = [3, 4, 5];
 
@@ -1143,7 +1205,7 @@ let someResult: (int, int, int, int, int, int, int, int, int, int, int, int, int
   10
 );
 
-
+/* The rhs of = shouldn't be broken onto its own newline: @see ensureSingleTokenSticksToLabel */
 let someResult: (
   int,
   int,
@@ -1161,7 +1223,7 @@ let someResult: (
   int,
   int,
   int
-) = someResult;  /* This shouldn't be broken onto its own newline: @see ensureSingleTokenSticksToLabel */
+) = someResult;
 
 type sevenStrings = (string, string, string, string, string, string, string);
 let (only, the, type_, should, have, to_, wrap) = (
@@ -1844,3 +1906,48 @@ let x = calWith
           a
           a
           alskdjfalskdjfalsdf + reallyReallyLongName;
+
+
+
+
+let onlyDoingThisTopLevelLetToBypassTopLevelSequence = {
+    let x = {
+      print_int 1;
+      print_int 20;  /* Missing trailing SEMI */
+    };
+
+    let x = {
+      print_int 1;
+      print_int 20;   /* Ensure missing middle SEMI reported well */
+      print_int 20;
+    };
+
+    let x = {
+      print_int 1;
+      print_int 20;
+      10;
+    };  /* Missing final SEMI */
+
+    let x = {
+      print_int 1;
+      print_int 20;
+      10;
+    };
+    x + x;  /* Final item */
+};
+
+
+/* With this unification, anywhere eyou see `= fun` you can just ommit it */
+let blah = fun a => a;         /* Done */
+let blah a => a;               /* Done (almost) */
+
+let blah = fun a b => a;       /* Done */
+let blah a b => a;             /* Done (almost) */
+
+let tryingTheSameInLocalScope = {
+  let blah = fun a => a;         /* Done */
+  let blah a => a;               /* Done (almost) */
+
+  let blah = fun a b => a;       /* Done */
+  let blah a b => a;             /* Done (almost) */
+};


### PR DESCRIPTION
```
Summary: This diff preserves many of the common patterns for commenting
at the end of lines. It does not perfectly implement `ocamldoc`, or the
new commenting convention which `4.03` uses, rather the goal is to make
sure that the most common pattern of commenting is correctly preserved
when converting from ML to Reason, and that while using Reason, most
kinds of end-of-line comments can be used.

Meanwhile, we can find a comprehensive solution that covers every edge
case and adheres faithfully to one of the upstream conventions for
documenting.

Test Plan:

Reviewers:jberdine, cristianoc, kayceesrk, dxu, yunxing

CC:
```
