### PR TITLE
Fix rtop -stdin

### DIFF
--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -1129,7 +1129,6 @@ interface:
 toplevel_phrase: _toplevel_phrase {apply_mapper_chain_to_toplevel_phrase $1 default_mapper_chain}
 _toplevel_phrase:
     structure_item SEMI                 { Ptop_def [$1]}
-  | structure_item EOF                  { Ptop_def []}
   | EOF                                 { raise End_of_file}
   | toplevel_directive SEMI             { $1 }
 ;

--- a/src/rtop.sh
+++ b/src/rtop.sh
@@ -16,9 +16,7 @@
 touch $HOME/.utoprc
 touch $HOME/.utop-history
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-if [[ $@ =~ "stdin" ]]; then
-   export stdin=1
-fi
+
 
 if [ ! -f $HOME/.reasoninit ]; then
     # TODO: ideally we should generate this file by refmtting
@@ -30,4 +28,8 @@ let () =
   };" > $HOME/.reasoninit
 fi
 
-utop -init $DIR/rtop_init.ml -I $HOME
+if [[ $@ =~ "stdin" ]]; then
+    refmt -parse re -print ml -use-stdin true -is-interface-pp false | utop $@
+else
+    utop -init $DIR/rtop_init.ml -I $HOME
+fi

--- a/src/rtop_init.ml
+++ b/src/rtop_init.ml
@@ -3,8 +3,6 @@
 #require "reason";;
 #use ".reasoninit";;
 
-let interactive = try let _ = Sys.getenv "stdin" in false with | Not_found -> true in
-if interactive then
 print_string
 "
                    ___  _______   ________  _  __


### PR DESCRIPTION
- Completely throw away the hack that we put into to suppoert `rtop -stdin`.
Now use `refmt | utop -stdin` instead.

- Remove a hack in reason_parser.mly which causes
"rtop finishes parsing when not terminated with a `;` with no execution" (https://github.com/facebook/reason/issues/505). This hack was there to support `rtop -stdin`