### PR TITLE
Minor cleanup

### DIFF
--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -19,7 +19,7 @@ let () =
     Pkg.lib ~exts:[`Ext ".cmo"; `Ext ".cmx";`Ext ".cmi"; `Ext ".cmt"] "src/reason_pprint_ast";
     Pkg.lib ~exts:[`Ext ".cmo"; `Ext ".cmx";`Ext ".cmi"; `Ext ".cmt"; `Ext ".cmxs"] "src/reason_oprint";
     Pkg.lib ~exts:[`Ext ".cmo"; `Ext ".cmx";`Ext  ".cmi"; `Ext ".cmt"] "src/reason_config";
-    Pkg.lib ~exts:[`Ext ".cmo"; `Ext ".cmx";`Ext  ".cmi"; `Ext ".cmt"] "src/reason_utils";
+    Pkg.lib ~exts:[`Ext ".cmo"; `Ext ".cmx";`Ext  ".cmi"; `Ext ".cmt"] "src/syntax_util";
     Pkg.lib ~exts:[`Ext ".cmo"; `Ext ".cmx";`Ext  ".cmi"; `Ext ".cmt"; `Ext ".cmxs"] "src/redoc_html";
     Pkg.lib ~exts:Exts.library "src/reasondoc";
     Pkg.lib ~exts:[`Ext ".cmo"] "src/reason_toploop";

--- a/src/reason.mllib
+++ b/src/reason.mllib
@@ -3,7 +3,7 @@ Reason_lexer
 Reason_pprint_ast
 Reason_oprint
 Reason_config
-Reason_utils
+Syntax_util
 Reason_util
 Reason_toolchain
 Reason_utop

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -56,7 +56,7 @@ open Longident
 open Parsetree
 open Ast_helper
 open Ast_mapper
-open Reason_utils
+open Syntax_util
 
 (*
    TODO:
@@ -418,7 +418,7 @@ let array_function ?(loc=dummy_loc()) str name =
 
 let syntax_error_str loc msg =
   if !Reason_config.recoverable then
-    Str.mk ~loc:loc (Pstr_extension (Reason_utils.syntax_error_extension_node loc msg, []))
+    Str.mk ~loc:loc (Pstr_extension (Syntax_util.syntax_error_extension_node loc msg, []))
   else
     raise(Syntaxerr.Error(Syntaxerr.Other loc))
 
@@ -427,7 +427,7 @@ let syntax_error () =
 
 let syntax_error_exp loc msg =
   if !Reason_config.recoverable then
-    Exp.mk ~loc (Pexp_extension (Reason_utils.syntax_error_extension_node loc msg))
+    Exp.mk ~loc (Pexp_extension (Syntax_util.syntax_error_extension_node loc msg))
   else
     syntax_error ()
 
@@ -436,7 +436,7 @@ let unclosed opening closing =
                                            closing.loc, closing.txt)))
 
 let unclosed_extension closing =
-  Reason_utils.syntax_error_extension_node closing.loc ("Expecting \"" ^ closing.txt ^ "\"")
+  Syntax_util.syntax_error_extension_node closing.loc ("Expecting \"" ^ closing.txt ^ "\"")
 
 let unclosed_mod opening closing =
   if !Reason_config.recoverable then
@@ -479,7 +479,7 @@ let expecting nonterm =
 
 let expecting_pat nonterm =
   if !Reason_config.recoverable then
-    mkpat(Ppat_extension (Reason_utils.syntax_error_extension_node nonterm.loc ("Expecting " ^ nonterm.txt)))
+    mkpat(Ppat_extension (Syntax_util.syntax_error_extension_node nonterm.loc ("Expecting " ^ nonterm.txt)))
   else
     expecting nonterm
 

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -55,7 +55,7 @@ open Location
 open Longident
 open Parsetree
 open Easy_format
-open Reason_utils
+open Syntax_util
 open Ast_mapper
 
 

--- a/src/reason_toolchain.ml
+++ b/src/reason_toolchain.ml
@@ -81,20 +81,20 @@ let invalidLex = "invalidCharacter.orComment.orString"
 let syntax_error_str err loc =
   if !Reason_config.recoverable then
     [
-      Ast_helper.Str.mk ~loc:loc (Parsetree.Pstr_extension (Reason_utils.syntax_error_extension_node loc invalidLex, []))
+      Ast_helper.Str.mk ~loc:loc (Parsetree.Pstr_extension (Syntax_util.syntax_error_extension_node loc invalidLex, []))
     ]
   else
     raise err
 
 let syntax_error_core_type err loc =
   if !Reason_config.recoverable then
-    Ast_helper.Typ.mk ~loc:loc (Parsetree.Ptyp_extension (Reason_utils.syntax_error_extension_node loc invalidLex))
+    Ast_helper.Typ.mk ~loc:loc (Parsetree.Ptyp_extension (Syntax_util.syntax_error_extension_node loc invalidLex))
   else
     raise err
 
 let syntax_error_sig err loc =
   if !Reason_config.recoverable then
-    [Ast_helper.Sig.mk ~loc:loc (Parsetree.Psig_extension (Reason_utils.syntax_error_extension_node loc invalidLex, []))]
+    [Ast_helper.Sig.mk ~loc:loc (Parsetree.Psig_extension (Syntax_util.syntax_error_extension_node loc invalidLex, []))]
   else
     raise err
 
@@ -281,7 +281,7 @@ module OCaml_syntax = struct
 
   (* Skip tokens to the end of the phrase *)
   (* TODO: consolidate these copy-paste skip/trys into something that works for
-   * every syntax (also see [reason_util]). *)
+   * every syntax (also see [syntax_util]). *)
   let rec skip_phrase lexbuf =
     try
       match Lexer_impl.token lexbuf with
@@ -324,26 +324,6 @@ module OCaml_syntax = struct
   let format_implementation_with_comments (implementation, _) formatter =
     Pprintast.structure formatter implementation
 end
-
-
-(* The following logic defines our own Error object
- * and register it with ocaml so it knows how to print it
- *)
-type error = Syntax_error of string
-
-exception Error of Location.t * error
-
-let report_error ppf (Syntax_error err) =
-  Format.(fprintf ppf "%s" err)
-
-let () =
-  Location.register_error_of_exn
-    (function
-     | Error (loc, err) ->
-        Some (Location.error_of_printer loc report_error err)
-     | _ ->
-        None
-     )
 
 module JS_syntax = struct
   module I = Reason_parser.MenhirInterpreter
@@ -492,7 +472,7 @@ module JS_syntax = struct
           *)
          let msg = Reason_parser_message.message state in
          let msg_with_state = Printf.sprintf "%d: %s" state msg in
-         raise (Error (loc, (Syntax_error msg_with_state)))
+         raise (Syntax_util.Error (loc, (Syntax_util.Syntax_error msg_with_state)))
     | I.Rejected ->
        begin
          let loc = last_token_loc supplier in

--- a/src/reason_util.ml
+++ b/src/reason_util.ml
@@ -3,7 +3,6 @@
  *)
  (* Portions Copyright (c) 2015-present, Facebook, Inc. All rights reserved. *)
 
-
 let transmogrify_exn exn template =
   assert (Obj.tag (Obj.repr exn) = 0);
   Obj.set_field (Obj.repr exn) 0 (Obj.field (Obj.repr template) 0);
@@ -50,5 +49,5 @@ let correctly_catch_parse_errors fn lexbuf =
     raise (match exn with
           | Reason_lexer.Error _ -> transmogrify_exn exn exn_Lexer_Error
           | Syntaxerr.Error _ -> transmogrify_exn exn exn_Syntaxerr_Error
-          | Reason_toolchain.Error (loc, _) -> transmogrify_exn (Syntaxerr.Error(Syntaxerr.Other loc)) exn_Syntaxerr_Error
+          | Syntax_util.Error (loc, _) -> transmogrify_exn (Syntaxerr.Error(Syntaxerr.Other loc)) exn_Syntaxerr_Error
           | _ -> exn)

--- a/src/reasonsyntax.mllib
+++ b/src/reasonsyntax.mllib
@@ -2,4 +2,4 @@ Reason_parser
 Reason_lexer
 Reason_pprint_ast
 Reason_config
-Reason_utils
+Syntax_util

--- a/src/syntax_util.ml
+++ b/src/syntax_util.ml
@@ -186,3 +186,23 @@ let apply_mapper_chain_to_toplevel_phrase toplevel_phrase chain =
 
 let apply_mapper_chain_to_use_file use_file chain =
   List.map (fun x -> apply_mapper_chain_to_toplevel_phrase x chain) use_file
+
+(* The following logic defines our own Error object
+ * and register it with ocaml so it knows how to print it
+ *)
+
+type error = Syntax_error of string
+
+exception Error of Location.t * error
+
+let report_error ppf (Syntax_error err) =
+  Format.(fprintf ppf "%s" err)
+
+let () =
+  Location.register_error_of_exn
+    (function
+     | Error (loc, err) ->
+        Some (Location.error_of_printer loc report_error err)
+     | _ ->
+        None
+     )


### PR DESCRIPTION
It is confusing to have both `Reason_util` and `Reason_utils`. This patch will change `Reason_utils` to `Syntax_util` as it has more syntax related utilities. 