### PR TITLE
[readme] instructions for linux pointing out the need for opam >= 1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ Install Stable
 ----------
 
 ```sh
+# On OSX, install opam via Homebrew:
 brew update
 brew install opam --HEAD
+# On Linux, see here (you will need opam >= 1.2.2): http://opam.ocaml.org/doc/Install.html
+
 opam init
 # Add this to your ~/.bashrc (or ~/.zshrc):
 #   eval `opam config env`


### PR DESCRIPTION
This change points out the required opam version for Linux users to clear out possible confusion. The instructions in the README failed on my Debian Jessie because my opam was too old, but that took me a while to track down given the cryptic `git fetch` error that opam pointed me to.
