### PR TITLE
fix URL to doc page

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ rebuild Hello.native # Automatically generates Hello.native from Hello.re
 
 Get Started Now
 ---------------
-Checkout the [docs](http://facebook.github.io/Reason) which guide you through the basic syntax and toolchain features.
+Checkout the [docs](http://facebook.github.io/reason) which guide you through the basic syntax and toolchain features.
 
 Contribute back to that documentation in the [`gh-pages` branch](https://github.com/facebook/Reason/tree/gh-pages).
 


### PR DESCRIPTION
URL is case sensitive and is redirected to code.facebook.com instead.