### PR TITLE
fix a broken link in projects page

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -55,7 +55,7 @@ get started.
 
 
 Once you've
-[installed](file:///Users/jwalke/githubDocs/Reason/index.html#reason-install)
+[installed](https://github.com/facebook/reason/blob/master/README.md#install-stable)
 `Reason`, you can clone the example CommonML playground.
 
 ###Example Project


### PR DESCRIPTION
I linked it to github readme, let me know if you want it link to [index.html#reason-install](http://facebook.github.io/reason/index.html#reason-install) instead