### PR TITLE
Enable strict mode in Menhir

### DIFF
--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -4,7 +4,7 @@
 #use "topkg.ml"
 let trace = try let _ = Sys.getenv "trace" in true with | Not_found -> false
 
-let menhir_options = "'menhir --fixed-exception --table " ^ (if trace then "--trace" else "") ^ " '"
+let menhir_options = "'menhir --strict --unused-tokens --fixed-exception --table " ^ (if trace then "--trace" else "") ^ " '"
 let menhir_command = "-menhir " ^ menhir_options
 
 (* ; "-menhir 'menhir --trace'" *)


### PR DESCRIPTION
In strict mode, Menhir fails as long as there is a  compiler warning. This patch :
1. removes all existing warnings
2. enables strict mode

This patch is needed to prevent parsing conflicts from getting into master.
