### PR TITLE
Fix old syntax `functor`, should be `fun` instead.

### DIFF
--- a/modules.html
+++ b/modules.html
@@ -277,7 +277,7 @@ keyword designates functor in this case.
 module type HasT = {
   type t;
 };
-let module Pairify = func (X: HasT) => {
+let module Pairify = fun (X: HasT) => {
    type p = (X.t, X.t);
    let create = fun (x: X.t) => (x, x);
 };


### PR DESCRIPTION
Functor doesn't compile, it should be fun instead. 
Replaced the faulty entries in the docs with syntax that compiles, i.e. functor becomes fun.