### PR TITLE
correct reason.0.0.5 download URL

### DIFF
--- a/packages/reason/reason.0.0.5/url
+++ b/packages/reason/reason.0.0.5/url
@@ -1,2 +1,2 @@
-http: "https://github.com/facebook/Reason/archive/0.0.5.tar.gz"
-checksum: "75421e5814f8b1c17a20c760d653a9be"
+http: "https://github.com/facebook/reason/archive/0.0.5.tar.gz"
+checksum: "8f6d86d9510a338480606c1d6f843892"


### PR DESCRIPTION
Changed due to repo renaming from Reason -> reason