### PR TITLE
[Reason] Don't interleave comments if instructed not to.

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -208,8 +208,8 @@ let a = ();
 
 for i in 0 to 10 {
   a
-  /* bla  */
-};
+}
+/* bla  */;
 
 if true {
   ()


### PR DESCRIPTION
Summary: This makes formatting worse, but makes it abide by the
instructed formatting, which will make it simpler for us to make it
better.

Test Plan:

Reviewers:

CC:
