### PR TITLE
Remove Redoc_html from reason.mllib

### DIFF
--- a/src/reason.mllib
+++ b/src/reason.mllib
@@ -7,5 +7,4 @@ Reason_utils
 Reason_util
 Reason_toolchain
 Reason_utop
-Redoc_html
 Reason_parser_message


### PR DESCRIPTION
This ensures that `rtop` does not complain about the missing module
`Odoc_html`. Moreover, loading Redoc_html rebinds the ocamldoc html
generator and shouldn't be part of the reason lib. It is only meant to
be dynamically loaded by redoc. Fixes #447.
