### PR TITLE
[Reason] Fix issue with printing of interface files.

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.rei
+++ b/formatTest/typeCheckedTests/expected_output/attributes.rei
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 let test: int;
 
 /**

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -251,6 +251,7 @@ let module HasTupleClasses: {
       method x: int;
       method y: int
     };
+
   /**
    * anotherExportedClass.
    */

--- a/formatTest/unit_tests/expected_output/syntax.rei
+++ b/formatTest/unit_tests/expected_output/syntax.rei
@@ -3,6 +3,7 @@
  * Typically the "interface file" is where you would write a ton of
  * comments/documentation.
  */
+
 type adders = {
   /*
    * Adds two numbers together.
@@ -18,10 +19,12 @@ type adders = {
   addThreeNumbersTupled: (int, int, int) => int
 };
 
+
 /**
  * Public function.
  */
 let myRecordWithFunctions: adders;
+
 
 /**
  * Public result.

--- a/formatTest/unit_tests/expected_output/wrappingTest.rei
+++ b/formatTest/unit_tests/expected_output/wrappingTest.rei
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 let named: a::int => b::int => int;
 
 let namedAlias: a::int => b::int => int;
@@ -50,13 +51,16 @@ let test:
        And it still works correctly. */
 let test: int;
 
+
 /** Include multiple opening stars if you like.
     And it will still work. */
 let test: int;
 
+
 /** This comment will be corrected.
     when printed. */
 let test: int;
+
 
 /**  Comments with text on line zero
  *   Still work well with comments that have stars on the left side.


### PR DESCRIPTION
Summary: I had forgotten to switch over interface printing to the new
way that works well with EOL comments.

Test Plan:

Reviewers:

CC:
