### PR TITLE
docs: Fix non-tail-recursive neverTerminate

### DIFF
--- a/index.html
+++ b/index.html
@@ -536,7 +536,7 @@ By default, values can't see a binding that points to it, but including the
 to see and call themselves, giving us the power of recursion.
 
 ```reason
-let rec neverTerminate = fun n => n + neverTerminate (n - 1);
+let rec neverTerminate = fun () => neverTerminate ();
 ```
 
 #### Mutually Recursive Functions


### PR DESCRIPTION
The original example definitely terminates for me (even if not
theoretically):

    Reason # let rec neverTerminate = fun n => n + neverTerminate (n - 1);
    let neverTerminate : int => int = <fun>
    Reason # neverTerminate 1
    Reason # neverTerminate 1;
    Stack overflow during evaluation (looping recursion?).

Signed-off-by: Si Beaumont <simonjbeaumont@gmail.com>