### PR TITLE
Catch exception `Not_found` from error message database

### DIFF
--- a/src/reason_parser.messages
+++ b/src/reason_parser.messages
@@ -398,7 +398,7 @@ parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT WITH
 ## pattern_comma_list COMMA DOTDOTDOT
 ##
 
-Expecting a valid list identifier.
+Expecting a valid list identifier
 
 parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
@@ -13359,7 +13359,7 @@ implementation: LET LIDENT UNDERSCORE WITH
 Defining a function?
 Expecting one of the following:
   - "=>" to start the function body
-  - an identifier to add an function parameter
+  - an identifier to add a function parameter
   - ":" to specify the return type
 
 implementation: LET LIDENT WITH

--- a/src/reason_parser_message.ml
+++ b/src/reason_parser_message.ml
@@ -663,7 +663,7 @@ let message =
     | 1157 ->
         "<SYNTAX ERROR>\n"
     | 1278 ->
-        "Defining a function?\nExpecting one of the following:\n  - \"=>\" to start the function body\n  - an identifier to add an function parameter\n  - \":\" to specify the return type\n"
+        "Defining a function?\nExpecting one of the following:\n  - \"=>\" to start the function body\n  - an identifier to add a function parameter\n  - \":\" to specify the return type\n"
     | 1246 ->
         "<SYNTAX ERROR>\n"
     | 1162 ->
@@ -2295,7 +2295,7 @@ let message =
     | 747 ->
         "<SYNTAX ERROR>\n"
     | 745 ->
-        "<SYNTAX ERROR>\n"
+        "Expecting a valid list identifier\n"
     | 746 ->
         "<SYNTAX ERROR>\n"
     | 749 ->

--- a/src/reason_toolchain.ml
+++ b/src/reason_toolchain.ml
@@ -470,7 +470,12 @@ module JS_syntax = struct
          (* Check the error database to see what's the error message
           * associated with the current parser state
           *)
-         let msg = Reason_parser_message.message state in
+         let msg =
+           try
+             Reason_parser_message.message state
+           with
+             | Not_found -> "<UNKNOWN SYNTAX ERROR>"
+         in
          let msg_with_state = Printf.sprintf "%d: %s" state msg in
          raise (Syntax_util.Error (loc, (Syntax_util.Syntax_error msg_with_state)))
     | I.Rejected ->


### PR DESCRIPTION
- Catch exception `Not_found` from error message database and provide a nicer error
- Fix some typos in existing error messages

#553