### PR TITLE
Fix capitalization of GitHub

### DIFF
--- a/examples/patterns.html
+++ b/examples/patterns.html
@@ -39,7 +39,7 @@
     <div class='left'>
       <h1 role='flatdoc-title'></h1>
       <ul>
-        <li><a href='https://github.com/r'>View on Github</a></li>
+        <li><a href='https://github.com/r'>View on GitHub</a></li>
         <li><a href='https://github.com/r'>Issues</a></li>
       </ul>
     </div>

--- a/examples/patterns.md
+++ b/examples/patterns.md
@@ -1021,7 +1021,7 @@ its [contributors][c]. It is sponsored by my startup, [Sinefunc, Inc][sf].
 
  * [My website](http://ricostacruz.com) (ricostacruz.com)
  * [Sinefunc, Inc.](http://sinefunc.com) (sinefunc.com)
- * [Github](http://github.com/rstacruz) (@rstacruz)
+ * [GitHub](http://github.com/rstacruz) (@rstacruz)
  * [Twitter](http://twitter.com/rstacruz) (@rstacruz)
 
 [rsc]: http://ricostacruz.com

--- a/flatdoc.js
+++ b/flatdoc.js
@@ -70,7 +70,7 @@
   };
 
   /**
-   * Github fetcher.
+   * GitHub fetcher.
    * Fetches from repo `repo` (in format 'user/repo').
    *
    * If the parameter `filepath` is supplied, it fetches the contents of that
@@ -115,7 +115,7 @@
    * See: http://ben.onfabrik.com/posts/embed-bitbucket-source-code-on-your-website
    * Bitbucket appears to have stricter restrictions on
    * Access-Control-Allow-Origin, and so the method here is a bit
-   * more complicated than for Github
+   * more complicated than for GitHub
    *
    * If you don't pass a branch name, then 'default' for Hg repos is assumed
    * For git, you should pass 'master'. In both cases, you should also be able

--- a/highlightJs/CHANGES.md
+++ b/highlightJs/CHANGES.md
@@ -72,7 +72,7 @@ New Styles:
 
 - *Atelier Cave*, *Atelier Estuary*,
   *Atelier Plateau* and *Atelier Savanna* by [Bram de Haan][]
-- *Github Gist* by [Louis Barranqueiro][]
+- *GitHub Gist* by [Louis Barranqueiro][]
 
 Notable fixes and improvements to existing languages:
 

--- a/highlightJs/build/demo/index.html
+++ b/highlightJs/build/demo/index.html
@@ -72,9 +72,9 @@
   
   <link rel="alternate stylesheet" title="Foundation" href="styles/foundation.css">
   
-  <link rel="alternate stylesheet" title="Github Gist" href="styles/github-gist.css">
+  <link rel="alternate stylesheet" title="GitHub Gist" href="styles/github-gist.css">
   
-  <link rel="alternate stylesheet" title="Github" href="styles/github.css">
+  <link rel="alternate stylesheet" title="GitHub" href="styles/github.css">
   
   <link rel="alternate stylesheet" title="Googlecode" href="styles/googlecode.css">
   

--- a/index.html
+++ b/index.html
@@ -1302,7 +1302,7 @@ opam upgrade reason
       <ul>
         <li><a href='projects.html'>Projects</a></li>
         <li><a href='tools.html'>Tools</a></li>
-        <li><a href='https://github.com/facebook/reason'>Github</a></li>
+        <li><a href='https://github.com/facebook/reason'>GitHub</a></li>
       </ul>
     </div>
   </div>

--- a/javaScriptCompared.html
+++ b/javaScriptCompared.html
@@ -405,7 +405,7 @@ let res = switch thing {
       <ul>
         <li><a href='projects.html'>Projects</a></li>
         <li><a href='tools.html'>Tools</a></li>
-        <li><a href='https://github.com/facebook/reason'>Github</a></li>
+        <li><a href='https://github.com/facebook/reason'>GitHub</a></li>
       </ul>
     </div>
   </div>

--- a/mlCompared.html
+++ b/mlCompared.html
@@ -1215,7 +1215,7 @@ x \=== y</pre>
       <ul>
         <li><a href='projects.html'>Projects</a></li>
         <li><a href='tools.html'>Tools</a></li>
-        <li><a href='https://github.com/facebook/reason'>Github</a></li>
+        <li><a href='https://github.com/facebook/reason'>GitHub</a></li>
       </ul>
     </div>
   </div>

--- a/modules.html
+++ b/modules.html
@@ -360,7 +360,7 @@ let module Pairify: ParifyT = functor (X:HasT) => {
       <ul>
         <li><a href='projects.html'>Projects</a></li>
         <li><a href='tools.html'>Tools</a></li>
-        <li><a href='https://github.com/facebook/reason'>Github</a></li>
+        <li><a href='https://github.com/facebook/reason'>GitHub</a></li>
       </ul>
     </div>
   </div>

--- a/projects.html
+++ b/projects.html
@@ -191,7 +191,7 @@ new artifact.
       <ul>
         <li><a href='projects.html'>Projects</a></li>
         <li><a href='tools.html'>Tools</a></li>
-        <li><a href='https://github.com/facebook/reason'>Github</a></li>
+        <li><a href='https://github.com/facebook/reason'>GitHub</a></li>
       </ul>
     </div>
   </div>

--- a/tools.html
+++ b/tools.html
@@ -360,7 +360,7 @@ OPAM toolchain.
       <ul>
         <li><a href='projects.html'>Projects</a></li>
         <li><a href='tools.html'>Tools</a></li>
-        <li><a href='https://github.com/facebook/reason'>Github</a></li>
+        <li><a href='https://github.com/facebook/reason'>GitHub</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
It's a small and insignificant change, but it bugs me whenever I see GitHub without the capital h.