### PR TITLE
Require ocaml 4.02.3

### DIFF
--- a/opam
+++ b/opam
@@ -31,4 +31,4 @@ depopts: [
 conflicts: [
   "utop" {< "1.17"}
 ]
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.02.3" ]


### PR DESCRIPTION
We've seen multiple issues with comments formatting in 4.02.1,
let's drop the support for it (or at least for now).

cc @jordwalke, @dxu
