### PR TITLE
Use .reasoninit instead of .ocamlinit

### DIFF
--- a/src/rtop.sh
+++ b/src/rtop.sh
@@ -20,4 +20,13 @@ if [[ $@ =~ "stdin" ]]; then
    export stdin=1
 fi
 
+if [ ! -f $HOME/.reasoninit ]; then
+    # TODO: ideally we should generate this file by refmtting
+    # .ocamlinit. But refmt doesn't support toplevel formatting yet
+    echo "/* Added by rtop */
+try Topdirs.dir_directory (Sys.getenv \"OCAML_TOPLEVEL_PATH\")
+with Not_found => ()
+" > $HOME/.reasoninit
+fi
+
 utop -init $DIR/rtop_init.ml -I $HOME

--- a/src/rtop_init.ml
+++ b/src/rtop_init.ml
@@ -1,7 +1,7 @@
 #!/usr/bin/env ocaml
-#use ".ocamlinit";;
 #require "menhirLib";;
 #require "reason";;
+#use ".reasoninit";;
 
 let interactive = try let _ = Sys.getenv "stdin" in false with | Not_found -> true in
 if interactive then


### PR DESCRIPTION
By changing the loading order in rtop_init, I believe rtop can use
whatever directives that are valid in .ocamlinit (including #camlp4o).

The only requirement is that the loaded file should be in reason syntax. Thus
we have to create a new file.

#510 