### PR TITLE
Give error when using :: notation as a pattern.

### DIFF
--- a/formatTest/unit_tests/input/variants.re
+++ b/formatTest/unit_tests/input/variants.re
@@ -276,7 +276,7 @@ let res = switch (ylw, prp) {
 
 let rec atLeastOneFlushableChildAndNoWipNoPending composition atPriority => switch composition {
   | [] => false
-  | hd::tl =>
+  | [hd, ...tl] =>
       switch hd {
         | OpaqueGraph {lifecycle: Reconciled (_, [])} =>
             atLeastOneFlushableChildAndNoWipNoPending tl atPriority

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -3278,7 +3278,7 @@ _pattern_without_or:
     {
       mkpat (Ppat_variant($1, Some $2))
     }
-  | pattern_without_or as_loc(COLONCOLON) pattern_without_or
+  | pattern_without_or COLONCOLON pattern_without_or
       { not_expecting 2 "::" }
   | pattern_without_or COLONCOLON as_loc(error)
       { expecting_pat (with_txt $3 "pattern") }

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -3278,12 +3278,8 @@ _pattern_without_or:
     {
       mkpat (Ppat_variant($1, Some $2))
     }
-  | pattern_without_or COLONCOLON pattern_without_or
-      {
-         let loc = mklocation $symbolstartpos $endpos in
-         let loc_coloncolon = mklocation $startpos($2) $endpos($2) in
-         mkpat_cons loc_coloncolon (mkpat ~ghost:true ~loc (Ppat_tuple[$1;$3])) loc
-      }
+  | pattern_without_or as_loc(COLONCOLON) pattern_without_or
+      { not_expecting 2 "::" }
   | pattern_without_or COLONCOLON as_loc(error)
       { expecting_pat (with_txt $3 "pattern") }
   | LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -3278,8 +3278,8 @@ _pattern_without_or:
     {
       mkpat (Ppat_variant($1, Some $2))
     }
-  | pattern_without_or COLONCOLON pattern_without_or
-      { not_expecting 2 "::" }
+  | pattern_without_or as_loc(COLONCOLON) pattern_without_or
+      { Location.raise_errorf ~loc:$2.loc ":: is not supported in Reason, please use [hd, ...tl] instead" }
   | pattern_without_or COLONCOLON as_loc(error)
       { expecting_pat (with_txt $3 "pattern") }
   | LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN


### PR DESCRIPTION
With this change the following error: 

```
File "Hello.re", line 8, characters 6-8:
:: is not supported in Reason, please use [hd, ...tl] instead
```

will be given when

```
| hd :: tl -> 
```

is used.
