### PR TITLE
Make compilation work again.

### DIFF
--- a/_tags
+++ b/_tags
@@ -3,7 +3,7 @@ true: warn(@5@8@10@11@12@14@23-24@26@29@40), bin_annot, safe_string, debug
 <editorSupport/**>: -traverse
 "formatTest": -traverse
 "src": include
-<src/*>: package(menhirLib unix compiler-libs.common ocamlbuild findlib easy-format str BetterErrors merlin_extend ocamldoc)
+<src/*>: package(menhirLib unix compiler-libs.common ocamlbuild findlib easy-format str BetterErrors merlin_extend)
 <src/reason_utop.*>: package(menhirLib utop str)
 
 <src_gen/*>: package(sedlex str)

--- a/pkg/META.in
+++ b/pkg/META.in
@@ -19,7 +19,7 @@ archive(byte, toploop, pkg_utop) += "reason_utop.cmo"
 package "lib" (
   version = "%{version}%"
   description = "Library version of reason"
-  requires = "compiler-libs.common easy-format BetterErrors menhirLib ocamldoc"
+  requires = "compiler-libs.common easy-format BetterErrors menhirLib"
 
   archive(byte) = "reason.cma"
   archive(native) = "reason.cmxa"

--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -9,7 +9,7 @@ let menhir_command = "-menhir " ^ menhir_options
 
 (* ; "-menhir 'menhir --trace'" *)
 let () =
-  Pkg.describe "reason" ~builder:(`OCamlbuild ["-use-menhir"; menhir_command ]) [
+  Pkg.describe "reason" ~builder:(`OCamlbuild ["-use-menhir"; menhir_command; "-cflags -I,+ocamldoc"]) [
     Pkg.lib "pkg/META";
     (* The .mllib *)
     (* So much redundancy - this should be implicit in the mllib! *)


### PR DESCRIPTION
Since `ocamldoc` package is not always available, update the build to
remove dependency on `ocamldoc` package and instead pass `ocamldoc` as
an explicit directory inclusion to `ocamlbuild`. This patch should fix the build. 
