### PR TITLE
#491 - Remove "of" word.

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/arityConversion.re
+++ b/formatTest/typeCheckedTests/expected_output/arityConversion.re
@@ -2,8 +2,8 @@
 Some (1, 2, 3);
 
 type bcd =
-  | TupleConstructor of (int, int)
-  | MultiArgumentsConstructor of int int;
+  | TupleConstructor (int, int)
+  | MultiArgumentsConstructor int int;
 
 let a = TupleConstructor (1, 2);
 
@@ -11,7 +11,7 @@ let b =
   MultiArgumentsConstructor 1 2 [@implicit_arity];
 
 let module Test = {
-  type a = | And of (int, int) | Or of (int, int);
+  type a = | And (int, int) | Or (int, int);
 };
 
 Test.And (1, 2);

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -36,7 +36,7 @@ type attributedIntsInTuple = (
 )
 [@@onTopLevelTypeDef];
 
-type myDataType 'x 'y = | MyDataType of 'x 'y;
+type myDataType 'x 'y = | MyDataType 'x 'y;
 
 type myType =
   (
@@ -190,14 +190,12 @@ let result =
     () [@onSecondSend];
 
 type variantType =
-  | Foo of int [@onInt]
-  | Bar of (int [@onInt])
-  | Baz
+  | Foo int [@onInt] | Bar (int [@onInt]) | Baz
 [@@onVariantType];
 
 type gadtType 'x =
-  | Foo of int :(gadtType int) [@onFirstRow]
-  | Bar of
+  | Foo int :(gadtType int) [@onFirstRow]
+  | Bar
       (int [@onInt])
       :(gadtType unit) [@onSecondRow]
   | Baz
@@ -303,14 +301,14 @@ module type HasAttrs = {
   class fooBar : int => new foo [@@sigItem];
 };
 
-type s = | S of string;
+type s = | S string;
 
 let S (str [@onStr]) = S ("hello" [@onHello]);
 
 let S str [@onConstruction] =
   S "hello" [@onConstruction];
 
-type xy = | X of string | Y of string;
+type xy = | X string | Y string;
 
 let myFun
     (

--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -1,7 +1,7 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
 type reasonXyz =
-  | X | Y of int int int | Z of int int | Q | R;
+  | X | Y int int int | Z int int | Q | R;
 
 let reasonBarAs =
   fun

--- a/formatTest/typeCheckedTests/expected_output/comments.re
+++ b/formatTest/typeCheckedTests/expected_output/comments.re
@@ -61,9 +61,9 @@ type t22 =
 
 type variant =
   /* Comment above X */
-  | X of int /* End of line on X */
+  | X int /* End of line on X */
   /* Comment above Y */
-  | Y of int /* End of line on Y */;
+  | Y int /* End of line on Y */;
 
 /* Comment on entire type def for variant */
 type x = {

--- a/formatTest/typeCheckedTests/expected_output/knownMlIssues.re
+++ b/formatTest/typeCheckedTests/expected_output/knownMlIssues.re
@@ -4,9 +4,9 @@ type t2 =
   (int, int) /* attributed to entire type not binding */;
 
 type color =
-  | Red of int /* After red */
-  | Black of int /* After black */
-  | Green of int /* Does not remain here */;
+  | Red int /* After red */
+  | Black int /* After black */
+  | Green int /* Does not remain here */;
 
 let blahCurriedX x =>
   fun

--- a/formatTest/typeCheckedTests/expected_output/lazy.re
+++ b/formatTest/typeCheckedTests/expected_output/lazy.re
@@ -17,7 +17,7 @@ let result = operateOnLazyValue (
   lazy {myRecordField: 100}
 );
 
-type box 'a = | Box of 'a;
+type box 'a = | Box 'a;
 
 let lazy thisIsActuallyAPatternMatch = lazy 200;
 

--- a/formatTest/typeCheckedTests/expected_output/mlSyntax.re
+++ b/formatTest/typeCheckedTests/expected_output/mlSyntax.re
@@ -4,7 +4,7 @@
  */
 
 type xyz =
-  | X | Y of int int int | Z of int int | Q | R;
+  | X | Y int int int | Z int int | Q | R;
 
 let doubleBar =
   fun
@@ -41,7 +41,7 @@ let doubleBarNestedAnyPatterns =
 
 type bcd = | B | C | D | E;
 
-type a = | A of bcd;
+type a = | A bcd;
 
 let result =
   switch B {
@@ -85,7 +85,7 @@ let nestedSomeSimple = Some (Some (1, 2, 3));
 
 let module EM = {
   /** Exception */
-  exception E of int int;
+  exception E int int;
 };
 
 exception Ealias = EM.E;

--- a/formatTest/typeCheckedTests/expected_output/mlVariants.re
+++ b/formatTest/typeCheckedTests/expected_output/mlVariants.re
@@ -1,8 +1,8 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
 type polyVariantsInMl = [
-  | `IntTuple of (int, int)
-  | `StillAnIntTuple of (int, int)
+  | `IntTuple (int, int)
+  | `StillAnIntTuple (int, int)
 ];
 
 let intTuple = `IntTuple (1, 2);
@@ -14,4 +14,4 @@ let sumThem =
   | `IntTuple (x, y) => x + y
   | `StillAnIntTuple (a, b) => a + b;
 
-type nonrec t = | A of int | B of bool;
+type nonrec t = | A int | B bool;

--- a/formatTest/typeCheckedTests/expected_output/patternMatching.re
+++ b/formatTest/typeCheckedTests/expected_output/patternMatching.re
@@ -4,12 +4,11 @@ type point = {x: int, y: int};
 let id x => x;
 
 type myVariant =
-  | TwoCombos of inner inner
+  | TwoCombos inner inner
   | Short
-  | AlsoHasARecord of int int point
+  | AlsoHasARecord int int point
 and inner =
-  | Unused
-  | HeresTwoConstructorArguments of int int;
+  | Unused | HeresTwoConstructorArguments int int;
 
 let computeTuple a b c d e f g h => (
   a + b,

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -156,8 +156,8 @@ type t3 =
   (int, int) /* End of line on (int, int) */;
 
 type variant =
-  | X of (int, int) /* End of line on X */
-  | Y of (int, int) /* End of line on Y */;
+  | X (int, int) /* End of line on X */
+  | Y (int, int) /* End of line on Y */;
 
 /* Comment on entire type def for variant */
 /* Before let */
@@ -190,15 +190,15 @@ let res =
 
 type variant2 =
   /* Comment above X */
-  | X of (int, int) /* End of line on X */
+  | X (int, int) /* End of line on X */
   /* Comment above Y */
-  | Y of (int, int);
+  | Y (int, int);
 
 type variant3 =
   /* Comment above X */
-  | X of (int, int) /* End of line on X */
+  | X (int, int) /* End of line on X */
   /* Comment above Y */
-  | Y of (int, int) /* End of line on Y  */;
+  | Y (int, int) /* End of line on Y  */;
 
 type x = {
   /* not attached *above* x */
@@ -293,7 +293,7 @@ let res =
   };
 
 type optionalTuple =
-  | OptTup of (
+  | OptTup (
       option
         (
           int, /* First int */
@@ -342,9 +342,9 @@ if true {
 
 /* hello */
 type color =
-  | Red of int /* After red end of line */
-  | Black of int /* After black end of line */
-  | Green of int /* After green end of line */;
+  | Red int /* After red end of line */
+  | Black int /* After black end of line */
+  | Green int /* After green end of line */;
 
 /* On next line after color type def */
 let blahCurriedX x =>

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -34,7 +34,7 @@ type x = int [@@itemAttributeOnTypeDef];
 type attributedInt = int [@onTopLevelTypeDef];
 type attributedIntsInTuple = (int [@onInt], float [@onFloat]) [@@onTopLevelTypeDef];
 
-type myDataType 'x 'y = | MyDataType of 'x 'y;
+type myDataType 'x 'y = | MyDataType 'x 'y;
 
 type myType =
   myDataType
@@ -133,13 +133,13 @@ and unused = () [@@onUnused];
 let result = (myRecord.p() [@attOnFirstSend]).q() [@onSecondSend];
 
 type variantType =
-   | Foo of int [@onInt]
-   | Bar of (int [@onInt])
+   | Foo int [@onInt]
+   | Bar (int [@onInt])
    | Baz [@@onVariantType];
 
 type gadtType 'x =
-   | Foo of int : gadtType int [@onFirstRow]
-   | Bar of (int [@onInt]) : gadtType unit [@onSecondRow]
+   | Foo int : gadtType int [@onFirstRow]
+   | Bar (int [@onInt]) : gadtType unit [@onSecondRow]
    | Baz: gadtType (unit [@onUnit]) [@onThirdRow] [@@onVariantType];
 
 [@@@floatingTopLevelStructureItem hello];
@@ -231,13 +231,13 @@ module type HasAttrs = {
 }
 [@@structureItem];
 
-type s = S of string;
+type s = S string;
 
 let S (str [@onStr]) = S ("hello" [@onHello]);
 let (S str) [@onConstruction] = (S "hello") [@onConstruction];
 
-type xy = | X of string
-          | Y of string;
+type xy = | X string
+          | Y string;
 
 let myFun = fun (X hello [@onConstruction] | Y hello [@onConstruction]) => hello;
 let myFun = fun (X (hello [@onHello]) | Y (hello [@onHello])) => hello;

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -2,8 +2,8 @@
 
 type reasonXyz =
   | X
-  | Y of int int int
-  | Z of int int
+  | Y int int int
+  | Z int int
   | Q
   | R;
 

--- a/formatTest/typeCheckedTests/input/lazy.re
+++ b/formatTest/typeCheckedTests/input/lazy.re
@@ -13,7 +13,7 @@ let operateOnLazyValue (lazy {myRecordField}) => {
 
 let result = operateOnLazyValue (lazy {myRecordField: 100});
 
-type box 'a = Box of 'a;
+type box 'a = Box 'a;
 
 let lazy thisIsActuallyAPatternMatch = lazy (200);
 let tmp: int = thisIsActuallyAPatternMatch;

--- a/formatTest/typeCheckedTests/input/patternMatching.re
+++ b/formatTest/typeCheckedTests/input/patternMatching.re
@@ -3,12 +3,12 @@ type point = {x: int, y: int};
 let id x => x;
 
 type myVariant =
-  | TwoCombos of inner inner
+  | TwoCombos inner inner
   | Short
-  | AlsoHasARecord of int int point
+  | AlsoHasARecord int int point
 and inner =
   | Unused
-  | HeresTwoConstructorArguments of int int;
+  | HeresTwoConstructorArguments int int;
 
 let computeTuple a b c d e f g h => (
   a + b,

--- a/formatTest/typeCheckedTests/input/reasonComments.re
+++ b/formatTest/typeCheckedTests/input/reasonComments.re
@@ -156,8 +156,8 @@ type t3 =
 
 
 type variant =
-  | X of (int, int) /* End of line on X */
-  | Y of (int, int) /* End of line on Y */
+  | X (int, int) /* End of line on X */
+  | Y (int, int) /* End of line on Y */
 ; /* Comment on entire type def for variant */
 
 /* Before let */
@@ -186,15 +186,15 @@ let res =
 
 type variant2 =
   /* Comment above X */
-  | X of (int, int) /* End of line on X */
+  | X (int, int) /* End of line on X */
   /* Comment above Y */
-  | Y of (int, int);
+  | Y (int, int);
 
 type variant3 =
   /* Comment above X */
-  | X of (int, int) /* End of line on X */
+  | X (int, int) /* End of line on X */
   /* Comment above Y */
-  | Y of (int, int) /* End of line on Y  */
+  | Y (int, int) /* End of line on Y  */
 ;
 
 
@@ -279,7 +279,7 @@ let res =
 
 
 type optionalTuple =
-  | OptTup of (
+  | OptTup (
       option (
         int, /* First int */
         int /* Second int */
@@ -326,9 +326,9 @@ if true {
 };
 
 type color =
-  | Red of int /* After red end of line */
-  | Black of int /* After black end of line */
-  | Green of int /* After green end of line */
+  | Red int /* After red end of line */
+  | Black int /* After black end of line */
+  | Green int /* After green end of line */
 ; /* On next line after color type def */
 
 let blahCurriedX x =>

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -385,7 +385,7 @@ let nestedMatchWithWhen lstLst =>
 /**
  * Aliasing with "as" during matches.
  */
-type mine = | MyThing of int | YourThing of int;
+type mine = | MyThing int | YourThing int;
 
 /*
  * Reason parses "as" aliases differently than OCaml.

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -382,10 +382,10 @@ let module ReturnsAFunctor2
  * TODO: Test [Psig_recmodule]
  */
 let module rec A: {
-  type t = | Leaf of string | Node of ASet.t;
+  type t = | Leaf string | Node ASet.t;
   let compare: t => t => int;
 } = {
-  type t = | Leaf of string | Node of ASet.t;
+  type t = | Leaf string | Node ASet.t;
   let compare t1 t2 =>
     switch (t1, t2) {
     | (Leaf s1, Leaf s2) =>
@@ -402,7 +402,7 @@ and ASet: Set.S with type elt = A.t = Set.Make A;
  */
 module type HasRecursiveModules = {
   let module rec A: {
-    type t = | Leaf of string | Node of ASet.t;
+    type t = | Leaf string | Node ASet.t;
     let compare: t => t => int;
   }
   and ASet: Set.S with type elt = A.t;

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -164,12 +164,11 @@ constraint 'a = (unit, unit);
 type onelineConstrain = 'a constraint 'a = int;
 
 /* This must be in trunk but not in this branch of OCaml */
-/* type withNestedRecords = MyConstructor of {myField: int} */
-type colors =
-  | Red of int | Black of int | Green of int;
+/* type withNestedRecords = MyConstructor {myField: int} */
+type colors = | Red int | Black int | Green int;
 
 /* Another approach is to require declared variants to wrap any record */
-/* type myRecord = MyRecord of {name: int}; */
+/* type myRecord = MyRecord {name: int}; */
 /* let myValue = MyRecord {name: int}; */
 /* This would force importing of the module */
 /* This would also lend itself naturally to pattern matching - and avoid having
@@ -660,11 +659,11 @@ type stillARecord = {name: string, age: int};
 
 /* Rebase latest OCaml to get the following: And fixup
    `generalized_constructor_arguments` according to master. */
-/* type ('a, 'b) myOtherThing = Leaf of {first:'a, second: 'b} | Null; */
+/* type ('a, 'b) myOtherThing = Leaf {first:'a, second: 'b} | Null; */
 type branch 'a 'b = {first: 'a, second: 'b};
 
 type myOtherThing 'a 'b =
-  | Leaf of (branch 'a 'b) | Null;
+  | Leaf (branch 'a 'b) | Null;
 
 type yourThing = myOtherThing int int;
 

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -4,21 +4,20 @@ let module LocalModule = {
   type accessedThroughModule =
     | AccessedThroughModule;
   type accessedThroughModuleWithArg =
-    | AccessedThroughModuleWith of int
-    | AccessedThroughModuleWithTwo of int int;
+    | AccessedThroughModuleWith int
+    | AccessedThroughModuleWithTwo int int;
 };
 
 type notTupleVariant =
-  | NotActuallyATuple of int int;
+  | NotActuallyATuple int int;
 
 type notTupleVariantExtraParens =
-  | NotActuallyATuple2 of int int;
+  | NotActuallyATuple2 int int;
 
 type simpleTupleVariant =
-  | SimpleActuallyATuple of (int, int);
+  | SimpleActuallyATuple (int, int);
 
-type tupleVariant =
-  | ActuallyATuple of (int, int);
+type tupleVariant = | ActuallyATuple (int, int);
 
 let intTuple = (20, 20);
 
@@ -56,7 +55,7 @@ let yesTupled: tupleVariant =
   ActuallyATuple intTuple;
 
 type threeForms =
-  | FormOne of int | FormTwo of int | FormThree;
+  | FormOne int | FormTwo int | FormThree;
 
 let doesntCareWhichForm x =>
   switch x {
@@ -79,8 +78,8 @@ type colorList1 = [
 ];
 
 type colorList = [<
-  | `Red of (int, int) &int
-  | `Black of &(int, int) &int
+  | `Red (int, int) &int
+  | `Black &(int, int) &int
   | `Blue
   > `Red `Black
 ];
@@ -169,7 +168,7 @@ let run () => {
 };
 
 type combination 'a =
-  | HeresTwoConstructorArguments of int int;
+  | HeresTwoConstructorArguments int int;
 
 
 /** But then how do we parse matches in function arguments? */
@@ -194,8 +193,7 @@ let matchingTwoCurriedConstructorsInTuple x =>
   };
 
 type twoCurriedConstructors =
-  | TwoCombos of
-      (combination int) (combination int);
+  | TwoCombos (combination int) (combination int);
 
 let matchingTwoCurriedConstructorInConstructor x =>
   switch x {
@@ -206,14 +204,13 @@ let matchingTwoCurriedConstructorInConstructor x =>
   };
 
 type twoCurriedConstructorsPolyMorphic 'a =
-  | TwoCombos of
-      (combination 'a) (combination 'a);
+  | TwoCombos (combination 'a) (combination 'a);
 
 /* Matching records */
 type pointRecord = {x: int, y: int};
 
 type alsoHasARecord =
-  | Blah | AlsoHasARecord of int int pointRecord;
+  | Blah | AlsoHasARecord int int pointRecord;
 
 let result =
   switch (AlsoHasARecord 10 10 {x: 10, y: 20}) {
@@ -247,9 +244,9 @@ let thisWontCompileButLetsSeeHowItFormats =
  * GADTs.
  */
 type term _ =
-  | Int of int :term int
+  | Int int :term int
   | Add :term (int => int => int)
-  | App of (term ('b => 'a)) (term 'b) :term 'a;
+  | App (term ('b => 'a)) (term 'b) :term 'a;
 
 let rec eval: type a. term a => a =
   fun
@@ -274,8 +271,7 @@ let evalArg = App (App Add (Int 1)) (Int 1);
 
 let two = eval (App (App Add (Int 1)) (Int 1));
 
-type someVariant =
-  | Purple of int | Yellow of int;
+type someVariant = | Purple int | Yellow int;
 
 let Purple x | Yellow x =
   switch (Yellow 100, Purple 101) {
@@ -287,9 +283,9 @@ let Purple x | Yellow x =
 
 type tuples =
   | Zero
-  | One of int
-  | Two of int int
-  | OneTuple of (int, int);
+  | One int
+  | Two int int
+  | OneTuple (int, int);
 
 let myTuple = OneTuple (20, 30);
 
@@ -307,7 +303,7 @@ let res =
     }
   };
 
-/* FIXME type somePolyVariant = [ `Purple of int | `Yellow of int]; */
+/* FIXME type somePolyVariant = [ `Purple int | `Yellow int]; */
 let ylw = `Yellow (100, 100);
 
 let prp = `Purple (101, 100);

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -2039,11 +2039,11 @@ type x = private int;
 type myType 'a 'b 'c = private ('a, 'b, 'c);
 
 type privateVariant = private
-  | BigSize of int | SmallSize of int;
+  | BigSize int | SmallSize int;
 
 type doubleEqualsDoublePrivateVariant =
   privateVariant =
-    private | BigSize of int | SmallSize of int;
+    private | BigSize int | SmallSize int;
 
 type myRecordWithReallyLongName = {
   xx: int,
@@ -2058,7 +2058,7 @@ type doubleEqualsDoublePrivateRecord =
     private {xx: int, yy: int};
 
 type someConstructor =
-  | SomeConstructorHi of int int;
+  | SomeConstructorHi int int;
 
 type someRecord = {
   firstFieldInRecord: int,
@@ -2108,7 +2108,7 @@ let funcOnSomeRecord
     secondArg => firstFieldInRecord + secondField;
 
 type simpleTupleVariant =
-  | SimpleActuallyATuple of (int, int);
+  | SimpleActuallyATuple (int, int);
 
 let returnTheSimpleTupleVariant i =>
   SimpleActuallyATuple (i, i);
@@ -2128,7 +2128,7 @@ type recursiveType =
   /* First variant of first mutually recursive */
   | Blah
   /* Second variant of first mutually recursive */
-  | Another of (option anotherRecursiveType)
+  | Another (option anotherRecursiveType)
 /*
  * Commenting second of two mutually recursive types.
  */
@@ -2136,7 +2136,7 @@ and anotherRecursiveType =
   /* Second variant of second mutually recursive */
   | Baz
   /* Second variant of second mutually recursive */
-  | Recursive of (option recursiveType);
+  | Recursive (option recursiveType);
 
 
 /**
@@ -2144,21 +2144,21 @@ and anotherRecursiveType =
  */
 type term _ =
   /* First variant leaf of GADT */
-  | Int of
+  | Int
       /*first var arg */
       int
       :/* First GADT res */
        term
          int
   /* Second variant leaf of GADT */
-  | Float of
+  | Float
       /*second var arg */
       int
       :/* Second GADT res */
        term
          int
   /* Third variant leaf of GADT */
-  | Bool of
+  | Bool
       /*third var arg */
       int
       :/* Third GADT res */
@@ -2170,7 +2170,7 @@ type commentedTypeDef =
   /*
    * Commenting first variant member.
    */
-  | First of (
+  | First (
       /* First field of tuple in first variant member */
       int,
       /* Second field of tuple in first variant member */
@@ -2179,18 +2179,17 @@ type commentedTypeDef =
   /*
    * Commenting second variant member.
    */
-  | Second of int
+  | Second int
   /*
    * Commenting third variant member.
    */
-  | Third of (
+  | Third (
       list
         /* Commenting deep in type def */
         (list int)
     );
 
-type colors =
-  | Red of int | Black of int | Green of int;
+type colors = | Red int | Black int | Green int;
 
 let blah arg =>
   switch arg {
@@ -2225,9 +2224,9 @@ let blahCurriedX x =>
   | Green x => 0;
 
 type reallyLongVariantNames =
-  | ReallyLongVariantName of recordWithLong
-  | AnotherReallyLongVariantName of int int int
-  | AnotherReallyLongVariantName2 of int int int;
+  | ReallyLongVariantName recordWithLong
+  | AnotherReallyLongVariantName int int int
+  | AnotherReallyLongVariantName2 int int int;
 
 let howDoLongMultiBarPatternsWrap x =>
   switch x {
@@ -2271,10 +2270,10 @@ let letsPutAWhereClauseOnTheLast x =>
   };
 
 type wrappingGadt _ =
-  | ThisIsLongSoTypeWillWrap of
+  | ThisIsLongSoTypeWillWrap
       int :wrappingGadt int
   | Add :wrappingGadt (int => int => int)
-  | App of
+  | App
       (wrappingGadt ('b => 'a))
       (wrappingGadt 'b)
       :wrappingGadt 'a;

--- a/formatTest/unit_tests/input/basicStructures.re
+++ b/formatTest/unit_tests/input/basicStructures.re
@@ -301,7 +301,7 @@ let nestedMatchWithWhen lstLst => switch lstLst {
 /**
  * Aliasing with "as" during matches.
  */
-type mine = MyThing of int | YourThing of int;
+type mine = MyThing int | YourThing int;
 /*
  * Reason parses "as" aliases differently than OCaml.
  */

--- a/formatTest/unit_tests/input/modules.re
+++ b/formatTest/unit_tests/input/modules.re
@@ -319,10 +319,10 @@ let module ReturnsAFunctor2 (A:ASig) (B:BSig): (ASig => BSig => SigResult) =>
  * TODO: Test [Psig_recmodule]
  */
 let module rec A : {
-  type t = Leaf of string | Node of ASet.t;
+  type t = Leaf string | Node ASet.t;
   let compare: t => t => int;
 } = {
-  type t = Leaf of string | Node of ASet.t;
+  type t = Leaf string | Node ASet.t;
   let compare t1 t2 => switch (t1, t2) {
     | (Leaf s1, Leaf s2) => Pervasives.compare s1 s2
     | (Leaf _, Node _) => 1
@@ -338,7 +338,7 @@ and ASet: Set.S with type elt = A.t = Set.Make A;
  */
 module type HasRecursiveModules = {
   let module rec A: {
-    type t = | Leaf of string | Node of ASet.t;
+    type t = | Leaf string | Node ASet.t;
     let compare: t => t => int;
   }
   and ASet: Set.S with type elt = A.t;

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -133,15 +133,15 @@ type semiLongWrappingTypeWithConstraint =
 type onelineConstrain = 'a constraint 'a = int;
 
 /* This must be in trunk but not in this branch of OCaml */
-/* type withNestedRecords = MyConstructor of {myField: int} */
+/* type withNestedRecords = MyConstructor {myField: int} */
 
 type colors =
-  | Red of int
-  | Black of int
-  | Green of int;
+  | Red int
+  | Black int
+  | Green int;
 
 /* Another approach is to require declared variants to wrap any record */
-/* type myRecord = MyRecord of {name: int}; */
+/* type myRecord = MyRecord {name: int}; */
 /* let myValue = MyRecord {name: int}; */
 /* This would force importing of the module */
 /* This would also lend itself naturally to pattern matching - and avoid having
@@ -592,9 +592,9 @@ type stillARecord = {name: string, age: int};
 
 /* Rebase latest OCaml to get the following: And fixup
   `generalized_constructor_arguments` according to master. */
-/* type ('a, 'b) myOtherThing = Leaf of {first:'a, second: 'b} | Null; */
+/* type ('a, 'b) myOtherThing = Leaf {first:'a, second: 'b} | Null; */
 type branch 'a 'b = {first: 'a, second: 'b};
-type myOtherThing 'a 'b = Leaf of (branch 'a 'b) | Null;
+type myOtherThing 'a 'b = Leaf (branch 'a 'b) | Null;
 
 type yourThing = myOtherThing int int;
 

--- a/formatTest/unit_tests/input/variants.re
+++ b/formatTest/unit_tests/input/variants.re
@@ -3,16 +3,16 @@
 let module LocalModule = {
   type accessedThroughModule = | AccessedThroughModule;
   type accessedThroughModuleWithArg =
-    | AccessedThroughModuleWith of int | AccessedThroughModuleWithTwo of int int;
+    | AccessedThroughModuleWith int | AccessedThroughModuleWithTwo int int;
 };
 
-type notTupleVariant = | NotActuallyATuple of int int;
+type notTupleVariant = | NotActuallyATuple int int;
 
-type notTupleVariantExtraParens = | NotActuallyATuple2 of int int;
+type notTupleVariantExtraParens = | NotActuallyATuple2 int int;
 
-type simpleTupleVariant = | SimpleActuallyATuple of (int, int);
+type simpleTupleVariant = | SimpleActuallyATuple (int, int);
 
-type tupleVariant = | ActuallyATuple of (int, int);
+type tupleVariant = | ActuallyATuple (int, int);
 
 let intTuple = (20, 20);
 
@@ -41,7 +41,7 @@ let yesTupled: tupleVariant = ActuallyATuple (10, 10);
 
 let yesTupled: tupleVariant = ActuallyATuple intTuple;
 
-type threeForms = | FormOne of int | FormTwo of int | FormThree;
+type threeForms = | FormOne int | FormTwo int | FormThree;
 
 let doesntCareWhichForm x => switch x {
   | FormOne q
@@ -62,8 +62,8 @@ type colorList1 = [
 ];
 
 type colorList = [<
-  | `Red of (int, int) &int
-  | `Black of &(int, int) &int
+  | `Red (int, int) &int
+  | `Black &(int, int) &int
   | `Blue
   > `Red `Black
 ];
@@ -125,7 +125,7 @@ let run () => {
   Printf.printf "%d %d \n" x y;
 };
 
-type combination 'a = | HeresTwoConstructorArguments of int int;
+type combination 'a = | HeresTwoConstructorArguments int int;
 
 /** But then how do we parse matches in function arguments? */
 /* We must require parenthesis around construction matching in function args only*/
@@ -138,18 +138,18 @@ let matchingTwoCurriedConstructorsInTuple x => switch x {
   | (HeresTwoConstructorArguments x y, HeresTwoConstructorArguments a b) => x + y + a + b
 };
 
-type twoCurriedConstructors = | TwoCombos of (combination int) (combination int);
+type twoCurriedConstructors = | TwoCombos (combination int) (combination int);
 
 let matchingTwoCurriedConstructorInConstructor x => switch x {
   | TwoCombos (HeresTwoConstructorArguments x y) (HeresTwoConstructorArguments a b) => a + b + x + y
 };
 
-type twoCurriedConstructorsPolyMorphic 'a = | TwoCombos of (combination 'a) (combination 'a);
+type twoCurriedConstructorsPolyMorphic 'a = | TwoCombos (combination 'a) (combination 'a);
 
 /* Matching records */
 type pointRecord = {x: int, y: int};
 
-type alsoHasARecord = | Blah | AlsoHasARecord of int int pointRecord;
+type alsoHasARecord = | Blah | AlsoHasARecord int int pointRecord;
 
 let result = switch (AlsoHasARecord 10 10 {x: 10, y: 20}) {
   | Blah => 1000
@@ -174,7 +174,7 @@ let thisWontCompileButLetsSeeHowItFormats = fun | Zero
  * GADTs.
  */
 type term _ =
-  | Int of int : term int | Add : term (int => int => int) | App of (term ('b => 'a)) (term 'b) : term 'a;
+  | Int int : term int | Add : term (int => int => int) | App (term ('b => 'a)) (term 'b) : term 'a;
 
 let rec eval: type a. (term a) => a =
   fun | Int n => n
@@ -197,7 +197,7 @@ let evalArg = App (App Add (Int 1)) (Int 1);
 
 let two = eval (App (App Add (Int 1)) (Int 1));
 
-type someVariant = | Purple of int | Yellow of int;
+type someVariant = | Purple int | Yellow int;
 
 let Purple x | Yellow x = switch (Yellow 100, Purple 101) {
   | (Yellow y, Purple p) => Yellow (p + y)
@@ -206,7 +206,7 @@ let Purple x | Yellow x = switch (Yellow 100, Purple 101) {
   | (Yellow p, Yellow y) => Purple (y + p)
 };
 
-type tuples = | Zero | One of int | Two of int int | OneTuple of (int, int);
+type tuples = | Zero | One int | Two int int | OneTuple (int, int);
 
 let myTuple = OneTuple (20, 30);
 
@@ -221,7 +221,7 @@ let res = switch myTuple {
            }
 };
 
-/* FIXME type somePolyVariant = [ `Purple of int | `Yellow of int]; */
+/* FIXME type somePolyVariant = [ `Purple int | `Yellow int]; */
 
 let ylw = `Yellow (100, 100);
 

--- a/formatTest/unit_tests/input/wrappingTest.re
+++ b/formatTest/unit_tests/input/wrappingTest.re
@@ -1427,14 +1427,14 @@ type x = private int;
 type myType 'a 'b 'c = private ('a, 'b, 'c);
 
 type privateVariant = private
-  | BigSize of int
-  | SmallSize of int;
+  | BigSize int
+  | SmallSize int;
 
 type doubleEqualsDoublePrivateVariant =
   privateVariant =
   private
-    | BigSize of int
-    | SmallSize of int;
+    | BigSize int
+    | SmallSize int;
 
 type myRecordWithReallyLongName = {xx:int, yy:int};
 type doubleEqualsRecord = myRecordWithReallyLongName = {xx:int, yy:int};
@@ -1442,7 +1442,7 @@ type doubleEqualsDoublePrivateRecord = myRecordWithReallyLongName = private {xx:
 
 
 
-type someConstructor = SomeConstructorHi of int int;
+type someConstructor = SomeConstructorHi int int;
 type someRecord = {firstFieldInRecord: int, secondField: int};
 
 /*
@@ -1495,7 +1495,7 @@ let funcOnSomeRecord
 
 
 type simpleTupleVariant =
-  SimpleActuallyATuple of (int, int);
+  SimpleActuallyATuple (int, int);
 
 let returnTheSimpleTupleVariant i =>
   SimpleActuallyATuple (i, i);
@@ -1517,7 +1517,7 @@ type recursiveType =
   /* First variant of first mutually recursive */
   | Blah
   /* Second variant of first mutually recursive */
-  | Another of (option anotherRecursiveType)
+  | Another (option anotherRecursiveType)
 
 /*
  * Commenting second of two mutually recursive types.
@@ -1526,18 +1526,18 @@ and anotherRecursiveType =
   /* Second variant of second mutually recursive */
   | Baz
   /* Second variant of second mutually recursive */
-  | Recursive of (option recursiveType);
+  | Recursive (option recursiveType);
 
 /**
  * Commented GADT definition.
  */
 type term _ =
   /* First variant leaf of GADT */
-  | Int of /*first var arg */ int : /* First GADT res */ term int
+  | Int /*first var arg */ int : /* First GADT res */ term int
   /* Second variant leaf of GADT */
-  | Float of /*second var arg */ int : /* Second GADT res */ term int
+  | Float /*second var arg */ int : /* Second GADT res */ term int
   /* Third variant leaf of GADT */
-  | Bool of /*third var arg */ int : /* Third GADT res */ term int;
+  | Bool /*third var arg */ int : /* Third GADT res */ term int;
 
 
 /* Commented colors */
@@ -1545,7 +1545,7 @@ type commentedTypeDef =
   /*
    * Commenting first variant member.
    */
-  | First of (
+  | First (
     /* First field of tuple in first variant member */
     int,
     /* Second field of tuple in first variant member */
@@ -1554,20 +1554,20 @@ type commentedTypeDef =
   /*
    * Commenting second variant member.
    */
-  | Second of int
+  | Second int
   /*
    * Commenting third variant member.
    */
-  | Third of (
+  | Third (
       list
         /* Commenting deep in type def */
         (list int)
     );
 
 type colors =
-  | Red of int
-  | Black of int
-  | Green of int;
+  | Red int
+  | Black int
+  | Green int;
 
 let blah = fun arg => switch arg {
   /* Comment before Bar */
@@ -1599,9 +1599,9 @@ let blahCurriedX x => fun
 
 
 type reallyLongVariantNames =
-  | ReallyLongVariantName of recordWithLong
-  | AnotherReallyLongVariantName of int int int
-  | AnotherReallyLongVariantName2 of int int int;
+  | ReallyLongVariantName recordWithLong
+  | AnotherReallyLongVariantName int int int
+  | AnotherReallyLongVariantName2 int int int;
 
 let howDoLongMultiBarPatternsWrap = fun x => switch x {
   | AnotherReallyLongVariantName _ _ _ => 0
@@ -1633,10 +1633,10 @@ let letsPutAWhereClauseOnTheLast x =>
 
 
 type wrappingGadt _ =
-  | ThisIsLongSoTypeWillWrap of int
+  | ThisIsLongSoTypeWillWrap int
     :wrappingGadt int
   | Add :wrappingGadt (int => int => int)
-  | App of
+  | App
       (wrappingGadt ('b => 'a)) (wrappingGadt 'b)
       :wrappingGadt 'a;
 

--- a/src/reason_lexer.mll
+++ b/src/reason_lexer.mll
@@ -103,7 +103,6 @@ let keyword_table =
     "new", NEW;
     "nonrec", NONREC;
     "object", OBJECT;
-    "of", OF;
     "open", OPEN;
     "or", OR;
 (*  "parser", PARSER; *)

--- a/src/reason_parser.messages
+++ b/src/reason_parser.messages
@@ -1,6 +1,6 @@
 use_file: SHARP LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2664.
+## Ends in an error in state: 2656.
 ##
 ## _use_file -> toplevel_directive SEMI . use_file [ # ]
 ##
@@ -12,7 +12,7 @@ use_file: SHARP LIDENT SEMI WITH
 
 use_file: SHARP LIDENT TRUE WITH
 ##
-## Ends in an error in state: 2663.
+## Ends in an error in state: 2655.
 ##
 ## _use_file -> toplevel_directive . SEMI use_file [ # ]
 ## _use_file -> toplevel_directive . EOF [ # ]
@@ -25,7 +25,7 @@ use_file: SHARP LIDENT TRUE WITH
 
 use_file: UIDENT RPAREN
 ##
-## Ends in an error in state: 2666.
+## Ends in an error in state: 2658.
 ##
 ## _use_file -> structure_item . SEMI use_file [ # ]
 ## _use_file -> structure_item . EOF [ # ]
@@ -37,28 +37,28 @@ use_file: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1522, spurious reduction of production post_item_attributes ->
-## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1519, spurious reduction of production post_item_attributes ->
+## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 use_file: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2667.
+## Ends in an error in state: 2659.
 ##
 ## _use_file -> structure_item SEMI . use_file [ # ]
 ##
@@ -70,7 +70,7 @@ use_file: UIDENT SEMI WITH
 
 use_file: WITH
 ##
-## Ends in an error in state: 2660.
+## Ends in an error in state: 2652.
 ##
 ## use_file' -> . use_file [ # ]
 ##
@@ -82,7 +82,7 @@ use_file: WITH
 
 toplevel_phrase: SHARP UIDENT EOF
 ##
-## Ends in an error in state: 2655.
+## Ends in an error in state: 2647.
 ##
 ## _toplevel_phrase -> toplevel_directive . SEMI [ # ]
 ##
@@ -93,14 +93,14 @@ toplevel_phrase: SHARP UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2645, spurious reduction of production toplevel_directive -> SHARP ident
+## In state 2637, spurious reduction of production toplevel_directive -> SHARP ident
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 ##
-## Ends in an error in state: 2652.
+## Ends in an error in state: 2644.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ SEMI EOF DOT ]
 ## val_longident -> mod_longident DOT . val_ident [ SEMI EOF ]
@@ -113,7 +113,7 @@ toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 
 toplevel_phrase: SHARP UIDENT UIDENT WITH
 ##
-## Ends in an error in state: 2651.
+## Ends in an error in state: 2643.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ SEMI EOF DOT ]
 ## toplevel_directive -> SHARP ident mod_longident . [ SEMI EOF ]
@@ -127,7 +127,7 @@ toplevel_phrase: SHARP UIDENT UIDENT WITH
 
 toplevel_phrase: SHARP UIDENT WITH
 ##
-## Ends in an error in state: 2645.
+## Ends in an error in state: 2637.
 ##
 ## toplevel_directive -> SHARP ident . [ SEMI EOF ]
 ## toplevel_directive -> SHARP ident . STRING [ SEMI EOF ]
@@ -145,7 +145,7 @@ toplevel_phrase: SHARP UIDENT WITH
 
 toplevel_phrase: SHARP WITH
 ##
-## Ends in an error in state: 2644.
+## Ends in an error in state: 2636.
 ##
 ## toplevel_directive -> SHARP . ident [ SEMI EOF ]
 ## toplevel_directive -> SHARP . ident STRING [ SEMI EOF ]
@@ -163,7 +163,7 @@ toplevel_phrase: SHARP WITH
 
 toplevel_phrase: UIDENT RPAREN
 ##
-## Ends in an error in state: 2657.
+## Ends in an error in state: 2649.
 ##
 ## _toplevel_phrase -> structure_item . SEMI [ # ]
 ##
@@ -174,28 +174,28 @@ toplevel_phrase: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1522, spurious reduction of production post_item_attributes ->
-## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1519, spurious reduction of production post_item_attributes ->
+## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: WITH
 ##
-## Ends in an error in state: 2643.
+## Ends in an error in state: 2635.
 ##
 ## toplevel_phrase' -> . toplevel_phrase [ # ]
 ##
@@ -207,7 +207,7 @@ toplevel_phrase: WITH
 
 parse_pattern: EXCEPTION UNDERSCORE WITH
 ##
-## Ends in an error in state: 781.
+## Ends in an error in state: 777.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -224,7 +224,7 @@ parse_pattern: EXCEPTION UNDERSCORE WITH
 
 parse_pattern: EXCEPTION WITH
 ##
-## Ends in an error in state: 779.
+## Ends in an error in state: 775.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -236,7 +236,7 @@ parse_pattern: EXCEPTION WITH
 
 parse_pattern: LAZY WITH
 ##
-## Ends in an error in state: 763.
+## Ends in an error in state: 759.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -248,7 +248,7 @@ parse_pattern: LAZY WITH
 
 parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ##
-## Ends in an error in state: 824.
+## Ends in an error in state: 820.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error RBRACE COMMA BAR ]
 ## lbl_pattern -> label_longident COLON pattern . [ error RBRACE COMMA ]
@@ -260,14 +260,14 @@ parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 717, spurious reduction of production pattern -> pattern_without_or
+## In state 713, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 675.
+## Ends in an error in state: 671.
 ##
 ## lbl_pattern -> label_longident COLON . pattern [ error RBRACE COMMA ]
 ##
@@ -279,7 +279,7 @@ parse_pattern: LBRACE LIDENT COLON WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 760.
+## Ends in an error in state: 756.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -292,7 +292,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 670.
+## Ends in an error in state: 666.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA UNDERSCORE . opt_comma [ error RBRACE ]
 ##
@@ -304,7 +304,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 
 parse_pattern: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 669.
+## Ends in an error in state: 665.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA . [ error RBRACE ]
 ## lbl_pattern_list -> lbl_pattern COMMA . UNDERSCORE opt_comma [ error RBRACE ]
@@ -318,7 +318,7 @@ parse_pattern: LBRACE LIDENT COMMA WITH
 
 parse_pattern: LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 674.
+## Ends in an error in state: 670.
 ##
 ## lbl_pattern -> label_longident . COLON pattern [ error RBRACE COMMA ]
 ## lbl_pattern -> label_longident . [ error RBRACE COMMA ]
@@ -331,7 +331,7 @@ parse_pattern: LBRACE LIDENT WITH
 
 parse_pattern: LBRACE UIDENT DOT WITH
 ##
-## Ends in an error in state: 663.
+## Ends in an error in state: 659.
 ##
 ## label_longident -> mod_longident DOT . LIDENT [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident DOT . UIDENT [ DOT ]
@@ -344,7 +344,7 @@ parse_pattern: LBRACE UIDENT DOT WITH
 
 parse_pattern: LBRACE UIDENT WITH
 ##
-## Ends in an error in state: 662.
+## Ends in an error in state: 658.
 ##
 ## label_longident -> mod_longident . DOT LIDENT [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident . DOT UIDENT [ DOT ]
@@ -357,7 +357,7 @@ parse_pattern: LBRACE UIDENT WITH
 
 parse_pattern: LBRACE WITH
 ##
-## Ends in an error in state: 759.
+## Ends in an error in state: 755.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -370,7 +370,7 @@ parse_pattern: LBRACE WITH
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 756.
+## Ends in an error in state: 752.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET BAR ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT pattern . [ error SEMI RBRACKET ]
@@ -382,14 +382,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 717, spurious reduction of production pattern -> pattern_without_or
+## In state 713, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT WITH
 ##
-## Ends in an error in state: 755.
+## Ends in an error in state: 751.
 ##
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT . pattern [ error SEMI RBRACKET ]
 ##
@@ -401,7 +401,7 @@ Expecting a valid list identifier
 
 parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 757.
+## Ends in an error in state: 753.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ COMMA ]
@@ -414,14 +414,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 717, spurious reduction of production pattern -> pattern_without_or
+## In state 713, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 754.
+## Ends in an error in state: 750.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ COMMA ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA . DOTDOTDOT pattern [ error SEMI RBRACKET ]
@@ -435,7 +435,7 @@ parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKET UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 758.
+## Ends in an error in state: 754.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern . [ COMMA ]
@@ -448,14 +448,14 @@ parse_pattern: LBRACKET UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 717, spurious reduction of production pattern -> pattern_without_or
+## In state 713, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 750.
+## Ends in an error in state: 746.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -468,7 +468,7 @@ parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LBRACKET WITH
 ##
-## Ends in an error in state: 747.
+## Ends in an error in state: 743.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -482,7 +482,7 @@ parse_pattern: LBRACKET WITH
 
 parse_pattern: LBRACKETBAR MINUS WITH
 ##
-## Ends in an error in state: 658.
+## Ends in an error in state: 654.
 ##
 ## signed_constant -> MINUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> MINUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -498,7 +498,7 @@ parse_pattern: LBRACKETBAR MINUS WITH
 
 parse_pattern: LBRACKETBAR PLUS WITH
 ##
-## Ends in an error in state: 657.
+## Ends in an error in state: 653.
 ##
 ## signed_constant -> PLUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> PLUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -514,7 +514,7 @@ parse_pattern: LBRACKETBAR PLUS WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 737.
+## Ends in an error in state: 733.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -526,14 +526,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 717, spurious reduction of production pattern -> pattern_without_or
+## In state 713, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 736.
+## Ends in an error in state: 732.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ error SEMI COMMA BARRBRACKET ]
 ##
@@ -545,7 +545,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 746.
+## Ends in an error in state: 742.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -557,14 +557,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 717, spurious reduction of production pattern -> pattern_without_or
+## In state 713, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 743.
+## Ends in an error in state: 739.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -577,7 +577,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LBRACKETBAR WITH
 ##
-## Ends in an error in state: 732.
+## Ends in an error in state: 728.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -591,7 +591,7 @@ parse_pattern: LBRACKETBAR WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 2431.
+## Ends in an error in state: 2428.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -609,7 +609,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 2430.
+## Ends in an error in state: 2427.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -622,7 +622,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2429.
+## Ends in an error in state: 2426.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -640,7 +640,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2428.
+## Ends in an error in state: 2425.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -653,7 +653,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2427.
+## Ends in an error in state: 2424.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -666,7 +666,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2426.
+## Ends in an error in state: 2423.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -679,7 +679,7 @@ parse_pattern: LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN EXCEPTION UNDERSCORE WITH
 ##
-## Ends in an error in state: 692.
+## Ends in an error in state: 688.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -696,7 +696,7 @@ parse_pattern: LPAREN EXCEPTION UNDERSCORE WITH
 
 parse_pattern: LPAREN EXCEPTION WITH
 ##
-## Ends in an error in state: 684.
+## Ends in an error in state: 680.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -708,7 +708,7 @@ parse_pattern: LPAREN EXCEPTION WITH
 
 parse_pattern: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 676.
+## Ends in an error in state: 672.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -720,7 +720,7 @@ parse_pattern: LPAREN LAZY WITH
 
 parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 665.
+## Ends in an error in state: 661.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -733,7 +733,7 @@ parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 660.
+## Ends in an error in state: 656.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -746,7 +746,7 @@ parse_pattern: LPAREN LBRACE WITH
 
 parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 826.
+## Ends in an error in state: 822.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -759,7 +759,7 @@ parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LPAREN LBRACKET WITH
 ##
-## Ends in an error in state: 659.
+## Ends in an error in state: 655.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -773,7 +773,7 @@ parse_pattern: LPAREN LBRACKET WITH
 
 parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 831.
+## Ends in an error in state: 827.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -786,7 +786,7 @@ parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LPAREN LBRACKETBAR WITH
 ##
-## Ends in an error in state: 656.
+## Ends in an error in state: 652.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -800,7 +800,7 @@ parse_pattern: LPAREN LBRACKETBAR WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 839.
+## Ends in an error in state: 835.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -818,7 +818,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCOR
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 838.
+## Ends in an error in state: 834.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -831,7 +831,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 837.
+## Ends in an error in state: 833.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -849,7 +849,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 836.
+## Ends in an error in state: 832.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -862,7 +862,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 835.
+## Ends in an error in state: 831.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -875,7 +875,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 834.
+## Ends in an error in state: 830.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -888,7 +888,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 644.
+## Ends in an error in state: 640.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -901,7 +901,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 642.
+## Ends in an error in state: 638.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -915,7 +915,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 
 parse_pattern: LPAREN LPAREN MODULE WITH
 ##
-## Ends in an error in state: 641.
+## Ends in an error in state: 637.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -929,7 +929,7 @@ parse_pattern: LPAREN LPAREN MODULE WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 818.
+## Ends in an error in state: 814.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -944,7 +944,7 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 729.
+## Ends in an error in state: 725.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -962,17 +962,17 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 804, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
-## In state 811, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 810, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 814, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 800, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
+## In state 807, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 806, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 810, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 640.
+## Ends in an error in state: 636.
 ##
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -996,7 +996,7 @@ parse_pattern: LPAREN LPAREN WITH
 
 parse_pattern: LPAREN MINUS WITH
 ##
-## Ends in an error in state: 634.
+## Ends in an error in state: 630.
 ##
 ## operator -> MINUS . [ RPAREN ]
 ## signed_constant -> MINUS . INT [ error RPAREN LBRACKETAT DOTDOT COMMA COLONCOLON COLON BAR AS ]
@@ -1026,7 +1026,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 234, spurious reduction of production ident -> UIDENT
-## In state 652, spurious reduction of production mty_longident -> ident
+## In state 648, spurious reduction of production mty_longident -> ident
 ##
 
 <SYNTAX ERROR>
@@ -1047,7 +1047,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WHILE
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2424.
+## Ends in an error in state: 2421.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ error RPAREN ]
 ##
@@ -1059,7 +1059,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2423.
+## Ends in an error in state: 2420.
 ##
 ## package_type_cstrs -> package_type_cstr . [ error RPAREN ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ error RPAREN ]
@@ -1077,7 +1077,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 ## In state 445, spurious reduction of production _core_type -> core_type2
 ## In state 454, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 444, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2421, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 2418, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
@@ -1236,7 +1236,7 @@ parse_pattern: LPAREN SHARP WITH
 
 parse_pattern: LPAREN STRING DOTDOT WITH
 ##
-## Ends in an error in state: 689.
+## Ends in an error in state: 685.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ##
@@ -1248,7 +1248,7 @@ parse_pattern: LPAREN STRING DOTDOT WITH
 
 parse_pattern: LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 698.
+## Ends in an error in state: 694.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ error WITH UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS AND ]
 ##
@@ -1260,7 +1260,7 @@ parse_pattern: LPAREN UIDENT DOT WITH
 
 parse_pattern: LPAREN UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 677.
+## Ends in an error in state: 673.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1282,7 +1282,7 @@ parse_pattern: LPAREN UIDENT LPAREN WITH
 
 parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 708.
+## Ends in an error in state: 704.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1295,7 +1295,7 @@ parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE AS LPAREN WITH
 ##
-## Ends in an error in state: 723.
+## Ends in an error in state: 719.
 ##
 ## val_ident -> LPAREN . operator RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -1307,7 +1307,7 @@ parse_pattern: LPAREN UNDERSCORE AS LPAREN WITH
 
 parse_pattern: LPAREN UNDERSCORE AS WITH
 ##
-## Ends in an error in state: 721.
+## Ends in an error in state: 717.
 ##
 ## _pattern_without_or -> pattern_without_or AS . val_ident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> pattern_without_or AS . error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -1320,7 +1320,7 @@ parse_pattern: LPAREN UNDERSCORE AS WITH
 
 parse_pattern: LPAREN UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 738.
+## Ends in an error in state: 734.
 ##
 ## _or_pattern -> pattern BAR . pattern [ error SEMI RPAREN RBRACKET RBRACE COMMA COLON BARRBRACKET BAR ]
 ##
@@ -1345,7 +1345,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BACKQUOTE LIDENT GREATER
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 160, spurious reduction of production attributes ->
-## In state 2528, spurious reduction of production tag_field -> name_tag attributes
+## In state 2525, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
@@ -1555,7 +1555,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LESS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2419.
+## Ends in an error in state: 2416.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1774,7 +1774,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 847.
+## Ends in an error in state: 843.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1789,7 +1789,7 @@ parse_pattern: LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 720.
+## Ends in an error in state: 716.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -1806,7 +1806,7 @@ parse_pattern: LPAREN UNDERSCORE COLONCOLON UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLONCOLON WITH
 ##
-## Ends in an error in state: 718.
+## Ends in an error in state: 714.
 ##
 ## _pattern_without_or -> pattern_without_or COLONCOLON . pattern_without_or [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> pattern_without_or COLONCOLON . error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -1819,7 +1819,7 @@ parse_pattern: LPAREN UNDERSCORE COLONCOLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 731.
+## Ends in an error in state: 727.
 ##
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1831,7 +1831,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 803.
+## Ends in an error in state: 799.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ RPAREN COMMA ]
 ##
@@ -1843,7 +1843,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ##
-## Ends in an error in state: 842.
+## Ends in an error in state: 838.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -1855,18 +1855,18 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production pattern -> pattern_without_or
-## In state 802, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 811, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 810, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 814, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 787, spurious reduction of production pattern -> pattern_without_or
+## In state 798, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 807, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 806, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 810, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 813.
+## Ends in an error in state: 809.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1878,7 +1878,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 812.
+## Ends in an error in state: 808.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint . COMMA pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1889,10 +1889,10 @@ parse_pattern: LPAREN UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 717, spurious reduction of production pattern -> pattern_without_or
-## In state 844, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 811, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 810, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 713, spurious reduction of production pattern -> pattern_without_or
+## In state 840, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 807, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 806, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
 ##
 
 <SYNTAX ERROR>
@@ -1967,7 +1967,7 @@ parse_pattern: SHARP WITH
 
 parse_pattern: STRING DOTDOT WITH
 ##
-## Ends in an error in state: 768.
+## Ends in an error in state: 764.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ##
@@ -1979,7 +1979,7 @@ parse_pattern: STRING DOTDOT WITH
 
 parse_pattern: UIDENT DOT WITH
 ##
-## Ends in an error in state: 596.
+## Ends in an error in state: 592.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ WITH WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS AND ]
 ##
@@ -1991,7 +1991,7 @@ parse_pattern: UIDENT DOT WITH
 
 parse_pattern: UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 632.
+## Ends in an error in state: 628.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -2013,7 +2013,7 @@ parse_pattern: UIDENT LPAREN WITH
 
 parse_pattern: UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 787.
+## Ends in an error in state: 783.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -2026,7 +2026,7 @@ parse_pattern: UIDENT UNDERSCORE WITH
 
 parse_pattern: UNDERSCORE AS WITH
 ##
-## Ends in an error in state: 795.
+## Ends in an error in state: 791.
 ##
 ## _pattern_without_or -> pattern_without_or AS . val_ident [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> pattern_without_or AS . error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -2039,7 +2039,7 @@ parse_pattern: UNDERSCORE AS WITH
 
 parse_pattern: UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 805.
+## Ends in an error in state: 801.
 ##
 ## _or_pattern -> pattern BAR . pattern [ WHEN SEMI RPAREN RBRACKET IN EQUALGREATER EQUAL EOF COMMA COLON BAR ]
 ##
@@ -2051,7 +2051,7 @@ parse_pattern: UNDERSCORE BAR WITH
 
 parse_pattern: UNDERSCORE COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 794.
+## Ends in an error in state: 790.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -2068,7 +2068,7 @@ parse_pattern: UNDERSCORE COLONCOLON UNDERSCORE WITH
 
 parse_pattern: UNDERSCORE COLONCOLON WITH
 ##
-## Ends in an error in state: 792.
+## Ends in an error in state: 788.
 ##
 ## _pattern_without_or -> pattern_without_or COLONCOLON . pattern_without_or [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> pattern_without_or COLONCOLON . error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -2081,7 +2081,7 @@ parse_pattern: UNDERSCORE COLONCOLON WITH
 
 parse_pattern: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2640.
+## Ends in an error in state: 2632.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EOF BAR ]
 ## parse_pattern -> pattern . EOF [ # ]
@@ -2093,14 +2093,14 @@ parse_pattern: UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production pattern -> pattern_without_or
+## In state 787, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: WITH
 ##
-## Ends in an error in state: 2639.
+## Ends in an error in state: 2631.
 ##
 ## parse_pattern' -> . parse_pattern [ # ]
 ##
@@ -2112,7 +2112,7 @@ parse_pattern: WITH
 
 parse_expression: UIDENT SEMI
 ##
-## Ends in an error in state: 2637.
+## Ends in an error in state: 2629.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -2146,21 +2146,21 @@ parse_expression: UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 parse_expression: WITH
 ##
-## Ends in an error in state: 2635.
+## Ends in an error in state: 2627.
 ##
 ## parse_expression' -> . parse_expression [ # ]
 ##
@@ -2172,7 +2172,7 @@ parse_expression: WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 2522.
+## Ends in an error in state: 2519.
 ##
 ## tag_field -> name_tag opt_ampersand . amper_type_list attributes [ RBRACKET GREATER BAR ]
 ##
@@ -2184,7 +2184,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 ##
-## Ends in an error in state: 2525.
+## Ends in an error in state: 2522.
 ##
 ## amper_type_list -> amper_type_list AMPERSAND . core_type [ RBRACKET LBRACKETAT GREATER BAR AMPERSAND ]
 ##
@@ -2196,7 +2196,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ##
-## Ends in an error in state: 2529.
+## Ends in an error in state: 2526.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET tag_field . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field -> tag_field . [ BAR ]
@@ -2209,7 +2209,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 160, spurious reduction of production attributes ->
-## In state 2528, spurious reduction of production tag_field -> name_tag attributes
+## In state 2525, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
@@ -2241,7 +2241,7 @@ parse_core_type: LBRACKET BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 2533.
+## Ends in an error in state: 2530.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2254,7 +2254,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 2532.
+## Ends in an error in state: 2529.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2266,7 +2266,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE WITH
 ##
-## Ends in an error in state: 2531.
+## Ends in an error in state: 2528.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field . BAR row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2304,7 +2304,7 @@ parse_core_type: LBRACKETGREATER BAR ASSERT
 
 parse_core_type: LBRACKETGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 2535.
+## Ends in an error in state: 2532.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2355,7 +2355,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2540.
+## Ends in an error in state: 2537.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER name_tag_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## name_tag_list -> name_tag_list . name_tag [ RBRACKET BACKQUOTE ]
@@ -2368,7 +2368,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 ##
-## Ends in an error in state: 2539.
+## Ends in an error in state: 2536.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER . name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2380,7 +2380,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE WITH
 ##
-## Ends in an error in state: 2537.
+## Ends in an error in state: 2534.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . GREATER name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2432,7 +2432,7 @@ parse_core_type: LESS LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 ##
-## Ends in an error in state: 498.
+## Ends in an error in state: 495.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ##
@@ -2444,7 +2444,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 495.
+## Ends in an error in state: 492.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -2457,7 +2457,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE WITH
 ##
-## Ends in an error in state: 496.
+## Ends in an error in state: 493.
 ##
 ## typevar_list -> typevar_list QUOTE . ident [ QUOTE DOT ]
 ##
@@ -2500,11 +2500,11 @@ parse_core_type: LESS LIDENT COLON UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 505, spurious reduction of production _poly_type -> core_type
-## In state 506, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 504, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 2542, spurious reduction of production attributes ->
-## In state 2543, spurious reduction of production field -> label COLON poly_type attributes
+## In state 502, spurious reduction of production _poly_type -> core_type
+## In state 503, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 501, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 2539, spurious reduction of production attributes ->
+## In state 2540, spurious reduction of production field -> label COLON poly_type attributes
 ##
 
 <SYNTAX ERROR>
@@ -2547,7 +2547,7 @@ parse_core_type: LESS WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2548.
+## Ends in an error in state: 2545.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2559,7 +2559,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 ##
-## Ends in an error in state: 2546.
+## Ends in an error in state: 2543.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2571,7 +2571,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 ##
-## Ends in an error in state: 2545.
+## Ends in an error in state: 2542.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION . EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2583,7 +2583,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2544.
+## Ends in an error in state: 2541.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . QUESTION EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2675,7 +2675,7 @@ parse_core_type: LPAREN MODULE UIDENT SEMI
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2553.
+## Ends in an error in state: 2550.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ RPAREN COLONGREATER ]
 ##
@@ -2687,7 +2687,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER A
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2552.
+## Ends in an error in state: 2549.
 ##
 ## package_type_cstrs -> package_type_cstr . [ RPAREN COLONGREATER ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ RPAREN COLONGREATER ]
@@ -2705,7 +2705,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER W
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2550, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 2547, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
@@ -2784,7 +2784,7 @@ parse_core_type: LPAREN UNDERSCORE COMMA WITH
 
 parse_core_type: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2555.
+## Ends in an error in state: 2552.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN core_type_comma_list . RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## core_type_comma_list -> core_type_comma_list . COMMA core_type [ RPAREN COMMA ]
@@ -2823,7 +2823,7 @@ parse_core_type: QUOTE WITH
 
 parse_core_type: SHARP LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 2557.
+## Ends in an error in state: 2554.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP class_longident non_arrowed_simple_core_type_list . [ WITH SEMI RPAREN RBRACKET RBRACE QUESTION LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2990,7 +2990,7 @@ parse_core_type: UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2633.
+## Ends in an error in state: 2625.
 ##
 ## parse_core_type -> core_type . EOF [ # ]
 ##
@@ -3013,7 +3013,7 @@ parse_core_type: UNDERSCORE WITH
 
 parse_core_type: WITH
 ##
-## Ends in an error in state: 2631.
+## Ends in an error in state: 2623.
 ##
 ## parse_core_type' -> . parse_core_type [ # ]
 ##
@@ -3025,7 +3025,7 @@ parse_core_type: WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 ##
-## Ends in an error in state: 1752.
+## Ends in an error in state: 1749.
 ##
 ## and_class_description -> AND . class_description_details post_item_attributes [ SEMI AND ]
 ##
@@ -3037,7 +3037,7 @@ interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ##
-## Ends in an error in state: 1751.
+## Ends in an error in state: 1748.
 ##
 ## _signature_item -> many_class_descriptions . [ SEMI ]
 ## many_class_descriptions -> many_class_descriptions . and_class_description [ SEMI AND ]
@@ -3049,22 +3049,22 @@ interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1635, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1639, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1633, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1637, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1648, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1646, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
-## In state 1734, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
-## In state 1735, spurious reduction of production post_item_attributes ->
-## In state 1736, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
+## In state 1632, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1636, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1630, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1634, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1645, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1643, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1731, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
+## In state 1732, spurious reduction of production post_item_attributes ->
+## In state 1733, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 1733.
+## Ends in an error in state: 1730.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters COLON . class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -3076,7 +3076,7 @@ interface: CLASS LIDENT COLON WITH
 
 interface: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1657.
+## Ends in an error in state: 1654.
 ##
 ## type_parameter -> type_variance . type_variable [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLON CHAR BACKQUOTE ]
 ##
@@ -3088,7 +3088,7 @@ interface: CLASS LIDENT PLUS WITH
 
 interface: CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1732.
+## Ends in an error in state: 1729.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters . COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS COLON ]
@@ -3101,7 +3101,7 @@ interface: CLASS LIDENT WITH
 
 interface: CLASS TYPE LIDENT EQUAL LIDENT RBRACKET
 ##
-## Ends in an error in state: 1750.
+## Ends in an error in state: 1747.
 ##
 ## _signature_item -> many_class_type_declarations . [ SEMI ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ SEMI AND ]
@@ -3113,19 +3113,19 @@ interface: CLASS TYPE LIDENT EQUAL LIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1635, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1639, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1633, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1707, spurious reduction of production class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type
-## In state 1708, spurious reduction of production post_item_attributes ->
-## In state 1709, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
+## In state 1632, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1636, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1630, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1704, spurious reduction of production class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type
+## In state 1705, spurious reduction of production post_item_attributes ->
+## In state 1706, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 1730.
+## Ends in an error in state: 1727.
 ##
 ## class_description_details -> virtual_flag . LIDENT class_type_parameters COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -3137,7 +3137,7 @@ interface: CLASS VIRTUAL LET
 
 interface: CLASS WITH
 ##
-## Ends in an error in state: 1729.
+## Ends in an error in state: 1726.
 ##
 ## many_class_descriptions -> CLASS . class_description_details post_item_attributes [ SEMI AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ SEMI AND ]
@@ -3150,7 +3150,7 @@ interface: CLASS WITH
 
 interface: EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 948.
+## Ends in an error in state: 945.
 ##
 ## extension_constructor_declaration -> constr_ident . generalized_constructor_arguments attributes [ SEMI LBRACKETATAT BAR ]
 ##
@@ -3162,7 +3162,7 @@ interface: EXCEPTION UIDENT WITH
 
 interface: EXCEPTION WITH
 ##
-## Ends in an error in state: 1726.
+## Ends in an error in state: 1723.
 ##
 ## sig_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ SEMI ]
 ##
@@ -3174,7 +3174,7 @@ interface: EXCEPTION WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1723.
+## Ends in an error in state: 1720.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3186,7 +3186,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1722.
+## Ends in an error in state: 1719.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3209,7 +3209,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 interface: EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1721.
+## Ends in an error in state: 1718.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3221,7 +3221,7 @@ interface: EXTERNAL LIDENT COLON WITH
 
 interface: EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 1720.
+## Ends in an error in state: 1717.
 ##
 ## _signature_item -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3233,7 +3233,7 @@ interface: EXTERNAL LIDENT WITH
 
 interface: EXTERNAL WITH
 ##
-## Ends in an error in state: 1719.
+## Ends in an error in state: 1716.
 ##
 ## _signature_item -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3245,7 +3245,7 @@ interface: EXTERNAL WITH
 
 interface: INCLUDE LBRACE OPEN UIDENT WITH
 ##
-## Ends in an error in state: 1737.
+## Ends in an error in state: 1734.
 ##
 ## signature -> signature_item . SEMI signature [ error RBRACE ]
 ##
@@ -3257,17 +3257,17 @@ interface: INCLUDE LBRACE OPEN UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 402, spurious reduction of production post_item_attributes ->
-## In state 2414, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 1742, spurious reduction of production _signature_item -> open_statement
-## In state 1759, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 1743, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 2411, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 1739, spurious reduction of production _signature_item -> open_statement
+## In state 1756, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 1740, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 1738.
+## Ends in an error in state: 1735.
 ##
 ## signature -> signature_item SEMI . signature [ error RBRACE ]
 ##
@@ -3279,7 +3279,7 @@ interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 
 interface: INCLUDE LBRACE WITH
 ##
-## Ends in an error in state: 927.
+## Ends in an error in state: 923.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LBRACE . signature error [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3292,7 +3292,7 @@ interface: INCLUDE LBRACE WITH
 
 interface: INCLUDE LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 1917.
+## Ends in an error in state: 1914.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## _simple_module_type -> LBRACE . signature error [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3305,7 +3305,7 @@ interface: INCLUDE LPAREN LBRACE WITH
 
 interface: INCLUDE LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 2320.
+## Ends in an error in state: 2317.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3321,7 +3321,7 @@ interface: INCLUDE LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 1924.
+## Ends in an error in state: 1921.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3337,7 +3337,7 @@ interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 1975.
+## Ends in an error in state: 1972.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3352,7 +3352,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LID
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1974.
+## Ends in an error in state: 1971.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3364,7 +3364,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WIT
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1973.
+## Ends in an error in state: 1970.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3376,7 +3376,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1972.
+## Ends in an error in state: 1969.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3392,22 +3392,22 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 967, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 964, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1971.
+## Ends in an error in state: 1968.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3419,7 +3419,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1970.
+## Ends in an error in state: 1967.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3431,7 +3431,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 1916.
+## Ends in an error in state: 1913.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3445,7 +3445,7 @@ interface: INCLUDE LPAREN LPAREN WITH
 
 interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2319.
+## Ends in an error in state: 2316.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER ]
@@ -3459,19 +3459,19 @@ interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN MODULE TYPE WITH
 ##
-## Ends in an error in state: 557.
+## Ends in an error in state: 553.
 ##
 ## _non_arrowed_module_type -> MODULE TYPE . module_expr [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3483,7 +3483,7 @@ interface: INCLUDE LPAREN MODULE TYPE WITH
 
 interface: INCLUDE LPAREN MODULE WITH
 ##
-## Ends in an error in state: 556.
+## Ends in an error in state: 552.
 ##
 ## _non_arrowed_module_type -> MODULE . TYPE module_expr [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3495,7 +3495,7 @@ interface: INCLUDE LPAREN MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 ##
-## Ends in an error in state: 650.
+## Ends in an error in state: 646.
 ##
 ## ident -> UIDENT . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## mod_ext2 -> mod_ext_longident DOT UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -3509,7 +3509,7 @@ interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 649.
+## Ends in an error in state: 645.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -3523,7 +3523,7 @@ interface: INCLUDE LPAREN UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 1961.
+## Ends in an error in state: 1958.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3538,7 +3538,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1960.
+## Ends in an error in state: 1957.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3550,7 +3550,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 648.
+## Ends in an error in state: 644.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -3570,7 +3570,7 @@ interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UIDENT WHILE
 ##
-## Ends in an error in state: 555.
+## Ends in an error in state: 551.
 ##
 ## functor_arg_name -> UIDENT . [ COLON ]
 ## ident -> UIDENT . [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3585,7 +3585,7 @@ interface: INCLUDE LPAREN UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 ##
-## Ends in an error in state: 1943.
+## Ends in an error in state: 1940.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
@@ -3598,7 +3598,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1940.
+## Ends in an error in state: 1937.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ RPAREN LPAREN DOT ]
 ## mod_ext2 -> UIDENT LPAREN mod_ext_longident . RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
@@ -3618,7 +3618,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UID
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1939.
+## Ends in an error in state: 1936.
 ##
 ## mod_ext2 -> UIDENT LPAREN . mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
 ##
@@ -3643,7 +3643,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WIT
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1937.
+## Ends in an error in state: 1934.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ##
@@ -3655,7 +3655,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 1952.
+## Ends in an error in state: 1949.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3668,7 +3668,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 ##
-## Ends in an error in state: 1938.
+## Ends in an error in state: 1935.
 ##
 ## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
 ## mod_ext_longident -> UIDENT . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
@@ -3681,7 +3681,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1953.
+## Ends in an error in state: 1950.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ##
@@ -3693,7 +3693,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1936.
+## Ends in an error in state: 1933.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3706,7 +3706,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 1935.
+## Ends in an error in state: 1932.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3719,7 +3719,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 1956.
+## Ends in an error in state: 1953.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ##
@@ -3731,7 +3731,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER A
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER EQUAL
 ##
-## Ends in an error in state: 1955.
+## Ends in an error in state: 1952.
 ##
 ## _module_type -> module_type WITH with_constraints . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## with_constraints -> with_constraints . AND with_constraint [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3749,15 +3749,15 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER E
 ## In state 445, spurious reduction of production _core_type -> core_type2
 ## In state 454, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 444, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1931, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1958, spurious reduction of production with_constraints -> with_constraint
+## In state 1928, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1955, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1930.
+## Ends in an error in state: 1927.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ##
@@ -3769,7 +3769,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1932.
+## Ends in an error in state: 1929.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ##
@@ -3781,7 +3781,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ##
-## Ends in an error in state: 1934.
+## Ends in an error in state: 1931.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3799,14 +3799,14 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ## In state 445, spurious reduction of production _core_type -> core_type2
 ## In state 454, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 444, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1933, spurious reduction of production constraints ->
+## In state 1930, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ##
-## Ends in an error in state: 1929.
+## Ends in an error in state: 1926.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3818,14 +3818,14 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 539, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 535, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 1927.
+## Ends in an error in state: 1924.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3838,7 +3838,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH WITH
 ##
-## Ends in an error in state: 1926.
+## Ends in an error in state: 1923.
 ##
 ## _module_type -> module_type WITH . with_constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3850,7 +3850,7 @@ interface: INCLUDE LPAREN UIDENT WITH WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2328.
+## Ends in an error in state: 2325.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3866,22 +3866,22 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COL
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 967, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 964, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2327.
+## Ends in an error in state: 2324.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3893,7 +3893,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2326.
+## Ends in an error in state: 2323.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3905,7 +3905,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2325.
+## Ends in an error in state: 2322.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3921,22 +3921,22 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 967, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 964, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2324.
+## Ends in an error in state: 2321.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3948,7 +3948,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2323.
+## Ends in an error in state: 2320.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3960,7 +3960,7 @@ interface: INCLUDE LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN WITH
 ##
-## Ends in an error in state: 554.
+## Ends in an error in state: 550.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3974,7 +3974,7 @@ interface: INCLUDE LPAREN WITH
 
 interface: INCLUDE MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2408.
+## Ends in an error in state: 2405.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
@@ -3988,12 +3988,12 @@ interface: INCLUDE MODULE TYPE UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 861, spurious reduction of production _module_expr -> simple_module_expr
-## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 857, spurious reduction of production _module_expr -> simple_module_expr
+## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
@@ -4052,7 +4052,7 @@ interface: INCLUDE UIDENT DOT WITH
 
 interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 997.
+## Ends in an error in state: 994.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4068,22 +4068,22 @@ interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 967, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 964, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 996.
+## Ends in an error in state: 993.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4143,7 +4143,7 @@ interface: INCLUDE UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 987.
+## Ends in an error in state: 984.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4155,7 +4155,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 989.
+## Ends in an error in state: 986.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4181,7 +4181,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 990.
+## Ends in an error in state: 987.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4193,7 +4193,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 986.
+## Ends in an error in state: 983.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4206,7 +4206,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 985.
+## Ends in an error in state: 982.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4219,7 +4219,7 @@ interface: INCLUDE UIDENT WITH MODULE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 993.
+## Ends in an error in state: 990.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4231,7 +4231,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ##
-## Ends in an error in state: 992.
+## Ends in an error in state: 989.
 ##
 ## _module_type -> module_type WITH with_constraints . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraints -> with_constraints . AND with_constraint [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4249,15 +4249,15 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 976, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 995, spurious reduction of production with_constraints -> with_constraint
+## In state 973, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 992, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 975.
+## Ends in an error in state: 972.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4269,7 +4269,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 977.
+## Ends in an error in state: 974.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4281,7 +4281,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ##
-## Ends in an error in state: 979.
+## Ends in an error in state: 976.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4299,14 +4299,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 978, spurious reduction of production constraints ->
+## In state 975, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 973.
+## Ends in an error in state: 970.
 ##
 ## with_type_binder -> EQUAL . [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
 ## with_type_binder -> EQUAL . PRIVATE [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
@@ -4319,7 +4319,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ##
-## Ends in an error in state: 972.
+## Ends in an error in state: 969.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4331,14 +4331,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 971, spurious reduction of production optional_type_parameters ->
+## In state 968, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 970.
+## Ends in an error in state: 967.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4351,7 +4351,7 @@ interface: INCLUDE UIDENT WITH TYPE WITH
 
 interface: INCLUDE UIDENT WITH WITH
 ##
-## Ends in an error in state: 969.
+## Ends in an error in state: 966.
 ##
 ## _module_type -> module_type WITH . with_constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4363,7 +4363,7 @@ interface: INCLUDE UIDENT WITH WITH
 
 interface: INCLUDE WITH
 ##
-## Ends in an error in state: 1716.
+## Ends in an error in state: 1713.
 ##
 ## _signature_item -> INCLUDE . module_type post_item_attributes [ SEMI ]
 ##
@@ -4375,7 +4375,7 @@ interface: INCLUDE WITH
 
 interface: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 1035.
+## Ends in an error in state: 1032.
 ##
 ## _signature_item -> LET val_ident COLON . core_type post_item_attributes [ SEMI ]
 ##
@@ -4387,7 +4387,7 @@ interface: LET LIDENT COLON WITH
 
 interface: LET LIDENT WITH
 ##
-## Ends in an error in state: 1034.
+## Ends in an error in state: 1031.
 ##
 ## _signature_item -> LET val_ident . COLON core_type post_item_attributes [ SEMI ]
 ##
@@ -4399,7 +4399,7 @@ interface: LET LIDENT WITH
 
 interface: LET LPAREN WITH
 ##
-## Ends in an error in state: 797.
+## Ends in an error in state: 793.
 ##
 ## val_ident -> LPAREN . operator RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -4411,7 +4411,7 @@ interface: LET LPAREN WITH
 
 interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
 ##
-## Ends in an error in state: 1746.
+## Ends in an error in state: 1743.
 ##
 ## and_module_rec_declaration -> AND . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4423,7 +4423,7 @@ interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
 
 interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1745.
+## Ends in an error in state: 1742.
 ##
 ## _signature_item -> many_module_rec_declarations . [ SEMI ]
 ## many_module_rec_declarations -> many_module_rec_declarations . and_module_rec_declaration [ SEMI AND ]
@@ -4435,16 +4435,16 @@ interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 932, spurious reduction of production post_item_attributes ->
-## In state 933, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1033, spurious reduction of production many_module_rec_declarations -> LET MODULE REC module_rec_declaration_details post_item_attributes
+## In state 928, spurious reduction of production post_item_attributes ->
+## In state 929, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1030, spurious reduction of production many_module_rec_declarations -> LET MODULE REC module_rec_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 1031.
+## Ends in an error in state: 1028.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -4460,22 +4460,22 @@ interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 967, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 964, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON WITH
 ##
-## Ends in an error in state: 1030.
+## Ends in an error in state: 1027.
 ##
 ## module_rec_declaration_details -> UIDENT COLON . module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4487,7 +4487,7 @@ interface: LET MODULE REC UIDENT COLON WITH
 
 interface: LET MODULE REC UIDENT WITH
 ##
-## Ends in an error in state: 1029.
+## Ends in an error in state: 1026.
 ##
 ## module_rec_declaration_details -> UIDENT . COLON module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4499,7 +4499,7 @@ interface: LET MODULE REC UIDENT WITH
 
 interface: LET MODULE REC WITH
 ##
-## Ends in an error in state: 1028.
+## Ends in an error in state: 1025.
 ##
 ## many_module_rec_declarations -> LET MODULE REC . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4511,7 +4511,7 @@ interface: LET MODULE REC WITH
 
 interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 1017.
+## Ends in an error in state: 1014.
 ##
 ## _module_declaration -> COLON module_type . [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -4527,22 +4527,22 @@ interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 967, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 964, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 1016.
+## Ends in an error in state: 1013.
 ##
 ## _module_declaration -> COLON . module_type [ SEMI LBRACKETATAT ]
 ##
@@ -4554,7 +4554,7 @@ interface: LET MODULE UIDENT COLON WITH
 
 interface: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1023.
+## Ends in an error in state: 1020.
 ##
 ## _signature_item -> LET MODULE UIDENT EQUAL . mod_longident post_item_attributes [ SEMI ]
 ##
@@ -4566,7 +4566,7 @@ interface: LET MODULE UIDENT EQUAL WITH
 
 interface: LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1021.
+## Ends in an error in state: 1018.
 ##
 ## _module_declaration -> LPAREN RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4578,7 +4578,7 @@ interface: LET MODULE UIDENT LPAREN RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1015.
+## Ends in an error in state: 1012.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4590,7 +4590,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1014.
+## Ends in an error in state: 1011.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type . RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -4606,22 +4606,22 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 967, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 964, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1013.
+## Ends in an error in state: 1010.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON . module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4633,7 +4633,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1012.
+## Ends in an error in state: 1009.
 ##
 ## _module_declaration -> LPAREN UIDENT . COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4645,7 +4645,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT WITH
 
 interface: LET MODULE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1011.
+## Ends in an error in state: 1008.
 ##
 ## _module_declaration -> LPAREN . UIDENT COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_declaration -> LPAREN . RPAREN module_declaration [ SEMI LBRACKETATAT ]
@@ -4658,7 +4658,7 @@ interface: LET MODULE UIDENT LPAREN WITH
 
 interface: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1010.
+## Ends in an error in state: 1007.
 ##
 ## _signature_item -> LET MODULE UIDENT . module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> LET MODULE UIDENT . EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4671,7 +4671,7 @@ interface: LET MODULE UIDENT WITH
 
 interface: LET MODULE WITH
 ##
-## Ends in an error in state: 1009.
+## Ends in an error in state: 1006.
 ##
 ## _signature_item -> LET MODULE . UIDENT module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> LET MODULE . UIDENT EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4685,7 +4685,7 @@ interface: LET MODULE WITH
 
 interface: LET WITH
 ##
-## Ends in an error in state: 1008.
+## Ends in an error in state: 1005.
 ##
 ## _signature_item -> LET . val_ident COLON core_type post_item_attributes [ SEMI ]
 ## _signature_item -> LET . MODULE UIDENT module_declaration post_item_attributes [ SEMI ]
@@ -4700,7 +4700,7 @@ interface: LET WITH
 
 interface: MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 964.
+## Ends in an error in state: 961.
 ##
 ## _signature_item -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ SEMI ]
 ##
@@ -4712,7 +4712,7 @@ interface: MODULE TYPE UIDENT EQUAL WITH
 
 interface: MODULE TYPE WITH
 ##
-## Ends in an error in state: 962.
+## Ends in an error in state: 959.
 ##
 ## _signature_item -> MODULE TYPE . ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4725,7 +4725,7 @@ interface: MODULE TYPE WITH
 
 interface: MODULE WITH
 ##
-## Ends in an error in state: 961.
+## Ends in an error in state: 958.
 ##
 ## _signature_item -> MODULE . TYPE ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4738,7 +4738,7 @@ interface: MODULE WITH
 
 interface: OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2625.
+## Ends in an error in state: 2617.
 ##
 ## signature -> signature_item . SEMI signature [ EOF ]
 ##
@@ -4750,17 +4750,17 @@ interface: OPEN UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 402, spurious reduction of production post_item_attributes ->
-## In state 2414, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 1742, spurious reduction of production _signature_item -> open_statement
-## In state 1759, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 1743, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 2411, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 1739, spurious reduction of production _signature_item -> open_statement
+## In state 1756, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 1740, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 938.
+## Ends in an error in state: 934.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4772,7 +4772,7 @@ interface: TYPE LIDENT PLUSEQ BAR WITH
 
 interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 937.
+## Ends in an error in state: 933.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4784,7 +4784,7 @@ interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 
 interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 946.
+## Ends in an error in state: 942.
 ##
 ## sig_extension_constructors -> sig_extension_constructors BAR . extension_constructor_declaration [ SEMI LBRACKETATAT BAR ]
 ##
@@ -4796,7 +4796,7 @@ interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 interface: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 935.
+## Ends in an error in state: 931.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4808,7 +4808,7 @@ interface: TYPE LIDENT PLUSEQ WITH
 
 interface: TYPE LIDENT RBRACKET
 ##
-## Ends in an error in state: 1744.
+## Ends in an error in state: 1741.
 ##
 ## _signature_item -> many_type_declarations . [ SEMI ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ SEMI AND ]
@@ -4822,17 +4822,17 @@ interface: TYPE LIDENT RBRACKET
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 89, spurious reduction of production optional_type_parameters ->
 ## In state 104, spurious reduction of production type_kind ->
-## In state 1139, spurious reduction of production constraints ->
-## In state 1140, spurious reduction of production type_declaration_details -> LIDENT optional_type_parameters type_kind constraints
-## In state 930, spurious reduction of production post_item_attributes ->
-## In state 931, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 1136, spurious reduction of production constraints ->
+## In state 1137, spurious reduction of production type_declaration_details -> LIDENT optional_type_parameters type_kind constraints
+## In state 926, spurious reduction of production post_item_attributes ->
+## In state 927, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2626.
+## Ends in an error in state: 2618.
 ##
 ## signature -> signature_item SEMI . signature [ EOF ]
 ##
@@ -4844,7 +4844,7 @@ interface: TYPE LIDENT SEMI WITH
 
 interface: TYPE NONREC LET
 ##
-## Ends in an error in state: 929.
+## Ends in an error in state: 925.
 ##
 ## many_type_declarations -> TYPE nonrec_flag . type_declaration_details post_item_attributes [ SEMI AND ]
 ## sig_type_extension -> TYPE nonrec_flag . potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
@@ -4857,7 +4857,7 @@ interface: TYPE NONREC LET
 
 interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ##
-## Ends in an error in state: 934.
+## Ends in an error in state: 930.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters . PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4868,15 +4868,15 @@ interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 539, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
-## In state 538, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
+## In state 535, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 534, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
 ##
 
 <SYNTAX ERROR>
 
 interface: WITH
 ##
-## Ends in an error in state: 2624.
+## Ends in an error in state: 2616.
 ##
 ## interface' -> . interface [ # ]
 ##
@@ -4888,7 +4888,7 @@ interface: WITH
 
 implementation: ASSERT WITH
 ##
-## Ends in an error in state: 893.
+## Ends in an error in state: 889.
 ##
 ## _expr -> ASSERT . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -4912,7 +4912,7 @@ implementation: BACKQUOTE WITH
 
 implementation: BANG WITH
 ##
-## Ends in an error in state: 572.
+## Ends in an error in state: 568.
 ##
 ## _simple_expr -> BANG . simple_expr [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -4924,7 +4924,7 @@ implementation: BANG WITH
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1652.
+## Ends in an error in state: 1649.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4936,7 +4936,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WIT
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1651.
+## Ends in an error in state: 1648.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4949,7 +4949,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE WITH
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1650.
+## Ends in an error in state: 1647.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4961,7 +4961,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON WITH
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1643.
+## Ends in an error in state: 1640.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4973,7 +4973,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE 
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 1642.
+## Ends in an error in state: 1639.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4986,7 +4986,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE 
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1641.
+## Ends in an error in state: 1638.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4998,7 +4998,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: CLASS LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1644.
+## Ends in an error in state: 1641.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -5010,7 +5010,7 @@ implementation: CLASS LIDENT COLON LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1640, spurious reduction of production type_longident -> LIDENT
+## In state 1637, spurious reduction of production type_longident -> LIDENT
 ## In state 261, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
 ## In state 266, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
 ## In state 264, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
@@ -5021,7 +5021,7 @@ implementation: CLASS LIDENT COLON LIDENT WITH
 
 implementation: CLASS LIDENT COLON NEW LIDENT EQUAL LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1656.
+## Ends in an error in state: 1653.
 ##
 ## _class_expr -> class_expr . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL class_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5034,7 +5034,7 @@ implementation: CLASS LIDENT COLON NEW LIDENT EQUAL LBRACKETPERCENT AND RBRACKET
 
 implementation: CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1655.
+## Ends in an error in state: 1652.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL . class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5046,7 +5046,7 @@ implementation: CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 
 implementation: CLASS LIDENT COLON NEW LIDENT RBRACKET
 ##
-## Ends in an error in state: 1637.
+## Ends in an error in state: 1634.
 ##
 ## _class_constructor_type -> NEW class_instance_type . [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _class_instance_type -> class_instance_type . attribute [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUAL AND ]
@@ -5058,16 +5058,16 @@ implementation: CLASS LIDENT COLON NEW LIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1635, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1639, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1633, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1632, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1636, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1630, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1654.
+## Ends in an error in state: 1651.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type . EQUAL class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5078,19 +5078,19 @@ implementation: CLASS LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1635, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1639, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1633, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1637, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1648, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1646, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1632, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1636, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1630, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1634, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1645, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1643, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1629.
+## Ends in an error in state: 1626.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -5102,7 +5102,7 @@ implementation: CLASS LIDENT COLON NEW WITH
 
 implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1645.
+## Ends in an error in state: 1642.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -5114,7 +5114,7 @@ implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 1628.
+## Ends in an error in state: 1625.
 ##
 ## _constrained_class_declaration -> COLON . class_constructor_type EQUAL class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5126,7 +5126,7 @@ implementation: CLASS LIDENT COLON WITH
 
 implementation: CLASS LIDENT EQUAL CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1613.
+## Ends in an error in state: 1610.
 ##
 ## _class_expr -> CLASS class_longident non_arrowed_simple_core_type_list . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ UNDERSCORE UIDENT SHARP SEMI RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
@@ -5139,7 +5139,7 @@ implementation: CLASS LIDENT EQUAL CLASS LIDENT UNDERSCORE WITH
 
 implementation: CLASS LIDENT EQUAL CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1612.
+## Ends in an error in state: 1609.
 ##
 ## _class_expr -> CLASS class_longident . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_expr -> CLASS class_longident . non_arrowed_simple_core_type_list [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -5152,7 +5152,7 @@ implementation: CLASS LIDENT EQUAL CLASS LIDENT WITH
 
 implementation: CLASS LIDENT EQUAL CLASS WITH
 ##
-## Ends in an error in state: 1611.
+## Ends in an error in state: 1608.
 ##
 ## _class_expr -> CLASS . class_longident [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_expr -> CLASS . class_longident non_arrowed_simple_core_type_list [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -5165,7 +5165,7 @@ implementation: CLASS LIDENT EQUAL CLASS WITH
 
 implementation: CLASS LIDENT EQUAL FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1620.
+## Ends in an error in state: 1617.
 ##
 ## _class_expr -> class_expr . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER class_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -5178,7 +5178,7 @@ implementation: CLASS LIDENT EQUAL FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT A
 
 implementation: CLASS LIDENT EQUAL FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1610.
+## Ends in an error in state: 1607.
 ##
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER . class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ##
@@ -5190,7 +5190,7 @@ implementation: CLASS LIDENT EQUAL FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT EQUAL FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1609.
+## Ends in an error in state: 1606.
 ##
 ## _class_fun_def -> labeled_simple_pattern . EQUALGREATER class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_fun_def -> labeled_simple_pattern . class_fun_def [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -5203,7 +5203,7 @@ implementation: CLASS LIDENT EQUAL FUN UNDERSCORE WITH
 
 implementation: CLASS LIDENT EQUAL FUN WITH
 ##
-## Ends in an error in state: 1607.
+## Ends in an error in state: 1604.
 ##
 ## _class_expr -> FUN . class_fun_def [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ##
@@ -5215,7 +5215,7 @@ implementation: CLASS LIDENT EQUAL FUN WITH
 
 implementation: CLASS LIDENT EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 1603.
+## Ends in an error in state: 1600.
 ##
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest RBRACE [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest error [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
@@ -5228,7 +5228,7 @@ implementation: CLASS LIDENT EQUAL LBRACE WITH
 
 implementation: CLASS LIDENT EQUAL LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1627.
+## Ends in an error in state: 1624.
 ##
 ## _class_expr -> class_expr . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5241,7 +5241,7 @@ implementation: CLASS LIDENT EQUAL LBRACKETPERCENT AND RBRACKET WITH
 
 implementation: CLASS LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1155.
+## Ends in an error in state: 1152.
 ##
 ## and_class_declaration -> AND . class_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5253,7 +5253,7 @@ implementation: CLASS LIDENT EQUAL LIDENT AND WITH
 
 implementation: CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1154.
+## Ends in an error in state: 1151.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_declarations . [ SEMI RBRACKET RBRACE EOF ]
 ## many_class_declarations -> many_class_declarations . and_class_declaration [ SEMI RBRACKET RBRACE EOF AND ]
@@ -5265,16 +5265,16 @@ implementation: CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 932, spurious reduction of production post_item_attributes ->
-## In state 933, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1711, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
+## In state 928, spurious reduction of production post_item_attributes ->
+## In state 929, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1708, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT EQUAL LIDENT UIDENT WITH
 ##
-## Ends in an error in state: 1618.
+## Ends in an error in state: 1615.
 ##
 ## _class_expr -> class_simple_expr simple_labeled_expr_list . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## simple_labeled_expr_list -> simple_labeled_expr_list . labeled_simple_expr [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
@@ -5286,20 +5286,20 @@ implementation: CLASS LIDENT EQUAL LIDENT UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 890, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1180, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1185, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
-## In state 1188, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 886, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1177, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1182, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
+## In state 1185, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT EQUAL LIDENT WITH
 ##
-## Ends in an error in state: 1617.
+## Ends in an error in state: 1614.
 ##
 ## _class_expr -> class_simple_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_expr -> class_simple_expr . simple_labeled_expr_list [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -5312,7 +5312,7 @@ implementation: CLASS LIDENT EQUAL LIDENT WITH
 
 implementation: CLASS LIDENT EQUAL LPAREN LIDENT COLON WITH
 ##
-## Ends in an error in state: 1599.
+## Ends in an error in state: 1596.
 ##
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type RPAREN [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type error [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
@@ -5325,7 +5325,7 @@ implementation: CLASS LIDENT EQUAL LPAREN LIDENT COLON WITH
 
 implementation: CLASS LIDENT EQUAL LPAREN LIDENT SEMI
 ##
-## Ends in an error in state: 1596.
+## Ends in an error in state: 1593.
 ##
 ## _class_expr -> class_expr . attribute [ error RPAREN LBRACKETAT COLON ]
 ## _class_simple_expr -> LPAREN class_expr . COLON class_constructor_type RPAREN [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
@@ -5340,16 +5340,16 @@ implementation: CLASS LIDENT EQUAL LPAREN LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1311, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1332, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1309, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1308, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1329, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1306, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 1162.
+## Ends in an error in state: 1159.
 ##
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type RPAREN [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type error [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
@@ -5364,7 +5364,7 @@ implementation: CLASS LIDENT EQUAL LPAREN WITH
 
 implementation: CLASS LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1161.
+## Ends in an error in state: 1158.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5376,7 +5376,7 @@ implementation: CLASS LIDENT EQUAL WITH
 
 implementation: CLASS LIDENT MINUS WITH
 ##
-## Ends in an error in state: 1160.
+## Ends in an error in state: 1157.
 ##
 ## signed_constant -> MINUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> MINUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -5393,7 +5393,7 @@ implementation: CLASS LIDENT MINUS WITH
 
 implementation: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1159.
+## Ends in an error in state: 1156.
 ##
 ## signed_constant -> PLUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> PLUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -5410,7 +5410,7 @@ implementation: CLASS LIDENT PLUS WITH
 
 implementation: CLASS LIDENT QUOTE WITH
 ##
-## Ends in an error in state: 1658.
+## Ends in an error in state: 1655.
 ##
 ## _type_variable -> QUOTE . ident [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLON CHAR BACKQUOTE ]
 ##
@@ -5422,7 +5422,7 @@ implementation: CLASS LIDENT QUOTE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1084.
+## Ends in an error in state: 1081.
 ##
 ## class_sig_body -> class_self_type . class_sig_fields opt_semi [ error RBRACE ]
 ##
@@ -5434,7 +5434,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 ##
-## Ends in an error in state: 1079.
+## Ends in an error in state: 1076.
 ##
 ## class_self_type -> AS core_type . SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -5457,7 +5457,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 ##
-## Ends in an error in state: 1078.
+## Ends in an error in state: 1075.
 ##
 ## class_self_type -> AS . core_type SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -5469,7 +5469,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1694.
+## Ends in an error in state: 1691.
 ##
 ## _class_sig_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5481,7 +5481,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1691.
+## Ends in an error in state: 1688.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT ]
 ## _class_sig_field -> INHERIT class_instance_type . [ error SEMI RBRACE ]
@@ -5494,16 +5494,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1574, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1578, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1572, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1571, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1575, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1569, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1690.
+## Ends in an error in state: 1687.
 ##
 ## _class_sig_field -> INHERIT . class_instance_type [ error SEMI RBRACE ]
 ## _class_sig_field -> INHERIT . class_instance_type item_attribute post_item_attributes [ error SEMI RBRACE ]
@@ -5516,7 +5516,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH RBRACKET WITH
 ##
-## Ends in an error in state: 1081.
+## Ends in an error in state: 1078.
 ##
 ## _class_instance_type -> LBRACE class_sig_body . RBRACE [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE class_sig_body . error [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5528,20 +5528,20 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1698, spurious reduction of production post_item_attributes ->
-## In state 1699, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
-## In state 1704, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
-## In state 1697, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
-## In state 1706, spurious reduction of production class_sig_fields -> class_sig_field
-## In state 1701, spurious reduction of production opt_semi ->
-## In state 1705, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
+## In state 1695, spurious reduction of production post_item_attributes ->
+## In state 1696, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
+## In state 1701, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
+## In state 1694, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
+## In state 1703, spurious reduction of production class_sig_fields -> class_sig_field
+## In state 1698, spurious reduction of production opt_semi ->
+## In state 1702, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 ##
-## Ends in an error in state: 1110.
+## Ends in an error in state: 1107.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label COLON . poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5553,7 +5553,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 ##
-## Ends in an error in state: 1109.
+## Ends in an error in state: 1106.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label . COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5565,7 +5565,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 ##
-## Ends in an error in state: 1106.
+## Ends in an error in state: 1103.
 ##
 ## private_virtual_flags -> PRIVATE . [ LIDENT ]
 ## private_virtual_flags -> PRIVATE . VIRTUAL [ LIDENT ]
@@ -5578,7 +5578,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1108.
+## Ends in an error in state: 1105.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags . label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5590,7 +5590,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 ##
-## Ends in an error in state: 1104.
+## Ends in an error in state: 1101.
 ##
 ## private_virtual_flags -> VIRTUAL . [ LIDENT ]
 ## private_virtual_flags -> VIRTUAL . PRIVATE [ LIDENT ]
@@ -5603,7 +5603,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 ##
-## Ends in an error in state: 1103.
+## Ends in an error in state: 1100.
 ##
 ## _class_sig_field -> METHOD . private_virtual_flags label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5615,7 +5615,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1101.
+## Ends in an error in state: 1098.
 ##
 ## value_type -> label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5627,7 +5627,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1100.
+## Ends in an error in state: 1097.
 ##
 ## value_type -> label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5639,7 +5639,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1094.
+## Ends in an error in state: 1091.
 ##
 ## value_type -> MUTABLE virtual_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5651,7 +5651,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 ##
-## Ends in an error in state: 1093.
+## Ends in an error in state: 1090.
 ##
 ## value_type -> MUTABLE virtual_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5663,7 +5663,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 ##
-## Ends in an error in state: 1092.
+## Ends in an error in state: 1089.
 ##
 ## value_type -> MUTABLE virtual_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5675,7 +5675,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1091.
+## Ends in an error in state: 1088.
 ##
 ## value_type -> MUTABLE . virtual_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5687,7 +5687,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1089.
+## Ends in an error in state: 1086.
 ##
 ## value_type -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5699,7 +5699,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1088.
+## Ends in an error in state: 1085.
 ##
 ## value_type -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5711,7 +5711,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1087.
+## Ends in an error in state: 1084.
 ##
 ## value_type -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5723,7 +5723,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1086.
+## Ends in an error in state: 1083.
 ##
 ## value_type -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5735,7 +5735,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 ##
-## Ends in an error in state: 1085.
+## Ends in an error in state: 1082.
 ##
 ## _class_sig_field -> VAL . value_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5747,7 +5747,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 ##
-## Ends in an error in state: 1077.
+## Ends in an error in state: 1074.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5760,7 +5760,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1675.
+## Ends in an error in state: 1672.
 ##
 ## _class_expr -> class_expr . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER class_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5773,7 +5773,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER LBRACKETPERCEN
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1674.
+## Ends in an error in state: 1671.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER . class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5785,7 +5785,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ##
-## Ends in an error in state: 1677.
+## Ends in an error in state: 1674.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## _non_arrowed_class_constructor_type -> class_instance_type . [ EQUALGREATER ]
@@ -5797,16 +5797,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1635, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1639, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1633, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1632, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1636, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1630, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1636.
+## Ends in an error in state: 1633.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
@@ -5819,7 +5819,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 ##
-## Ends in an error in state: 1635.
+## Ends in an error in state: 1632.
 ##
 ## _class_instance_type -> clty_longident . [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5832,7 +5832,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1673.
+## Ends in an error in state: 1670.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type . EQUALGREATER class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5844,7 +5844,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT RPAREN WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1671.
+## Ends in an error in state: 1668.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN class_constructor_type . RPAREN [ EQUALGREATER ]
 ##
@@ -5855,19 +5855,19 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1635, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1639, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1633, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1637, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1648, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1646, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1632, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1636, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1630, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1634, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1645, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1643, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 ##
-## Ends in an error in state: 1670.
+## Ends in an error in state: 1667.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN . class_constructor_type RPAREN [ EQUALGREATER ]
 ##
@@ -5879,7 +5879,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 ##
-## Ends in an error in state: 1631.
+## Ends in an error in state: 1628.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5893,7 +5893,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 ##
-## Ends in an error in state: 1630.
+## Ends in an error in state: 1627.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5913,7 +5913,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1669.
+## Ends in an error in state: 1666.
 ##
 ## class_fun_return -> COLON . non_arrowed_class_constructor_type EQUALGREATER class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5925,7 +5925,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1668.
+## Ends in an error in state: 1665.
 ##
 ## _class_expr -> class_expr . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> EQUALGREATER class_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5938,7 +5938,7 @@ implementation: CLASS LIDENT UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKE
 
 implementation: CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1667.
+## Ends in an error in state: 1664.
 ##
 ## class_fun_return -> EQUALGREATER . class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5950,7 +5950,7 @@ implementation: CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1666.
+## Ends in an error in state: 1663.
 ##
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_binding [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_return [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5963,7 +5963,7 @@ implementation: CLASS LIDENT UNDERSCORE WITH
 
 implementation: CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1158.
+## Ends in an error in state: 1155.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . class_fun_binding [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . constrained_class_declaration [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5978,7 +5978,7 @@ implementation: CLASS LIDENT WITH
 
 implementation: CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1150.
+## Ends in an error in state: 1147.
 ##
 ## and_class_type_declaration -> AND . class_type_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5990,7 +5990,7 @@ implementation: CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 
 implementation: CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1149.
+## Ends in an error in state: 1146.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_type_declarations . [ SEMI RBRACKET RBRACE EOF ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ SEMI RBRACKET RBRACE EOF AND ]
@@ -6002,16 +6002,16 @@ implementation: CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 932, spurious reduction of production post_item_attributes ->
-## In state 933, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1709, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
+## In state 928, spurious reduction of production post_item_attributes ->
+## In state 929, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1706, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1707.
+## Ends in an error in state: 1704.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -6023,16 +6023,16 @@ implementation: CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1635, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1639, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1633, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1632, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1636, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1630, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1075.
+## Ends in an error in state: 1072.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_instance_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -6044,7 +6044,7 @@ implementation: CLASS TYPE LIDENT EQUAL WITH
 
 implementation: CLASS TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1072.
+## Ends in an error in state: 1069.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters . EQUAL class_instance_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS EQUAL ]
@@ -6057,7 +6057,7 @@ implementation: CLASS TYPE LIDENT WITH
 
 implementation: CLASS TYPE VIRTUAL LET
 ##
-## Ends in an error in state: 1070.
+## Ends in an error in state: 1067.
 ##
 ## class_type_declaration_details -> virtual_flag . LIDENT class_type_parameters EQUAL class_instance_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -6069,7 +6069,7 @@ implementation: CLASS TYPE VIRTUAL LET
 
 implementation: CLASS TYPE WITH
 ##
-## Ends in an error in state: 1069.
+## Ends in an error in state: 1066.
 ##
 ## many_class_type_declarations -> CLASS TYPE . class_type_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -6081,7 +6081,7 @@ implementation: CLASS TYPE WITH
 
 implementation: CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 1156.
+## Ends in an error in state: 1153.
 ##
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters class_fun_binding [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters constrained_class_declaration [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -6095,7 +6095,7 @@ implementation: CLASS VIRTUAL LET
 
 implementation: CLASS WITH
 ##
-## Ends in an error in state: 1067.
+## Ends in an error in state: 1064.
 ##
 ## many_class_declarations -> CLASS . class_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
@@ -6108,9 +6108,9 @@ implementation: CLASS WITH
 
 implementation: EXCEPTION LPAREN WITH
 ##
-## Ends in an error in state: 941.
+## Ends in an error in state: 937.
 ##
-## constr_ident -> LPAREN . RPAREN [ UNDERSCORE UIDENT SHARP SEMI RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUAL EOF CONSTRAINT COLON BAR AND ]
+## constr_ident2 -> LPAREN . RPAREN [ UNDERSCORE UIDENT SHARP SEMI RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUAL EOF CONSTRAINT COLON BAR AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -6120,7 +6120,7 @@ implementation: EXCEPTION LPAREN WITH
 
 implementation: EXCEPTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 949.
+## Ends in an error in state: 946.
 ##
 ## generalized_constructor_arguments -> COLON . core_type [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -6132,7 +6132,7 @@ implementation: EXCEPTION UIDENT COLON WITH
 
 implementation: EXCEPTION UIDENT EQUAL LBRACKET WITH
 ##
-## Ends in an error in state: 1062.
+## Ends in an error in state: 1059.
 ##
 ## constr_longident -> LBRACKET . RBRACKET [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -6144,7 +6144,7 @@ implementation: EXCEPTION UIDENT EQUAL LBRACKET WITH
 
 implementation: EXCEPTION UIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 1061.
+## Ends in an error in state: 1058.
 ##
 ## constr_longident -> LPAREN . RPAREN [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -6156,7 +6156,7 @@ implementation: EXCEPTION UIDENT EQUAL LPAREN WITH
 
 implementation: EXCEPTION UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1060.
+## Ends in an error in state: 1057.
 ##
 ## extension_constructor_rebind -> constr_ident EQUAL . constr_longident attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ##
@@ -6168,7 +6168,7 @@ implementation: EXCEPTION UIDENT EQUAL WITH
 
 implementation: EXCEPTION UIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 952.
+## Ends in an error in state: 949.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list COLON . core_type [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -6180,7 +6180,7 @@ implementation: EXCEPTION UIDENT UNDERSCORE COLON WITH
 
 implementation: EXCEPTION UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 951.
+## Ends in an error in state: 948.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . COLON core_type [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
@@ -6194,7 +6194,7 @@ implementation: EXCEPTION UIDENT UNDERSCORE WITH
 
 implementation: EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1059.
+## Ends in an error in state: 1056.
 ##
 ## extension_constructor_declaration -> constr_ident . generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## extension_constructor_rebind -> constr_ident . EQUAL constr_longident attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -6207,7 +6207,7 @@ implementation: EXCEPTION UIDENT WITH
 
 implementation: EXCEPTION WITH
 ##
-## Ends in an error in state: 1054.
+## Ends in an error in state: 1051.
 ##
 ## str_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ## str_exception_declaration -> EXCEPTION . extension_constructor_rebind post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
@@ -6220,7 +6220,7 @@ implementation: EXCEPTION WITH
 
 implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 ##
-## Ends in an error in state: 1050.
+## Ends in an error in state: 1047.
 ##
 ## primitive_declaration -> STRING . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ## primitive_declaration -> STRING . primitive_declaration [ SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
@@ -6233,7 +6233,7 @@ implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 
 implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1049.
+## Ends in an error in state: 1046.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6245,7 +6245,7 @@ implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1048.
+## Ends in an error in state: 1045.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6268,7 +6268,7 @@ implementation: EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 implementation: EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1047.
+## Ends in an error in state: 1044.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6280,7 +6280,7 @@ implementation: EXTERNAL LIDENT COLON WITH
 
 implementation: EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 1046.
+## Ends in an error in state: 1043.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6292,7 +6292,7 @@ implementation: EXTERNAL LIDENT WITH
 
 implementation: EXTERNAL WITH
 ##
-## Ends in an error in state: 1045.
+## Ends in an error in state: 1042.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6304,7 +6304,7 @@ implementation: EXTERNAL WITH
 
 implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ##
-## Ends in an error in state: 886.
+## Ends in an error in state: 882.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag simple_expr . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -6322,17 +6322,17 @@ implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 890, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 886, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FOR UNDERSCORE IN UIDENT TO WITH
 ##
-## Ends in an error in state: 885.
+## Ends in an error in state: 881.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag . simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6344,7 +6344,7 @@ implementation: FOR UNDERSCORE IN UIDENT TO WITH
 
 implementation: FOR UNDERSCORE IN UIDENT WITH
 ##
-## Ends in an error in state: 882.
+## Ends in an error in state: 878.
 ##
 ## _expr -> FOR pattern IN simple_expr . direction_flag simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ TO SHARP DOWNTO DOT ]
@@ -6362,17 +6362,17 @@ implementation: FOR UNDERSCORE IN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 890, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 886, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FOR UNDERSCORE IN WITH
 ##
-## Ends in an error in state: 881.
+## Ends in an error in state: 877.
 ##
 ## _expr -> FOR pattern IN . simple_expr direction_flag simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6384,7 +6384,7 @@ implementation: FOR UNDERSCORE IN WITH
 
 implementation: FOR UNDERSCORE WHEN
 ##
-## Ends in an error in state: 880.
+## Ends in an error in state: 876.
 ##
 ## _expr -> FOR pattern . IN simple_expr direction_flag simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _or_pattern -> pattern . BAR pattern [ IN BAR ]
@@ -6396,14 +6396,14 @@ implementation: FOR UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production pattern -> pattern_without_or
+## In state 787, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: FOR WITH
 ##
-## Ends in an error in state: 879.
+## Ends in an error in state: 875.
 ##
 ## _expr -> FOR . pattern IN simple_expr direction_flag simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6415,7 +6415,7 @@ implementation: FOR WITH
 
 implementation: FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 1890.
+## Ends in an error in state: 1887.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6449,17 +6449,17 @@ implementation: FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1889.
+## Ends in an error in state: 1886.
 ##
 ## leading_bar_match_case -> bar_located_pattern EQUALGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6471,7 +6471,7 @@ implementation: FUN BAR UNDERSCORE EQUALGREATER WITH
 
 implementation: FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 1888.
+## Ends in an error in state: 1885.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6505,17 +6505,17 @@ implementation: FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1887.
+## Ends in an error in state: 1884.
 ##
 ## leading_bar_match_case -> bar_located_pattern WHEN expr EQUALGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6527,7 +6527,7 @@ implementation: FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 
 implementation: FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 1886.
+## Ends in an error in state: 1883.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -6561,21 +6561,21 @@ implementation: FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 1885.
+## Ends in an error in state: 1882.
 ##
 ## leading_bar_match_case -> bar_located_pattern WHEN . expr EQUALGREATER expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6587,7 +6587,7 @@ implementation: FUN BAR UNDERSCORE WHEN WITH
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 855.
+## Ends in an error in state: 851.
 ##
 ## _simple_expr -> simple_expr . DOT label_longident [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
 ## _simple_expr -> simple_expr . DOT LPAREN expr RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
@@ -6605,17 +6605,17 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 890, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 886, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 854.
+## Ends in an error in state: 850.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern EQUAL . simple_expr [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ##
@@ -6627,7 +6627,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 852.
+## Ends in an error in state: 848.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -6641,7 +6641,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 
 implementation: FUN LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 631.
+## Ends in an error in state: 627.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -6655,7 +6655,7 @@ implementation: FUN LIDENT COLONCOLON WITH
 
 implementation: FUN LIDENT WITH
 ##
-## Ends in an error in state: 1892.
+## Ends in an error in state: 1889.
 ##
 ## _expr -> FUN labeled_simple_pattern . fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6666,18 +6666,18 @@ implementation: FUN LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 630, spurious reduction of production val_ident -> LIDENT
-## In state 764, spurious reduction of production _simple_pattern -> val_ident
-## In state 778, spurious reduction of production mark_position_pat(_simple_pattern) -> _simple_pattern
-## In state 774, spurious reduction of production simple_pattern -> mark_position_pat(_simple_pattern)
-## In state 1254, spurious reduction of production labeled_simple_pattern -> simple_pattern
+## In state 626, spurious reduction of production val_ident -> LIDENT
+## In state 760, spurious reduction of production _simple_pattern -> val_ident
+## In state 774, spurious reduction of production mark_position_pat(_simple_pattern) -> _simple_pattern
+## In state 770, spurious reduction of production simple_pattern -> mark_position_pat(_simple_pattern)
+## In state 1251, spurious reduction of production labeled_simple_pattern -> simple_pattern
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 873.
+## Ends in an error in state: 869.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT RPAREN . fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6689,7 +6689,7 @@ implementation: FUN LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: FUN LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 872.
+## Ends in an error in state: 868.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT . RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6701,7 +6701,7 @@ implementation: FUN LPAREN TYPE LIDENT WITH
 
 implementation: FUN LPAREN TYPE WITH
 ##
-## Ends in an error in state: 871.
+## Ends in an error in state: 867.
 ##
 ## _expr -> FUN LPAREN TYPE . LIDENT RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6713,7 +6713,7 @@ implementation: FUN LPAREN TYPE WITH
 
 implementation: FUN LPAREN WITH
 ##
-## Ends in an error in state: 870.
+## Ends in an error in state: 866.
 ##
 ## _expr -> FUN LPAREN . TYPE LIDENT RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
@@ -6736,7 +6736,7 @@ implementation: FUN LPAREN WITH
 
 implementation: FUN UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 1875.
+## Ends in an error in state: 1872.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6770,17 +6770,17 @@ implementation: FUN UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 878.
+## Ends in an error in state: 874.
 ##
 ## fun_def -> EQUALGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6792,7 +6792,7 @@ implementation: FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 877.
+## Ends in an error in state: 873.
 ##
 ## fun_def -> LPAREN TYPE LIDENT RPAREN . fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6804,7 +6804,7 @@ implementation: FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 876.
+## Ends in an error in state: 872.
 ##
 ## fun_def -> LPAREN TYPE LIDENT . RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6816,7 +6816,7 @@ implementation: FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: FUN UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 875.
+## Ends in an error in state: 871.
 ##
 ## fun_def -> LPAREN TYPE . LIDENT RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6828,7 +6828,7 @@ implementation: FUN UNDERSCORE LPAREN TYPE WITH
 
 implementation: FUN UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 874.
+## Ends in an error in state: 870.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
@@ -6851,7 +6851,7 @@ implementation: FUN UNDERSCORE LPAREN WITH
 
 implementation: FUN UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 1876.
+## Ends in an error in state: 1873.
 ##
 ## fun_def -> labeled_simple_pattern . fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6863,7 +6863,7 @@ implementation: FUN UNDERSCORE UNDERSCORE WITH
 
 implementation: FUN WITH
 ##
-## Ends in an error in state: 869.
+## Ends in an error in state: 865.
 ##
 ## _expr -> FUN . labeled_simple_pattern fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> FUN . LPAREN TYPE LIDENT RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6877,7 +6877,7 @@ implementation: FUN WITH
 
 implementation: IF UIDENT UIDENT ELSE WITH
 ##
-## Ends in an error in state: 868.
+## Ends in an error in state: 864.
 ##
 ## _expr -> IF simple_expr simple_expr ELSE . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6889,7 +6889,7 @@ implementation: IF UIDENT UIDENT ELSE WITH
 
 implementation: IF UIDENT WITH
 ##
-## Ends in an error in state: 866.
+## Ends in an error in state: 862.
 ##
 ## _expr -> IF simple_expr . simple_expr ELSE expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF simple_expr . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6908,17 +6908,17 @@ implementation: IF UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 890, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 886, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: IF WITH
 ##
-## Ends in an error in state: 865.
+## Ends in an error in state: 861.
 ##
 ## _expr -> IF . simple_expr simple_expr ELSE expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF . simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6931,7 +6931,7 @@ implementation: IF WITH
 
 implementation: INCLUDE FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 2333.
+## Ends in an error in state: 2330.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER module_expr . [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _module_expr -> module_expr . simple_module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -6946,7 +6946,7 @@ implementation: INCLUDE FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 
 implementation: INCLUDE FUN LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2332.
+## Ends in an error in state: 2329.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER . module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -6958,7 +6958,7 @@ implementation: INCLUDE FUN LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE FUN LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2331.
+## Ends in an error in state: 2328.
 ##
 ## _module_expr -> FUN functor_args . EQUALGREATER module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## functor_args -> functor_args . functor_arg [ LPAREN EQUALGREATER ]
@@ -6971,7 +6971,7 @@ implementation: INCLUDE FUN LPAREN RPAREN WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2329.
+## Ends in an error in state: 2326.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -6987,22 +6987,22 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 967, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 964, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 553.
+## Ends in an error in state: 549.
 ##
 ## functor_arg -> LPAREN functor_arg_name COLON . module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -7014,7 +7014,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 552.
+## Ends in an error in state: 548.
 ##
 ## functor_arg -> LPAREN functor_arg_name . COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -7026,7 +7026,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 
 implementation: INCLUDE FUN LPAREN WITH
 ##
-## Ends in an error in state: 548.
+## Ends in an error in state: 544.
 ##
 ## functor_arg -> LPAREN . RPAREN [ LPAREN EQUALGREATER COLON ]
 ## functor_arg -> LPAREN . functor_arg_name COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
@@ -7039,7 +7039,7 @@ implementation: INCLUDE FUN LPAREN WITH
 
 implementation: INCLUDE FUN WITH
 ##
-## Ends in an error in state: 547.
+## Ends in an error in state: 543.
 ##
 ## _module_expr -> FUN . functor_args EQUALGREATER module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -7051,7 +7051,7 @@ implementation: INCLUDE FUN WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 2124.
+## Ends in an error in state: 2121.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL class_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7063,16 +7063,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1311, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1332, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1309, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1308, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1329, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1306, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2123.
+## Ends in an error in state: 2120.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL . class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7084,7 +7084,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 2122.
+## Ends in an error in state: 2119.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type . EQUAL class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7095,19 +7095,19 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1635, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1639, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1633, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1637, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1648, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1646, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1632, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1636, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1630, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1634, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1645, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1643, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 2121.
+## Ends in an error in state: 2118.
 ##
 ## _constrained_class_declaration -> COLON . class_constructor_type EQUAL class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7119,7 +7119,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 2169.
+## Ends in an error in state: 2166.
 ##
 ## and_class_declaration -> AND . class_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7131,7 +7131,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2168.
+## Ends in an error in state: 2165.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_declarations . [ error SEMI RBRACE ]
 ## many_class_declarations -> many_class_declarations . and_class_declaration [ error SEMI RBRACE AND ]
@@ -7143,16 +7143,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1098, spurious reduction of production post_item_attributes ->
-## In state 1099, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2141, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
+## In state 1095, spurious reduction of production post_item_attributes ->
+## In state 1096, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2138, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 2120.
+## Ends in an error in state: 2117.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7164,16 +7164,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1311, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1332, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1309, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1308, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1329, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1306, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2119.
+## Ends in an error in state: 2116.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7185,7 +7185,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 2133.
+## Ends in an error in state: 2130.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER class_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7197,16 +7197,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1311, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1332, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1309, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1308, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1329, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1306, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2132.
+## Ends in an error in state: 2129.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER . class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7218,7 +7218,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2131.
+## Ends in an error in state: 2128.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type . EQUALGREATER class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7230,7 +7230,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT R
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2130.
+## Ends in an error in state: 2127.
 ##
 ## class_fun_return -> COLON . non_arrowed_class_constructor_type EQUALGREATER class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7242,7 +7242,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 2129.
+## Ends in an error in state: 2126.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## class_fun_return -> EQUALGREATER class_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7254,16 +7254,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1311, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1332, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1309, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1308, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1329, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1306, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2128.
+## Ends in an error in state: 2125.
 ##
 ## class_fun_return -> EQUALGREATER . class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7275,7 +7275,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2127.
+## Ends in an error in state: 2124.
 ##
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_binding [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_return [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7288,7 +7288,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT WITH
 ##
-## Ends in an error in state: 2118.
+## Ends in an error in state: 2115.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . class_fun_binding [ error SEMI RBRACE LBRACKETATAT AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . constrained_class_declaration [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7303,7 +7303,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 2164.
+## Ends in an error in state: 2161.
 ##
 ## and_class_type_declaration -> AND . class_type_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7315,7 +7315,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2163.
+## Ends in an error in state: 2160.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_type_declarations . [ error SEMI RBRACE ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ error SEMI RBRACE AND ]
@@ -7327,16 +7327,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND R
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1098, spurious reduction of production post_item_attributes ->
-## In state 1099, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2115, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
+## In state 1095, spurious reduction of production post_item_attributes ->
+## In state 1096, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2112, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 2113.
+## Ends in an error in state: 2110.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7348,16 +7348,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1574, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1578, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1572, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1571, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1575, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1569, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2112.
+## Ends in an error in state: 2109.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_instance_type [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7369,7 +7369,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 ##
-## Ends in an error in state: 2111.
+## Ends in an error in state: 2108.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters . EQUAL class_instance_type [ error SEMI RBRACE LBRACKETATAT AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS EQUAL ]
@@ -7382,7 +7382,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 ##
-## Ends in an error in state: 2109.
+## Ends in an error in state: 2106.
 ##
 ## class_type_declaration_details -> virtual_flag . LIDENT class_type_parameters EQUAL class_instance_type [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7394,7 +7394,7 @@ implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE WITH
 ##
-## Ends in an error in state: 2108.
+## Ends in an error in state: 2105.
 ##
 ## many_class_type_declarations -> CLASS TYPE . class_type_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7406,7 +7406,7 @@ implementation: INCLUDE LBRACE CLASS TYPE WITH
 
 implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 2116.
+## Ends in an error in state: 2113.
 ##
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters class_fun_binding [ error SEMI RBRACE LBRACKETATAT AND ]
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters constrained_class_declaration [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7420,7 +7420,7 @@ implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 
 implementation: INCLUDE LBRACE CLASS WITH
 ##
-## Ends in an error in state: 2107.
+## Ends in an error in state: 2104.
 ##
 ## many_class_declarations -> CLASS . class_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
@@ -7433,9 +7433,9 @@ implementation: INCLUDE LBRACE CLASS WITH
 
 implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 ##
-## Ends in an error in state: 471.
+## Ends in an error in state: 470.
 ##
-## constr_ident -> LPAREN . RPAREN [ error UNDERSCORE UIDENT SHARP SEMI RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUAL CONSTRAINT COLON BAR AND ]
+## constr_ident2 -> LPAREN . RPAREN [ error UNDERSCORE UIDENT SHARP SEMI RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUAL CONSTRAINT COLON BAR AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -7457,7 +7457,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 ##
-## Ends in an error in state: 2102.
+## Ends in an error in state: 2099.
 ##
 ## constr_longident -> LBRACKET . RBRACKET [ error SEMI RBRACE LBRACKETATAT LBRACKETAT BAR ]
 ##
@@ -7469,7 +7469,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 2101.
+## Ends in an error in state: 2098.
 ##
 ## constr_longident -> LPAREN . RPAREN [ error SEMI RBRACE LBRACKETATAT LBRACKETAT BAR ]
 ##
@@ -7481,7 +7481,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2100.
+## Ends in an error in state: 2097.
 ##
 ## extension_constructor_rebind -> constr_ident EQUAL . constr_longident attributes [ error SEMI RBRACE LBRACKETATAT BAR ]
 ##
@@ -7519,7 +7519,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 2099.
+## Ends in an error in state: 2096.
 ##
 ## extension_constructor_declaration -> constr_ident . generalized_constructor_arguments attributes [ error SEMI RBRACE LBRACKETATAT BAR ]
 ## extension_constructor_rebind -> constr_ident . EQUAL constr_longident attributes [ error SEMI RBRACE LBRACKETATAT BAR ]
@@ -7532,7 +7532,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 
 implementation: INCLUDE LBRACE EXCEPTION WITH
 ##
-## Ends in an error in state: 2094.
+## Ends in an error in state: 2091.
 ##
 ## str_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ error SEMI RBRACE ]
 ## str_exception_declaration -> EXCEPTION . extension_constructor_rebind post_item_attributes [ error SEMI RBRACE ]
@@ -7545,7 +7545,7 @@ implementation: INCLUDE LBRACE EXCEPTION WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 ##
-## Ends in an error in state: 2090.
+## Ends in an error in state: 2087.
 ##
 ## primitive_declaration -> STRING . [ error SEMI RBRACE LBRACKETATAT ]
 ## primitive_declaration -> STRING . primitive_declaration [ error SEMI RBRACE LBRACKETATAT ]
@@ -7558,7 +7558,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WIT
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2089.
+## Ends in an error in state: 2086.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7570,7 +7570,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2088.
+## Ends in an error in state: 2085.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7593,7 +7593,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 2087.
+## Ends in an error in state: 2084.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7605,7 +7605,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 2086.
+## Ends in an error in state: 2083.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7617,7 +7617,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 
 implementation: INCLUDE LBRACE EXTERNAL WITH
 ##
-## Ends in an error in state: 2085.
+## Ends in an error in state: 2082.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7629,7 +7629,7 @@ implementation: INCLUDE LBRACE EXTERNAL WITH
 
 implementation: INCLUDE LBRACE INCLUDE WITH
 ##
-## Ends in an error in state: 2082.
+## Ends in an error in state: 2079.
 ##
 ## _structure_item_without_item_extension_sugar -> INCLUDE . module_expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7641,7 +7641,7 @@ implementation: INCLUDE LBRACE INCLUDE WITH
 
 implementation: INCLUDE LBRACE LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 ##
-## Ends in an error in state: 2159.
+## Ends in an error in state: 2156.
 ##
 ## and_nonlocal_module_bindings -> AND . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7653,7 +7653,7 @@ implementation: INCLUDE LBRACE LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 
 implementation: INCLUDE LBRACE LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2158.
+## Ends in an error in state: 2155.
 ##
 ## _structure_item_without_item_extension_sugar -> many_nonlocal_module_bindings . [ error SEMI RBRACE ]
 ## many_nonlocal_module_bindings -> many_nonlocal_module_bindings . and_nonlocal_module_bindings [ error SEMI RBRACE AND ]
@@ -7665,16 +7665,16 @@ implementation: INCLUDE LBRACE LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT A
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1098, spurious reduction of production post_item_attributes ->
-## In state 1099, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2039, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
+## In state 1095, spurious reduction of production post_item_attributes ->
+## In state 1096, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2036, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE REC WITH
 ##
-## Ends in an error in state: 2037.
+## Ends in an error in state: 2034.
 ##
 ## many_nonlocal_module_bindings -> LET MODULE REC . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7686,7 +7686,7 @@ implementation: INCLUDE LBRACE LET MODULE REC WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2024.
+## Ends in an error in state: 2021.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
@@ -7700,19 +7700,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2023.
+## Ends in an error in state: 2020.
 ##
 ## module_binding_body_expr -> COLON module_type EQUAL . module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7724,7 +7724,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2022.
+## Ends in an error in state: 2019.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER EQUAL ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER EQUAL ]
@@ -7740,22 +7740,22 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 967, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 964, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2021.
+## Ends in an error in state: 2018.
 ##
 ## module_binding_body_expr -> COLON . module_type EQUAL module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7767,7 +7767,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT COLON WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2020.
+## Ends in an error in state: 2017.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
@@ -7781,19 +7781,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1982.
+## Ends in an error in state: 1979.
 ##
 ## module_binding_body_expr -> EQUAL . module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7805,7 +7805,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2035.
+## Ends in an error in state: 2032.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER module_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
@@ -7819,19 +7819,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2034.
+## Ends in an error in state: 2031.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER . module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7843,7 +7843,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUA
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2033.
+## Ends in an error in state: 2030.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type . EQUALGREATER module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _module_type -> non_arrowed_module_type . [ WITH LBRACKETAT EQUALGREATER ]
@@ -7857,19 +7857,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 967, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 964, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON WITH
 ##
-## Ends in an error in state: 2032.
+## Ends in an error in state: 2029.
 ##
 ## _module_binding_body_functor -> functor_args COLON . non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7881,7 +7881,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2031.
+## Ends in an error in state: 2028.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER module_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
@@ -7895,19 +7895,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2030.
+## Ends in an error in state: 2027.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER . module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7919,7 +7919,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2029.
+## Ends in an error in state: 2026.
 ##
 ## _module_binding_body_functor -> functor_args . EQUALGREATER module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _module_binding_body_functor -> functor_args . COLON non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7933,7 +7933,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1981.
+## Ends in an error in state: 1978.
 ##
 ## nonlocal_module_binding_details -> UIDENT . module_binding_body [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7945,7 +7945,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT WITH
 
 implementation: INCLUDE LBRACE LET MODULE WITH
 ##
-## Ends in an error in state: 1980.
+## Ends in an error in state: 1977.
 ##
 ## _structure_item_without_item_extension_sugar -> LET MODULE . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE ]
 ## many_nonlocal_module_bindings -> LET MODULE . REC nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE AND ]
@@ -7958,7 +7958,7 @@ implementation: INCLUDE LBRACE LET MODULE WITH
 
 implementation: INCLUDE LBRACE LET WITH
 ##
-## Ends in an error in state: 1979.
+## Ends in an error in state: 1976.
 ##
 ## _structure_item_without_item_extension_sugar -> LET . MODULE nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ error SEMI RBRACE AND ]
@@ -7972,7 +7972,7 @@ implementation: INCLUDE LBRACE LET WITH
 
 implementation: INCLUDE LBRACE MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1915.
+## Ends in an error in state: 1912.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7984,7 +7984,7 @@ implementation: INCLUDE LBRACE MODULE TYPE UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE MODULE TYPE WITH
 ##
-## Ends in an error in state: 1913.
+## Ends in an error in state: 1910.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE . ident post_item_attributes [ error SEMI RBRACE ]
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ error SEMI RBRACE ]
@@ -7997,7 +7997,7 @@ implementation: INCLUDE LBRACE MODULE TYPE WITH
 
 implementation: INCLUDE LBRACE MODULE WITH
 ##
-## Ends in an error in state: 1912.
+## Ends in an error in state: 1909.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident post_item_attributes [ error SEMI RBRACE ]
 ## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ error SEMI RBRACE ]
@@ -8010,7 +8010,7 @@ implementation: INCLUDE LBRACE MODULE WITH
 
 implementation: INCLUDE LBRACE OPEN BANG WITH
 ##
-## Ends in an error in state: 1909.
+## Ends in an error in state: 1906.
 ##
 ## open_statement -> OPEN override_flag . mod_longident post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8022,7 +8022,7 @@ implementation: INCLUDE LBRACE OPEN BANG WITH
 
 implementation: INCLUDE LBRACE OPEN WITH
 ##
-## Ends in an error in state: 1908.
+## Ends in an error in state: 1905.
 ##
 ## open_statement -> OPEN . override_flag mod_longident post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8034,7 +8034,7 @@ implementation: INCLUDE LBRACE OPEN WITH
 
 implementation: INCLUDE LBRACE STRING WITH
 ##
-## Ends in an error in state: 2143.
+## Ends in an error in state: 2140.
 ##
 ## structure -> structure_item . [ error RBRACE ]
 ## structure -> structure_item . SEMI structure [ error RBRACE ]
@@ -8046,24 +8046,24 @@ implementation: INCLUDE LBRACE STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2186, spurious reduction of production post_item_attributes ->
-## In state 2187, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 2188, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 2149, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 2142, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 2189, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 2150, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2183, spurious reduction of production post_item_attributes ->
+## In state 2184, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 2185, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 2146, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 2139, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 2186, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 2147, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT AND LIDENT WITH
 ##
-## Ends in an error in state: 2154.
+## Ends in an error in state: 2151.
 ##
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -8074,14 +8074,14 @@ implementation: INCLUDE LBRACE TYPE LIDENT AND LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2153, spurious reduction of production optional_type_parameters ->
+## In state 2150, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT AND WITH
 ##
-## Ends in an error in state: 2152.
+## Ends in an error in state: 2149.
 ##
 ## and_type_declaration -> AND . type_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -8093,7 +8093,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT AND WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 531.
+## Ends in an error in state: 527.
 ##
 ## constrain -> core_type EQUAL . core_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER CONSTRAINT AND ]
 ##
@@ -8105,7 +8105,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 530.
+## Ends in an error in state: 526.
 ##
 ## constrain -> core_type . EQUAL core_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER CONSTRAINT AND ]
 ##
@@ -8128,7 +8128,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT WITH
 ##
-## Ends in an error in state: 529.
+## Ends in an error in state: 525.
 ##
 ## constraints -> constraints CONSTRAINT . constrain [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER CONSTRAINT AND ]
 ##
@@ -8140,7 +8140,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL DOTDOT WITH
 ##
-## Ends in an error in state: 528.
+## Ends in an error in state: 524.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ## type_declaration_details -> LIDENT optional_type_parameters type_kind constraints . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -8153,7 +8153,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL DOTDOT WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 507.
+## Ends in an error in state: 504.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8165,17 +8165,17 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LBRACE LIDENT COLON LESSDOTDOTG
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 502, spurious reduction of production attributes ->
-## In state 503, spurious reduction of production attributes -> attribute attributes
-## In state 501, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 512, spurious reduction of production label_declarations -> label_declaration
+## In state 499, spurious reduction of production attributes ->
+## In state 500, spurious reduction of production attributes -> attribute attributes
+## In state 498, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 509, spurious reduction of production label_declarations -> label_declaration
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 490.
+## Ends in an error in state: 487.
 ##
 ## type_kind -> EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ##
@@ -8227,7 +8227,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UIDENT BAR WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 482.
+## Ends in an error in state: 479.
 ##
 ## constructor_declarations -> constructor_declaration_no_leading_bar . [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ## constructor_declarations -> constructor_declaration_no_leading_bar . constructor_declarations_leading_bar [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8268,7 +8268,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UIDENT WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 522.
+## Ends in an error in state: 518.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8280,17 +8280,17 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 502, spurious reduction of production attributes ->
-## In state 503, spurious reduction of production attributes -> attribute attributes
-## In state 501, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 512, spurious reduction of production label_declarations -> label_declaration
+## In state 499, spurious reduction of production attributes ->
+## In state 500, spurious reduction of production attributes -> attribute attributes
+## In state 498, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 509, spurious reduction of production label_declarations -> label_declaration
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 521.
+## Ends in an error in state: 517.
 ##
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ##
@@ -8302,7 +8302,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 ##
-## Ends in an error in state: 516.
+## Ends in an error in state: 513.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL core_type EQUAL PRIVATE . constructor_declarations [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8315,7 +8315,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 514.
+## Ends in an error in state: 511.
 ##
 ## type_kind -> EQUAL core_type EQUAL . constructor_declarations [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type EQUAL . PRIVATE constructor_declarations [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8330,7 +8330,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 513.
+## Ends in an error in state: 510.
 ##
 ## type_kind -> EQUAL core_type . [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type . EQUAL constructor_declarations [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8378,7 +8378,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT LBRACKETATAT WITH RBRACKET WITH
 ##
-## Ends in an error in state: 2151.
+## Ends in an error in state: 2148.
 ##
 ## _structure_item_without_item_extension_sugar -> many_type_declarations . [ error SEMI RBRACE ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ error SEMI RBRACE AND ]
@@ -8390,9 +8390,9 @@ implementation: INCLUDE LBRACE TYPE LIDENT LBRACKETATAT WITH RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1098, spurious reduction of production post_item_attributes ->
-## In state 1099, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2362, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 1095, spurious reduction of production post_item_attributes ->
+## In state 1096, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2359, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
@@ -8449,7 +8449,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUS WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 2366.
+## Ends in an error in state: 2363.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . str_extension_constructors post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8461,7 +8461,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ BAR WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 2365.
+## Ends in an error in state: 2362.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8473,7 +8473,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ PRIVATE BANG
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 2368.
+## Ends in an error in state: 2365.
 ##
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_declaration [ error SEMI RBRACE LBRACKETATAT BAR ]
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_rebind [ error SEMI RBRACE LBRACKETATAT BAR ]
@@ -8486,7 +8486,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 2364.
+## Ends in an error in state: 2361.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8522,7 +8522,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 534, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 530, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
 ##
 
 <SYNTAX ERROR>
@@ -8548,7 +8548,7 @@ implementation: INCLUDE LBRACE TYPE WITH
 
 implementation: INCLUDE LBRACE UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2144.
+## Ends in an error in state: 2141.
 ##
 ## structure -> structure_item SEMI . structure [ error RBRACE ]
 ##
@@ -8573,7 +8573,7 @@ implementation: INCLUDE LBRACE WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1987.
+## Ends in an error in state: 1984.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER module_expr . [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8588,7 +8588,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHIL
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1985.
+## Ends in an error in state: 1982.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER . module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8600,7 +8600,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1984.
+## Ends in an error in state: 1981.
 ##
 ## _module_expr -> FUN functor_args . EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## functor_args -> functor_args . functor_arg [ LPAREN EQUALGREATER ]
@@ -8613,7 +8613,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 
 implementation: INCLUDE LPAREN FUN WITH
 ##
-## Ends in an error in state: 1983.
+## Ends in an error in state: 1980.
 ##
 ## _module_expr -> FUN . functor_args EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8625,7 +8625,7 @@ implementation: INCLUDE LPAREN FUN WITH
 
 implementation: INCLUDE LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 1907.
+## Ends in an error in state: 1904.
 ##
 ## _module_expr -> LBRACE . structure error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LBRACE . structure RBRACE [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8638,7 +8638,7 @@ implementation: INCLUDE LPAREN LBRACE WITH
 
 implementation: INCLUDE LPAREN LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2009.
+## Ends in an error in state: 2006.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -8654,23 +8654,23 @@ implementation: INCLUDE LPAREN LPAREN UIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 234, spurious reduction of production ident -> UIDENT
-## In state 652, spurious reduction of production mty_longident -> ident
-## In state 1923, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1967, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1963, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1921, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1968, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1964, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1922, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1969, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1965, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 648, spurious reduction of production mty_longident -> ident
+## In state 1920, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1964, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1960, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1918, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1965, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1961, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1919, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1966, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1962, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 2008.
+## Ends in an error in state: 2005.
 ##
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8683,7 +8683,7 @@ implementation: INCLUDE LPAREN LPAREN UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2317.
+## Ends in an error in state: 2314.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -8700,19 +8700,19 @@ implementation: INCLUDE LPAREN LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1999.
+## Ends in an error in state: 1996.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8732,7 +8732,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDEN
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1998.
+## Ends in an error in state: 1995.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8744,7 +8744,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 2315.
+## Ends in an error in state: 2312.
 ##
 ## _module_expr -> LPAREN VAL expr COLON . error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8758,7 +8758,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1993.
+## Ends in an error in state: 1990.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8778,7 +8778,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATE
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 2313.
+## Ends in an error in state: 2310.
 ##
 ## _module_expr -> LPAREN VAL expr COLONGREATER . error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8791,7 +8791,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 2311.
+## Ends in an error in state: 2308.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -8831,21 +8831,21 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN LPAREN VAL WITH
 ##
-## Ends in an error in state: 559.
+## Ends in an error in state: 555.
 ##
 ## _module_expr -> LPAREN VAL . expr COLON error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _module_expr -> LPAREN VAL . expr COLONGREATER error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8863,7 +8863,7 @@ implementation: INCLUDE LPAREN LPAREN VAL WITH
 
 implementation: INCLUDE LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 558.
+## Ends in an error in state: 554.
 ##
 ## _module_expr -> LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _module_expr -> LPAREN . VAL expr COLON error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8886,7 +8886,7 @@ implementation: INCLUDE LPAREN LPAREN WITH
 
 implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2196.
+## Ends in an error in state: 2193.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -8902,23 +8902,23 @@ implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 234, spurious reduction of production ident -> UIDENT
-## In state 652, spurious reduction of production mty_longident -> ident
-## In state 1923, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1967, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1963, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1921, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1968, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1964, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1922, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1969, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1965, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 648, spurious reduction of production mty_longident -> ident
+## In state 1920, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1964, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1960, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1918, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1965, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1961, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1919, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1966, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1962, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 2195.
+## Ends in an error in state: 2192.
 ##
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -8931,7 +8931,7 @@ implementation: INCLUDE LPAREN UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN UIDENT LBRACE UIDENT EOF
 ##
-## Ends in an error in state: 2006.
+## Ends in an error in state: 2003.
 ##
 ## _simple_module_expr -> LBRACE structure . RBRACE [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8942,29 +8942,29 @@ implementation: INCLUDE LPAREN UIDENT LBRACE UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1522, spurious reduction of production post_item_attributes ->
-## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1124, spurious reduction of production structure -> structure_item
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1519, spurious reduction of production post_item_attributes ->
+## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1121, spurious reduction of production structure -> structure_item
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2005.
+## Ends in an error in state: 2002.
 ##
 ## _simple_module_expr -> LBRACE . structure RBRACE [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8976,7 +8976,7 @@ implementation: INCLUDE LPAREN UIDENT LBRACE WITH
 
 implementation: INCLUDE LPAREN UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2002.
+## Ends in an error in state: 1999.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -8993,19 +8993,19 @@ implementation: INCLUDE LPAREN UIDENT LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 1995.
+## Ends in an error in state: 1992.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type COLONGREATER package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -9018,7 +9018,7 @@ implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1992.
+## Ends in an error in state: 1989.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -9030,7 +9030,7 @@ implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 1990.
+## Ends in an error in state: 1987.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -9067,21 +9067,21 @@ implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT LPAREN VAL WITH
 ##
-## Ends in an error in state: 1989.
+## Ends in an error in state: 1986.
 ##
 ## _simple_module_expr -> LPAREN VAL . expr RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN VAL . expr COLON package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -9096,7 +9096,7 @@ implementation: INCLUDE LPAREN UIDENT LPAREN VAL WITH
 
 implementation: INCLUDE LPAREN UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1988.
+## Ends in an error in state: 1985.
 ##
 ## _module_expr -> module_expr LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN . module_expr COLON module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -9116,7 +9116,7 @@ implementation: INCLUDE LPAREN UIDENT LPAREN WITH
 
 implementation: INCLUDE LPAREN UIDENT WHILE
 ##
-## Ends in an error in state: 2013.
+## Ends in an error in state: 2010.
 ##
 ## _simple_module_expr -> mod_longident . [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER DOT COLON AND ]
@@ -9129,7 +9129,7 @@ implementation: INCLUDE LPAREN UIDENT WHILE
 
 implementation: INCLUDE LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2406.
+## Ends in an error in state: 2403.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -9146,19 +9146,19 @@ implementation: INCLUDE LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1904.
+## Ends in an error in state: 1901.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER package_type . RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9178,7 +9178,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLON
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1903.
+## Ends in an error in state: 1900.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER . package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9190,7 +9190,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 2404.
+## Ends in an error in state: 2401.
 ##
 ## _module_expr -> LPAREN VAL expr COLON . error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9204,7 +9204,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1898.
+## Ends in an error in state: 1895.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER package_type . RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9224,7 +9224,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 2402.
+## Ends in an error in state: 2399.
 ##
 ## _module_expr -> LPAREN VAL expr COLONGREATER . error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9237,7 +9237,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 2400.
+## Ends in an error in state: 2397.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -9277,14 +9277,14 @@ implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -9332,7 +9332,7 @@ implementation: INCLUDE LPAREN WITH
 
 implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ##
-## Ends in an error in state: 1786.
+## Ends in an error in state: 1783.
 ##
 ## _simple_module_expr -> LBRACE structure . RBRACE [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9343,29 +9343,29 @@ implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1522, spurious reduction of production post_item_attributes ->
-## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1124, spurious reduction of production structure -> structure_item
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1519, spurious reduction of production post_item_attributes ->
+## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1121, spurious reduction of production structure -> structure_item
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 912.
+## Ends in an error in state: 908.
 ##
 ## _simple_module_expr -> LBRACE . structure RBRACE [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9377,7 +9377,7 @@ implementation: INCLUDE UIDENT LBRACE WITH
 
 implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2192.
+## Ends in an error in state: 2189.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -9394,19 +9394,19 @@ implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 1900.
+## Ends in an error in state: 1897.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type COLONGREATER package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9419,7 +9419,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1897.
+## Ends in an error in state: 1894.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9431,7 +9431,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 1895.
+## Ends in an error in state: 1892.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -9468,21 +9468,21 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL WITH
 ##
-## Ends in an error in state: 864.
+## Ends in an error in state: 860.
 ##
 ## _simple_module_expr -> LPAREN VAL . expr RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL . expr COLON package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9497,7 +9497,7 @@ implementation: INCLUDE UIDENT LPAREN VAL WITH
 
 implementation: INCLUDE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 863.
+## Ends in an error in state: 859.
 ##
 ## _module_expr -> module_expr LPAREN . module_expr error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN . module_expr COLON module_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9517,7 +9517,7 @@ implementation: INCLUDE UIDENT LPAREN WITH
 
 implementation: INCLUDE UIDENT WHILE
 ##
-## Ends in an error in state: 919.
+## Ends in an error in state: 915.
 ##
 ## _simple_module_expr -> mod_longident . [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF DOT COLON AND ]
@@ -9530,7 +9530,7 @@ implementation: INCLUDE UIDENT WHILE
 
 implementation: INCLUDE WITH
 ##
-## Ends in an error in state: 1042.
+## Ends in an error in state: 1039.
 ##
 ## _structure_item_without_item_extension_sugar -> INCLUDE . module_expr post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -9542,7 +9542,7 @@ implementation: INCLUDE WITH
 
 implementation: LAZY WITH
 ##
-## Ends in an error in state: 565.
+## Ends in an error in state: 561.
 ##
 ## _expr -> LAZY . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -9554,7 +9554,7 @@ implementation: LAZY WITH
 
 implementation: LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1348.
+## Ends in an error in state: 1345.
 ##
 ## class_self_pattern_and_structure -> class_self_pattern . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -9566,7 +9566,7 @@ implementation: LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: LBRACE AS UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1337.
+## Ends in an error in state: 1334.
 ##
 ## _class_self_pattern -> AS pattern . SEMI [ error VAL RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ## _or_pattern -> pattern . BAR pattern [ SEMI BAR ]
@@ -9578,14 +9578,14 @@ implementation: LBRACE AS UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production pattern -> pattern_without_or
+## In state 787, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE AS WITH
 ##
-## Ends in an error in state: 1336.
+## Ends in an error in state: 1333.
 ##
 ## _class_self_pattern -> AS . pattern SEMI [ error VAL RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ##
@@ -9597,7 +9597,7 @@ implementation: LBRACE AS WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1539.
+## Ends in an error in state: 1536.
 ##
 ## constrain_field -> core_type EQUAL . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -9609,7 +9609,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1538.
+## Ends in an error in state: 1535.
 ##
 ## constrain_field -> core_type . EQUAL core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -9632,7 +9632,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 
 implementation: LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1537.
+## Ends in an error in state: 1534.
 ##
 ## _class_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -9644,7 +9644,7 @@ implementation: LBRACE CONSTRAINT WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1835.
+## Ends in an error in state: 1832.
 ##
 ## record_expr -> DOTDOTDOT expr_optional_constraint COMMA . lbl_expr_list [ error RBRACE ]
 ##
@@ -9656,7 +9656,7 @@ implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ##
-## Ends in an error in state: 1834.
+## Ends in an error in state: 1831.
 ##
 ## record_expr -> DOTDOTDOT expr_optional_constraint . COMMA lbl_expr_list [ error RBRACE ]
 ##
@@ -9667,22 +9667,22 @@ implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1819, spurious reduction of production expr_optional_constraint -> expr
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1816, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE DOTDOTDOT WITH
 ##
-## Ends in an error in state: 1833.
+## Ends in an error in state: 1830.
 ##
 ## record_expr -> DOTDOTDOT . expr_optional_constraint COMMA lbl_expr_list [ error RBRACE ]
 ##
@@ -9694,7 +9694,7 @@ implementation: LBRACE DOTDOTDOT WITH
 
 implementation: LBRACE INHERIT BANG WITH
 ##
-## Ends in an error in state: 1531.
+## Ends in an error in state: 1528.
 ##
 ## _class_field -> INHERIT override_flag . class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -9706,7 +9706,7 @@ implementation: LBRACE INHERIT BANG WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1307.
+## Ends in an error in state: 1304.
 ##
 ## _class_expr -> CLASS class_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET COLON AS AND ]
@@ -9719,7 +9719,7 @@ implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1306.
+## Ends in an error in state: 1303.
 ##
 ## _class_expr -> CLASS class_longident . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## _class_expr -> CLASS class_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
@@ -9732,7 +9732,7 @@ implementation: LBRACE INHERIT CLASS LIDENT WITH
 
 implementation: LBRACE INHERIT CLASS WITH
 ##
-## Ends in an error in state: 1305.
+## Ends in an error in state: 1302.
 ##
 ## _class_expr -> CLASS . class_longident [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## _class_expr -> CLASS . class_longident non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
@@ -9745,7 +9745,7 @@ implementation: LBRACE INHERIT CLASS WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1329.
+## Ends in an error in state: 1326.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER class_expr . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
@@ -9758,7 +9758,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND R
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1304.
+## Ends in an error in state: 1301.
 ##
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER . class_expr [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ##
@@ -9770,7 +9770,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1303.
+## Ends in an error in state: 1300.
 ##
 ## _class_fun_def -> labeled_simple_pattern . EQUALGREATER class_expr [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern . class_fun_def [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
@@ -9783,7 +9783,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 
 implementation: LBRACE INHERIT FUN WITH
 ##
-## Ends in an error in state: 1301.
+## Ends in an error in state: 1298.
 ##
 ## _class_expr -> FUN . class_fun_def [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ##
@@ -9795,7 +9795,7 @@ implementation: LBRACE INHERIT FUN WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 1342.
+## Ends in an error in state: 1339.
 ##
 ## _class_expr_lets_and_rest -> let_bindings SEMI . class_expr_lets_and_rest [ error RBRACE ]
 ##
@@ -9807,7 +9807,7 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ##
-## Ends in an error in state: 1341.
+## Ends in an error in state: 1338.
 ##
 ## _class_expr_lets_and_rest -> let_bindings . SEMI class_expr_lets_and_rest [ error RBRACE ]
 ## let_bindings -> let_bindings . and_let_binding [ SEMI AND ]
@@ -9819,22 +9819,22 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1298, spurious reduction of production let_binding_body -> pattern EQUAL expr
-## In state 1299, spurious reduction of production post_item_attributes ->
-## In state 1300, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
-## In state 1343, spurious reduction of production let_binding -> let_binding_impl
-## In state 1344, spurious reduction of production let_bindings -> let_binding
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1295, spurious reduction of production let_binding_body -> pattern EQUAL expr
+## In state 1296, spurious reduction of production post_item_attributes ->
+## In state 1297, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
+## In state 1340, spurious reduction of production let_binding -> let_binding_impl
+## In state 1341, spurious reduction of production let_bindings -> let_binding
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE LET WITH
 ##
-## Ends in an error in state: 1165.
+## Ends in an error in state: 1162.
 ##
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI AND ]
 ##
@@ -9846,7 +9846,7 @@ implementation: LBRACE INHERIT LBRACE LET WITH
 
 implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ##
-## Ends in an error in state: 1553.
+## Ends in an error in state: 1550.
 ##
 ## _class_expr -> class_expr . attribute [ error RBRACE LBRACKETAT ]
 ## _class_expr_lets_and_rest -> class_expr . [ error RBRACE ]
@@ -9858,16 +9858,16 @@ implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1311, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1332, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1309, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1308, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1329, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1306, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 ##
-## Ends in an error in state: 1345.
+## Ends in an error in state: 1342.
 ##
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI AND ]
 ##
@@ -9886,7 +9886,7 @@ implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 
 implementation: LBRACE INHERIT LBRACE WITH
 ##
-## Ends in an error in state: 1164.
+## Ends in an error in state: 1161.
 ##
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest RBRACE [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest error [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
@@ -9899,7 +9899,7 @@ implementation: LBRACE INHERIT LBRACE WITH
 
 implementation: LBRACE INHERIT LIDENT AS WITH
 ##
-## Ends in an error in state: 1533.
+## Ends in an error in state: 1530.
 ##
 ## parent_binder -> AS . LIDENT [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -9911,7 +9911,7 @@ implementation: LBRACE INHERIT LIDENT AS WITH
 
 implementation: LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1532.
+## Ends in an error in state: 1529.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AS ]
 ## _class_field -> INHERIT override_flag class_expr . parent_binder post_item_attributes [ error SEMI RBRACE ]
@@ -9923,16 +9923,16 @@ implementation: LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1311, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1332, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1309, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1308, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1329, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1306, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT SEMI WITH
 ##
-## Ends in an error in state: 1549.
+## Ends in an error in state: 1546.
 ##
 ## semi_terminated_class_fields -> class_field SEMI . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -9944,7 +9944,7 @@ implementation: LBRACE INHERIT LIDENT SEMI WITH
 
 implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ##
-## Ends in an error in state: 1323.
+## Ends in an error in state: 1320.
 ##
 ## _class_expr -> class_simple_expr simple_labeled_expr_list . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## simple_labeled_expr_list -> simple_labeled_expr_list . labeled_simple_expr [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
@@ -9956,20 +9956,20 @@ implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1318, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1314, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1324, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
-## In state 1327, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1315, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1311, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1321, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
+## In state 1324, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT WITH
 ##
-## Ends in an error in state: 1311.
+## Ends in an error in state: 1308.
 ##
 ## _class_expr -> class_simple_expr . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## _class_expr -> class_simple_expr . simple_labeled_expr_list [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
@@ -9982,7 +9982,7 @@ implementation: LBRACE INHERIT LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1591.
+## Ends in an error in state: 1588.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -9994,7 +9994,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE 
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1590.
+## Ends in an error in state: 1587.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -10007,7 +10007,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE 
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1589.
+## Ends in an error in state: 1586.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -10019,7 +10019,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1582.
+## Ends in an error in state: 1579.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -10031,7 +10031,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 1581.
+## Ends in an error in state: 1578.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -10044,7 +10044,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1580.
+## Ends in an error in state: 1577.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -10056,7 +10056,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1583.
+## Ends in an error in state: 1580.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -10068,7 +10068,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1579, spurious reduction of production type_longident -> LIDENT
+## In state 1576, spurious reduction of production type_longident -> LIDENT
 ## In state 261, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
 ## In state 266, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
 ## In state 264, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
@@ -10079,7 +10079,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 ##
-## Ends in an error in state: 1565.
+## Ends in an error in state: 1562.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT AND ]
@@ -10092,7 +10092,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1576.
+## Ends in an error in state: 1573.
 ##
 ## _class_constructor_type -> NEW class_instance_type . [ error RPAREN ]
 ## _class_instance_type -> class_instance_type . attribute [ error RPAREN LBRACKETAT ]
@@ -10104,16 +10104,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1574, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1578, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1572, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1571, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1575, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1569, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1575.
+## Ends in an error in state: 1572.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET AND ]
@@ -10126,7 +10126,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 ##
-## Ends in an error in state: 1574.
+## Ends in an error in state: 1571.
 ##
 ## _class_instance_type -> clty_longident . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT AND ]
@@ -10139,7 +10139,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 ##
-## Ends in an error in state: 1570.
+## Ends in an error in state: 1567.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -10153,7 +10153,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 ##
-## Ends in an error in state: 1569.
+## Ends in an error in state: 1566.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -10173,7 +10173,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1563.
+## Ends in an error in state: 1560.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ error RPAREN ]
 ##
@@ -10185,7 +10185,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1584.
+## Ends in an error in state: 1581.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -10197,7 +10197,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 ##
-## Ends in an error in state: 1562.
+## Ends in an error in state: 1559.
 ##
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
@@ -10210,7 +10210,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ##
-## Ends in an error in state: 1559.
+## Ends in an error in state: 1556.
 ##
 ## _class_expr -> class_expr . attribute [ error RPAREN LBRACKETAT COLON ]
 ## _class_simple_expr -> LPAREN class_expr . COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
@@ -10225,16 +10225,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1311, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1332, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1309, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1308, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1329, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1306, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN WITH
 ##
-## Ends in an error in state: 1163.
+## Ends in an error in state: 1160.
 ##
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
@@ -10249,7 +10249,7 @@ implementation: LBRACE INHERIT LPAREN WITH
 
 implementation: LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1530.
+## Ends in an error in state: 1527.
 ##
 ## _class_field -> INHERIT . override_flag class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -10261,7 +10261,7 @@ implementation: LBRACE INHERIT WITH
 
 implementation: LBRACE INITIALIZER EQUALGREATER WITH
 ##
-## Ends in an error in state: 1527.
+## Ends in an error in state: 1524.
 ##
 ## _class_field -> INITIALIZER EQUALGREATER . expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -10273,7 +10273,7 @@ implementation: LBRACE INITIALIZER EQUALGREATER WITH
 
 implementation: LBRACE INITIALIZER WITH
 ##
-## Ends in an error in state: 1526.
+## Ends in an error in state: 1523.
 ##
 ## _class_field -> INITIALIZER . EQUALGREATER expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -10285,7 +10285,7 @@ implementation: LBRACE INITIALIZER WITH
 
 implementation: LBRACE LBRACKETATATAT UNDERSCORE
 ##
-## Ends in an error in state: 1507.
+## Ends in an error in state: 1504.
 ##
 ## floating_attribute -> LBRACKETATATAT . attr_id payload RBRACKET [ error SEMI RBRACE ]
 ##
@@ -10297,7 +10297,7 @@ implementation: LBRACE LBRACKETATATAT UNDERSCORE
 
 implementation: LBRACE LBRACKETATATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 1510.
+## Ends in an error in state: 1507.
 ##
 ## floating_attribute -> LBRACKETATATAT attr_id payload . RBRACKET [ error SEMI RBRACE ]
 ##
@@ -10308,30 +10308,30 @@ implementation: LBRACE LBRACKETATATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1522, spurious reduction of production post_item_attributes ->
-## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1124, spurious reduction of production structure -> structure_item
-## In state 1509, spurious reduction of production payload -> structure
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1519, spurious reduction of production post_item_attributes ->
+## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1121, spurious reduction of production structure -> structure_item
+## In state 1506, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LBRACKETPERCENTPERCENT UNDERSCORE
 ##
-## Ends in an error in state: 1121.
+## Ends in an error in state: 1118.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT . attr_id payload RBRACKET [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -10343,7 +10343,7 @@ implementation: LBRACE LBRACKETPERCENTPERCENT UNDERSCORE
 
 implementation: LBRACE LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 1688.
+## Ends in an error in state: 1685.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT attr_id payload . RBRACKET [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -10354,30 +10354,30 @@ implementation: LBRACE LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1522, spurious reduction of production post_item_attributes ->
-## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1124, spurious reduction of production structure -> structure_item
-## In state 1509, spurious reduction of production payload -> structure
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1519, spurious reduction of production post_item_attributes ->
+## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1121, spurious reduction of production structure -> structure_item
+## In state 1506, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET CHAR EQUAL CHAR AND WITH
 ##
-## Ends in an error in state: 2174.
+## Ends in an error in state: 2171.
 ##
 ## and_let_binding -> AND . let_binding_body post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -10389,7 +10389,7 @@ implementation: LBRACE LET CHAR EQUAL CHAR AND WITH
 
 implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 2440.
+## Ends in an error in state: 2437.
 ##
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . RBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -10401,17 +10401,17 @@ implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2265, spurious reduction of production opt_semi -> SEMI
-## In state 2276, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
-## In state 2274, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2263, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2262, spurious reduction of production opt_semi -> SEMI
+## In state 2273, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
+## In state 2271, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2260, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
 ##
 
 Expecting "}" to finish the block
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 2058.
+## Ends in an error in state: 2055.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -10445,21 +10445,21 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2062.
+## Ends in an error in state: 2059.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10471,7 +10471,7 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2061.
+## Ends in an error in state: 2058.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10494,7 +10494,7 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 2060.
+## Ends in an error in state: 2057.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10506,7 +10506,7 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2059.
+## Ends in an error in state: 2056.
 ##
 ## let_binding_body -> val_ident COLON typevar_list . DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -10519,7 +10519,7 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 
 implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2056.
+## Ends in an error in state: 2053.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10531,7 +10531,7 @@ implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2055.
+## Ends in an error in state: 2052.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10554,7 +10554,7 @@ implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 2054.
+## Ends in an error in state: 2051.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10566,7 +10566,7 @@ implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LBRACE LET LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 2052.
+## Ends in an error in state: 2049.
 ##
 ## let_binding_body -> val_ident COLON TYPE . lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10578,7 +10578,7 @@ implementation: LBRACE LET LIDENT COLON TYPE WITH
 
 implementation: LBRACE LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 2051.
+## Ends in an error in state: 2048.
 ##
 ## let_binding_body -> val_ident COLON . typevar_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ## let_binding_body -> val_ident COLON . TYPE lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -10592,7 +10592,7 @@ implementation: LBRACE LET LIDENT COLON WITH
 
 implementation: LBRACE LET LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 ##
-## Ends in an error in state: 2065.
+## Ends in an error in state: 2062.
 ##
 ## let_binding_body -> val_ident type_constraint EQUAL . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10604,7 +10604,7 @@ implementation: LBRACE LET LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 
 implementation: LBRACE LET LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2064.
+## Ends in an error in state: 2061.
 ##
 ## let_binding_body -> val_ident type_constraint . EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10621,14 +10621,14 @@ implementation: LBRACE LET LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1263, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1260, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2049.
+## Ends in an error in state: 2046.
 ##
 ## _curried_binding_return_typed -> EQUALGREATER . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10640,7 +10640,7 @@ implementation: LBRACE LET LIDENT EQUALGREATER WITH
 
 implementation: LBRACE LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2047.
+## Ends in an error in state: 2044.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10652,7 +10652,7 @@ implementation: LBRACE LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LBRACE LET LIDENT LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 2046.
+## Ends in an error in state: 2043.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10664,7 +10664,7 @@ implementation: LBRACE LET LIDENT LPAREN TYPE LIDENT WITH
 
 implementation: LBRACE LET LIDENT LPAREN TYPE WITH
 ##
-## Ends in an error in state: 2045.
+## Ends in an error in state: 2042.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10676,7 +10676,7 @@ implementation: LBRACE LET LIDENT LPAREN TYPE WITH
 
 implementation: LBRACE LET LIDENT LPAREN WITH
 ##
-## Ends in an error in state: 2044.
+## Ends in an error in state: 2041.
 ##
 ## _curried_binding_return_typed -> LPAREN . TYPE LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -10699,7 +10699,7 @@ implementation: LBRACE LET LIDENT LPAREN WITH
 
 implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1487.
+## Ends in an error in state: 1484.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -10733,21 +10733,21 @@ implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1486.
+## Ends in an error in state: 1483.
 ##
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type EQUALGREATER . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10759,7 +10759,7 @@ implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1485.
+## Ends in an error in state: 1482.
 ##
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type . EQUALGREATER expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -10772,7 +10772,7 @@ implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE WITH
 
 implementation: LBRACE LET LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1484.
+## Ends in an error in state: 1481.
 ##
 ## curried_binding_return_typed_ -> COLON . non_arrowed_core_type EQUALGREATER expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10784,7 +10784,7 @@ implementation: LBRACE LET LIDENT UNDERSCORE COLON WITH
 
 implementation: LBRACE LET LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2068.
+## Ends in an error in state: 2065.
 ##
 ## _curried_binding_return_typed -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10796,7 +10796,7 @@ implementation: LBRACE LET LIDENT UNDERSCORE WITH
 
 implementation: LBRACE LET LIDENT WITH
 ##
-## Ends in an error in state: 2043.
+## Ends in an error in state: 2040.
 ##
 ## _simple_pattern -> val_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> val_ident . type_constraint EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -10812,7 +10812,7 @@ implementation: LBRACE LET LIDENT WITH
 
 implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT RBRACKET
 ##
-## Ends in an error in state: 2280.
+## Ends in an error in state: 2277.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes . SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10823,22 +10823,22 @@ implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 861, spurious reduction of production _module_expr -> simple_module_expr
-## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
-## In state 917, spurious reduction of production module_binding_body_expr -> EQUAL module_expr
-## In state 1767, spurious reduction of production module_binding_body -> module_binding_body_expr
-## In state 2279, spurious reduction of production post_item_attributes ->
+## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 857, spurious reduction of production _module_expr -> simple_module_expr
+## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 913, spurious reduction of production module_binding_body_expr -> EQUAL module_expr
+## In state 1764, spurious reduction of production module_binding_body -> module_binding_body_expr
+## In state 2276, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2281.
+## Ends in an error in state: 2278.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10850,7 +10850,7 @@ implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 
 implementation: LBRACE LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2278.
+## Ends in an error in state: 2275.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10862,7 +10862,7 @@ implementation: LBRACE LET MODULE UIDENT WITH
 
 implementation: LBRACE LET MODULE WITH
 ##
-## Ends in an error in state: 2277.
+## Ends in an error in state: 2274.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10874,7 +10874,7 @@ implementation: LBRACE LET MODULE WITH
 
 implementation: LBRACE LET OPEN BANG WITH
 ##
-## Ends in an error in state: 594.
+## Ends in an error in state: 590.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10886,7 +10886,7 @@ implementation: LBRACE LET OPEN BANG WITH
 
 implementation: LBRACE LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 598.
+## Ends in an error in state: 594.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10898,7 +10898,7 @@ implementation: LBRACE LET OPEN UIDENT SEMI WITH
 
 implementation: LBRACE LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 597.
+## Ends in an error in state: 593.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10909,14 +10909,14 @@ implementation: LBRACE LET OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 595, spurious reduction of production post_item_attributes ->
+## In state 591, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET OPEN WITH
 ##
-## Ends in an error in state: 593.
+## Ends in an error in state: 589.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10928,7 +10928,7 @@ implementation: LBRACE LET OPEN WITH
 
 implementation: LBRACE LET REC ASSERT
 ##
-## Ends in an error in state: 2042.
+## Ends in an error in state: 2039.
 ##
 ## let_binding_impl -> LET rec_flag . let_binding_body post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -10940,7 +10940,7 @@ implementation: LBRACE LET REC ASSERT
 
 implementation: LBRACE LET UIDENT UNDERSCORE WHEN
 ##
-## Ends in an error in state: 2077.
+## Ends in an error in state: 2074.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EQUAL BAR ]
 ## let_binding_body -> pattern . EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -10952,17 +10952,17 @@ implementation: LBRACE LET UIDENT UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 787, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
-## In state 790, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
-## In state 785, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
-## In state 791, spurious reduction of production pattern -> pattern_without_or
+## In state 783, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
+## In state 786, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
+## In state 781, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
+## In state 787, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2075.
+## Ends in an error in state: 2072.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10974,7 +10974,7 @@ implementation: LBRACE LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 
 implementation: LBRACE LET UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2074.
+## Ends in an error in state: 2071.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10997,7 +10997,7 @@ implementation: LBRACE LET UNDERSCORE COLON UNDERSCORE WITH
 
 implementation: LBRACE LET UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2073.
+## Ends in an error in state: 2070.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON . core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11009,7 +11009,7 @@ implementation: LBRACE LET UNDERSCORE COLON WITH
 
 implementation: LBRACE LET UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2078.
+## Ends in an error in state: 2075.
 ##
 ## let_binding_body -> pattern EQUAL . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11021,7 +11021,7 @@ implementation: LBRACE LET UNDERSCORE EQUAL WITH
 
 implementation: LBRACE LET UNDERSCORE WITH
 ##
-## Ends in an error in state: 2072.
+## Ends in an error in state: 2069.
 ##
 ## _simple_pattern -> simple_pattern_not_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> simple_pattern_not_ident . COLON core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -11034,7 +11034,7 @@ implementation: LBRACE LET UNDERSCORE WITH
 
 implementation: LBRACE LET WITH
 ##
-## Ends in an error in state: 591.
+## Ends in an error in state: 587.
 ##
 ## _semi_terminated_seq_expr_row -> LET . MODULE UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ## _semi_terminated_seq_expr_row -> LET . OPEN override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
@@ -11048,7 +11048,7 @@ implementation: LBRACE LET WITH
 
 implementation: LBRACE LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1853.
+## Ends in an error in state: 1850.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11083,21 +11083,21 @@ implementation: LBRACE LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1852.
+## Ends in an error in state: 1849.
 ##
 ## lbl_expr -> label_longident COLON . expr [ COMMA ]
 ## non_punned_lbl_expression -> label_longident COLON . expr [ error RBRACE ]
@@ -11110,7 +11110,7 @@ implementation: LBRACE LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1842.
+## Ends in an error in state: 1839.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11144,21 +11144,21 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 ##
-## Ends in an error in state: 1841.
+## Ends in an error in state: 1838.
 ##
 ## lbl_expr -> label_longident COLON . expr [ error RBRACE COMMA ]
 ##
@@ -11170,7 +11170,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 ##
-## Ends in an error in state: 1838.
+## Ends in an error in state: 1835.
 ##
 ## lbl_expr_list -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ## lbl_expr_list -> lbl_expr COMMA . [ error RBRACE ]
@@ -11183,7 +11183,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT WITH
 ##
-## Ends in an error in state: 1840.
+## Ends in an error in state: 1837.
 ##
 ## lbl_expr -> label_longident . COLON expr [ error RBRACE COMMA ]
 ## lbl_expr -> label_longident . [ error RBRACE COMMA ]
@@ -11196,7 +11196,7 @@ implementation: LBRACE LIDENT COMMA LIDENT WITH
 
 implementation: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 1849.
+## Ends in an error in state: 1846.
 ##
 ## lbl_expr_list_that_is_not_a_single_punned_field -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ##
@@ -11208,7 +11208,7 @@ implementation: LBRACE LIDENT COMMA WITH
 
 implementation: LBRACE METHOD BANG WITH
 ##
-## Ends in an error in state: 1465.
+## Ends in an error in state: 1462.
 ##
 ## method_ -> override_flag . PRIVATE VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag . VIRTUAL private_flag label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -11225,7 +11225,7 @@ implementation: LBRACE METHOD BANG WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1500.
+## Ends in an error in state: 1497.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11259,21 +11259,21 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1499.
+## Ends in an error in state: 1496.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT core_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11285,7 +11285,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1498.
+## Ends in an error in state: 1495.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT core_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11308,7 +11308,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1497.
+## Ends in an error in state: 1494.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT . core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11320,7 +11320,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 1495.
+## Ends in an error in state: 1492.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE . lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11332,7 +11332,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE WITH
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1503.
+## Ends in an error in state: 1500.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11366,21 +11366,21 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1502.
+## Ends in an error in state: 1499.
 ##
 ## method_ -> override_flag private_flag label COLON poly_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11392,7 +11392,7 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1501.
+## Ends in an error in state: 1498.
 ##
 ## method_ -> override_flag private_flag label COLON poly_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11409,16 +11409,16 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 505, spurious reduction of production _poly_type -> core_type
-## In state 506, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 504, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 502, spurious reduction of production _poly_type -> core_type
+## In state 503, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 501, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON WITH
 ##
-## Ends in an error in state: 1494.
+## Ends in an error in state: 1491.
 ##
 ## method_ -> override_flag private_flag label COLON . poly_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag private_flag label COLON . TYPE lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -11431,7 +11431,7 @@ implementation: LBRACE METHOD LIDENT COLON WITH
 
 implementation: LBRACE METHOD LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1493.
+## Ends in an error in state: 1490.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11465,21 +11465,21 @@ implementation: LBRACE METHOD LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1492.
+## Ends in an error in state: 1489.
 ##
 ## method_ -> override_flag private_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11491,7 +11491,7 @@ implementation: LBRACE METHOD LIDENT EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1548.
+## Ends in an error in state: 1545.
 ##
 ## semi_terminated_class_fields -> class_field . [ error RBRACE ]
 ## semi_terminated_class_fields -> class_field . SEMI semi_terminated_class_fields [ error RBRACE ]
@@ -11503,27 +11503,27 @@ implementation: LBRACE METHOD LIDENT EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1483, spurious reduction of production curried_binding -> EQUALGREATER expr
-## In state 1504, spurious reduction of production method_ -> override_flag private_flag label curried_binding
-## In state 1505, spurious reduction of production post_item_attributes ->
-## In state 1506, spurious reduction of production _class_field -> METHOD method_ post_item_attributes
-## In state 1551, spurious reduction of production mark_position_cf(_class_field) -> _class_field
-## In state 1544, spurious reduction of production class_field -> mark_position_cf(_class_field)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1480, spurious reduction of production curried_binding -> EQUALGREATER expr
+## In state 1501, spurious reduction of production method_ -> override_flag private_flag label curried_binding
+## In state 1502, spurious reduction of production post_item_attributes ->
+## In state 1503, spurious reduction of production _class_field -> METHOD method_ post_item_attributes
+## In state 1548, spurious reduction of production mark_position_cf(_class_field) -> _class_field
+## In state 1541, spurious reduction of production class_field -> mark_position_cf(_class_field)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1482.
+## Ends in an error in state: 1479.
 ##
 ## curried_binding -> EQUALGREATER . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11535,7 +11535,7 @@ implementation: LBRACE METHOD LIDENT EQUALGREATER WITH
 
 implementation: LBRACE METHOD LIDENT LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1481.
+## Ends in an error in state: 1478.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11547,7 +11547,7 @@ implementation: LBRACE METHOD LIDENT LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LBRACE METHOD LIDENT LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1480.
+## Ends in an error in state: 1477.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11559,7 +11559,7 @@ implementation: LBRACE METHOD LIDENT LPAREN TYPE LIDENT WITH
 
 implementation: LBRACE METHOD LIDENT LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1479.
+## Ends in an error in state: 1476.
 ##
 ## curried_binding -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11571,7 +11571,7 @@ implementation: LBRACE METHOD LIDENT LPAREN TYPE WITH
 
 implementation: LBRACE METHOD LIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1478.
+## Ends in an error in state: 1475.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -11594,7 +11594,7 @@ implementation: LBRACE METHOD LIDENT LPAREN WITH
 
 implementation: LBRACE METHOD LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1488.
+## Ends in an error in state: 1485.
 ##
 ## curried_binding -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11606,7 +11606,7 @@ implementation: LBRACE METHOD LIDENT UNDERSCORE WITH
 
 implementation: LBRACE METHOD LIDENT WITH
 ##
-## Ends in an error in state: 1477.
+## Ends in an error in state: 1474.
 ##
 ## method_ -> override_flag private_flag label . curried_binding [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag private_flag label . COLON poly_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -11621,7 +11621,7 @@ implementation: LBRACE METHOD LIDENT WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1474.
+## Ends in an error in state: 1471.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11633,7 +11633,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1473.
+## Ends in an error in state: 1470.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11645,7 +11645,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL WITH
 ##
-## Ends in an error in state: 1472.
+## Ends in an error in state: 1469.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11657,7 +11657,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL WITH
 
 implementation: LBRACE METHOD PRIVATE WITH
 ##
-## Ends in an error in state: 1471.
+## Ends in an error in state: 1468.
 ##
 ## method_ -> override_flag PRIVATE . VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## private_flag -> PRIVATE . [ LIDENT ]
@@ -11670,7 +11670,7 @@ implementation: LBRACE METHOD PRIVATE WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1114.
+## Ends in an error in state: 1111.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11682,7 +11682,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1113.
+## Ends in an error in state: 1110.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -11695,7 +11695,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WIT
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE WITH
 ##
-## Ends in an error in state: 1111.
+## Ends in an error in state: 1108.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ error SEMI RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AS ]
 ## typevar_list -> QUOTE . ident [ QUOTE DOT ]
@@ -11708,7 +11708,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1469.
+## Ends in an error in state: 1466.
 ##
 ## method_ -> override_flag VIRTUAL private_flag label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11720,7 +11720,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1468.
+## Ends in an error in state: 1465.
 ##
 ## method_ -> override_flag VIRTUAL private_flag label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11732,7 +11732,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT WITH
 
 implementation: LBRACE METHOD VIRTUAL PRIVATE LET
 ##
-## Ends in an error in state: 1467.
+## Ends in an error in state: 1464.
 ##
 ## method_ -> override_flag VIRTUAL private_flag . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11744,7 +11744,7 @@ implementation: LBRACE METHOD VIRTUAL PRIVATE LET
 
 implementation: LBRACE METHOD VIRTUAL WITH
 ##
-## Ends in an error in state: 1466.
+## Ends in an error in state: 1463.
 ##
 ## method_ -> override_flag VIRTUAL . private_flag label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11756,7 +11756,7 @@ implementation: LBRACE METHOD VIRTUAL WITH
 
 implementation: LBRACE METHOD WITH
 ##
-## Ends in an error in state: 1464.
+## Ends in an error in state: 1461.
 ##
 ## _class_field -> METHOD . method_ post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -11768,7 +11768,7 @@ implementation: LBRACE METHOD WITH
 
 implementation: LBRACE PERCENT WITH TYPE
 ##
-## Ends in an error in state: 2267.
+## Ends in an error in state: 2264.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ error RBRACE ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ error SEMI RBRACE AND ]
@@ -11788,7 +11788,7 @@ implementation: LBRACE PERCENT WITH TYPE
 
 implementation: LBRACE UIDENT DOT WITH
 ##
-## Ends in an error in state: 2290.
+## Ends in an error in state: 2287.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
@@ -11813,7 +11813,7 @@ implementation: LBRACE UIDENT DOT WITH
 
 implementation: LBRACE UIDENT LBRACKETATAT UNDERSCORE
 ##
-## Ends in an error in state: 543.
+## Ends in an error in state: 539.
 ##
 ## item_attribute -> LBRACKETATAT . attr_id payload RBRACKET [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11825,7 +11825,7 @@ implementation: LBRACE UIDENT LBRACKETATAT UNDERSCORE
 
 implementation: LBRACE UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2360.
+## Ends in an error in state: 2357.
 ##
 ## item_attribute -> LBRACKETATAT attr_id payload . RBRACKET [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11836,30 +11836,30 @@ implementation: LBRACE UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1522, spurious reduction of production post_item_attributes ->
-## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1124, spurious reduction of production structure -> structure_item
-## In state 1509, spurious reduction of production payload -> structure
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1519, spurious reduction of production post_item_attributes ->
+## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1121, spurious reduction of production structure -> structure_item
+## In state 1506, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL BANG WITH
 ##
-## Ends in an error in state: 1358.
+## Ends in an error in state: 1355.
 ##
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -11874,7 +11874,7 @@ implementation: LBRACE VAL BANG WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1463.
+## Ends in an error in state: 1460.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11908,21 +11908,21 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL UIDENT RP
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 ##
-## Ends in an error in state: 1462.
+## Ends in an error in state: 1459.
 ##
 ## value -> override_flag mutable_flag label type_constraint EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11934,7 +11934,7 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1461.
+## Ends in an error in state: 1458.
 ##
 ## value -> override_flag mutable_flag label type_constraint . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11951,14 +11951,14 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1263, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1260, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1459.
+## Ends in an error in state: 1456.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11992,21 +11992,21 @@ implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1367.
+## Ends in an error in state: 1364.
 ##
 ## value -> override_flag mutable_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -12018,7 +12018,7 @@ implementation: LBRACE VAL LIDENT EQUAL WITH
 
 implementation: LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1366.
+## Ends in an error in state: 1363.
 ##
 ## value -> override_flag mutable_flag label . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag mutable_flag label . type_constraint EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -12031,7 +12031,7 @@ implementation: LBRACE VAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1363.
+## Ends in an error in state: 1360.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12055,7 +12055,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1362.
+## Ends in an error in state: 1359.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12068,7 +12068,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1361.
+## Ends in an error in state: 1358.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12081,7 +12081,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 ##
-## Ends in an error in state: 1360.
+## Ends in an error in state: 1357.
 ##
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12094,7 +12094,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 
 implementation: LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1359.
+## Ends in an error in state: 1356.
 ##
 ## mutable_flag -> MUTABLE . [ LIDENT ]
 ## value -> override_flag MUTABLE . VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -12108,7 +12108,7 @@ implementation: LBRACE VAL MUTABLE WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1354.
+## Ends in an error in state: 1351.
 ##
 ## value -> VIRTUAL mutable_flag label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12132,7 +12132,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1353.
+## Ends in an error in state: 1350.
 ##
 ## value -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12145,7 +12145,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1352.
+## Ends in an error in state: 1349.
 ##
 ## value -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12158,7 +12158,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1351.
+## Ends in an error in state: 1348.
 ##
 ## value -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12171,7 +12171,7 @@ implementation: LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1350.
+## Ends in an error in state: 1347.
 ##
 ## value -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL . mutable_flag label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12184,7 +12184,7 @@ implementation: LBRACE VAL VIRTUAL WITH
 
 implementation: LBRACE VAL WITH
 ##
-## Ends in an error in state: 1349.
+## Ends in an error in state: 1346.
 ##
 ## _class_field -> VAL . value post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -12213,7 +12213,7 @@ implementation: LBRACE WITH
 
 implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2491.
+## Ends in an error in state: 2488.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -12247,14 +12247,14 @@ implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -12273,7 +12273,7 @@ implementation: LBRACELESS LIDENT COLON WITH
 
 implementation: LBRACELESS LIDENT COMMA WITH
 ##
-## Ends in an error in state: 583.
+## Ends in an error in state: 579.
 ##
 ## field_expr_list -> field_expr_list COMMA . field_expr [ error GREATERRBRACE COMMA ]
 ## opt_comma -> COMMA . [ error GREATERRBRACE ]
@@ -12313,7 +12313,7 @@ implementation: LBRACELESS WITH
 
 implementation: LBRACKET DOTDOTDOT UIDENT COMMA
 ##
-## Ends in an error in state: 2213.
+## Ends in an error in state: 2210.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT expr_optional_constraint . RBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -12324,22 +12324,22 @@ implementation: LBRACKET DOTDOTDOT UIDENT COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1819, spurious reduction of production expr_optional_constraint -> expr
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1816, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKET DOTDOTDOT WITH
 ##
-## Ends in an error in state: 2212.
+## Ends in an error in state: 2209.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT . expr_optional_constraint RBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -12351,7 +12351,7 @@ implementation: LBRACKET DOTDOTDOT WITH
 
 implementation: LBRACKET UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2216.
+## Ends in an error in state: 2213.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint COMMA . expr_comma_seq_extension [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## opt_comma -> COMMA . [ RBRACKET ]
@@ -12364,7 +12364,7 @@ implementation: LBRACKET UIDENT COMMA WITH
 
 implementation: LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2215.
+## Ends in an error in state: 2212.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint . opt_comma RBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## expr_comma_seq_extension -> expr_optional_constraint . COMMA expr_comma_seq_extension [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -12376,15 +12376,15 @@ implementation: LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1819, spurious reduction of production expr_optional_constraint -> expr
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1816, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 Expecting one of the following:
@@ -12409,7 +12409,7 @@ Expecting one of the following:
 
 implementation: LBRACKETATATAT UNDERSCORE
 ##
-## Ends in an error in state: 1040.
+## Ends in an error in state: 1037.
 ##
 ## floating_attribute -> LBRACKETATATAT . attr_id payload RBRACKET [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12421,7 +12421,7 @@ implementation: LBRACKETATATAT UNDERSCORE
 
 implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 1712.
+## Ends in an error in state: 1709.
 ##
 ## floating_attribute -> LBRACKETATATAT attr_id payload . RBRACKET [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12432,30 +12432,30 @@ implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1522, spurious reduction of production post_item_attributes ->
-## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1124, spurious reduction of production structure -> structure_item
-## In state 1509, spurious reduction of production payload -> structure
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1519, spurious reduction of production post_item_attributes ->
+## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1121, spurious reduction of production structure -> structure_item
+## In state 1506, spurious reduction of production payload -> structure
 ##
 
 Expecting "]" to finish current floating attribute
 
 implementation: LBRACKETBAR BANG WITH
 ##
-## Ends in an error in state: 606.
+## Ends in an error in state: 602.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12467,7 +12467,7 @@ implementation: LBRACKETBAR BANG WITH
 
 implementation: LBRACKETBAR MINUSDOT WITH
 ##
-## Ends in an error in state: 1370.
+## Ends in an error in state: 1367.
 ##
 ## _expr -> subtractive . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12479,7 +12479,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR PLUSDOT WITH
 ##
-## Ends in an error in state: 1394.
+## Ends in an error in state: 1391.
 ##
 ## _expr -> additive . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12503,7 +12503,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1809.
+## Ends in an error in state: 1806.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -12515,7 +12515,7 @@ Expecting a type name
 
 implementation: LBRACKETBAR UIDENT COLON WITH
 ##
-## Ends in an error in state: 1806.
+## Ends in an error in state: 1803.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -12527,7 +12527,7 @@ implementation: LBRACKETBAR UIDENT COLON WITH
 
 implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1804.
+## Ends in an error in state: 1801.
 ##
 ## type_constraint -> COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -12539,7 +12539,7 @@ implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 
 implementation: LBRACKETBAR UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1801.
+## Ends in an error in state: 1798.
 ##
 ## expr_comma_seq -> expr_comma_seq COMMA . expr_optional_constraint [ error COMMA BARRBRACKET ]
 ## opt_comma -> COMMA . [ error BARRBRACKET ]
@@ -12552,7 +12552,7 @@ implementation: LBRACKETBAR UIDENT COMMA WITH
 
 implementation: LBRACKETBAR UIDENT SEMI
 ##
-## Ends in an error in state: 2509.
+## Ends in an error in state: 2506.
 ##
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -12565,16 +12565,16 @@ implementation: LBRACKETBAR UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1803, spurious reduction of production expr_optional_constraint -> expr
-## In state 1799, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1800, spurious reduction of production expr_optional_constraint -> expr
+## In state 1796, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
@@ -12607,7 +12607,7 @@ implementation: LBRACKETPERCENT UNDERSCORE
 
 implementation: LBRACKETPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2611.
+## Ends in an error in state: 2603.
 ##
 ## extension -> LBRACKETPERCENT attr_id payload . RBRACKET [ WITH WHEN UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR OPTIONAL_NO_DEFAULT NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 IN GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOWNTO DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12618,30 +12618,30 @@ implementation: LBRACKETPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1522, spurious reduction of production post_item_attributes ->
-## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1124, spurious reduction of production structure -> structure_item
-## In state 1509, spurious reduction of production payload -> structure
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1519, spurious reduction of production post_item_attributes ->
+## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1121, spurious reduction of production structure -> structure_item
+## In state 1506, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 ##
-## Ends in an error in state: 1038.
+## Ends in an error in state: 1035.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT . attr_id payload RBRACKET [ SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -12653,7 +12653,7 @@ implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH COLON WITH
 ##
-## Ends in an error in state: 1065.
+## Ends in an error in state: 1062.
 ##
 ## payload -> COLON . core_type [ RBRACKET ]
 ##
@@ -12677,7 +12677,7 @@ implementation: LBRACKETPERCENTPERCENT WITH DOT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ##
-## Ends in an error in state: 2434.
+## Ends in an error in state: 2431.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN RBRACKET BAR ]
 ## payload -> QUESTION pattern . [ RBRACKET ]
@@ -12690,14 +12690,14 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production pattern -> pattern_without_or
+## In state 787, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2436.
+## Ends in an error in state: 2433.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -12731,21 +12731,21 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2435.
+## Ends in an error in state: 2432.
 ##
 ## payload -> QUESTION pattern WHEN . expr [ RBRACKET ]
 ##
@@ -12770,7 +12770,7 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION WITH
 
 implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 1714.
+## Ends in an error in state: 1711.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT attr_id payload . RBRACKET [ SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -12781,23 +12781,23 @@ implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1522, spurious reduction of production post_item_attributes ->
-## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1124, spurious reduction of production structure -> structure_item
-## In state 1509, spurious reduction of production payload -> structure
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1519, spurious reduction of production post_item_attributes ->
+## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1121, spurious reduction of production structure -> structure_item
+## In state 1506, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
@@ -12817,7 +12817,7 @@ implementation: LBRACKETPERCENTPERCENT WITH WITH
 
 implementation: LET CHAR EQUAL CHAR AND WITH
 ##
-## Ends in an error in state: 1513.
+## Ends in an error in state: 1510.
 ##
 ## and_let_binding -> AND . let_binding_body post_item_attributes [ SEMI RBRACKET RBRACE EOF BAR AND ]
 ##
@@ -12829,7 +12829,7 @@ implementation: LET CHAR EQUAL CHAR AND WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1273.
+## Ends in an error in state: 1270.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -12863,21 +12863,21 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1277.
+## Ends in an error in state: 1274.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type EQUAL . mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12889,7 +12889,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1276.
+## Ends in an error in state: 1273.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type . EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12912,7 +12912,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1275.
+## Ends in an error in state: 1272.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT . core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12924,7 +12924,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1274.
+## Ends in an error in state: 1271.
 ##
 ## let_binding_body -> val_ident COLON typevar_list . DOT core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -12937,7 +12937,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1271.
+## Ends in an error in state: 1268.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type EQUAL . mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12949,7 +12949,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1270.
+## Ends in an error in state: 1267.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type . EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12972,7 +12972,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1269.
+## Ends in an error in state: 1266.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT . core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12984,7 +12984,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1266.
+## Ends in an error in state: 1263.
 ##
 ## lident_list -> LIDENT . [ DOT ]
 ## lident_list -> LIDENT . lident_list [ DOT ]
@@ -12997,7 +12997,7 @@ implementation: LET LIDENT COLON TYPE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 1265.
+## Ends in an error in state: 1262.
 ##
 ## let_binding_body -> val_ident COLON TYPE . lident_list DOT core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13009,7 +13009,7 @@ implementation: LET LIDENT COLON TYPE WITH
 
 implementation: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 1264.
+## Ends in an error in state: 1261.
 ##
 ## let_binding_body -> val_ident COLON . typevar_list DOT core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ## let_binding_body -> val_ident COLON . TYPE lident_list DOT core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
@@ -13023,7 +13023,7 @@ implementation: LET LIDENT COLON WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1284.
+## Ends in an error in state: 1281.
 ##
 ## let_binding_body -> val_ident type_constraint EQUAL . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13035,7 +13035,7 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 1283.
+## Ends in an error in state: 1280.
 ##
 ## let_binding_body -> val_ident type_constraint . EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13052,14 +13052,14 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1263, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1260, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1260.
+## Ends in an error in state: 1257.
 ##
 ## _curried_binding_return_typed -> EQUALGREATER . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13071,7 +13071,7 @@ implementation: LET LIDENT EQUALGREATER WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1171.
+## Ends in an error in state: 1168.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13083,7 +13083,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1170.
+## Ends in an error in state: 1167.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13095,7 +13095,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1169.
+## Ends in an error in state: 1166.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13107,7 +13107,7 @@ implementation: LET LIDENT LPAREN TYPE WITH
 
 implementation: LET LIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1168.
+## Ends in an error in state: 1165.
 ##
 ## _curried_binding_return_typed -> LPAREN . TYPE LIDENT RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -13130,7 +13130,7 @@ implementation: LET LIDENT LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1253.
+## Ends in an error in state: 1250.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -13164,21 +13164,21 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1252.
+## Ends in an error in state: 1249.
 ##
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type EQUALGREATER . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13190,7 +13190,7 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1251.
+## Ends in an error in state: 1248.
 ##
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type . EQUALGREATER expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
@@ -13204,7 +13204,7 @@ Expecting "=>" to start the function body
 
 implementation: LET LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1250.
+## Ends in an error in state: 1247.
 ##
 ## curried_binding_return_typed_ -> COLON . non_arrowed_core_type EQUALGREATER expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13216,7 +13216,7 @@ implementation: LET LIDENT UNDERSCORE COLON WITH
 
 implementation: LET LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1176.
+## Ends in an error in state: 1173.
 ##
 ## curried_binding -> EQUALGREATER . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13228,7 +13228,7 @@ Expecting an expression as function body
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1175.
+## Ends in an error in state: 1172.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13240,7 +13240,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1174.
+## Ends in an error in state: 1171.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13252,7 +13252,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1173.
+## Ends in an error in state: 1170.
 ##
 ## curried_binding -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13264,7 +13264,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 1172.
+## Ends in an error in state: 1169.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -13287,7 +13287,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 1255.
+## Ends in an error in state: 1252.
 ##
 ## curried_binding -> labeled_simple_pattern . curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13299,7 +13299,7 @@ implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 
 implementation: LET LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1287.
+## Ends in an error in state: 1284.
 ##
 ## _curried_binding_return_typed -> labeled_simple_pattern . curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13315,7 +13315,7 @@ Expecting one of the following:
 
 implementation: LET LIDENT WITH
 ##
-## Ends in an error in state: 1167.
+## Ends in an error in state: 1164.
 ##
 ## _simple_pattern -> val_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> val_ident . type_constraint EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
@@ -13331,7 +13331,7 @@ implementation: LET LIDENT WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 ##
-## Ends in an error in state: 1145.
+## Ends in an error in state: 1142.
 ##
 ## and_nonlocal_module_bindings -> AND . nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -13343,7 +13343,7 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1144.
+## Ends in an error in state: 1141.
 ##
 ## _structure_item_without_item_extension_sugar -> many_nonlocal_module_bindings . [ SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> many_nonlocal_module_bindings . and_nonlocal_module_bindings [ SEMI RBRACKET RBRACE EOF AND ]
@@ -13355,16 +13355,16 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WIT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 932, spurious reduction of production post_item_attributes ->
-## In state 933, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1783, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
+## In state 928, spurious reduction of production post_item_attributes ->
+## In state 929, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1780, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE REC WITH
 ##
-## Ends in an error in state: 1781.
+## Ends in an error in state: 1778.
 ##
 ## many_nonlocal_module_bindings -> LET MODULE REC . nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -13376,7 +13376,7 @@ implementation: LET MODULE REC WITH
 
 implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 1765.
+## Ends in an error in state: 1762.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -13390,19 +13390,19 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 861, spurious reduction of production _module_expr -> simple_module_expr
-## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 857, spurious reduction of production _module_expr -> simple_module_expr
+## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1764.
+## Ends in an error in state: 1761.
 ##
 ## module_binding_body_expr -> COLON module_type EQUAL . module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13414,7 +13414,7 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
 
 implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1763.
+## Ends in an error in state: 1760.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER EQUAL ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER EQUAL ]
@@ -13430,22 +13430,22 @@ implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 967, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 964, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 926.
+## Ends in an error in state: 922.
 ##
 ## module_binding_body_expr -> COLON . module_type EQUAL module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13457,7 +13457,7 @@ implementation: LET MODULE UIDENT COLON WITH
 
 implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 917.
+## Ends in an error in state: 913.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -13471,19 +13471,19 @@ implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 861, spurious reduction of production _module_expr -> simple_module_expr
-## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 857, spurious reduction of production _module_expr -> simple_module_expr
+## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 916.
+## Ends in an error in state: 912.
 ##
 ## module_binding_body_expr -> EQUAL . module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13495,7 +13495,7 @@ implementation: LET MODULE UIDENT EQUAL WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 1776.
+## Ends in an error in state: 1773.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER module_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -13509,19 +13509,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 861, spurious reduction of production _module_expr -> simple_module_expr
-## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 857, spurious reduction of production _module_expr -> simple_module_expr
+## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1775.
+## Ends in an error in state: 1772.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER . module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13533,7 +13533,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1774.
+## Ends in an error in state: 1771.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type . EQUALGREATER module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_type -> non_arrowed_module_type . [ WITH LBRACKETAT EQUALGREATER ]
@@ -13547,19 +13547,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 967, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 964, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER SEMI
 ##
-## Ends in an error in state: 1777.
+## Ends in an error in state: 1774.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER ]
@@ -13578,18 +13578,18 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT CO
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 976, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 995, spurious reduction of production with_constraints -> with_constraint
-## In state 992, spurious reduction of production _module_type -> module_type WITH with_constraints
-## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 973, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 992, spurious reduction of production with_constraints -> with_constraint
+## In state 989, spurious reduction of production _module_type -> module_type WITH with_constraints
+## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
 ##
-## Ends in an error in state: 1773.
+## Ends in an error in state: 1770.
 ##
 ## _module_binding_body_functor -> functor_args COLON . non_arrowed_module_type EQUALGREATER module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13601,7 +13601,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 1772.
+## Ends in an error in state: 1769.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER module_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -13615,19 +13615,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 861, spurious reduction of production _module_expr -> simple_module_expr
-## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 857, spurious reduction of production _module_expr -> simple_module_expr
+## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1771.
+## Ends in an error in state: 1768.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER . module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13639,7 +13639,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1770.
+## Ends in an error in state: 1767.
 ##
 ## _module_binding_body_functor -> functor_args . EQUALGREATER module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_binding_body_functor -> functor_args . COLON non_arrowed_module_type EQUALGREATER module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -13653,7 +13653,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 
 implementation: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 915.
+## Ends in an error in state: 911.
 ##
 ## nonlocal_module_binding_details -> UIDENT . module_binding_body [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13665,7 +13665,7 @@ implementation: LET MODULE UIDENT WITH
 
 implementation: LET MODULE WITH
 ##
-## Ends in an error in state: 914.
+## Ends in an error in state: 910.
 ##
 ## _structure_item_without_item_extension_sugar -> LET MODULE . nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> LET MODULE . REC nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
@@ -13678,7 +13678,7 @@ implementation: LET MODULE WITH
 
 implementation: LET REC ASSERT
 ##
-## Ends in an error in state: 1166.
+## Ends in an error in state: 1163.
 ##
 ## let_binding_impl -> LET rec_flag . let_binding_body post_item_attributes [ SEMI RBRACKET RBRACE EOF BAR AND ]
 ##
@@ -13690,7 +13690,7 @@ implementation: LET REC ASSERT
 
 implementation: LET UIDENT UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1296.
+## Ends in an error in state: 1293.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EQUAL BAR ]
 ## let_binding_body -> pattern . EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
@@ -13702,17 +13702,17 @@ implementation: LET UIDENT UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 787, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
-## In state 790, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
-## In state 785, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
-## In state 791, spurious reduction of production pattern -> pattern_without_or
+## In state 783, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
+## In state 786, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
+## In state 781, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
+## In state 787, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1294.
+## Ends in an error in state: 1291.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type EQUAL . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13724,7 +13724,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1293.
+## Ends in an error in state: 1290.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type . EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13747,7 +13747,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 
 implementation: LET UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1292.
+## Ends in an error in state: 1289.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON . core_type EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13759,7 +13759,7 @@ implementation: LET UNDERSCORE COLON WITH
 
 implementation: LET UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1297.
+## Ends in an error in state: 1294.
 ##
 ## let_binding_body -> pattern EQUAL . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13771,7 +13771,7 @@ implementation: LET UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE WITH
 ##
-## Ends in an error in state: 1291.
+## Ends in an error in state: 1288.
 ##
 ## _simple_pattern -> simple_pattern_not_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> simple_pattern_not_ident . COLON core_type EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
@@ -13784,7 +13784,7 @@ implementation: LET UNDERSCORE WITH
 
 implementation: LET WITH
 ##
-## Ends in an error in state: 913.
+## Ends in an error in state: 909.
 ##
 ## _structure_item_without_item_extension_sugar -> LET . MODULE nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
@@ -13798,7 +13798,7 @@ Incomplete let binding
 
 implementation: LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1190.
+## Ends in an error in state: 1187.
 ##
 ## _expr -> label EQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13810,7 +13810,7 @@ implementation: LIDENT EQUAL WITH
 
 implementation: LPAREN ASSERT WITH
 ##
-## Ends in an error in state: 1368.
+## Ends in an error in state: 1365.
 ##
 ## _expr -> ASSERT . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13822,7 +13822,7 @@ implementation: LPAREN ASSERT WITH
 
 implementation: LPAREN BACKQUOTE WITH
 ##
-## Ends in an error in state: 607.
+## Ends in an error in state: 603.
 ##
 ## name_tag -> BACKQUOTE . ident [ error UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -13834,7 +13834,7 @@ implementation: LPAREN BACKQUOTE WITH
 
 implementation: LPAREN BANG WITH
 ##
-## Ends in an error in state: 1794.
+## Ends in an error in state: 1791.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SHARP RPAREN QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## operator -> BANG . [ RPAREN ]
@@ -13847,7 +13847,7 @@ implementation: LPAREN BANG WITH
 
 implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ##
-## Ends in an error in state: 2345.
+## Ends in an error in state: 2342.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr . RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13881,21 +13881,21 @@ implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2344.
+## Ends in an error in state: 2341.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA . expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13907,7 +13907,7 @@ implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2343.
+## Ends in an error in state: 2340.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr . COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13941,21 +13941,21 @@ implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2342.
+## Ends in an error in state: 2339.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN . expr COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13967,7 +13967,7 @@ implementation: LPAREN COLONCOLON RPAREN LPAREN WITH
 
 implementation: LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2341.
+## Ends in an error in state: 2338.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN . LPAREN expr COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13979,7 +13979,7 @@ implementation: LPAREN COLONCOLON RPAREN WITH
 
 implementation: LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2340.
+## Ends in an error in state: 2337.
 ##
 ## _expr -> LPAREN COLONCOLON . RPAREN LPAREN expr COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13991,7 +13991,7 @@ implementation: LPAREN COLONCOLON WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ##
-## Ends in an error in state: 904.
+## Ends in an error in state: 900.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag simple_expr . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -14009,17 +14009,17 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 890, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 886, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 ##
-## Ends in an error in state: 903.
+## Ends in an error in state: 899.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag . simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14031,7 +14031,7 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ##
-## Ends in an error in state: 902.
+## Ends in an error in state: 898.
 ##
 ## _expr -> FOR pattern IN simple_expr . direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ TO SHARP DOWNTO DOT ]
@@ -14049,17 +14049,17 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 890, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 886, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FOR UNDERSCORE IN WITH
 ##
-## Ends in an error in state: 901.
+## Ends in an error in state: 897.
 ##
 ## _expr -> FOR pattern IN . simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14071,7 +14071,7 @@ implementation: LPAREN FOR UNDERSCORE IN WITH
 
 implementation: LPAREN FOR UNDERSCORE WHEN
 ##
-## Ends in an error in state: 900.
+## Ends in an error in state: 896.
 ##
 ## _expr -> FOR pattern . IN simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _or_pattern -> pattern . BAR pattern [ IN BAR ]
@@ -14083,14 +14083,14 @@ implementation: LPAREN FOR UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production pattern -> pattern_without_or
+## In state 787, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FOR WITH
 ##
-## Ends in an error in state: 899.
+## Ends in an error in state: 895.
 ##
 ## _expr -> FOR . pattern IN simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14102,7 +14102,7 @@ implementation: LPAREN FOR WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2245.
+## Ends in an error in state: 2242.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14136,17 +14136,17 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2244.
+## Ends in an error in state: 2241.
 ##
 ## leading_bar_match_case -> bar_located_pattern EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14158,7 +14158,7 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2243.
+## Ends in an error in state: 2240.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14192,17 +14192,17 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2242.
+## Ends in an error in state: 2239.
 ##
 ## leading_bar_match_case -> bar_located_pattern WHEN expr EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14214,7 +14214,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2241.
+## Ends in an error in state: 2238.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -14248,21 +14248,21 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2240.
+## Ends in an error in state: 2237.
 ##
 ## leading_bar_match_case -> bar_located_pattern WHEN . expr EQUALGREATER expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14274,7 +14274,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 625.
+## Ends in an error in state: 621.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14286,7 +14286,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 624.
+## Ends in an error in state: 620.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14298,7 +14298,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN LPAREN TYPE WITH
 ##
-## Ends in an error in state: 623.
+## Ends in an error in state: 619.
 ##
 ## _expr -> FUN LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14310,7 +14310,7 @@ implementation: LPAREN FUN LPAREN TYPE WITH
 
 implementation: LPAREN FUN LPAREN WITH
 ##
-## Ends in an error in state: 622.
+## Ends in an error in state: 618.
 ##
 ## _expr -> FUN LPAREN . TYPE LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
@@ -14333,7 +14333,7 @@ implementation: LPAREN FUN LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2232.
+## Ends in an error in state: 2229.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14367,17 +14367,17 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2231.
+## Ends in an error in state: 2228.
 ##
 ## fun_def -> EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14389,7 +14389,7 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 629.
+## Ends in an error in state: 625.
 ##
 ## fun_def -> LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14401,7 +14401,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 628.
+## Ends in an error in state: 624.
 ##
 ## fun_def -> LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14413,7 +14413,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 627.
+## Ends in an error in state: 623.
 ##
 ## fun_def -> LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14425,7 +14425,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 626.
+## Ends in an error in state: 622.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
@@ -14448,7 +14448,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 2233.
+## Ends in an error in state: 2230.
 ##
 ## fun_def -> labeled_simple_pattern . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14460,7 +14460,7 @@ implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 
 implementation: LPAREN FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2247.
+## Ends in an error in state: 2244.
 ##
 ## _expr -> FUN labeled_simple_pattern . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14472,7 +14472,7 @@ implementation: LPAREN FUN UNDERSCORE WITH
 
 implementation: LPAREN FUN WITH
 ##
-## Ends in an error in state: 621.
+## Ends in an error in state: 617.
 ##
 ## _expr -> FUN . labeled_simple_pattern fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> FUN . LPAREN TYPE LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14486,7 +14486,7 @@ implementation: LPAREN FUN WITH
 
 implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 ##
-## Ends in an error in state: 620.
+## Ends in an error in state: 616.
 ##
 ## _expr -> IF simple_expr simple_expr ELSE . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14498,7 +14498,7 @@ implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 
 implementation: LPAREN IF UIDENT WITH
 ##
-## Ends in an error in state: 618.
+## Ends in an error in state: 614.
 ##
 ## _expr -> IF simple_expr . simple_expr ELSE expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF simple_expr . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14517,17 +14517,17 @@ implementation: LPAREN IF UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 890, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 886, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN IF WITH
 ##
-## Ends in an error in state: 617.
+## Ends in an error in state: 613.
 ##
 ## _expr -> IF . simple_expr simple_expr ELSE expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF . simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14540,7 +14540,7 @@ implementation: LPAREN IF WITH
 
 implementation: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 599.
+## Ends in an error in state: 595.
 ##
 ## _expr -> LAZY . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14552,7 +14552,7 @@ implementation: LPAREN LAZY WITH
 
 implementation: LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 589.
+## Ends in an error in state: 585.
 ##
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14569,7 +14569,7 @@ implementation: LPAREN LBRACE WITH
 
 implementation: LPAREN LBRACELESS WITH
 ##
-## Ends in an error in state: 580.
+## Ends in an error in state: 576.
 ##
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14583,7 +14583,7 @@ implementation: LPAREN LBRACELESS WITH
 
 implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ##
-## Ends in an error in state: 1817.
+## Ends in an error in state: 1814.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT expr_optional_constraint . RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -14594,22 +14594,22 @@ implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1819, spurious reduction of production expr_optional_constraint -> expr
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1816, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKET DOTDOTDOT WITH
 ##
-## Ends in an error in state: 1816.
+## Ends in an error in state: 1813.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT . expr_optional_constraint RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -14621,7 +14621,7 @@ implementation: LPAREN LBRACKET DOTDOTDOT WITH
 
 implementation: LPAREN LBRACKET UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1821.
+## Ends in an error in state: 1818.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint . opt_comma RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## expr_comma_seq_extension -> expr_optional_constraint . COMMA expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14639,15 +14639,15 @@ implementation: LPAREN LBRACKET UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1263, spurious reduction of production type_constraint -> COLONGREATER core_type
-## In state 1820, spurious reduction of production expr_optional_constraint -> expr type_constraint
+## In state 1260, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1817, spurious reduction of production expr_optional_constraint -> expr type_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKET UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1822.
+## Ends in an error in state: 1819.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint COMMA . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## opt_comma -> COMMA . [ RBRACKET ]
@@ -14660,7 +14660,7 @@ implementation: LPAREN LBRACKET UIDENT COMMA WITH
 
 implementation: LPAREN LBRACKET WITH
 ##
-## Ends in an error in state: 562.
+## Ends in an error in state: 558.
 ##
 ## _simple_expr -> LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## constr_longident -> LBRACKET . RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14673,7 +14673,7 @@ implementation: LPAREN LBRACKET WITH
 
 implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2307.
+## Ends in an error in state: 2304.
 ##
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14686,23 +14686,23 @@ implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1803, spurious reduction of production expr_optional_constraint -> expr
-## In state 1799, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1800, spurious reduction of production expr_optional_constraint -> expr
+## In state 1796, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKETBAR WITH
 ##
-## Ends in an error in state: 561.
+## Ends in an error in state: 557.
 ##
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14728,7 +14728,7 @@ implementation: LPAREN LBRACKETPERCENT UNDERSCORE
 
 implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2437.
+## Ends in an error in state: 2434.
 ##
 ## extension -> LBRACKETPERCENT attr_id payload . RBRACKET [ error WITH UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUALGREATER EQUAL ELSE DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -14739,30 +14739,30 @@ implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1522, spurious reduction of production post_item_attributes ->
-## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1124, spurious reduction of production structure -> structure_item
-## In state 1509, spurious reduction of production payload -> structure
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1519, spurious reduction of production post_item_attributes ->
+## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1121, spurious reduction of production structure -> structure_item
+## In state 1506, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1380.
+## Ends in an error in state: 1377.
 ##
 ## _expr -> label EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14774,7 +14774,7 @@ implementation: LPAREN LIDENT EQUAL WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ##
-## Ends in an error in state: 2390.
+## Ends in an error in state: 2387.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr . RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -14808,21 +14808,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2389.
+## Ends in an error in state: 2386.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA . expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14834,7 +14834,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2388.
+## Ends in an error in state: 2385.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr . COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -14868,21 +14868,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2387.
+## Ends in an error in state: 2384.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN . expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14894,7 +14894,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2386.
+## Ends in an error in state: 2383.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN . LPAREN expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14906,7 +14906,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2385.
+## Ends in an error in state: 2382.
 ##
 ## _expr -> LPAREN COLONCOLON . RPAREN LPAREN expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14918,7 +14918,7 @@ implementation: LPAREN LPAREN COLONCOLON WITH
 
 implementation: LPAREN LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2383.
+## Ends in an error in state: 2380.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -14938,7 +14938,7 @@ implementation: LPAREN LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: LPAREN LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2381.
+## Ends in an error in state: 2378.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14951,7 +14951,7 @@ implementation: LPAREN LPAREN MODULE UIDENT COLON WITH
 
 implementation: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2379.
+## Ends in an error in state: 2376.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -14967,12 +14967,12 @@ implementation: LPAREN LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 861, spurious reduction of production _module_expr -> simple_module_expr
-## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 857, spurious reduction of production _module_expr -> simple_module_expr
+## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
@@ -14993,7 +14993,7 @@ Expecting a module expression
 
 implementation: LPAREN LPAREN STAR WITH
 ##
-## Ends in an error in state: 726.
+## Ends in an error in state: 722.
 ##
 ## val_ident -> LPAREN operator . RPAREN [ error UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15005,7 +15005,7 @@ implementation: LPAREN LPAREN STAR WITH
 
 implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ##
-## Ends in an error in state: 2392.
+## Ends in an error in state: 2389.
 ##
 ## _simple_expr -> LPAREN expr_comma_list . RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN expr_comma_list . error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15018,12 +15018,12 @@ implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1803, spurious reduction of production expr_optional_constraint -> expr
-## In state 2349, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1800, spurious reduction of production expr_optional_constraint -> expr
+## In state 2346, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
@@ -15057,7 +15057,7 @@ Expecting one of the following:
 
 implementation: LPAREN MINUS WITH
 ##
-## Ends in an error in state: 1793.
+## Ends in an error in state: 1790.
 ##
 ## operator -> MINUS . [ RPAREN ]
 ## subtractive -> MINUS . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
@@ -15070,7 +15070,7 @@ implementation: LPAREN MINUS WITH
 
 implementation: LPAREN MINUSDOT WITH
 ##
-## Ends in an error in state: 1792.
+## Ends in an error in state: 1789.
 ##
 ## operator -> MINUSDOT . [ RPAREN ]
 ## subtractive -> MINUSDOT . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
@@ -15083,7 +15083,7 @@ implementation: LPAREN MINUSDOT WITH
 
 implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2338.
+## Ends in an error in state: 2335.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON package_type . RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -15103,7 +15103,7 @@ implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2336.
+## Ends in an error in state: 2333.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON . package_type RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE module_expr COLON . error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15116,7 +15116,7 @@ implementation: LPAREN MODULE UIDENT COLON WITH
 
 implementation: LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2334.
+## Ends in an error in state: 2331.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -15132,19 +15132,19 @@ implementation: LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 861, spurious reduction of production _module_expr -> simple_module_expr
-## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 857, spurious reduction of production _module_expr -> simple_module_expr
+## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN MODULE WITH
 ##
-## Ends in an error in state: 546.
+## Ends in an error in state: 542.
 ##
 ## _simple_expr -> LPAREN MODULE . module_expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE . module_expr COLON package_type RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15235,7 +15235,7 @@ implementation: LPAREN PREFIXOP WITH
 
 implementation: LPAREN STAR WITH
 ##
-## Ends in an error in state: 798.
+## Ends in an error in state: 794.
 ##
 ## val_ident -> LPAREN operator . RPAREN [ WITH WHEN UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR OPTIONAL_NO_DEFAULT NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 IN GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15247,7 +15247,7 @@ implementation: LPAREN STAR WITH
 
 implementation: LPAREN STRING LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1321.
+## Ends in an error in state: 1318.
 ##
 ## label_expr -> LIDENT COLONCOLON . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15259,7 +15259,7 @@ implementation: LPAREN STRING LIDENT COLONCOLON WITH
 
 implementation: LPAREN STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1313.
+## Ends in an error in state: 1310.
 ##
 ## label_expr -> LIDENT EXPLICITLY_PASSED_OPTIONAL . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15271,7 +15271,7 @@ implementation: LPAREN STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: LPAREN SWITCH UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2450.
+## Ends in an error in state: 2447.
 ##
 ## _expr -> SWITCH simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15283,7 +15283,7 @@ implementation: LPAREN SWITCH UIDENT LBRACE WITH
 
 implementation: LPAREN SWITCH UIDENT WITH
 ##
-## Ends in an error in state: 2449.
+## Ends in an error in state: 2446.
 ##
 ## _expr -> SWITCH simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ SHARP LBRACE DOT ]
@@ -15301,10 +15301,10 @@ implementation: LPAREN SWITCH UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 890, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 886, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -15323,7 +15323,7 @@ implementation: LPAREN SWITCH WITH
 
 implementation: LPAREN TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 ##
-## Ends in an error in state: 1453.
+## Ends in an error in state: 1450.
 ##
 ## _expr -> simple_expr DOT LBRACE expr RBRACE EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15335,7 +15335,7 @@ implementation: LPAREN TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 
 implementation: LPAREN TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 1451.
+## Ends in an error in state: 1448.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -15370,21 +15370,21 @@ implementation: LPAREN TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 1450.
+## Ends in an error in state: 1447.
 ##
 ## _expr -> simple_expr DOT LBRACE . expr RBRACE EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15397,7 +15397,7 @@ implementation: LPAREN TRUE DOT LBRACE WITH
 
 implementation: LPAREN TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 ##
-## Ends in an error in state: 1448.
+## Ends in an error in state: 1445.
 ##
 ## _expr -> simple_expr DOT LBRACKET expr RBRACKET EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15409,7 +15409,7 @@ implementation: LPAREN TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 
 implementation: LPAREN TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 1445.
+## Ends in an error in state: 1442.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -15445,21 +15445,21 @@ implementation: LPAREN TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1444.
+## Ends in an error in state: 1441.
 ##
 ## _expr -> simple_expr DOT LBRACKET . expr RBRACKET EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15473,7 +15473,7 @@ implementation: LPAREN TRUE DOT LBRACKET WITH
 
 implementation: LPAREN TRUE DOT LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1456.
+## Ends in an error in state: 1453.
 ##
 ## _expr -> simple_expr DOT label_longident EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15485,7 +15485,7 @@ implementation: LPAREN TRUE DOT LIDENT EQUAL WITH
 
 implementation: LPAREN TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 ##
-## Ends in an error in state: 1438.
+## Ends in an error in state: 1435.
 ##
 ## _expr -> simple_expr DOT LPAREN expr RPAREN EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15497,7 +15497,7 @@ implementation: LPAREN TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 
 implementation: LPAREN TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1435.
+## Ends in an error in state: 1432.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -15533,21 +15533,21 @@ implementation: LPAREN TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 1373.
+## Ends in an error in state: 1370.
 ##
 ## _expr -> simple_expr DOT LPAREN . expr RPAREN EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15561,7 +15561,7 @@ implementation: LPAREN TRUE DOT LPAREN WITH
 
 implementation: LPAREN TRUE DOT WITH
 ##
-## Ends in an error in state: 1372.
+## Ends in an error in state: 1369.
 ##
 ## _expr -> simple_expr DOT . label_longident EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> simple_expr DOT . LPAREN expr RPAREN EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -15582,7 +15582,7 @@ implementation: LPAREN TRUE DOT WITH
 
 implementation: LPAREN TRY UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2505.
+## Ends in an error in state: 2502.
 ##
 ## _expr -> TRY simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15594,7 +15594,7 @@ implementation: LPAREN TRY UIDENT LBRACE WITH
 
 implementation: LPAREN TRY UIDENT UNDERSCORE
 ##
-## Ends in an error in state: 2502.
+## Ends in an error in state: 2499.
 ##
 ## _expr -> TRY simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> TRY simple_expr . WITH error [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -15613,17 +15613,17 @@ implementation: LPAREN TRY UIDENT UNDERSCORE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 890, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 886, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN TRY UIDENT WITH WITH
 ##
-## Ends in an error in state: 2503.
+## Ends in an error in state: 2500.
 ##
 ## _expr -> TRY simple_expr WITH . error [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15648,7 +15648,7 @@ implementation: LPAREN TRY WITH
 
 implementation: LPAREN UIDENT AMPERAMPER WITH
 ##
-## Ends in an error in state: 1431.
+## Ends in an error in state: 1428.
 ##
 ## _expr -> expr AMPERAMPER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15660,7 +15660,7 @@ implementation: LPAREN UIDENT AMPERAMPER WITH
 
 implementation: LPAREN UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 1429.
+## Ends in an error in state: 1426.
 ##
 ## _expr -> expr AMPERSAND . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15672,7 +15672,7 @@ implementation: LPAREN UIDENT AMPERSAND WITH
 
 implementation: LPAREN UIDENT BARBAR WITH
 ##
-## Ends in an error in state: 1427.
+## Ends in an error in state: 1424.
 ##
 ## _expr -> expr BARBAR . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15684,7 +15684,7 @@ implementation: LPAREN UIDENT BARBAR WITH
 
 implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1281.
+## Ends in an error in state: 1278.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ RPAREN RBRACKET EQUAL COMMA ]
 ##
@@ -15696,7 +15696,7 @@ implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 
 implementation: LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1460.
+## Ends in an error in state: 1457.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ RPAREN RBRACKET EQUAL COMMA ]
 ##
@@ -15708,7 +15708,7 @@ implementation: LPAREN UIDENT COLON WITH
 
 implementation: LPAREN UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1433.
+## Ends in an error in state: 1430.
 ##
 ## _expr -> expr COLONEQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15720,7 +15720,7 @@ implementation: LPAREN UIDENT COLONEQUAL WITH
 
 implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2347.
+## Ends in an error in state: 2344.
 ##
 ## expr_comma_list -> expr_optional_constraint . COMMA expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -15737,15 +15737,15 @@ implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1263, spurious reduction of production type_constraint -> COLONGREATER core_type
-## In state 2358, spurious reduction of production expr_optional_constraint -> expr type_constraint
+## In state 1260, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 2355, spurious reduction of production expr_optional_constraint -> expr type_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1262.
+## Ends in an error in state: 1259.
 ##
 ## type_constraint -> COLONGREATER . core_type [ RPAREN RBRACKET EQUAL COMMA ]
 ##
@@ -15757,7 +15757,7 @@ implementation: LPAREN UIDENT COLONGREATER WITH
 
 implementation: LPAREN UIDENT COMMA CHAR BARRBRACKET
 ##
-## Ends in an error in state: 2350.
+## Ends in an error in state: 2347.
 ##
 ## _simple_expr -> LPAREN expr_comma_list . RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN expr_comma_list . error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15770,19 +15770,19 @@ implementation: LPAREN UIDENT COMMA CHAR BARRBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1803, spurious reduction of production expr_optional_constraint -> expr
-## In state 2349, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1800, spurious reduction of production expr_optional_constraint -> expr
+## In state 2346, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 2353.
+## Ends in an error in state: 2350.
 ##
 ## expr_comma_list -> expr_comma_list COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -15794,7 +15794,7 @@ implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 
 implementation: LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2348.
+## Ends in an error in state: 2345.
 ##
 ## expr_comma_list -> expr_optional_constraint COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -15806,7 +15806,7 @@ implementation: LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN UIDENT DOT LBRACE WITH
 ##
-## Ends in an error in state: 1832.
+## Ends in an error in state: 1829.
 ##
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15819,7 +15819,7 @@ implementation: LPAREN UIDENT DOT LBRACE WITH
 
 implementation: LPAREN UIDENT DOT LBRACELESS WITH
 ##
-## Ends in an error in state: 1827.
+## Ends in an error in state: 1824.
 ##
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15832,7 +15832,7 @@ implementation: LPAREN UIDENT DOT LBRACELESS WITH
 
 implementation: LPAREN UIDENT DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1815.
+## Ends in an error in state: 1812.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15844,7 +15844,7 @@ implementation: LPAREN UIDENT DOT LBRACKET WITH
 
 implementation: LPAREN UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 1800.
+## Ends in an error in state: 1797.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15857,23 +15857,23 @@ implementation: LPAREN UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1803, spurious reduction of production expr_optional_constraint -> expr
-## In state 1799, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1800, spurious reduction of production expr_optional_constraint -> expr
+## In state 1796, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT DOT LBRACKETBAR WITH
 ##
-## Ends in an error in state: 1798.
+## Ends in an error in state: 1795.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15886,7 +15886,7 @@ implementation: LPAREN UIDENT DOT LBRACKETBAR WITH
 
 implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1790.
+## Ends in an error in state: 1787.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15906,7 +15906,7 @@ implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 1788.
+## Ends in an error in state: 1785.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15919,7 +15919,7 @@ implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 
 implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 911.
+## Ends in an error in state: 907.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -15934,19 +15934,19 @@ implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 861, spurious reduction of production _module_expr -> simple_module_expr
-## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 857, spurious reduction of production _module_expr -> simple_module_expr
+## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT DOT LPAREN MODULE WITH
 ##
-## Ends in an error in state: 910.
+## Ends in an error in state: 906.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON package_type RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15959,7 +15959,7 @@ implementation: LPAREN UIDENT DOT LPAREN MODULE WITH
 
 implementation: LPAREN UIDENT DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1795.
+## Ends in an error in state: 1792.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -15994,21 +15994,21 @@ implementation: LPAREN UIDENT DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT DOT LPAREN WITH
 ##
-## Ends in an error in state: 909.
+## Ends in an error in state: 905.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN . expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16024,7 +16024,7 @@ implementation: LPAREN UIDENT DOT LPAREN WITH
 
 implementation: LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 908.
+## Ends in an error in state: 904.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16048,7 +16048,7 @@ implementation: LPAREN UIDENT DOT WITH
 
 implementation: LPAREN UIDENT GREATER WITH
 ##
-## Ends in an error in state: 1425.
+## Ends in an error in state: 1422.
 ##
 ## _expr -> expr GREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16060,7 +16060,7 @@ implementation: LPAREN UIDENT GREATER WITH
 
 implementation: LPAREN UIDENT INFIXOP0 WITH
 ##
-## Ends in an error in state: 1423.
+## Ends in an error in state: 1420.
 ##
 ## _expr -> expr INFIXOP0 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16072,7 +16072,7 @@ implementation: LPAREN UIDENT INFIXOP0 WITH
 
 implementation: LPAREN UIDENT INFIXOP1 WITH
 ##
-## Ends in an error in state: 1417.
+## Ends in an error in state: 1414.
 ##
 ## _expr -> expr INFIXOP1 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16084,7 +16084,7 @@ implementation: LPAREN UIDENT INFIXOP1 WITH
 
 implementation: LPAREN UIDENT INFIXOP2 WITH
 ##
-## Ends in an error in state: 1415.
+## Ends in an error in state: 1412.
 ##
 ## _expr -> expr INFIXOP2 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16096,7 +16096,7 @@ implementation: LPAREN UIDENT INFIXOP2 WITH
 
 implementation: LPAREN UIDENT INFIXOP3 WITH
 ##
-## Ends in an error in state: 1401.
+## Ends in an error in state: 1398.
 ##
 ## _expr -> expr INFIXOP3 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16108,7 +16108,7 @@ implementation: LPAREN UIDENT INFIXOP3 WITH
 
 implementation: LPAREN UIDENT INFIXOP4 WITH
 ##
-## Ends in an error in state: 1384.
+## Ends in an error in state: 1381.
 ##
 ## _expr -> expr INFIXOP4 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16132,7 +16132,7 @@ implementation: LPAREN UIDENT LBRACKETAT UNDERSCORE
 
 implementation: LPAREN UIDENT LBRACKETAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2415.
+## Ends in an error in state: 2412.
 ##
 ## attribute -> LBRACKETAT attr_id payload . RBRACKET [ error WITH UIDENT STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARRBRACKET BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -16143,30 +16143,30 @@ implementation: LPAREN UIDENT LBRACKETAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1522, spurious reduction of production post_item_attributes ->
-## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1124, spurious reduction of production structure -> structure_item
-## In state 1509, spurious reduction of production payload -> structure
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1519, spurious reduction of production post_item_attributes ->
+## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1121, spurious reduction of production structure -> structure_item
+## In state 1506, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT LESS WITH
 ##
-## Ends in an error in state: 1421.
+## Ends in an error in state: 1418.
 ##
 ## _expr -> expr LESS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16178,7 +16178,7 @@ implementation: LPAREN UIDENT LESS WITH
 
 implementation: LPAREN UIDENT LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1419.
+## Ends in an error in state: 1416.
 ##
 ## _expr -> expr LESSDOTDOTGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16190,7 +16190,7 @@ implementation: LPAREN UIDENT LESSDOTDOTGREATER WITH
 
 implementation: LPAREN UIDENT LESSGREATER WITH
 ##
-## Ends in an error in state: 1413.
+## Ends in an error in state: 1410.
 ##
 ## _expr -> expr LESSGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16223,7 +16223,7 @@ implementation: LPAREN UIDENT LPAREN WITH
 
 implementation: LPAREN UIDENT MINUS WITH
 ##
-## Ends in an error in state: 1411.
+## Ends in an error in state: 1408.
 ##
 ## _expr -> expr MINUS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16235,7 +16235,7 @@ implementation: LPAREN UIDENT MINUS WITH
 
 implementation: LPAREN UIDENT MINUSDOT WITH
 ##
-## Ends in an error in state: 1409.
+## Ends in an error in state: 1406.
 ##
 ## _expr -> expr MINUSDOT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16247,7 +16247,7 @@ implementation: LPAREN UIDENT MINUSDOT WITH
 
 implementation: LPAREN UIDENT OR WITH
 ##
-## Ends in an error in state: 1407.
+## Ends in an error in state: 1404.
 ##
 ## _expr -> expr OR . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16259,7 +16259,7 @@ implementation: LPAREN UIDENT OR WITH
 
 implementation: LPAREN UIDENT PERCENT WITH
 ##
-## Ends in an error in state: 1399.
+## Ends in an error in state: 1396.
 ##
 ## _expr -> expr PERCENT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16271,7 +16271,7 @@ implementation: LPAREN UIDENT PERCENT WITH
 
 implementation: LPAREN UIDENT PLUS WITH
 ##
-## Ends in an error in state: 1405.
+## Ends in an error in state: 1402.
 ##
 ## _expr -> expr PLUS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16283,7 +16283,7 @@ implementation: LPAREN UIDENT PLUS WITH
 
 implementation: LPAREN UIDENT PLUSDOT WITH
 ##
-## Ends in an error in state: 1403.
+## Ends in an error in state: 1400.
 ##
 ## _expr -> expr PLUSDOT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16295,7 +16295,7 @@ implementation: LPAREN UIDENT PLUSDOT WITH
 
 implementation: LPAREN UIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 1397.
+## Ends in an error in state: 1394.
 ##
 ## _expr -> expr PLUSEQ . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16307,7 +16307,7 @@ implementation: LPAREN UIDENT PLUSEQ WITH
 
 implementation: LPAREN UIDENT QUESTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1442.
+## Ends in an error in state: 1439.
 ##
 ## _expr -> expr QUESTION expr COLON . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16319,7 +16319,7 @@ implementation: LPAREN UIDENT QUESTION UIDENT COLON WITH
 
 implementation: LPAREN UIDENT QUESTION UIDENT SEMI
 ##
-## Ends in an error in state: 1441.
+## Ends in an error in state: 1438.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -16353,21 +16353,21 @@ implementation: LPAREN UIDENT QUESTION UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT QUESTION WITH
 ##
-## Ends in an error in state: 1440.
+## Ends in an error in state: 1437.
 ##
 ## _expr -> expr QUESTION . expr COLON expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16379,7 +16379,7 @@ implementation: LPAREN UIDENT QUESTION WITH
 
 implementation: LPAREN UIDENT SHARP WITH
 ##
-## Ends in an error in state: 612.
+## Ends in an error in state: 608.
 ##
 ## _simple_expr -> simple_expr SHARP . label [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -16391,7 +16391,7 @@ implementation: LPAREN UIDENT SHARP WITH
 
 implementation: LPAREN UIDENT STAR WITH
 ##
-## Ends in an error in state: 1382.
+## Ends in an error in state: 1379.
 ##
 ## _expr -> expr STAR . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16403,7 +16403,7 @@ implementation: LPAREN UIDENT STAR WITH
 
 implementation: LPAREN UIDENT TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 2256.
+## Ends in an error in state: 2253.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -16437,21 +16437,21 @@ implementation: LPAREN UIDENT TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 2255.
+## Ends in an error in state: 2252.
 ##
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -16463,7 +16463,7 @@ implementation: LPAREN UIDENT TRUE DOT LBRACE WITH
 
 implementation: LPAREN UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2253.
+## Ends in an error in state: 2250.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -16498,21 +16498,21 @@ implementation: LPAREN UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2252.
+## Ends in an error in state: 2249.
 ##
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16525,7 +16525,7 @@ implementation: LPAREN UIDENT TRUE DOT LBRACKET WITH
 
 implementation: LPAREN UIDENT TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2250.
+## Ends in an error in state: 2247.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -16560,21 +16560,21 @@ implementation: LPAREN UIDENT TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 616.
+## Ends in an error in state: 612.
 ##
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16587,7 +16587,7 @@ implementation: LPAREN UIDENT TRUE DOT LPAREN WITH
 
 implementation: LPAREN UIDENT TRUE DOT WITH
 ##
-## Ends in an error in state: 615.
+## Ends in an error in state: 611.
 ##
 ## _simple_expr -> simple_expr DOT . label_longident [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16604,7 +16604,7 @@ implementation: LPAREN UIDENT TRUE DOT WITH
 
 implementation: LPAREN WHILE UIDENT WITH
 ##
-## Ends in an error in state: 2613.
+## Ends in an error in state: 2605.
 ##
 ## _expr -> WHILE simple_expr . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -16622,10 +16622,10 @@ implementation: LPAREN WHILE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 890, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 886, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -16644,7 +16644,7 @@ implementation: LPAREN WHILE WITH
 
 implementation: LPAREN WITH
 ##
-## Ends in an error in state: 545.
+## Ends in an error in state: 541.
 ##
 ## _expr -> LPAREN . COLONCOLON RPAREN LPAREN expr COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . expr RPAREN [ UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -16666,7 +16666,7 @@ implementation: LPAREN WITH
 
 implementation: MINUSDOT WITH
 ##
-## Ends in an error in state: 895.
+## Ends in an error in state: 891.
 ##
 ## _expr -> subtractive . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16789,7 +16789,7 @@ implementation: PERCENT WITH WITH
 
 implementation: PLUSDOT WITH
 ##
-## Ends in an error in state: 1204.
+## Ends in an error in state: 1201.
 ##
 ## _expr -> additive . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16813,7 +16813,7 @@ implementation: PREFIXOP WITH
 
 implementation: STRING LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1182.
+## Ends in an error in state: 1179.
 ##
 ## label_expr -> LIDENT COLONCOLON . less_aggressive_simple_expression [ UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -16825,7 +16825,7 @@ implementation: STRING LIDENT COLONCOLON WITH
 
 implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1179.
+## Ends in an error in state: 1176.
 ##
 ## label_expr -> LIDENT EXPLICITLY_PASSED_OPTIONAL . less_aggressive_simple_expression [ UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -16837,7 +16837,7 @@ implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: STRING WITH
 ##
-## Ends in an error in state: 1124.
+## Ends in an error in state: 1121.
 ##
 ## structure -> structure_item . [ RBRACKET RBRACE EOF ]
 ## structure -> structure_item . SEMI structure [ RBRACKET RBRACE EOF ]
@@ -16849,24 +16849,24 @@ implementation: STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1522, spurious reduction of production post_item_attributes ->
-## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1519, spurious reduction of production post_item_attributes ->
+## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 Incomplete module item, forgetting a ";"?
 
 implementation: SWITCH UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2498.
+## Ends in an error in state: 2495.
 ##
 ## _expr -> SWITCH simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16878,7 +16878,7 @@ implementation: SWITCH UIDENT LBRACE WITH
 
 implementation: SWITCH UIDENT WITH
 ##
-## Ends in an error in state: 2497.
+## Ends in an error in state: 2494.
 ##
 ## _expr -> SWITCH simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ SHARP LBRACE DOT ]
@@ -16896,10 +16896,10 @@ implementation: SWITCH UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 890, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 886, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -16918,7 +16918,7 @@ implementation: SWITCH WITH
 
 implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 ##
-## Ends in an error in state: 1869.
+## Ends in an error in state: 1866.
 ##
 ## _expr -> simple_expr DOT LBRACE expr RBRACE EQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16930,7 +16930,7 @@ implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 
 implementation: TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 1867.
+## Ends in an error in state: 1864.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -16965,21 +16965,21 @@ implementation: TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 1866.
+## Ends in an error in state: 1863.
 ##
 ## _expr -> simple_expr DOT LBRACE . expr RBRACE EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -16992,7 +16992,7 @@ implementation: TRUE DOT LBRACE WITH
 
 implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 ##
-## Ends in an error in state: 1864.
+## Ends in an error in state: 1861.
 ##
 ## _expr -> simple_expr DOT LBRACKET expr RBRACKET EQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17004,7 +17004,7 @@ implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 
 implementation: TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 1861.
+## Ends in an error in state: 1858.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -17040,21 +17040,21 @@ implementation: TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1860.
+## Ends in an error in state: 1857.
 ##
 ## _expr -> simple_expr DOT LBRACKET . expr RBRACKET EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -17068,7 +17068,7 @@ implementation: TRUE DOT LBRACKET WITH
 
 implementation: TRUE DOT LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1872.
+## Ends in an error in state: 1869.
 ##
 ## _expr -> simple_expr DOT label_longident EQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17080,7 +17080,7 @@ implementation: TRUE DOT LIDENT EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 ##
-## Ends in an error in state: 1858.
+## Ends in an error in state: 1855.
 ##
 ## _expr -> simple_expr DOT LPAREN expr RPAREN EQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17092,7 +17092,7 @@ implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1855.
+## Ends in an error in state: 1852.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -17128,21 +17128,21 @@ implementation: TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 898.
+## Ends in an error in state: 894.
 ##
 ## _expr -> simple_expr DOT LPAREN . expr RPAREN EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -17182,7 +17182,7 @@ implementation: TRUE DOT UIDENT WITH
 
 implementation: TRUE DOT WITH
 ##
-## Ends in an error in state: 897.
+## Ends in an error in state: 893.
 ##
 ## _expr -> simple_expr DOT . label_longident EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> simple_expr DOT . LPAREN expr RPAREN EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -17203,7 +17203,7 @@ implementation: TRUE DOT WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER CHAR BAR WITH
 ##
-## Ends in an error in state: 1880.
+## Ends in an error in state: 1877.
 ##
 ## bar_located_pattern -> BAR . pattern [ WHEN EQUALGREATER ]
 ##
@@ -17215,7 +17215,7 @@ Expecting a match case
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT RBRACKET
 ##
-## Ends in an error in state: 2484.
+## Ends in an error in state: 2481.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes . SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17226,22 +17226,22 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 861, spurious reduction of production _module_expr -> simple_module_expr
-## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
-## In state 917, spurious reduction of production module_binding_body_expr -> EQUAL module_expr
-## In state 1767, spurious reduction of production module_binding_body -> module_binding_body_expr
-## In state 2483, spurious reduction of production post_item_attributes ->
+## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 857, spurious reduction of production _module_expr -> simple_module_expr
+## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 913, spurious reduction of production module_binding_body_expr -> EQUAL module_expr
+## In state 1764, spurious reduction of production module_binding_body -> module_binding_body_expr
+## In state 2480, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2485.
+## Ends in an error in state: 2482.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17253,7 +17253,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2482.
+## Ends in an error in state: 2479.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17265,7 +17265,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 ##
-## Ends in an error in state: 2481.
+## Ends in an error in state: 2478.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17277,7 +17277,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 ##
-## Ends in an error in state: 2460.
+## Ends in an error in state: 2457.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17289,7 +17289,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2463.
+## Ends in an error in state: 2460.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17301,7 +17301,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2462.
+## Ends in an error in state: 2459.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17312,14 +17312,14 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2461, spurious reduction of production post_item_attributes ->
+## In state 2458, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 ##
-## Ends in an error in state: 2459.
+## Ends in an error in state: 2456.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17331,7 +17331,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 ##
-## Ends in an error in state: 2458.
+## Ends in an error in state: 2455.
 ##
 ## _semi_terminated_seq_expr_row -> LET . MODULE UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ## _semi_terminated_seq_expr_row -> LET . OPEN override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
@@ -17345,7 +17345,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 ##
-## Ends in an error in state: 2471.
+## Ends in an error in state: 2468.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ RBRACE BAR ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI RBRACE BAR AND ]
@@ -17365,7 +17365,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 2517.
+## Ends in an error in state: 2514.
 ##
 ## _expr -> TRY simple_expr LBRACE leading_bar_match_cases_to_sequence_body . RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## leading_bar_match_cases_to_sequence_body -> leading_bar_match_cases_to_sequence_body . leading_bar_match_case_to_sequence_body [ RBRACE BAR ]
@@ -17377,24 +17377,24 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2473, spurious reduction of production post_item_attributes ->
-## In state 2474, spurious reduction of production opt_semi ->
-## In state 2479, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
-## In state 2477, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
-## In state 2466, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
-## In state 2464, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
-## In state 2478, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2467, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
-## In state 2489, spurious reduction of production leading_bar_match_case_to_sequence_body -> bar_located_pattern EQUALGREATER semi_terminated_seq_expr
-## In state 2490, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2470, spurious reduction of production post_item_attributes ->
+## In state 2471, spurious reduction of production opt_semi ->
+## In state 2476, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
+## In state 2474, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
+## In state 2463, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
+## In state 2461, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
+## In state 2475, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2464, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2486, spurious reduction of production leading_bar_match_case_to_sequence_body -> bar_located_pattern EQUALGREATER semi_terminated_seq_expr
+## In state 2487, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
 ##
 
 Expecting one of the following:
@@ -17403,7 +17403,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2488.
+## Ends in an error in state: 2485.
 ##
 ## leading_bar_match_case_to_sequence_body -> bar_located_pattern EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17415,7 +17415,7 @@ Expecting the body of the matched pattern
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ##
-## Ends in an error in state: 1881.
+## Ends in an error in state: 1878.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN EQUALGREATER BAR ]
 ## bar_located_pattern -> BAR pattern . [ WHEN EQUALGREATER ]
@@ -17427,7 +17427,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production pattern -> pattern_without_or
+## In state 787, spurious reduction of production pattern -> pattern_without_or
 ##
 
 Expecting one of the following:
@@ -17437,7 +17437,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2457.
+## Ends in an error in state: 2454.
 ##
 ## leading_bar_match_case_to_sequence_body -> bar_located_pattern WHEN expr EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17449,7 +17449,7 @@ Expecting a sequence item
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2456.
+## Ends in an error in state: 2453.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -17483,21 +17483,21 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2455.
+## Ends in an error in state: 2452.
 ##
 ## leading_bar_match_case_to_sequence_body -> bar_located_pattern WHEN . expr EQUALGREATER semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17509,7 +17509,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 
 implementation: TRY UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2516.
+## Ends in an error in state: 2513.
 ##
 ## _expr -> TRY simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17521,7 +17521,7 @@ implementation: TRY UIDENT LBRACE WITH
 
 implementation: TRY UIDENT UNDERSCORE
 ##
-## Ends in an error in state: 2513.
+## Ends in an error in state: 2510.
 ##
 ## _expr -> TRY simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> TRY simple_expr . WITH error [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -17540,17 +17540,17 @@ implementation: TRY UIDENT UNDERSCORE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 890, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 886, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT WITH WITH
 ##
-## Ends in an error in state: 2514.
+## Ends in an error in state: 2511.
 ##
 ## _expr -> TRY simple_expr WITH . error [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17575,7 +17575,7 @@ implementation: TRY WITH
 
 implementation: TYPE LIDENT AND LIDENT WITH
 ##
-## Ends in an error in state: 1138.
+## Ends in an error in state: 1135.
 ##
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -17586,14 +17586,14 @@ implementation: TYPE LIDENT AND LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1137, spurious reduction of production optional_type_parameters ->
+## In state 1134, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT AND WITH
 ##
-## Ends in an error in state: 1136.
+## Ends in an error in state: 1133.
 ##
 ## and_type_declaration -> AND . type_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -17605,7 +17605,7 @@ implementation: TYPE LIDENT AND WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 982.
+## Ends in an error in state: 979.
 ##
 ## constrain -> core_type EQUAL . core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ##
@@ -17617,7 +17617,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 981.
+## Ends in an error in state: 978.
 ##
 ## constrain -> core_type . EQUAL core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ##
@@ -17640,7 +17640,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 
 implementation: TYPE LIDENT CONSTRAINT WITH
 ##
-## Ends in an error in state: 980.
+## Ends in an error in state: 977.
 ##
 ## constraints -> constraints CONSTRAINT . constrain [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ##
@@ -17652,7 +17652,7 @@ implementation: TYPE LIDENT CONSTRAINT WITH
 
 implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2571.
+## Ends in an error in state: 2564.
 ##
 ## constructor_declarations -> constructor_declarations_leading_bar . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations_leading_bar -> constructor_declarations_leading_bar . constructor_declaration_leading_bar [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
@@ -17664,17 +17664,17 @@ implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 502, spurious reduction of production attributes ->
-## In state 503, spurious reduction of production attributes -> attribute attributes
-## In state 2569, spurious reduction of production constructor_declaration_leading_bar -> BAR constr_ident generalized_constructor_arguments attributes
-## In state 2576, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
+## In state 499, spurious reduction of production attributes ->
+## In state 500, spurious reduction of production attributes -> attribute attributes
+## In state 2562, spurious reduction of production constructor_declaration_leading_bar -> BAR constr_ident generalized_constructor_arguments attributes
+## In state 2569, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 ##
-## Ends in an error in state: 1140.
+## Ends in an error in state: 1137.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_declaration_details -> LIDENT optional_type_parameters type_kind constraints . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -17687,7 +17687,7 @@ implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 ##
-## Ends in an error in state: 508.
+## Ends in an error in state: 505.
 ##
 ## label_declarations -> label_declarations COMMA . label_declaration [ RBRACE COMMA ]
 ## opt_comma -> COMMA . [ RBRACE ]
@@ -17702,7 +17702,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2583.
+## Ends in an error in state: 2576.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17720,12 +17720,12 @@ implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 505, spurious reduction of production _poly_type -> core_type
-## In state 506, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 504, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 500, spurious reduction of production attributes ->
-## In state 501, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 512, spurious reduction of production label_declarations -> label_declaration
+## In state 502, spurious reduction of production _poly_type -> core_type
+## In state 503, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 501, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 497, spurious reduction of production attributes ->
+## In state 498, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 509, spurious reduction of production label_declarations -> label_declaration
 ##
 
 Expecting one of the following:
@@ -17734,7 +17734,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 494.
+## Ends in an error in state: 491.
 ##
 ## label_declaration -> mutable_flag LIDENT COLON . poly_type attributes [ RBRACE COMMA ]
 ##
@@ -17746,7 +17746,7 @@ Expecting a type name describing this field
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 493.
+## Ends in an error in state: 490.
 ##
 ## label_declaration -> mutable_flag LIDENT . COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -17759,7 +17759,7 @@ Expecting ":"
 
 implementation: TYPE LIDENT EQUAL LBRACE MUTABLE LET
 ##
-## Ends in an error in state: 492.
+## Ends in an error in state: 489.
 ##
 ## label_declaration -> mutable_flag . LIDENT COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -17772,7 +17772,7 @@ Expecting a type field definition in the form of:
 
 implementation: TYPE LIDENT EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2582.
+## Ends in an error in state: 2575.
 ##
 ## type_kind -> EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -17785,7 +17785,7 @@ Expecting at least one type field definition in the form of:
 
     implementation: TYPE LIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 2562.
+## Ends in an error in state: 2558.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
 ## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
@@ -17799,7 +17799,7 @@ Expecting at least one type field definition in the form of:
 
 implementation: TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 2561.
+## Ends in an error in state: 2557.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL PRIVATE . core_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17827,7 +17827,7 @@ implementation: TYPE LIDENT EQUAL UIDENT WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 ##
-## Ends in an error in state: 2566.
+## Ends in an error in state: 2559.
 ##
 ## constructor_declaration_leading_bar -> BAR . constr_ident generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
 ##
@@ -17839,7 +17839,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 2595.
+## Ends in an error in state: 2587.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17851,17 +17851,17 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDO
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 502, spurious reduction of production attributes ->
-## In state 503, spurious reduction of production attributes -> attribute attributes
-## In state 501, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 512, spurious reduction of production label_declarations -> label_declaration
+## In state 499, spurious reduction of production attributes ->
+## In state 500, spurious reduction of production attributes -> attribute attributes
+## In state 498, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 509, spurious reduction of production label_declarations -> label_declaration
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2594.
+## Ends in an error in state: 2586.
 ##
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -17873,7 +17873,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 ##
-## Ends in an error in state: 2589.
+## Ends in an error in state: 2582.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL core_type EQUAL PRIVATE . constructor_declarations [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17886,7 +17886,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2574.
+## Ends in an error in state: 2567.
 ##
 ## constructor_declarations -> constructor_declaration_no_leading_bar . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations -> constructor_declaration_no_leading_bar . constructor_declarations_leading_bar [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17898,16 +17898,16 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 502, spurious reduction of production attributes ->
-## In state 503, spurious reduction of production attributes -> attribute attributes
-## In state 2559, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
+## In state 499, spurious reduction of production attributes ->
+## In state 500, spurious reduction of production attributes -> attribute attributes
+## In state 2556, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2587.
+## Ends in an error in state: 2580.
 ##
 ## type_kind -> EQUAL core_type EQUAL . constructor_declarations [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type EQUAL . PRIVATE constructor_declarations [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17922,7 +17922,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 2586.
+## Ends in an error in state: 2579.
 ##
 ## type_kind -> EQUAL core_type . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type . EQUAL constructor_declarations [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17970,7 +17970,7 @@ implementation: TYPE LIDENT EQUAL WITH
 
 implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1135.
+## Ends in an error in state: 1132.
 ##
 ## _structure_item_without_item_extension_sugar -> many_type_declarations . [ SEMI RBRACKET RBRACE EOF ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ SEMI RBRACKET RBRACE EOF AND ]
@@ -17982,9 +17982,9 @@ implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 932, spurious reduction of production post_item_attributes ->
-## In state 933, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 931, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 928, spurious reduction of production post_item_attributes ->
+## In state 929, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 927, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
@@ -18041,7 +18041,7 @@ implementation: TYPE LIDENT PLUS WITH
 
 implementation: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 2603.
+## Ends in an error in state: 2595.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . str_extension_constructors post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -18053,7 +18053,7 @@ implementation: TYPE LIDENT PLUSEQ BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 2602.
+## Ends in an error in state: 2594.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar str_extension_constructors post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -18065,7 +18065,7 @@ implementation: TYPE LIDENT PLUSEQ PRIVATE BANG
 
 implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 2605.
+## Ends in an error in state: 2597.
 ##
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_declaration [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_rebind [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -18078,7 +18078,7 @@ implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 2601.
+## Ends in an error in state: 2593.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar str_extension_constructors post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -18126,7 +18126,7 @@ Expecting one of the following:
 
 implementation: TYPE UIDENT DOT WITH
 ##
-## Ends in an error in state: 959.
+## Ends in an error in state: 956.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -18140,7 +18140,7 @@ implementation: TYPE UIDENT DOT WITH
 
 implementation: TYPE UIDENT WITH
 ##
-## Ends in an error in state: 958.
+## Ends in an error in state: 955.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -18179,7 +18179,7 @@ implementation: TYPE WITH
 
 implementation: UIDENT AMPERAMPER WITH
 ##
-## Ends in an error in state: 1241.
+## Ends in an error in state: 1238.
 ##
 ## _expr -> expr AMPERAMPER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18191,7 +18191,7 @@ implementation: UIDENT AMPERAMPER WITH
 
 implementation: UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 1239.
+## Ends in an error in state: 1236.
 ##
 ## _expr -> expr AMPERSAND . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18203,7 +18203,7 @@ implementation: UIDENT AMPERSAND WITH
 
 implementation: UIDENT BARBAR WITH
 ##
-## Ends in an error in state: 1237.
+## Ends in an error in state: 1234.
 ##
 ## _expr -> expr BARBAR . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18215,7 +18215,7 @@ implementation: UIDENT BARBAR WITH
 
 implementation: UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1243.
+## Ends in an error in state: 1240.
 ##
 ## _expr -> expr COLONEQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18227,7 +18227,7 @@ implementation: UIDENT COLONEQUAL WITH
 
 implementation: UIDENT DOT LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 1851.
+## Ends in an error in state: 1848.
 ##
 ## lbl_expr -> label_longident . COLON expr [ COMMA ]
 ## lbl_expr -> label_longident . [ COMMA ]
@@ -18241,7 +18241,7 @@ implementation: UIDENT DOT LBRACE LIDENT WITH
 
 implementation: UIDENT DOT LBRACE WITH
 ##
-## Ends in an error in state: 2226.
+## Ends in an error in state: 2223.
 ##
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr RBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18254,7 +18254,7 @@ implementation: UIDENT DOT LBRACE WITH
 
 implementation: UIDENT DOT LBRACELESS WITH
 ##
-## Ends in an error in state: 2221.
+## Ends in an error in state: 2218.
 ##
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18267,7 +18267,7 @@ implementation: UIDENT DOT LBRACELESS WITH
 
 implementation: UIDENT DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2211.
+## Ends in an error in state: 2208.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKET . expr_comma_seq_extension [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -18279,7 +18279,7 @@ implementation: UIDENT DOT LBRACKET WITH
 
 implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2207.
+## Ends in an error in state: 2204.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18292,23 +18292,23 @@ implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1803, spurious reduction of production expr_optional_constraint -> expr
-## In state 1799, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1800, spurious reduction of production expr_optional_constraint -> expr
+## In state 1796, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LBRACKETBAR WITH
 ##
-## Ends in an error in state: 2206.
+## Ends in an error in state: 2203.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18321,7 +18321,7 @@ implementation: UIDENT DOT LBRACKETBAR WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2201.
+## Ends in an error in state: 2198.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON package_type . RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -18341,7 +18341,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2199.
+## Ends in an error in state: 2196.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . package_type RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18354,7 +18354,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 862.
+## Ends in an error in state: 858.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -18369,19 +18369,19 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 861, spurious reduction of production _module_expr -> simple_module_expr
-## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 857, spurious reduction of production _module_expr -> simple_module_expr
+## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN MODULE WITH
 ##
-## Ends in an error in state: 860.
+## Ends in an error in state: 856.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON package_type RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18394,7 +18394,7 @@ implementation: UIDENT DOT LPAREN MODULE WITH
 
 implementation: UIDENT DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2203.
+## Ends in an error in state: 2200.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -18429,21 +18429,21 @@ implementation: UIDENT DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN WITH
 ##
-## Ends in an error in state: 859.
+## Ends in an error in state: 855.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN . expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN . expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18459,7 +18459,7 @@ implementation: UIDENT DOT LPAREN WITH
 
 implementation: UIDENT DOT WITH
 ##
-## Ends in an error in state: 858.
+## Ends in an error in state: 854.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18483,7 +18483,7 @@ implementation: UIDENT DOT WITH
 
 implementation: UIDENT GREATER WITH
 ##
-## Ends in an error in state: 1235.
+## Ends in an error in state: 1232.
 ##
 ## _expr -> expr GREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18495,7 +18495,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP0 WITH
 ##
-## Ends in an error in state: 1233.
+## Ends in an error in state: 1230.
 ##
 ## _expr -> expr INFIXOP0 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18507,7 +18507,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP1 WITH
 ##
-## Ends in an error in state: 1227.
+## Ends in an error in state: 1224.
 ##
 ## _expr -> expr INFIXOP1 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18519,7 +18519,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP2 WITH
 ##
-## Ends in an error in state: 1225.
+## Ends in an error in state: 1222.
 ##
 ## _expr -> expr INFIXOP2 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18531,7 +18531,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP3 WITH
 ##
-## Ends in an error in state: 1211.
+## Ends in an error in state: 1208.
 ##
 ## _expr -> expr INFIXOP3 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18543,7 +18543,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP4 WITH
 ##
-## Ends in an error in state: 1194.
+## Ends in an error in state: 1191.
 ##
 ## _expr -> expr INFIXOP4 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18567,7 +18567,7 @@ Expecting an attribute id
 
 implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2519.
+## Ends in an error in state: 2516.
 ##
 ## attribute -> LBRACKETAT attr_id payload . RBRACKET [ WITH WHEN UIDENT STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 IN GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -18578,23 +18578,23 @@ implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1522, spurious reduction of production post_item_attributes ->
-## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1124, spurious reduction of production structure -> structure_item
-## In state 1509, spurious reduction of production payload -> structure
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1519, spurious reduction of production post_item_attributes ->
+## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1121, spurious reduction of production structure -> structure_item
+## In state 1506, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
@@ -18613,7 +18613,7 @@ Expecting an attributed id
 
 implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2412.
+## Ends in an error in state: 2409.
 ##
 ## item_attribute -> LBRACKETATAT attr_id payload . RBRACKET [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -18624,30 +18624,30 @@ implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1522, spurious reduction of production post_item_attributes ->
-## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1124, spurious reduction of production structure -> structure_item
-## In state 1509, spurious reduction of production payload -> structure
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1519, spurious reduction of production post_item_attributes ->
+## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1121, spurious reduction of production structure -> structure_item
+## In state 1506, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
 
 implementation: UIDENT LESS WITH
 ##
-## Ends in an error in state: 1231.
+## Ends in an error in state: 1228.
 ##
 ## _expr -> expr LESS . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18659,7 +18659,7 @@ Expecting an expression
 
 implementation: UIDENT LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1229.
+## Ends in an error in state: 1226.
 ##
 ## _expr -> expr LESSDOTDOTGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18671,7 +18671,7 @@ Expecting an expression
 
 implementation: UIDENT LESSGREATER WITH
 ##
-## Ends in an error in state: 1223.
+## Ends in an error in state: 1220.
 ##
 ## _expr -> expr LESSGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18708,7 +18708,7 @@ Expecting one of the following:
 
 implementation: UIDENT MINUS WITH
 ##
-## Ends in an error in state: 1221.
+## Ends in an error in state: 1218.
 ##
 ## _expr -> expr MINUS . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18720,7 +18720,7 @@ Expecting an expression
 
 implementation: UIDENT MINUSDOT WITH
 ##
-## Ends in an error in state: 1219.
+## Ends in an error in state: 1216.
 ##
 ## _expr -> expr MINUSDOT . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18732,7 +18732,7 @@ Expecting an expression
 
 implementation: UIDENT OR WITH
 ##
-## Ends in an error in state: 1217.
+## Ends in an error in state: 1214.
 ##
 ## _expr -> expr OR . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18744,7 +18744,7 @@ Expecting an expression
 
 implementation: UIDENT PERCENT WITH
 ##
-## Ends in an error in state: 1209.
+## Ends in an error in state: 1206.
 ##
 ## _expr -> expr PERCENT . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18756,7 +18756,7 @@ Expecting an expression
 
 implementation: UIDENT PLUS WITH
 ##
-## Ends in an error in state: 1215.
+## Ends in an error in state: 1212.
 ##
 ## _expr -> expr PLUS . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18768,7 +18768,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSDOT WITH
 ##
-## Ends in an error in state: 1213.
+## Ends in an error in state: 1210.
 ##
 ## _expr -> expr PLUSDOT . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18780,7 +18780,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 1207.
+## Ends in an error in state: 1204.
 ##
 ## _expr -> expr PLUSEQ . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18792,7 +18792,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1248.
+## Ends in an error in state: 1245.
 ##
 ## _expr -> expr QUESTION expr COLON . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18804,7 +18804,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT SEMI
 ##
-## Ends in an error in state: 1247.
+## Ends in an error in state: 1244.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -18838,14 +18838,14 @@ implementation: UIDENT QUESTION UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -18854,7 +18854,7 @@ Expecting one of the following:
 
 implementation: UIDENT QUESTION WITH
 ##
-## Ends in an error in state: 1246.
+## Ends in an error in state: 1243.
 ##
 ## _expr -> expr QUESTION . expr COLON expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18866,7 +18866,7 @@ Expecting an expression
 
 implementation: UIDENT RBRACKET
 ##
-## Ends in an error in state: 2621.
+## Ends in an error in state: 2613.
 ##
 ## implementation -> structure . EOF [ # ]
 ##
@@ -18877,29 +18877,29 @@ implementation: UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1522, spurious reduction of production post_item_attributes ->
-## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1124, spurious reduction of production structure -> structure_item
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1519, spurious reduction of production post_item_attributes ->
+## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1121, spurious reduction of production structure -> structure_item
 ##
 
 Invalid token
 
 implementation: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 1125.
+## Ends in an error in state: 1122.
 ##
 ## structure -> structure_item SEMI . structure [ RBRACKET RBRACE EOF ]
 ##
@@ -18911,7 +18911,7 @@ Expecting a structure item
 
 implementation: UIDENT SHARP WITH
 ##
-## Ends in an error in state: 576.
+## Ends in an error in state: 572.
 ##
 ## _simple_expr -> simple_expr SHARP . label [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -18923,7 +18923,7 @@ Expecting an identifier
 
 implementation: UIDENT STAR WITH
 ##
-## Ends in an error in state: 1192.
+## Ends in an error in state: 1189.
 ##
 ## _expr -> expr STAR . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18935,7 +18935,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 2301.
+## Ends in an error in state: 2298.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -18969,14 +18969,14 @@ implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 1197, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 1194, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -18985,7 +18985,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 2300.
+## Ends in an error in state: 2297.
 ##
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -18997,7 +18997,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2298.
+## Ends in an error in state: 2295.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -19032,14 +19032,14 @@ implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -19048,7 +19048,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2297.
+## Ends in an error in state: 2294.
 ##
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -19061,7 +19061,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2295.
+## Ends in an error in state: 2292.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -19096,14 +19096,14 @@ implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 907, spurious reduction of production constr_longident -> mod_longident
-## In state 1387, spurious reduction of production _simple_expr -> constr_longident
-## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 903, spurious reduction of production constr_longident -> mod_longident
+## In state 1384, spurious reduction of production _simple_expr -> constr_longident
+## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -19112,7 +19112,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 579.
+## Ends in an error in state: 575.
 ##
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -19125,7 +19125,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT WITH
 ##
-## Ends in an error in state: 578.
+## Ends in an error in state: 574.
 ##
 ## _simple_expr -> simple_expr DOT . label_longident [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT . LPAREN expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -19146,7 +19146,7 @@ Expecting one of the following:
 
 implementation: WHILE UIDENT WITH
 ##
-## Ends in an error in state: 2616.
+## Ends in an error in state: 2608.
 ##
 ## _expr -> WHILE simple_expr . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -19164,10 +19164,10 @@ implementation: WHILE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production constr_longident -> mod_longident
-## In state 890, spurious reduction of production _simple_expr -> constr_longident
-## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 853, spurious reduction of production constr_longident -> mod_longident
+## In state 886, spurious reduction of production _simple_expr -> constr_longident
+## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>

--- a/src/reason_parser.messages
+++ b/src/reason_parser.messages
@@ -1,6 +1,6 @@
 use_file: SHARP LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2646.
+## Ends in an error in state: 2664.
 ##
 ## _use_file -> toplevel_directive SEMI . use_file [ # ]
 ##
@@ -12,7 +12,7 @@ use_file: SHARP LIDENT SEMI WITH
 
 use_file: SHARP LIDENT TRUE WITH
 ##
-## Ends in an error in state: 2645.
+## Ends in an error in state: 2663.
 ##
 ## _use_file -> toplevel_directive . SEMI use_file [ # ]
 ## _use_file -> toplevel_directive . EOF [ # ]
@@ -25,7 +25,7 @@ use_file: SHARP LIDENT TRUE WITH
 
 use_file: UIDENT RPAREN
 ##
-## Ends in an error in state: 2648.
+## Ends in an error in state: 2666.
 ##
 ## _use_file -> structure_item . SEMI use_file [ # ]
 ## _use_file -> structure_item . EOF [ # ]
@@ -37,28 +37,28 @@ use_file: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1513, spurious reduction of production post_item_attributes ->
-## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1522, spurious reduction of production post_item_attributes ->
+## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 use_file: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2649.
+## Ends in an error in state: 2667.
 ##
 ## _use_file -> structure_item SEMI . use_file [ # ]
 ##
@@ -70,7 +70,7 @@ use_file: UIDENT SEMI WITH
 
 use_file: WITH
 ##
-## Ends in an error in state: 2642.
+## Ends in an error in state: 2660.
 ##
 ## use_file' -> . use_file [ # ]
 ##
@@ -82,7 +82,7 @@ use_file: WITH
 
 toplevel_phrase: SHARP UIDENT EOF
 ##
-## Ends in an error in state: 2637.
+## Ends in an error in state: 2655.
 ##
 ## _toplevel_phrase -> toplevel_directive . SEMI [ # ]
 ##
@@ -93,14 +93,14 @@ toplevel_phrase: SHARP UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2627, spurious reduction of production toplevel_directive -> SHARP ident
+## In state 2645, spurious reduction of production toplevel_directive -> SHARP ident
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 ##
-## Ends in an error in state: 2634.
+## Ends in an error in state: 2652.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ SEMI EOF DOT ]
 ## val_longident -> mod_longident DOT . val_ident [ SEMI EOF ]
@@ -113,7 +113,7 @@ toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 
 toplevel_phrase: SHARP UIDENT UIDENT WITH
 ##
-## Ends in an error in state: 2633.
+## Ends in an error in state: 2651.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ SEMI EOF DOT ]
 ## toplevel_directive -> SHARP ident mod_longident . [ SEMI EOF ]
@@ -127,7 +127,7 @@ toplevel_phrase: SHARP UIDENT UIDENT WITH
 
 toplevel_phrase: SHARP UIDENT WITH
 ##
-## Ends in an error in state: 2627.
+## Ends in an error in state: 2645.
 ##
 ## toplevel_directive -> SHARP ident . [ SEMI EOF ]
 ## toplevel_directive -> SHARP ident . STRING [ SEMI EOF ]
@@ -145,7 +145,7 @@ toplevel_phrase: SHARP UIDENT WITH
 
 toplevel_phrase: SHARP WITH
 ##
-## Ends in an error in state: 2626.
+## Ends in an error in state: 2644.
 ##
 ## toplevel_directive -> SHARP . ident [ SEMI EOF ]
 ## toplevel_directive -> SHARP . ident STRING [ SEMI EOF ]
@@ -163,7 +163,7 @@ toplevel_phrase: SHARP WITH
 
 toplevel_phrase: UIDENT RPAREN
 ##
-## Ends in an error in state: 2639.
+## Ends in an error in state: 2657.
 ##
 ## _toplevel_phrase -> structure_item . SEMI [ # ]
 ##
@@ -174,28 +174,28 @@ toplevel_phrase: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1513, spurious reduction of production post_item_attributes ->
-## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1522, spurious reduction of production post_item_attributes ->
+## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: WITH
 ##
-## Ends in an error in state: 2625.
+## Ends in an error in state: 2643.
 ##
 ## toplevel_phrase' -> . toplevel_phrase [ # ]
 ##
@@ -207,7 +207,7 @@ toplevel_phrase: WITH
 
 parse_pattern: EXCEPTION UNDERSCORE WITH
 ##
-## Ends in an error in state: 772.
+## Ends in an error in state: 781.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -224,7 +224,7 @@ parse_pattern: EXCEPTION UNDERSCORE WITH
 
 parse_pattern: EXCEPTION WITH
 ##
-## Ends in an error in state: 770.
+## Ends in an error in state: 779.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -236,7 +236,7 @@ parse_pattern: EXCEPTION WITH
 
 parse_pattern: LAZY WITH
 ##
-## Ends in an error in state: 754.
+## Ends in an error in state: 763.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -248,7 +248,7 @@ parse_pattern: LAZY WITH
 
 parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ##
-## Ends in an error in state: 815.
+## Ends in an error in state: 824.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error RBRACE COMMA BAR ]
 ## lbl_pattern -> label_longident COLON pattern . [ error RBRACE COMMA ]
@@ -260,14 +260,14 @@ parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 708, spurious reduction of production pattern -> pattern_without_or
+## In state 717, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 666.
+## Ends in an error in state: 675.
 ##
 ## lbl_pattern -> label_longident COLON . pattern [ error RBRACE COMMA ]
 ##
@@ -279,7 +279,7 @@ parse_pattern: LBRACE LIDENT COLON WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 751.
+## Ends in an error in state: 760.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -292,7 +292,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 661.
+## Ends in an error in state: 670.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA UNDERSCORE . opt_comma [ error RBRACE ]
 ##
@@ -304,7 +304,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 
 parse_pattern: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 660.
+## Ends in an error in state: 669.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA . [ error RBRACE ]
 ## lbl_pattern_list -> lbl_pattern COMMA . UNDERSCORE opt_comma [ error RBRACE ]
@@ -318,7 +318,7 @@ parse_pattern: LBRACE LIDENT COMMA WITH
 
 parse_pattern: LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 665.
+## Ends in an error in state: 674.
 ##
 ## lbl_pattern -> label_longident . COLON pattern [ error RBRACE COMMA ]
 ## lbl_pattern -> label_longident . [ error RBRACE COMMA ]
@@ -331,7 +331,7 @@ parse_pattern: LBRACE LIDENT WITH
 
 parse_pattern: LBRACE UIDENT DOT WITH
 ##
-## Ends in an error in state: 654.
+## Ends in an error in state: 663.
 ##
 ## label_longident -> mod_longident DOT . LIDENT [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident DOT . UIDENT [ DOT ]
@@ -344,7 +344,7 @@ parse_pattern: LBRACE UIDENT DOT WITH
 
 parse_pattern: LBRACE UIDENT WITH
 ##
-## Ends in an error in state: 653.
+## Ends in an error in state: 662.
 ##
 ## label_longident -> mod_longident . DOT LIDENT [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident . DOT UIDENT [ DOT ]
@@ -357,7 +357,7 @@ parse_pattern: LBRACE UIDENT WITH
 
 parse_pattern: LBRACE WITH
 ##
-## Ends in an error in state: 750.
+## Ends in an error in state: 759.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -370,7 +370,7 @@ parse_pattern: LBRACE WITH
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 747.
+## Ends in an error in state: 756.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET BAR ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT pattern . [ error SEMI RBRACKET ]
@@ -382,14 +382,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 708, spurious reduction of production pattern -> pattern_without_or
+## In state 717, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT WITH
 ##
-## Ends in an error in state: 746.
+## Ends in an error in state: 755.
 ##
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT . pattern [ error SEMI RBRACKET ]
 ##
@@ -401,7 +401,7 @@ Expecting a valid list identifier
 
 parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 748.
+## Ends in an error in state: 757.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ COMMA ]
@@ -414,14 +414,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 708, spurious reduction of production pattern -> pattern_without_or
+## In state 717, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 745.
+## Ends in an error in state: 754.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ COMMA ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA . DOTDOTDOT pattern [ error SEMI RBRACKET ]
@@ -435,7 +435,7 @@ parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKET UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 749.
+## Ends in an error in state: 758.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern . [ COMMA ]
@@ -448,14 +448,14 @@ parse_pattern: LBRACKET UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 708, spurious reduction of production pattern -> pattern_without_or
+## In state 717, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 741.
+## Ends in an error in state: 750.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -468,7 +468,7 @@ parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LBRACKET WITH
 ##
-## Ends in an error in state: 738.
+## Ends in an error in state: 747.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -482,7 +482,7 @@ parse_pattern: LBRACKET WITH
 
 parse_pattern: LBRACKETBAR MINUS WITH
 ##
-## Ends in an error in state: 649.
+## Ends in an error in state: 658.
 ##
 ## signed_constant -> MINUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> MINUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -498,7 +498,7 @@ parse_pattern: LBRACKETBAR MINUS WITH
 
 parse_pattern: LBRACKETBAR PLUS WITH
 ##
-## Ends in an error in state: 648.
+## Ends in an error in state: 657.
 ##
 ## signed_constant -> PLUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> PLUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -514,7 +514,7 @@ parse_pattern: LBRACKETBAR PLUS WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 728.
+## Ends in an error in state: 737.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -526,14 +526,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 708, spurious reduction of production pattern -> pattern_without_or
+## In state 717, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 727.
+## Ends in an error in state: 736.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ error SEMI COMMA BARRBRACKET ]
 ##
@@ -545,7 +545,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 737.
+## Ends in an error in state: 746.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -557,14 +557,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 708, spurious reduction of production pattern -> pattern_without_or
+## In state 717, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 734.
+## Ends in an error in state: 743.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -577,7 +577,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LBRACKETBAR WITH
 ##
-## Ends in an error in state: 723.
+## Ends in an error in state: 732.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -591,7 +591,7 @@ parse_pattern: LBRACKETBAR WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 2422.
+## Ends in an error in state: 2431.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -609,7 +609,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 2421.
+## Ends in an error in state: 2430.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -622,7 +622,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2420.
+## Ends in an error in state: 2429.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -640,7 +640,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2419.
+## Ends in an error in state: 2428.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -653,7 +653,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2418.
+## Ends in an error in state: 2427.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -666,7 +666,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2417.
+## Ends in an error in state: 2426.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -679,7 +679,7 @@ parse_pattern: LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN EXCEPTION UNDERSCORE WITH
 ##
-## Ends in an error in state: 683.
+## Ends in an error in state: 692.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -696,7 +696,7 @@ parse_pattern: LPAREN EXCEPTION UNDERSCORE WITH
 
 parse_pattern: LPAREN EXCEPTION WITH
 ##
-## Ends in an error in state: 675.
+## Ends in an error in state: 684.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -708,7 +708,7 @@ parse_pattern: LPAREN EXCEPTION WITH
 
 parse_pattern: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 667.
+## Ends in an error in state: 676.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -720,7 +720,7 @@ parse_pattern: LPAREN LAZY WITH
 
 parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 656.
+## Ends in an error in state: 665.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -733,7 +733,7 @@ parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 651.
+## Ends in an error in state: 660.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -746,7 +746,7 @@ parse_pattern: LPAREN LBRACE WITH
 
 parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 817.
+## Ends in an error in state: 826.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -759,7 +759,7 @@ parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LPAREN LBRACKET WITH
 ##
-## Ends in an error in state: 650.
+## Ends in an error in state: 659.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -773,7 +773,7 @@ parse_pattern: LPAREN LBRACKET WITH
 
 parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 822.
+## Ends in an error in state: 831.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -786,7 +786,7 @@ parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LPAREN LBRACKETBAR WITH
 ##
-## Ends in an error in state: 647.
+## Ends in an error in state: 656.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -800,7 +800,7 @@ parse_pattern: LPAREN LBRACKETBAR WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 830.
+## Ends in an error in state: 839.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -818,7 +818,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCOR
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 829.
+## Ends in an error in state: 838.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -831,7 +831,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 828.
+## Ends in an error in state: 837.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -849,7 +849,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 827.
+## Ends in an error in state: 836.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -862,7 +862,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 826.
+## Ends in an error in state: 835.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -875,7 +875,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 825.
+## Ends in an error in state: 834.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -888,7 +888,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 635.
+## Ends in an error in state: 644.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -901,7 +901,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 633.
+## Ends in an error in state: 642.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -915,7 +915,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 
 parse_pattern: LPAREN LPAREN MODULE WITH
 ##
-## Ends in an error in state: 632.
+## Ends in an error in state: 641.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -929,7 +929,7 @@ parse_pattern: LPAREN LPAREN MODULE WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 809.
+## Ends in an error in state: 818.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -944,7 +944,7 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 720.
+## Ends in an error in state: 729.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -962,17 +962,17 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 795, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
-## In state 802, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 801, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 805, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 804, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
+## In state 811, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 810, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 814, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 631.
+## Ends in an error in state: 640.
 ##
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -996,7 +996,7 @@ parse_pattern: LPAREN LPAREN WITH
 
 parse_pattern: LPAREN MINUS WITH
 ##
-## Ends in an error in state: 625.
+## Ends in an error in state: 634.
 ##
 ## operator -> MINUS . [ RPAREN ]
 ## signed_constant -> MINUS . INT [ error RPAREN LBRACKETAT DOTDOT COMMA COLONCOLON COLON BAR AS ]
@@ -1026,7 +1026,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 234, spurious reduction of production ident -> UIDENT
-## In state 643, spurious reduction of production mty_longident -> ident
+## In state 652, spurious reduction of production mty_longident -> ident
 ##
 
 <SYNTAX ERROR>
@@ -1047,7 +1047,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WHILE
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2415.
+## Ends in an error in state: 2424.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ error RPAREN ]
 ##
@@ -1059,7 +1059,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2414.
+## Ends in an error in state: 2423.
 ##
 ## package_type_cstrs -> package_type_cstr . [ error RPAREN ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ error RPAREN ]
@@ -1077,7 +1077,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 ## In state 445, spurious reduction of production _core_type -> core_type2
 ## In state 454, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 444, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2412, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 2421, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
@@ -1236,7 +1236,7 @@ parse_pattern: LPAREN SHARP WITH
 
 parse_pattern: LPAREN STRING DOTDOT WITH
 ##
-## Ends in an error in state: 680.
+## Ends in an error in state: 689.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ##
@@ -1248,7 +1248,7 @@ parse_pattern: LPAREN STRING DOTDOT WITH
 
 parse_pattern: LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 689.
+## Ends in an error in state: 698.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ error WITH UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS AND ]
 ##
@@ -1260,7 +1260,7 @@ parse_pattern: LPAREN UIDENT DOT WITH
 
 parse_pattern: LPAREN UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 668.
+## Ends in an error in state: 677.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1282,7 +1282,7 @@ parse_pattern: LPAREN UIDENT LPAREN WITH
 
 parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 699.
+## Ends in an error in state: 708.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1295,7 +1295,7 @@ parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE AS LPAREN WITH
 ##
-## Ends in an error in state: 714.
+## Ends in an error in state: 723.
 ##
 ## val_ident -> LPAREN . operator RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -1307,7 +1307,7 @@ parse_pattern: LPAREN UNDERSCORE AS LPAREN WITH
 
 parse_pattern: LPAREN UNDERSCORE AS WITH
 ##
-## Ends in an error in state: 712.
+## Ends in an error in state: 721.
 ##
 ## _pattern_without_or -> pattern_without_or AS . val_ident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> pattern_without_or AS . error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -1320,7 +1320,7 @@ parse_pattern: LPAREN UNDERSCORE AS WITH
 
 parse_pattern: LPAREN UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 729.
+## Ends in an error in state: 738.
 ##
 ## _or_pattern -> pattern BAR . pattern [ error SEMI RPAREN RBRACKET RBRACE COMMA COLON BARRBRACKET BAR ]
 ##
@@ -1345,7 +1345,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BACKQUOTE LIDENT GREATER
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 160, spurious reduction of production attributes ->
-## In state 2519, spurious reduction of production tag_field -> name_tag attributes
+## In state 2528, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
@@ -1555,7 +1555,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LESS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2410.
+## Ends in an error in state: 2419.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1774,7 +1774,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 838.
+## Ends in an error in state: 847.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1789,7 +1789,7 @@ parse_pattern: LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 711.
+## Ends in an error in state: 720.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -1806,7 +1806,7 @@ parse_pattern: LPAREN UNDERSCORE COLONCOLON UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLONCOLON WITH
 ##
-## Ends in an error in state: 709.
+## Ends in an error in state: 718.
 ##
 ## _pattern_without_or -> pattern_without_or COLONCOLON . pattern_without_or [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> pattern_without_or COLONCOLON . error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -1819,7 +1819,7 @@ parse_pattern: LPAREN UNDERSCORE COLONCOLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 722.
+## Ends in an error in state: 731.
 ##
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1831,7 +1831,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 794.
+## Ends in an error in state: 803.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ RPAREN COMMA ]
 ##
@@ -1843,7 +1843,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ##
-## Ends in an error in state: 833.
+## Ends in an error in state: 842.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -1855,18 +1855,18 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 782, spurious reduction of production pattern -> pattern_without_or
-## In state 793, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 802, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 801, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 805, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 791, spurious reduction of production pattern -> pattern_without_or
+## In state 802, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 811, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 810, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 814, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 804.
+## Ends in an error in state: 813.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1878,7 +1878,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 803.
+## Ends in an error in state: 812.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint . COMMA pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1889,10 +1889,10 @@ parse_pattern: LPAREN UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 708, spurious reduction of production pattern -> pattern_without_or
-## In state 835, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 802, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 801, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 717, spurious reduction of production pattern -> pattern_without_or
+## In state 844, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 811, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 810, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
 ##
 
 <SYNTAX ERROR>
@@ -1967,7 +1967,7 @@ parse_pattern: SHARP WITH
 
 parse_pattern: STRING DOTDOT WITH
 ##
-## Ends in an error in state: 759.
+## Ends in an error in state: 768.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ##
@@ -1979,7 +1979,7 @@ parse_pattern: STRING DOTDOT WITH
 
 parse_pattern: UIDENT DOT WITH
 ##
-## Ends in an error in state: 587.
+## Ends in an error in state: 596.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ WITH WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS AND ]
 ##
@@ -1991,7 +1991,7 @@ parse_pattern: UIDENT DOT WITH
 
 parse_pattern: UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 623.
+## Ends in an error in state: 632.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -2013,7 +2013,7 @@ parse_pattern: UIDENT LPAREN WITH
 
 parse_pattern: UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 778.
+## Ends in an error in state: 787.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -2026,7 +2026,7 @@ parse_pattern: UIDENT UNDERSCORE WITH
 
 parse_pattern: UNDERSCORE AS WITH
 ##
-## Ends in an error in state: 786.
+## Ends in an error in state: 795.
 ##
 ## _pattern_without_or -> pattern_without_or AS . val_ident [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> pattern_without_or AS . error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -2039,7 +2039,7 @@ parse_pattern: UNDERSCORE AS WITH
 
 parse_pattern: UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 796.
+## Ends in an error in state: 805.
 ##
 ## _or_pattern -> pattern BAR . pattern [ WHEN SEMI RPAREN RBRACKET IN EQUALGREATER EQUAL EOF COMMA COLON BAR ]
 ##
@@ -2051,7 +2051,7 @@ parse_pattern: UNDERSCORE BAR WITH
 
 parse_pattern: UNDERSCORE COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 785.
+## Ends in an error in state: 794.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -2068,7 +2068,7 @@ parse_pattern: UNDERSCORE COLONCOLON UNDERSCORE WITH
 
 parse_pattern: UNDERSCORE COLONCOLON WITH
 ##
-## Ends in an error in state: 783.
+## Ends in an error in state: 792.
 ##
 ## _pattern_without_or -> pattern_without_or COLONCOLON . pattern_without_or [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> pattern_without_or COLONCOLON . error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -2081,7 +2081,7 @@ parse_pattern: UNDERSCORE COLONCOLON WITH
 
 parse_pattern: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2622.
+## Ends in an error in state: 2640.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EOF BAR ]
 ## parse_pattern -> pattern . EOF [ # ]
@@ -2093,14 +2093,14 @@ parse_pattern: UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 782, spurious reduction of production pattern -> pattern_without_or
+## In state 791, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: WITH
 ##
-## Ends in an error in state: 2621.
+## Ends in an error in state: 2639.
 ##
 ## parse_pattern' -> . parse_pattern [ # ]
 ##
@@ -2112,7 +2112,7 @@ parse_pattern: WITH
 
 parse_expression: UIDENT SEMI
 ##
-## Ends in an error in state: 2619.
+## Ends in an error in state: 2637.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -2146,21 +2146,21 @@ parse_expression: UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 parse_expression: WITH
 ##
-## Ends in an error in state: 2617.
+## Ends in an error in state: 2635.
 ##
 ## parse_expression' -> . parse_expression [ # ]
 ##
@@ -2172,7 +2172,7 @@ parse_expression: WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 2513.
+## Ends in an error in state: 2522.
 ##
 ## tag_field -> name_tag opt_ampersand . amper_type_list attributes [ RBRACKET GREATER BAR ]
 ##
@@ -2184,7 +2184,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 ##
-## Ends in an error in state: 2516.
+## Ends in an error in state: 2525.
 ##
 ## amper_type_list -> amper_type_list AMPERSAND . core_type [ RBRACKET LBRACKETAT GREATER BAR AMPERSAND ]
 ##
@@ -2196,7 +2196,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ##
-## Ends in an error in state: 2520.
+## Ends in an error in state: 2529.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET tag_field . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field -> tag_field . [ BAR ]
@@ -2209,7 +2209,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 160, spurious reduction of production attributes ->
-## In state 2519, spurious reduction of production tag_field -> name_tag attributes
+## In state 2528, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
@@ -2241,7 +2241,7 @@ parse_core_type: LBRACKET BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 2524.
+## Ends in an error in state: 2533.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2254,7 +2254,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 2523.
+## Ends in an error in state: 2532.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2266,7 +2266,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE WITH
 ##
-## Ends in an error in state: 2522.
+## Ends in an error in state: 2531.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field . BAR row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2304,7 +2304,7 @@ parse_core_type: LBRACKETGREATER BAR ASSERT
 
 parse_core_type: LBRACKETGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 2526.
+## Ends in an error in state: 2535.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2355,7 +2355,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2531.
+## Ends in an error in state: 2540.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER name_tag_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## name_tag_list -> name_tag_list . name_tag [ RBRACKET BACKQUOTE ]
@@ -2368,7 +2368,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 ##
-## Ends in an error in state: 2530.
+## Ends in an error in state: 2539.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER . name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2380,7 +2380,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE WITH
 ##
-## Ends in an error in state: 2528.
+## Ends in an error in state: 2537.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . GREATER name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2432,7 +2432,7 @@ parse_core_type: LESS LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 ##
-## Ends in an error in state: 490.
+## Ends in an error in state: 498.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ##
@@ -2444,7 +2444,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 487.
+## Ends in an error in state: 495.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -2457,7 +2457,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE WITH
 ##
-## Ends in an error in state: 488.
+## Ends in an error in state: 496.
 ##
 ## typevar_list -> typevar_list QUOTE . ident [ QUOTE DOT ]
 ##
@@ -2500,11 +2500,11 @@ parse_core_type: LESS LIDENT COLON UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 497, spurious reduction of production _poly_type -> core_type
-## In state 498, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 496, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 2533, spurious reduction of production attributes ->
-## In state 2534, spurious reduction of production field -> label COLON poly_type attributes
+## In state 505, spurious reduction of production _poly_type -> core_type
+## In state 506, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 504, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 2542, spurious reduction of production attributes ->
+## In state 2543, spurious reduction of production field -> label COLON poly_type attributes
 ##
 
 <SYNTAX ERROR>
@@ -2547,7 +2547,7 @@ parse_core_type: LESS WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2539.
+## Ends in an error in state: 2548.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2559,7 +2559,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 ##
-## Ends in an error in state: 2537.
+## Ends in an error in state: 2546.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2571,7 +2571,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 ##
-## Ends in an error in state: 2536.
+## Ends in an error in state: 2545.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION . EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2583,7 +2583,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2535.
+## Ends in an error in state: 2544.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . QUESTION EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2675,7 +2675,7 @@ parse_core_type: LPAREN MODULE UIDENT SEMI
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2544.
+## Ends in an error in state: 2553.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ RPAREN COLONGREATER ]
 ##
@@ -2687,7 +2687,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER A
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2543.
+## Ends in an error in state: 2552.
 ##
 ## package_type_cstrs -> package_type_cstr . [ RPAREN COLONGREATER ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ RPAREN COLONGREATER ]
@@ -2705,7 +2705,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER W
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2541, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 2550, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
@@ -2784,7 +2784,7 @@ parse_core_type: LPAREN UNDERSCORE COMMA WITH
 
 parse_core_type: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2546.
+## Ends in an error in state: 2555.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN core_type_comma_list . RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## core_type_comma_list -> core_type_comma_list . COMMA core_type [ RPAREN COMMA ]
@@ -2823,7 +2823,7 @@ parse_core_type: QUOTE WITH
 
 parse_core_type: SHARP LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 2548.
+## Ends in an error in state: 2557.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP class_longident non_arrowed_simple_core_type_list . [ WITH SEMI RPAREN RBRACKET RBRACE QUESTION LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2990,7 +2990,7 @@ parse_core_type: UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2615.
+## Ends in an error in state: 2633.
 ##
 ## parse_core_type -> core_type . EOF [ # ]
 ##
@@ -3013,7 +3013,7 @@ parse_core_type: UNDERSCORE WITH
 
 parse_core_type: WITH
 ##
-## Ends in an error in state: 2613.
+## Ends in an error in state: 2631.
 ##
 ## parse_core_type' -> . parse_core_type [ # ]
 ##
@@ -3025,7 +3025,7 @@ parse_core_type: WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 ##
-## Ends in an error in state: 1743.
+## Ends in an error in state: 1752.
 ##
 ## and_class_description -> AND . class_description_details post_item_attributes [ SEMI AND ]
 ##
@@ -3037,7 +3037,7 @@ interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ##
-## Ends in an error in state: 1742.
+## Ends in an error in state: 1751.
 ##
 ## _signature_item -> many_class_descriptions . [ SEMI ]
 ## many_class_descriptions -> many_class_descriptions . and_class_description [ SEMI AND ]
@@ -3049,22 +3049,22 @@ interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1626, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1630, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1624, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1628, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1639, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1637, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
-## In state 1725, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
-## In state 1726, spurious reduction of production post_item_attributes ->
-## In state 1727, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
+## In state 1635, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1639, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1633, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1637, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1648, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1646, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1734, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
+## In state 1735, spurious reduction of production post_item_attributes ->
+## In state 1736, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 1724.
+## Ends in an error in state: 1733.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters COLON . class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -3076,7 +3076,7 @@ interface: CLASS LIDENT COLON WITH
 
 interface: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1648.
+## Ends in an error in state: 1657.
 ##
 ## type_parameter -> type_variance . type_variable [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLON CHAR BACKQUOTE ]
 ##
@@ -3088,7 +3088,7 @@ interface: CLASS LIDENT PLUS WITH
 
 interface: CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1723.
+## Ends in an error in state: 1732.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters . COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS COLON ]
@@ -3101,7 +3101,7 @@ interface: CLASS LIDENT WITH
 
 interface: CLASS TYPE LIDENT EQUAL LIDENT RBRACKET
 ##
-## Ends in an error in state: 1741.
+## Ends in an error in state: 1750.
 ##
 ## _signature_item -> many_class_type_declarations . [ SEMI ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ SEMI AND ]
@@ -3113,19 +3113,19 @@ interface: CLASS TYPE LIDENT EQUAL LIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1626, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1630, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1624, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1698, spurious reduction of production class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type
-## In state 1699, spurious reduction of production post_item_attributes ->
-## In state 1700, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
+## In state 1635, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1639, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1633, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1707, spurious reduction of production class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type
+## In state 1708, spurious reduction of production post_item_attributes ->
+## In state 1709, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 1721.
+## Ends in an error in state: 1730.
 ##
 ## class_description_details -> virtual_flag . LIDENT class_type_parameters COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -3137,7 +3137,7 @@ interface: CLASS VIRTUAL LET
 
 interface: CLASS WITH
 ##
-## Ends in an error in state: 1720.
+## Ends in an error in state: 1729.
 ##
 ## many_class_descriptions -> CLASS . class_description_details post_item_attributes [ SEMI AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ SEMI AND ]
@@ -3150,7 +3150,7 @@ interface: CLASS WITH
 
 interface: EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 939.
+## Ends in an error in state: 948.
 ##
 ## extension_constructor_declaration -> constr_ident . generalized_constructor_arguments attributes [ SEMI LBRACKETATAT BAR ]
 ##
@@ -3162,7 +3162,7 @@ interface: EXCEPTION UIDENT WITH
 
 interface: EXCEPTION WITH
 ##
-## Ends in an error in state: 1717.
+## Ends in an error in state: 1726.
 ##
 ## sig_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ SEMI ]
 ##
@@ -3174,7 +3174,7 @@ interface: EXCEPTION WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1714.
+## Ends in an error in state: 1723.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3186,7 +3186,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1713.
+## Ends in an error in state: 1722.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3209,7 +3209,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 interface: EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1712.
+## Ends in an error in state: 1721.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3221,7 +3221,7 @@ interface: EXTERNAL LIDENT COLON WITH
 
 interface: EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 1711.
+## Ends in an error in state: 1720.
 ##
 ## _signature_item -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3233,7 +3233,7 @@ interface: EXTERNAL LIDENT WITH
 
 interface: EXTERNAL WITH
 ##
-## Ends in an error in state: 1710.
+## Ends in an error in state: 1719.
 ##
 ## _signature_item -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3245,7 +3245,7 @@ interface: EXTERNAL WITH
 
 interface: INCLUDE LBRACE OPEN UIDENT WITH
 ##
-## Ends in an error in state: 1728.
+## Ends in an error in state: 1737.
 ##
 ## signature -> signature_item . SEMI signature [ error RBRACE ]
 ##
@@ -3257,17 +3257,17 @@ interface: INCLUDE LBRACE OPEN UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 402, spurious reduction of production post_item_attributes ->
-## In state 2405, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 1733, spurious reduction of production _signature_item -> open_statement
-## In state 1750, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 1734, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 2414, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 1742, spurious reduction of production _signature_item -> open_statement
+## In state 1759, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 1743, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 1729.
+## Ends in an error in state: 1738.
 ##
 ## signature -> signature_item SEMI . signature [ error RBRACE ]
 ##
@@ -3279,7 +3279,7 @@ interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 
 interface: INCLUDE LBRACE WITH
 ##
-## Ends in an error in state: 918.
+## Ends in an error in state: 927.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LBRACE . signature error [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3292,7 +3292,7 @@ interface: INCLUDE LBRACE WITH
 
 interface: INCLUDE LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 1908.
+## Ends in an error in state: 1917.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## _simple_module_type -> LBRACE . signature error [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3305,7 +3305,7 @@ interface: INCLUDE LPAREN LBRACE WITH
 
 interface: INCLUDE LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 2311.
+## Ends in an error in state: 2320.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3321,7 +3321,7 @@ interface: INCLUDE LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 1915.
+## Ends in an error in state: 1924.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3337,7 +3337,7 @@ interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 1966.
+## Ends in an error in state: 1975.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3352,7 +3352,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LID
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1965.
+## Ends in an error in state: 1974.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3364,7 +3364,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WIT
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1964.
+## Ends in an error in state: 1973.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3376,7 +3376,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1963.
+## Ends in an error in state: 1972.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3392,22 +3392,22 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 958, spurious reduction of production _simple_module_type -> mty_longident
-## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 967, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1962.
+## Ends in an error in state: 1971.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3419,7 +3419,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1961.
+## Ends in an error in state: 1970.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3431,7 +3431,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 1907.
+## Ends in an error in state: 1916.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3445,7 +3445,7 @@ interface: INCLUDE LPAREN LPAREN WITH
 
 interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2310.
+## Ends in an error in state: 2319.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER ]
@@ -3459,19 +3459,19 @@ interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN MODULE TYPE WITH
 ##
-## Ends in an error in state: 548.
+## Ends in an error in state: 557.
 ##
 ## _non_arrowed_module_type -> MODULE TYPE . module_expr [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3483,7 +3483,7 @@ interface: INCLUDE LPAREN MODULE TYPE WITH
 
 interface: INCLUDE LPAREN MODULE WITH
 ##
-## Ends in an error in state: 547.
+## Ends in an error in state: 556.
 ##
 ## _non_arrowed_module_type -> MODULE . TYPE module_expr [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3495,7 +3495,7 @@ interface: INCLUDE LPAREN MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 ##
-## Ends in an error in state: 641.
+## Ends in an error in state: 650.
 ##
 ## ident -> UIDENT . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## mod_ext2 -> mod_ext_longident DOT UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -3509,7 +3509,7 @@ interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 640.
+## Ends in an error in state: 649.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -3523,7 +3523,7 @@ interface: INCLUDE LPAREN UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 1952.
+## Ends in an error in state: 1961.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3538,7 +3538,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1951.
+## Ends in an error in state: 1960.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3550,7 +3550,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 639.
+## Ends in an error in state: 648.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -3570,7 +3570,7 @@ interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UIDENT WHILE
 ##
-## Ends in an error in state: 546.
+## Ends in an error in state: 555.
 ##
 ## functor_arg_name -> UIDENT . [ COLON ]
 ## ident -> UIDENT . [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3585,7 +3585,7 @@ interface: INCLUDE LPAREN UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 ##
-## Ends in an error in state: 1934.
+## Ends in an error in state: 1943.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
@@ -3598,7 +3598,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1931.
+## Ends in an error in state: 1940.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ RPAREN LPAREN DOT ]
 ## mod_ext2 -> UIDENT LPAREN mod_ext_longident . RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
@@ -3618,7 +3618,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UID
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1930.
+## Ends in an error in state: 1939.
 ##
 ## mod_ext2 -> UIDENT LPAREN . mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
 ##
@@ -3643,7 +3643,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WIT
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1928.
+## Ends in an error in state: 1937.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ##
@@ -3655,7 +3655,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 1943.
+## Ends in an error in state: 1952.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3668,7 +3668,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 ##
-## Ends in an error in state: 1929.
+## Ends in an error in state: 1938.
 ##
 ## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
 ## mod_ext_longident -> UIDENT . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
@@ -3681,7 +3681,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1944.
+## Ends in an error in state: 1953.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ##
@@ -3693,7 +3693,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1927.
+## Ends in an error in state: 1936.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3706,7 +3706,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 1926.
+## Ends in an error in state: 1935.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3719,7 +3719,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 1947.
+## Ends in an error in state: 1956.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ##
@@ -3731,7 +3731,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER A
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER EQUAL
 ##
-## Ends in an error in state: 1946.
+## Ends in an error in state: 1955.
 ##
 ## _module_type -> module_type WITH with_constraints . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## with_constraints -> with_constraints . AND with_constraint [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3749,15 +3749,15 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER E
 ## In state 445, spurious reduction of production _core_type -> core_type2
 ## In state 454, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 444, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1922, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1949, spurious reduction of production with_constraints -> with_constraint
+## In state 1931, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1958, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1921.
+## Ends in an error in state: 1930.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ##
@@ -3769,7 +3769,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1923.
+## Ends in an error in state: 1932.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ##
@@ -3781,7 +3781,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ##
-## Ends in an error in state: 1925.
+## Ends in an error in state: 1934.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3799,14 +3799,14 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ## In state 445, spurious reduction of production _core_type -> core_type2
 ## In state 454, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 444, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1924, spurious reduction of production constraints ->
+## In state 1933, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ##
-## Ends in an error in state: 1920.
+## Ends in an error in state: 1929.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3818,14 +3818,14 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 530, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 539, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 1918.
+## Ends in an error in state: 1927.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3838,7 +3838,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH WITH
 ##
-## Ends in an error in state: 1917.
+## Ends in an error in state: 1926.
 ##
 ## _module_type -> module_type WITH . with_constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3850,7 +3850,7 @@ interface: INCLUDE LPAREN UIDENT WITH WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2319.
+## Ends in an error in state: 2328.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3866,22 +3866,22 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COL
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 958, spurious reduction of production _simple_module_type -> mty_longident
-## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 967, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2318.
+## Ends in an error in state: 2327.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3893,7 +3893,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2317.
+## Ends in an error in state: 2326.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3905,7 +3905,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2316.
+## Ends in an error in state: 2325.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3921,22 +3921,22 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 958, spurious reduction of production _simple_module_type -> mty_longident
-## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 967, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2315.
+## Ends in an error in state: 2324.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3948,7 +3948,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2314.
+## Ends in an error in state: 2323.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3960,7 +3960,7 @@ interface: INCLUDE LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN WITH
 ##
-## Ends in an error in state: 545.
+## Ends in an error in state: 554.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3974,7 +3974,7 @@ interface: INCLUDE LPAREN WITH
 
 interface: INCLUDE MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2399.
+## Ends in an error in state: 2408.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
@@ -3988,12 +3988,12 @@ interface: INCLUDE MODULE TYPE UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 852, spurious reduction of production _module_expr -> simple_module_expr
-## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 861, spurious reduction of production _module_expr -> simple_module_expr
+## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
@@ -4052,7 +4052,7 @@ interface: INCLUDE UIDENT DOT WITH
 
 interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 988.
+## Ends in an error in state: 997.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4068,22 +4068,22 @@ interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 958, spurious reduction of production _simple_module_type -> mty_longident
-## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 967, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 987.
+## Ends in an error in state: 996.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4143,7 +4143,7 @@ interface: INCLUDE UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 978.
+## Ends in an error in state: 987.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4155,7 +4155,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 980.
+## Ends in an error in state: 989.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4181,7 +4181,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 981.
+## Ends in an error in state: 990.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4193,7 +4193,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 977.
+## Ends in an error in state: 986.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4206,7 +4206,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 976.
+## Ends in an error in state: 985.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4219,7 +4219,7 @@ interface: INCLUDE UIDENT WITH MODULE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 984.
+## Ends in an error in state: 993.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4231,7 +4231,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ##
-## Ends in an error in state: 983.
+## Ends in an error in state: 992.
 ##
 ## _module_type -> module_type WITH with_constraints . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraints -> with_constraints . AND with_constraint [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4249,15 +4249,15 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 967, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 986, spurious reduction of production with_constraints -> with_constraint
+## In state 976, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 995, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 966.
+## Ends in an error in state: 975.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4269,7 +4269,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 968.
+## Ends in an error in state: 977.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4281,7 +4281,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ##
-## Ends in an error in state: 970.
+## Ends in an error in state: 979.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4299,14 +4299,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 969, spurious reduction of production constraints ->
+## In state 978, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 964.
+## Ends in an error in state: 973.
 ##
 ## with_type_binder -> EQUAL . [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
 ## with_type_binder -> EQUAL . PRIVATE [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
@@ -4319,7 +4319,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ##
-## Ends in an error in state: 963.
+## Ends in an error in state: 972.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4331,14 +4331,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 962, spurious reduction of production optional_type_parameters ->
+## In state 971, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 961.
+## Ends in an error in state: 970.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4351,7 +4351,7 @@ interface: INCLUDE UIDENT WITH TYPE WITH
 
 interface: INCLUDE UIDENT WITH WITH
 ##
-## Ends in an error in state: 960.
+## Ends in an error in state: 969.
 ##
 ## _module_type -> module_type WITH . with_constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4363,7 +4363,7 @@ interface: INCLUDE UIDENT WITH WITH
 
 interface: INCLUDE WITH
 ##
-## Ends in an error in state: 1707.
+## Ends in an error in state: 1716.
 ##
 ## _signature_item -> INCLUDE . module_type post_item_attributes [ SEMI ]
 ##
@@ -4375,7 +4375,7 @@ interface: INCLUDE WITH
 
 interface: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 1026.
+## Ends in an error in state: 1035.
 ##
 ## _signature_item -> LET val_ident COLON . core_type post_item_attributes [ SEMI ]
 ##
@@ -4387,7 +4387,7 @@ interface: LET LIDENT COLON WITH
 
 interface: LET LIDENT WITH
 ##
-## Ends in an error in state: 1025.
+## Ends in an error in state: 1034.
 ##
 ## _signature_item -> LET val_ident . COLON core_type post_item_attributes [ SEMI ]
 ##
@@ -4399,7 +4399,7 @@ interface: LET LIDENT WITH
 
 interface: LET LPAREN WITH
 ##
-## Ends in an error in state: 788.
+## Ends in an error in state: 797.
 ##
 ## val_ident -> LPAREN . operator RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -4411,7 +4411,7 @@ interface: LET LPAREN WITH
 
 interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
 ##
-## Ends in an error in state: 1737.
+## Ends in an error in state: 1746.
 ##
 ## and_module_rec_declaration -> AND . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4423,7 +4423,7 @@ interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
 
 interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1736.
+## Ends in an error in state: 1745.
 ##
 ## _signature_item -> many_module_rec_declarations . [ SEMI ]
 ## many_module_rec_declarations -> many_module_rec_declarations . and_module_rec_declaration [ SEMI AND ]
@@ -4435,16 +4435,16 @@ interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 923, spurious reduction of production post_item_attributes ->
-## In state 924, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1024, spurious reduction of production many_module_rec_declarations -> LET MODULE REC module_rec_declaration_details post_item_attributes
+## In state 932, spurious reduction of production post_item_attributes ->
+## In state 933, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1033, spurious reduction of production many_module_rec_declarations -> LET MODULE REC module_rec_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 1022.
+## Ends in an error in state: 1031.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -4460,22 +4460,22 @@ interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 958, spurious reduction of production _simple_module_type -> mty_longident
-## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 967, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON WITH
 ##
-## Ends in an error in state: 1021.
+## Ends in an error in state: 1030.
 ##
 ## module_rec_declaration_details -> UIDENT COLON . module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4487,7 +4487,7 @@ interface: LET MODULE REC UIDENT COLON WITH
 
 interface: LET MODULE REC UIDENT WITH
 ##
-## Ends in an error in state: 1020.
+## Ends in an error in state: 1029.
 ##
 ## module_rec_declaration_details -> UIDENT . COLON module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4499,7 +4499,7 @@ interface: LET MODULE REC UIDENT WITH
 
 interface: LET MODULE REC WITH
 ##
-## Ends in an error in state: 1019.
+## Ends in an error in state: 1028.
 ##
 ## many_module_rec_declarations -> LET MODULE REC . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4511,7 +4511,7 @@ interface: LET MODULE REC WITH
 
 interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 1008.
+## Ends in an error in state: 1017.
 ##
 ## _module_declaration -> COLON module_type . [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -4527,22 +4527,22 @@ interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 958, spurious reduction of production _simple_module_type -> mty_longident
-## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 967, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 1007.
+## Ends in an error in state: 1016.
 ##
 ## _module_declaration -> COLON . module_type [ SEMI LBRACKETATAT ]
 ##
@@ -4554,7 +4554,7 @@ interface: LET MODULE UIDENT COLON WITH
 
 interface: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1014.
+## Ends in an error in state: 1023.
 ##
 ## _signature_item -> LET MODULE UIDENT EQUAL . mod_longident post_item_attributes [ SEMI ]
 ##
@@ -4566,7 +4566,7 @@ interface: LET MODULE UIDENT EQUAL WITH
 
 interface: LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1012.
+## Ends in an error in state: 1021.
 ##
 ## _module_declaration -> LPAREN RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4578,7 +4578,7 @@ interface: LET MODULE UIDENT LPAREN RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1006.
+## Ends in an error in state: 1015.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4590,7 +4590,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1005.
+## Ends in an error in state: 1014.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type . RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -4606,22 +4606,22 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 958, spurious reduction of production _simple_module_type -> mty_longident
-## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 967, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1004.
+## Ends in an error in state: 1013.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON . module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4633,7 +4633,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1003.
+## Ends in an error in state: 1012.
 ##
 ## _module_declaration -> LPAREN UIDENT . COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4645,7 +4645,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT WITH
 
 interface: LET MODULE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1002.
+## Ends in an error in state: 1011.
 ##
 ## _module_declaration -> LPAREN . UIDENT COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_declaration -> LPAREN . RPAREN module_declaration [ SEMI LBRACKETATAT ]
@@ -4658,7 +4658,7 @@ interface: LET MODULE UIDENT LPAREN WITH
 
 interface: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1001.
+## Ends in an error in state: 1010.
 ##
 ## _signature_item -> LET MODULE UIDENT . module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> LET MODULE UIDENT . EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4671,7 +4671,7 @@ interface: LET MODULE UIDENT WITH
 
 interface: LET MODULE WITH
 ##
-## Ends in an error in state: 1000.
+## Ends in an error in state: 1009.
 ##
 ## _signature_item -> LET MODULE . UIDENT module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> LET MODULE . UIDENT EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4685,7 +4685,7 @@ interface: LET MODULE WITH
 
 interface: LET WITH
 ##
-## Ends in an error in state: 999.
+## Ends in an error in state: 1008.
 ##
 ## _signature_item -> LET . val_ident COLON core_type post_item_attributes [ SEMI ]
 ## _signature_item -> LET . MODULE UIDENT module_declaration post_item_attributes [ SEMI ]
@@ -4700,7 +4700,7 @@ interface: LET WITH
 
 interface: MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 955.
+## Ends in an error in state: 964.
 ##
 ## _signature_item -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ SEMI ]
 ##
@@ -4712,7 +4712,7 @@ interface: MODULE TYPE UIDENT EQUAL WITH
 
 interface: MODULE TYPE WITH
 ##
-## Ends in an error in state: 953.
+## Ends in an error in state: 962.
 ##
 ## _signature_item -> MODULE TYPE . ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4725,7 +4725,7 @@ interface: MODULE TYPE WITH
 
 interface: MODULE WITH
 ##
-## Ends in an error in state: 952.
+## Ends in an error in state: 961.
 ##
 ## _signature_item -> MODULE . TYPE ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4738,7 +4738,7 @@ interface: MODULE WITH
 
 interface: OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2607.
+## Ends in an error in state: 2625.
 ##
 ## signature -> signature_item . SEMI signature [ EOF ]
 ##
@@ -4750,17 +4750,17 @@ interface: OPEN UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 402, spurious reduction of production post_item_attributes ->
-## In state 2405, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 1733, spurious reduction of production _signature_item -> open_statement
-## In state 1750, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 1734, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 2414, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 1742, spurious reduction of production _signature_item -> open_statement
+## In state 1759, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 1743, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 929.
+## Ends in an error in state: 938.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4772,7 +4772,7 @@ interface: TYPE LIDENT PLUSEQ BAR WITH
 
 interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 928.
+## Ends in an error in state: 937.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4784,7 +4784,7 @@ interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 
 interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 937.
+## Ends in an error in state: 946.
 ##
 ## sig_extension_constructors -> sig_extension_constructors BAR . extension_constructor_declaration [ SEMI LBRACKETATAT BAR ]
 ##
@@ -4796,7 +4796,7 @@ interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 interface: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 926.
+## Ends in an error in state: 935.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4808,7 +4808,7 @@ interface: TYPE LIDENT PLUSEQ WITH
 
 interface: TYPE LIDENT RBRACKET
 ##
-## Ends in an error in state: 1735.
+## Ends in an error in state: 1744.
 ##
 ## _signature_item -> many_type_declarations . [ SEMI ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ SEMI AND ]
@@ -4822,17 +4822,17 @@ interface: TYPE LIDENT RBRACKET
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 89, spurious reduction of production optional_type_parameters ->
 ## In state 104, spurious reduction of production type_kind ->
-## In state 1130, spurious reduction of production constraints ->
-## In state 1131, spurious reduction of production type_declaration_details -> LIDENT optional_type_parameters type_kind constraints
-## In state 921, spurious reduction of production post_item_attributes ->
-## In state 922, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 1139, spurious reduction of production constraints ->
+## In state 1140, spurious reduction of production type_declaration_details -> LIDENT optional_type_parameters type_kind constraints
+## In state 930, spurious reduction of production post_item_attributes ->
+## In state 931, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2608.
+## Ends in an error in state: 2626.
 ##
 ## signature -> signature_item SEMI . signature [ EOF ]
 ##
@@ -4844,7 +4844,7 @@ interface: TYPE LIDENT SEMI WITH
 
 interface: TYPE NONREC LET
 ##
-## Ends in an error in state: 920.
+## Ends in an error in state: 929.
 ##
 ## many_type_declarations -> TYPE nonrec_flag . type_declaration_details post_item_attributes [ SEMI AND ]
 ## sig_type_extension -> TYPE nonrec_flag . potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
@@ -4857,7 +4857,7 @@ interface: TYPE NONREC LET
 
 interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ##
-## Ends in an error in state: 925.
+## Ends in an error in state: 934.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters . PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4868,15 +4868,15 @@ interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 530, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
-## In state 529, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
+## In state 539, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 538, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
 ##
 
 <SYNTAX ERROR>
 
 interface: WITH
 ##
-## Ends in an error in state: 2606.
+## Ends in an error in state: 2624.
 ##
 ## interface' -> . interface [ # ]
 ##
@@ -4888,7 +4888,7 @@ interface: WITH
 
 implementation: ASSERT WITH
 ##
-## Ends in an error in state: 884.
+## Ends in an error in state: 893.
 ##
 ## _expr -> ASSERT . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -4912,7 +4912,7 @@ implementation: BACKQUOTE WITH
 
 implementation: BANG WITH
 ##
-## Ends in an error in state: 563.
+## Ends in an error in state: 572.
 ##
 ## _simple_expr -> BANG . simple_expr [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -4924,7 +4924,7 @@ implementation: BANG WITH
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1643.
+## Ends in an error in state: 1652.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4936,7 +4936,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WIT
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1642.
+## Ends in an error in state: 1651.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4949,7 +4949,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE WITH
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1641.
+## Ends in an error in state: 1650.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4961,7 +4961,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON WITH
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1634.
+## Ends in an error in state: 1643.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4973,7 +4973,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE 
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 1633.
+## Ends in an error in state: 1642.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4986,7 +4986,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE 
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1632.
+## Ends in an error in state: 1641.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4998,7 +4998,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: CLASS LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1635.
+## Ends in an error in state: 1644.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -5010,7 +5010,7 @@ implementation: CLASS LIDENT COLON LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1631, spurious reduction of production type_longident -> LIDENT
+## In state 1640, spurious reduction of production type_longident -> LIDENT
 ## In state 261, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
 ## In state 266, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
 ## In state 264, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
@@ -5021,7 +5021,7 @@ implementation: CLASS LIDENT COLON LIDENT WITH
 
 implementation: CLASS LIDENT COLON NEW LIDENT EQUAL LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1647.
+## Ends in an error in state: 1656.
 ##
 ## _class_expr -> class_expr . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL class_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5034,7 +5034,7 @@ implementation: CLASS LIDENT COLON NEW LIDENT EQUAL LBRACKETPERCENT AND RBRACKET
 
 implementation: CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1646.
+## Ends in an error in state: 1655.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL . class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5046,7 +5046,7 @@ implementation: CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 
 implementation: CLASS LIDENT COLON NEW LIDENT RBRACKET
 ##
-## Ends in an error in state: 1628.
+## Ends in an error in state: 1637.
 ##
 ## _class_constructor_type -> NEW class_instance_type . [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _class_instance_type -> class_instance_type . attribute [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUAL AND ]
@@ -5058,16 +5058,16 @@ implementation: CLASS LIDENT COLON NEW LIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1626, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1630, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1624, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1635, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1639, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1633, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1645.
+## Ends in an error in state: 1654.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type . EQUAL class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5078,19 +5078,19 @@ implementation: CLASS LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1626, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1630, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1624, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1628, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1639, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1637, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1635, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1639, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1633, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1637, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1648, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1646, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1620.
+## Ends in an error in state: 1629.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -5102,7 +5102,7 @@ implementation: CLASS LIDENT COLON NEW WITH
 
 implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1636.
+## Ends in an error in state: 1645.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -5114,7 +5114,7 @@ implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 1619.
+## Ends in an error in state: 1628.
 ##
 ## _constrained_class_declaration -> COLON . class_constructor_type EQUAL class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5126,7 +5126,7 @@ implementation: CLASS LIDENT COLON WITH
 
 implementation: CLASS LIDENT EQUAL CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1604.
+## Ends in an error in state: 1613.
 ##
 ## _class_expr -> CLASS class_longident non_arrowed_simple_core_type_list . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ UNDERSCORE UIDENT SHARP SEMI RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
@@ -5139,7 +5139,7 @@ implementation: CLASS LIDENT EQUAL CLASS LIDENT UNDERSCORE WITH
 
 implementation: CLASS LIDENT EQUAL CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1603.
+## Ends in an error in state: 1612.
 ##
 ## _class_expr -> CLASS class_longident . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_expr -> CLASS class_longident . non_arrowed_simple_core_type_list [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -5152,7 +5152,7 @@ implementation: CLASS LIDENT EQUAL CLASS LIDENT WITH
 
 implementation: CLASS LIDENT EQUAL CLASS WITH
 ##
-## Ends in an error in state: 1602.
+## Ends in an error in state: 1611.
 ##
 ## _class_expr -> CLASS . class_longident [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_expr -> CLASS . class_longident non_arrowed_simple_core_type_list [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -5165,7 +5165,7 @@ implementation: CLASS LIDENT EQUAL CLASS WITH
 
 implementation: CLASS LIDENT EQUAL FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1611.
+## Ends in an error in state: 1620.
 ##
 ## _class_expr -> class_expr . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER class_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -5178,7 +5178,7 @@ implementation: CLASS LIDENT EQUAL FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT A
 
 implementation: CLASS LIDENT EQUAL FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1601.
+## Ends in an error in state: 1610.
 ##
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER . class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ##
@@ -5190,7 +5190,7 @@ implementation: CLASS LIDENT EQUAL FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT EQUAL FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1600.
+## Ends in an error in state: 1609.
 ##
 ## _class_fun_def -> labeled_simple_pattern . EQUALGREATER class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_fun_def -> labeled_simple_pattern . class_fun_def [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -5203,7 +5203,7 @@ implementation: CLASS LIDENT EQUAL FUN UNDERSCORE WITH
 
 implementation: CLASS LIDENT EQUAL FUN WITH
 ##
-## Ends in an error in state: 1598.
+## Ends in an error in state: 1607.
 ##
 ## _class_expr -> FUN . class_fun_def [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ##
@@ -5215,7 +5215,7 @@ implementation: CLASS LIDENT EQUAL FUN WITH
 
 implementation: CLASS LIDENT EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 1594.
+## Ends in an error in state: 1603.
 ##
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest RBRACE [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest error [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
@@ -5228,7 +5228,7 @@ implementation: CLASS LIDENT EQUAL LBRACE WITH
 
 implementation: CLASS LIDENT EQUAL LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1618.
+## Ends in an error in state: 1627.
 ##
 ## _class_expr -> class_expr . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5241,7 +5241,7 @@ implementation: CLASS LIDENT EQUAL LBRACKETPERCENT AND RBRACKET WITH
 
 implementation: CLASS LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1146.
+## Ends in an error in state: 1155.
 ##
 ## and_class_declaration -> AND . class_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5253,7 +5253,7 @@ implementation: CLASS LIDENT EQUAL LIDENT AND WITH
 
 implementation: CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1145.
+## Ends in an error in state: 1154.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_declarations . [ SEMI RBRACKET RBRACE EOF ]
 ## many_class_declarations -> many_class_declarations . and_class_declaration [ SEMI RBRACKET RBRACE EOF AND ]
@@ -5265,16 +5265,16 @@ implementation: CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 923, spurious reduction of production post_item_attributes ->
-## In state 924, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1702, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
+## In state 932, spurious reduction of production post_item_attributes ->
+## In state 933, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1711, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT EQUAL LIDENT UIDENT WITH
 ##
-## Ends in an error in state: 1609.
+## Ends in an error in state: 1618.
 ##
 ## _class_expr -> class_simple_expr simple_labeled_expr_list . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## simple_labeled_expr_list -> simple_labeled_expr_list . labeled_simple_expr [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
@@ -5286,20 +5286,20 @@ implementation: CLASS LIDENT EQUAL LIDENT UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 881, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1171, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1176, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
-## In state 1179, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 890, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1180, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1185, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
+## In state 1188, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT EQUAL LIDENT WITH
 ##
-## Ends in an error in state: 1608.
+## Ends in an error in state: 1617.
 ##
 ## _class_expr -> class_simple_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_expr -> class_simple_expr . simple_labeled_expr_list [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -5312,7 +5312,7 @@ implementation: CLASS LIDENT EQUAL LIDENT WITH
 
 implementation: CLASS LIDENT EQUAL LPAREN LIDENT COLON WITH
 ##
-## Ends in an error in state: 1590.
+## Ends in an error in state: 1599.
 ##
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type RPAREN [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type error [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
@@ -5325,7 +5325,7 @@ implementation: CLASS LIDENT EQUAL LPAREN LIDENT COLON WITH
 
 implementation: CLASS LIDENT EQUAL LPAREN LIDENT SEMI
 ##
-## Ends in an error in state: 1587.
+## Ends in an error in state: 1596.
 ##
 ## _class_expr -> class_expr . attribute [ error RPAREN LBRACKETAT COLON ]
 ## _class_simple_expr -> LPAREN class_expr . COLON class_constructor_type RPAREN [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
@@ -5340,16 +5340,16 @@ implementation: CLASS LIDENT EQUAL LPAREN LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1302, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1323, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1300, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1311, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1332, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1309, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 1153.
+## Ends in an error in state: 1162.
 ##
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type RPAREN [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type error [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
@@ -5364,7 +5364,7 @@ implementation: CLASS LIDENT EQUAL LPAREN WITH
 
 implementation: CLASS LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1152.
+## Ends in an error in state: 1161.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5376,7 +5376,7 @@ implementation: CLASS LIDENT EQUAL WITH
 
 implementation: CLASS LIDENT MINUS WITH
 ##
-## Ends in an error in state: 1151.
+## Ends in an error in state: 1160.
 ##
 ## signed_constant -> MINUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> MINUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -5393,7 +5393,7 @@ implementation: CLASS LIDENT MINUS WITH
 
 implementation: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1150.
+## Ends in an error in state: 1159.
 ##
 ## signed_constant -> PLUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> PLUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -5410,7 +5410,7 @@ implementation: CLASS LIDENT PLUS WITH
 
 implementation: CLASS LIDENT QUOTE WITH
 ##
-## Ends in an error in state: 1649.
+## Ends in an error in state: 1658.
 ##
 ## _type_variable -> QUOTE . ident [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLON CHAR BACKQUOTE ]
 ##
@@ -5422,7 +5422,7 @@ implementation: CLASS LIDENT QUOTE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1075.
+## Ends in an error in state: 1084.
 ##
 ## class_sig_body -> class_self_type . class_sig_fields opt_semi [ error RBRACE ]
 ##
@@ -5434,7 +5434,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 ##
-## Ends in an error in state: 1070.
+## Ends in an error in state: 1079.
 ##
 ## class_self_type -> AS core_type . SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -5457,7 +5457,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 ##
-## Ends in an error in state: 1069.
+## Ends in an error in state: 1078.
 ##
 ## class_self_type -> AS . core_type SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -5469,7 +5469,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1685.
+## Ends in an error in state: 1694.
 ##
 ## _class_sig_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5481,7 +5481,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1682.
+## Ends in an error in state: 1691.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT ]
 ## _class_sig_field -> INHERIT class_instance_type . [ error SEMI RBRACE ]
@@ -5494,16 +5494,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1565, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1569, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1563, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1574, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1578, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1572, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1681.
+## Ends in an error in state: 1690.
 ##
 ## _class_sig_field -> INHERIT . class_instance_type [ error SEMI RBRACE ]
 ## _class_sig_field -> INHERIT . class_instance_type item_attribute post_item_attributes [ error SEMI RBRACE ]
@@ -5516,7 +5516,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH RBRACKET WITH
 ##
-## Ends in an error in state: 1072.
+## Ends in an error in state: 1081.
 ##
 ## _class_instance_type -> LBRACE class_sig_body . RBRACE [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE class_sig_body . error [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5528,20 +5528,20 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1689, spurious reduction of production post_item_attributes ->
-## In state 1690, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
-## In state 1695, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
-## In state 1688, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
-## In state 1697, spurious reduction of production class_sig_fields -> class_sig_field
-## In state 1692, spurious reduction of production opt_semi ->
-## In state 1696, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
+## In state 1698, spurious reduction of production post_item_attributes ->
+## In state 1699, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
+## In state 1704, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
+## In state 1697, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
+## In state 1706, spurious reduction of production class_sig_fields -> class_sig_field
+## In state 1701, spurious reduction of production opt_semi ->
+## In state 1705, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 ##
-## Ends in an error in state: 1101.
+## Ends in an error in state: 1110.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label COLON . poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5553,7 +5553,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 ##
-## Ends in an error in state: 1100.
+## Ends in an error in state: 1109.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label . COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5565,7 +5565,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 ##
-## Ends in an error in state: 1097.
+## Ends in an error in state: 1106.
 ##
 ## private_virtual_flags -> PRIVATE . [ LIDENT ]
 ## private_virtual_flags -> PRIVATE . VIRTUAL [ LIDENT ]
@@ -5578,7 +5578,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1099.
+## Ends in an error in state: 1108.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags . label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5590,7 +5590,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 ##
-## Ends in an error in state: 1095.
+## Ends in an error in state: 1104.
 ##
 ## private_virtual_flags -> VIRTUAL . [ LIDENT ]
 ## private_virtual_flags -> VIRTUAL . PRIVATE [ LIDENT ]
@@ -5603,7 +5603,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 ##
-## Ends in an error in state: 1094.
+## Ends in an error in state: 1103.
 ##
 ## _class_sig_field -> METHOD . private_virtual_flags label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5615,7 +5615,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1092.
+## Ends in an error in state: 1101.
 ##
 ## value_type -> label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5627,7 +5627,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1091.
+## Ends in an error in state: 1100.
 ##
 ## value_type -> label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5639,7 +5639,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1085.
+## Ends in an error in state: 1094.
 ##
 ## value_type -> MUTABLE virtual_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5651,7 +5651,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 ##
-## Ends in an error in state: 1084.
+## Ends in an error in state: 1093.
 ##
 ## value_type -> MUTABLE virtual_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5663,7 +5663,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 ##
-## Ends in an error in state: 1083.
+## Ends in an error in state: 1092.
 ##
 ## value_type -> MUTABLE virtual_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5675,7 +5675,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1082.
+## Ends in an error in state: 1091.
 ##
 ## value_type -> MUTABLE . virtual_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5687,7 +5687,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1080.
+## Ends in an error in state: 1089.
 ##
 ## value_type -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5699,7 +5699,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1079.
+## Ends in an error in state: 1088.
 ##
 ## value_type -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5711,7 +5711,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1078.
+## Ends in an error in state: 1087.
 ##
 ## value_type -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5723,7 +5723,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1077.
+## Ends in an error in state: 1086.
 ##
 ## value_type -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5735,7 +5735,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 ##
-## Ends in an error in state: 1076.
+## Ends in an error in state: 1085.
 ##
 ## _class_sig_field -> VAL . value_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5747,7 +5747,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 ##
-## Ends in an error in state: 1068.
+## Ends in an error in state: 1077.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5760,7 +5760,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1666.
+## Ends in an error in state: 1675.
 ##
 ## _class_expr -> class_expr . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER class_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5773,7 +5773,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER LBRACKETPERCEN
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1665.
+## Ends in an error in state: 1674.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER . class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5785,7 +5785,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ##
-## Ends in an error in state: 1668.
+## Ends in an error in state: 1677.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## _non_arrowed_class_constructor_type -> class_instance_type . [ EQUALGREATER ]
@@ -5797,16 +5797,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1626, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1630, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1624, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1635, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1639, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1633, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1627.
+## Ends in an error in state: 1636.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
@@ -5819,7 +5819,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 ##
-## Ends in an error in state: 1626.
+## Ends in an error in state: 1635.
 ##
 ## _class_instance_type -> clty_longident . [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5832,7 +5832,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1664.
+## Ends in an error in state: 1673.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type . EQUALGREATER class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5844,7 +5844,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT RPAREN WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1662.
+## Ends in an error in state: 1671.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN class_constructor_type . RPAREN [ EQUALGREATER ]
 ##
@@ -5855,19 +5855,19 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1626, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1630, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1624, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1628, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1639, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1637, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1635, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1639, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1633, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1637, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1648, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1646, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 ##
-## Ends in an error in state: 1661.
+## Ends in an error in state: 1670.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN . class_constructor_type RPAREN [ EQUALGREATER ]
 ##
@@ -5879,7 +5879,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 ##
-## Ends in an error in state: 1622.
+## Ends in an error in state: 1631.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5893,7 +5893,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 ##
-## Ends in an error in state: 1621.
+## Ends in an error in state: 1630.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5913,7 +5913,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1660.
+## Ends in an error in state: 1669.
 ##
 ## class_fun_return -> COLON . non_arrowed_class_constructor_type EQUALGREATER class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5925,7 +5925,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1659.
+## Ends in an error in state: 1668.
 ##
 ## _class_expr -> class_expr . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> EQUALGREATER class_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5938,7 +5938,7 @@ implementation: CLASS LIDENT UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKE
 
 implementation: CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1658.
+## Ends in an error in state: 1667.
 ##
 ## class_fun_return -> EQUALGREATER . class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5950,7 +5950,7 @@ implementation: CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1657.
+## Ends in an error in state: 1666.
 ##
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_binding [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_return [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5963,7 +5963,7 @@ implementation: CLASS LIDENT UNDERSCORE WITH
 
 implementation: CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1149.
+## Ends in an error in state: 1158.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . class_fun_binding [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . constrained_class_declaration [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5978,7 +5978,7 @@ implementation: CLASS LIDENT WITH
 
 implementation: CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1141.
+## Ends in an error in state: 1150.
 ##
 ## and_class_type_declaration -> AND . class_type_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5990,7 +5990,7 @@ implementation: CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 
 implementation: CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1140.
+## Ends in an error in state: 1149.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_type_declarations . [ SEMI RBRACKET RBRACE EOF ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ SEMI RBRACKET RBRACE EOF AND ]
@@ -6002,16 +6002,16 @@ implementation: CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 923, spurious reduction of production post_item_attributes ->
-## In state 924, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1700, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
+## In state 932, spurious reduction of production post_item_attributes ->
+## In state 933, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1709, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1698.
+## Ends in an error in state: 1707.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -6023,16 +6023,16 @@ implementation: CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1626, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1630, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1624, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1635, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1639, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1633, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1066.
+## Ends in an error in state: 1075.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_instance_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -6044,7 +6044,7 @@ implementation: CLASS TYPE LIDENT EQUAL WITH
 
 implementation: CLASS TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1063.
+## Ends in an error in state: 1072.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters . EQUAL class_instance_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS EQUAL ]
@@ -6057,7 +6057,7 @@ implementation: CLASS TYPE LIDENT WITH
 
 implementation: CLASS TYPE VIRTUAL LET
 ##
-## Ends in an error in state: 1061.
+## Ends in an error in state: 1070.
 ##
 ## class_type_declaration_details -> virtual_flag . LIDENT class_type_parameters EQUAL class_instance_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -6069,7 +6069,7 @@ implementation: CLASS TYPE VIRTUAL LET
 
 implementation: CLASS TYPE WITH
 ##
-## Ends in an error in state: 1060.
+## Ends in an error in state: 1069.
 ##
 ## many_class_type_declarations -> CLASS TYPE . class_type_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -6081,7 +6081,7 @@ implementation: CLASS TYPE WITH
 
 implementation: CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 1147.
+## Ends in an error in state: 1156.
 ##
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters class_fun_binding [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters constrained_class_declaration [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -6095,7 +6095,7 @@ implementation: CLASS VIRTUAL LET
 
 implementation: CLASS WITH
 ##
-## Ends in an error in state: 1058.
+## Ends in an error in state: 1067.
 ##
 ## many_class_declarations -> CLASS . class_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
@@ -6108,7 +6108,7 @@ implementation: CLASS WITH
 
 implementation: EXCEPTION LPAREN WITH
 ##
-## Ends in an error in state: 932.
+## Ends in an error in state: 941.
 ##
 ## constr_ident -> LPAREN . RPAREN [ UNDERSCORE UIDENT SHARP SEMI RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUAL EOF CONSTRAINT COLON BAR AND ]
 ##
@@ -6120,7 +6120,7 @@ implementation: EXCEPTION LPAREN WITH
 
 implementation: EXCEPTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 940.
+## Ends in an error in state: 949.
 ##
 ## generalized_constructor_arguments -> COLON . core_type [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -6132,7 +6132,7 @@ implementation: EXCEPTION UIDENT COLON WITH
 
 implementation: EXCEPTION UIDENT EQUAL LBRACKET WITH
 ##
-## Ends in an error in state: 1053.
+## Ends in an error in state: 1062.
 ##
 ## constr_longident -> LBRACKET . RBRACKET [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -6144,7 +6144,7 @@ implementation: EXCEPTION UIDENT EQUAL LBRACKET WITH
 
 implementation: EXCEPTION UIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 1052.
+## Ends in an error in state: 1061.
 ##
 ## constr_longident -> LPAREN . RPAREN [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -6156,7 +6156,7 @@ implementation: EXCEPTION UIDENT EQUAL LPAREN WITH
 
 implementation: EXCEPTION UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1051.
+## Ends in an error in state: 1060.
 ##
 ## extension_constructor_rebind -> constr_ident EQUAL . constr_longident attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ##
@@ -6168,7 +6168,7 @@ implementation: EXCEPTION UIDENT EQUAL WITH
 
 implementation: EXCEPTION UIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 943.
+## Ends in an error in state: 952.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list COLON . core_type [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -6180,7 +6180,7 @@ implementation: EXCEPTION UIDENT UNDERSCORE COLON WITH
 
 implementation: EXCEPTION UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 942.
+## Ends in an error in state: 951.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . COLON core_type [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
@@ -6194,7 +6194,7 @@ implementation: EXCEPTION UIDENT UNDERSCORE WITH
 
 implementation: EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1050.
+## Ends in an error in state: 1059.
 ##
 ## extension_constructor_declaration -> constr_ident . generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## extension_constructor_rebind -> constr_ident . EQUAL constr_longident attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -6207,7 +6207,7 @@ implementation: EXCEPTION UIDENT WITH
 
 implementation: EXCEPTION WITH
 ##
-## Ends in an error in state: 1045.
+## Ends in an error in state: 1054.
 ##
 ## str_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ## str_exception_declaration -> EXCEPTION . extension_constructor_rebind post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
@@ -6220,7 +6220,7 @@ implementation: EXCEPTION WITH
 
 implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 ##
-## Ends in an error in state: 1041.
+## Ends in an error in state: 1050.
 ##
 ## primitive_declaration -> STRING . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ## primitive_declaration -> STRING . primitive_declaration [ SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
@@ -6233,7 +6233,7 @@ implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 
 implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1040.
+## Ends in an error in state: 1049.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6245,7 +6245,7 @@ implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1039.
+## Ends in an error in state: 1048.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6268,7 +6268,7 @@ implementation: EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 implementation: EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1038.
+## Ends in an error in state: 1047.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6280,7 +6280,7 @@ implementation: EXTERNAL LIDENT COLON WITH
 
 implementation: EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 1037.
+## Ends in an error in state: 1046.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6292,7 +6292,7 @@ implementation: EXTERNAL LIDENT WITH
 
 implementation: EXTERNAL WITH
 ##
-## Ends in an error in state: 1036.
+## Ends in an error in state: 1045.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6304,7 +6304,7 @@ implementation: EXTERNAL WITH
 
 implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ##
-## Ends in an error in state: 877.
+## Ends in an error in state: 886.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag simple_expr . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -6322,17 +6322,17 @@ implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 881, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 890, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FOR UNDERSCORE IN UIDENT TO WITH
 ##
-## Ends in an error in state: 876.
+## Ends in an error in state: 885.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag . simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6344,7 +6344,7 @@ implementation: FOR UNDERSCORE IN UIDENT TO WITH
 
 implementation: FOR UNDERSCORE IN UIDENT WITH
 ##
-## Ends in an error in state: 873.
+## Ends in an error in state: 882.
 ##
 ## _expr -> FOR pattern IN simple_expr . direction_flag simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ TO SHARP DOWNTO DOT ]
@@ -6362,17 +6362,17 @@ implementation: FOR UNDERSCORE IN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 881, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 890, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FOR UNDERSCORE IN WITH
 ##
-## Ends in an error in state: 872.
+## Ends in an error in state: 881.
 ##
 ## _expr -> FOR pattern IN . simple_expr direction_flag simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6384,7 +6384,7 @@ implementation: FOR UNDERSCORE IN WITH
 
 implementation: FOR UNDERSCORE WHEN
 ##
-## Ends in an error in state: 871.
+## Ends in an error in state: 880.
 ##
 ## _expr -> FOR pattern . IN simple_expr direction_flag simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _or_pattern -> pattern . BAR pattern [ IN BAR ]
@@ -6396,14 +6396,14 @@ implementation: FOR UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 782, spurious reduction of production pattern -> pattern_without_or
+## In state 791, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: FOR WITH
 ##
-## Ends in an error in state: 870.
+## Ends in an error in state: 879.
 ##
 ## _expr -> FOR . pattern IN simple_expr direction_flag simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6415,7 +6415,7 @@ implementation: FOR WITH
 
 implementation: FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 1881.
+## Ends in an error in state: 1890.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6449,17 +6449,17 @@ implementation: FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1880.
+## Ends in an error in state: 1889.
 ##
 ## leading_bar_match_case -> bar_located_pattern EQUALGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6471,7 +6471,7 @@ implementation: FUN BAR UNDERSCORE EQUALGREATER WITH
 
 implementation: FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 1879.
+## Ends in an error in state: 1888.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6505,17 +6505,17 @@ implementation: FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1878.
+## Ends in an error in state: 1887.
 ##
 ## leading_bar_match_case -> bar_located_pattern WHEN expr EQUALGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6527,7 +6527,7 @@ implementation: FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 
 implementation: FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 1877.
+## Ends in an error in state: 1886.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -6561,21 +6561,21 @@ implementation: FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 1876.
+## Ends in an error in state: 1885.
 ##
 ## leading_bar_match_case -> bar_located_pattern WHEN . expr EQUALGREATER expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6587,7 +6587,7 @@ implementation: FUN BAR UNDERSCORE WHEN WITH
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 846.
+## Ends in an error in state: 855.
 ##
 ## _simple_expr -> simple_expr . DOT label_longident [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
 ## _simple_expr -> simple_expr . DOT LPAREN expr RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
@@ -6605,17 +6605,17 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 881, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 890, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 845.
+## Ends in an error in state: 854.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern EQUAL . simple_expr [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ##
@@ -6627,7 +6627,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 843.
+## Ends in an error in state: 852.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -6641,7 +6641,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 
 implementation: FUN LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 622.
+## Ends in an error in state: 631.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -6655,7 +6655,7 @@ implementation: FUN LIDENT COLONCOLON WITH
 
 implementation: FUN LIDENT WITH
 ##
-## Ends in an error in state: 1883.
+## Ends in an error in state: 1892.
 ##
 ## _expr -> FUN labeled_simple_pattern . fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6666,18 +6666,18 @@ implementation: FUN LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 621, spurious reduction of production val_ident -> LIDENT
-## In state 755, spurious reduction of production _simple_pattern -> val_ident
-## In state 769, spurious reduction of production mark_position_pat(_simple_pattern) -> _simple_pattern
-## In state 765, spurious reduction of production simple_pattern -> mark_position_pat(_simple_pattern)
-## In state 1245, spurious reduction of production labeled_simple_pattern -> simple_pattern
+## In state 630, spurious reduction of production val_ident -> LIDENT
+## In state 764, spurious reduction of production _simple_pattern -> val_ident
+## In state 778, spurious reduction of production mark_position_pat(_simple_pattern) -> _simple_pattern
+## In state 774, spurious reduction of production simple_pattern -> mark_position_pat(_simple_pattern)
+## In state 1254, spurious reduction of production labeled_simple_pattern -> simple_pattern
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 864.
+## Ends in an error in state: 873.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT RPAREN . fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6689,7 +6689,7 @@ implementation: FUN LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: FUN LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 863.
+## Ends in an error in state: 872.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT . RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6701,7 +6701,7 @@ implementation: FUN LPAREN TYPE LIDENT WITH
 
 implementation: FUN LPAREN TYPE WITH
 ##
-## Ends in an error in state: 862.
+## Ends in an error in state: 871.
 ##
 ## _expr -> FUN LPAREN TYPE . LIDENT RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6713,7 +6713,7 @@ implementation: FUN LPAREN TYPE WITH
 
 implementation: FUN LPAREN WITH
 ##
-## Ends in an error in state: 861.
+## Ends in an error in state: 870.
 ##
 ## _expr -> FUN LPAREN . TYPE LIDENT RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
@@ -6736,7 +6736,7 @@ implementation: FUN LPAREN WITH
 
 implementation: FUN UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 1866.
+## Ends in an error in state: 1875.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6770,17 +6770,17 @@ implementation: FUN UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 869.
+## Ends in an error in state: 878.
 ##
 ## fun_def -> EQUALGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6792,7 +6792,7 @@ implementation: FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 868.
+## Ends in an error in state: 877.
 ##
 ## fun_def -> LPAREN TYPE LIDENT RPAREN . fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6804,7 +6804,7 @@ implementation: FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 867.
+## Ends in an error in state: 876.
 ##
 ## fun_def -> LPAREN TYPE LIDENT . RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6816,7 +6816,7 @@ implementation: FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: FUN UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 866.
+## Ends in an error in state: 875.
 ##
 ## fun_def -> LPAREN TYPE . LIDENT RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6828,7 +6828,7 @@ implementation: FUN UNDERSCORE LPAREN TYPE WITH
 
 implementation: FUN UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 865.
+## Ends in an error in state: 874.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
@@ -6851,7 +6851,7 @@ implementation: FUN UNDERSCORE LPAREN WITH
 
 implementation: FUN UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 1867.
+## Ends in an error in state: 1876.
 ##
 ## fun_def -> labeled_simple_pattern . fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6863,7 +6863,7 @@ implementation: FUN UNDERSCORE UNDERSCORE WITH
 
 implementation: FUN WITH
 ##
-## Ends in an error in state: 860.
+## Ends in an error in state: 869.
 ##
 ## _expr -> FUN . labeled_simple_pattern fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> FUN . LPAREN TYPE LIDENT RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6877,7 +6877,7 @@ implementation: FUN WITH
 
 implementation: IF UIDENT UIDENT ELSE WITH
 ##
-## Ends in an error in state: 859.
+## Ends in an error in state: 868.
 ##
 ## _expr -> IF simple_expr simple_expr ELSE . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6889,7 +6889,7 @@ implementation: IF UIDENT UIDENT ELSE WITH
 
 implementation: IF UIDENT WITH
 ##
-## Ends in an error in state: 857.
+## Ends in an error in state: 866.
 ##
 ## _expr -> IF simple_expr . simple_expr ELSE expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF simple_expr . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6908,17 +6908,17 @@ implementation: IF UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 881, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 890, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: IF WITH
 ##
-## Ends in an error in state: 856.
+## Ends in an error in state: 865.
 ##
 ## _expr -> IF . simple_expr simple_expr ELSE expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF . simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6931,7 +6931,7 @@ implementation: IF WITH
 
 implementation: INCLUDE FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 2324.
+## Ends in an error in state: 2333.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER module_expr . [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _module_expr -> module_expr . simple_module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -6946,7 +6946,7 @@ implementation: INCLUDE FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 
 implementation: INCLUDE FUN LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2323.
+## Ends in an error in state: 2332.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER . module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -6958,7 +6958,7 @@ implementation: INCLUDE FUN LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE FUN LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2322.
+## Ends in an error in state: 2331.
 ##
 ## _module_expr -> FUN functor_args . EQUALGREATER module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## functor_args -> functor_args . functor_arg [ LPAREN EQUALGREATER ]
@@ -6971,7 +6971,7 @@ implementation: INCLUDE FUN LPAREN RPAREN WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2320.
+## Ends in an error in state: 2329.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -6987,22 +6987,22 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 958, spurious reduction of production _simple_module_type -> mty_longident
-## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 967, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 544.
+## Ends in an error in state: 553.
 ##
 ## functor_arg -> LPAREN functor_arg_name COLON . module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -7014,7 +7014,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 543.
+## Ends in an error in state: 552.
 ##
 ## functor_arg -> LPAREN functor_arg_name . COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -7026,7 +7026,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 
 implementation: INCLUDE FUN LPAREN WITH
 ##
-## Ends in an error in state: 539.
+## Ends in an error in state: 548.
 ##
 ## functor_arg -> LPAREN . RPAREN [ LPAREN EQUALGREATER COLON ]
 ## functor_arg -> LPAREN . functor_arg_name COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
@@ -7039,7 +7039,7 @@ implementation: INCLUDE FUN LPAREN WITH
 
 implementation: INCLUDE FUN WITH
 ##
-## Ends in an error in state: 538.
+## Ends in an error in state: 547.
 ##
 ## _module_expr -> FUN . functor_args EQUALGREATER module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -7051,7 +7051,7 @@ implementation: INCLUDE FUN WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 2115.
+## Ends in an error in state: 2124.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL class_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7063,16 +7063,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1302, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1323, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1300, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1311, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1332, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1309, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2114.
+## Ends in an error in state: 2123.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL . class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7084,7 +7084,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 2113.
+## Ends in an error in state: 2122.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type . EQUAL class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7095,19 +7095,19 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1626, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1630, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1624, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1628, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1639, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1637, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1635, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1639, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1633, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1637, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1648, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1646, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 2112.
+## Ends in an error in state: 2121.
 ##
 ## _constrained_class_declaration -> COLON . class_constructor_type EQUAL class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7119,7 +7119,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 2160.
+## Ends in an error in state: 2169.
 ##
 ## and_class_declaration -> AND . class_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7131,7 +7131,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2159.
+## Ends in an error in state: 2168.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_declarations . [ error SEMI RBRACE ]
 ## many_class_declarations -> many_class_declarations . and_class_declaration [ error SEMI RBRACE AND ]
@@ -7143,16 +7143,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1089, spurious reduction of production post_item_attributes ->
-## In state 1090, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2132, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
+## In state 1098, spurious reduction of production post_item_attributes ->
+## In state 1099, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2141, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 2111.
+## Ends in an error in state: 2120.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7164,16 +7164,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1302, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1323, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1300, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1311, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1332, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1309, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2110.
+## Ends in an error in state: 2119.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7185,7 +7185,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 2124.
+## Ends in an error in state: 2133.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER class_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7197,16 +7197,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1302, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1323, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1300, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1311, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1332, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1309, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2123.
+## Ends in an error in state: 2132.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER . class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7218,7 +7218,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2122.
+## Ends in an error in state: 2131.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type . EQUALGREATER class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7230,7 +7230,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT R
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2121.
+## Ends in an error in state: 2130.
 ##
 ## class_fun_return -> COLON . non_arrowed_class_constructor_type EQUALGREATER class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7242,7 +7242,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 2120.
+## Ends in an error in state: 2129.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## class_fun_return -> EQUALGREATER class_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7254,16 +7254,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1302, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1323, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1300, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1311, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1332, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1309, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2119.
+## Ends in an error in state: 2128.
 ##
 ## class_fun_return -> EQUALGREATER . class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7275,7 +7275,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2118.
+## Ends in an error in state: 2127.
 ##
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_binding [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_return [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7288,7 +7288,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT WITH
 ##
-## Ends in an error in state: 2109.
+## Ends in an error in state: 2118.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . class_fun_binding [ error SEMI RBRACE LBRACKETATAT AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . constrained_class_declaration [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7303,7 +7303,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 2155.
+## Ends in an error in state: 2164.
 ##
 ## and_class_type_declaration -> AND . class_type_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7315,7 +7315,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2154.
+## Ends in an error in state: 2163.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_type_declarations . [ error SEMI RBRACE ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ error SEMI RBRACE AND ]
@@ -7327,16 +7327,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND R
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1089, spurious reduction of production post_item_attributes ->
-## In state 1090, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2106, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
+## In state 1098, spurious reduction of production post_item_attributes ->
+## In state 1099, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2115, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 2104.
+## Ends in an error in state: 2113.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7348,16 +7348,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1565, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1569, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1563, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1574, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1578, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1572, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2103.
+## Ends in an error in state: 2112.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_instance_type [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7369,7 +7369,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 ##
-## Ends in an error in state: 2102.
+## Ends in an error in state: 2111.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters . EQUAL class_instance_type [ error SEMI RBRACE LBRACKETATAT AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS EQUAL ]
@@ -7382,7 +7382,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 ##
-## Ends in an error in state: 2100.
+## Ends in an error in state: 2109.
 ##
 ## class_type_declaration_details -> virtual_flag . LIDENT class_type_parameters EQUAL class_instance_type [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7394,7 +7394,7 @@ implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE WITH
 ##
-## Ends in an error in state: 2099.
+## Ends in an error in state: 2108.
 ##
 ## many_class_type_declarations -> CLASS TYPE . class_type_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7406,7 +7406,7 @@ implementation: INCLUDE LBRACE CLASS TYPE WITH
 
 implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 2107.
+## Ends in an error in state: 2116.
 ##
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters class_fun_binding [ error SEMI RBRACE LBRACKETATAT AND ]
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters constrained_class_declaration [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7420,7 +7420,7 @@ implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 
 implementation: INCLUDE LBRACE CLASS WITH
 ##
-## Ends in an error in state: 2098.
+## Ends in an error in state: 2107.
 ##
 ## many_class_declarations -> CLASS . class_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
@@ -7433,7 +7433,7 @@ implementation: INCLUDE LBRACE CLASS WITH
 
 implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 ##
-## Ends in an error in state: 466.
+## Ends in an error in state: 471.
 ##
 ## constr_ident -> LPAREN . RPAREN [ error UNDERSCORE UIDENT SHARP SEMI RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUAL CONSTRAINT COLON BAR AND ]
 ##
@@ -7457,7 +7457,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 ##
-## Ends in an error in state: 2093.
+## Ends in an error in state: 2102.
 ##
 ## constr_longident -> LBRACKET . RBRACKET [ error SEMI RBRACE LBRACKETATAT LBRACKETAT BAR ]
 ##
@@ -7469,7 +7469,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 2092.
+## Ends in an error in state: 2101.
 ##
 ## constr_longident -> LPAREN . RPAREN [ error SEMI RBRACE LBRACKETATAT LBRACKETAT BAR ]
 ##
@@ -7481,7 +7481,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2091.
+## Ends in an error in state: 2100.
 ##
 ## extension_constructor_rebind -> constr_ident EQUAL . constr_longident attributes [ error SEMI RBRACE LBRACKETATAT BAR ]
 ##
@@ -7519,7 +7519,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 2090.
+## Ends in an error in state: 2099.
 ##
 ## extension_constructor_declaration -> constr_ident . generalized_constructor_arguments attributes [ error SEMI RBRACE LBRACKETATAT BAR ]
 ## extension_constructor_rebind -> constr_ident . EQUAL constr_longident attributes [ error SEMI RBRACE LBRACKETATAT BAR ]
@@ -7532,7 +7532,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 
 implementation: INCLUDE LBRACE EXCEPTION WITH
 ##
-## Ends in an error in state: 2085.
+## Ends in an error in state: 2094.
 ##
 ## str_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ error SEMI RBRACE ]
 ## str_exception_declaration -> EXCEPTION . extension_constructor_rebind post_item_attributes [ error SEMI RBRACE ]
@@ -7545,7 +7545,7 @@ implementation: INCLUDE LBRACE EXCEPTION WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 ##
-## Ends in an error in state: 2081.
+## Ends in an error in state: 2090.
 ##
 ## primitive_declaration -> STRING . [ error SEMI RBRACE LBRACKETATAT ]
 ## primitive_declaration -> STRING . primitive_declaration [ error SEMI RBRACE LBRACKETATAT ]
@@ -7558,7 +7558,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WIT
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2080.
+## Ends in an error in state: 2089.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7570,7 +7570,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2079.
+## Ends in an error in state: 2088.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7593,7 +7593,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 2078.
+## Ends in an error in state: 2087.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7605,7 +7605,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 2077.
+## Ends in an error in state: 2086.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7617,7 +7617,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 
 implementation: INCLUDE LBRACE EXTERNAL WITH
 ##
-## Ends in an error in state: 2076.
+## Ends in an error in state: 2085.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7629,7 +7629,7 @@ implementation: INCLUDE LBRACE EXTERNAL WITH
 
 implementation: INCLUDE LBRACE INCLUDE WITH
 ##
-## Ends in an error in state: 2073.
+## Ends in an error in state: 2082.
 ##
 ## _structure_item_without_item_extension_sugar -> INCLUDE . module_expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7641,7 +7641,7 @@ implementation: INCLUDE LBRACE INCLUDE WITH
 
 implementation: INCLUDE LBRACE LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 ##
-## Ends in an error in state: 2150.
+## Ends in an error in state: 2159.
 ##
 ## and_nonlocal_module_bindings -> AND . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7653,7 +7653,7 @@ implementation: INCLUDE LBRACE LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 
 implementation: INCLUDE LBRACE LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2149.
+## Ends in an error in state: 2158.
 ##
 ## _structure_item_without_item_extension_sugar -> many_nonlocal_module_bindings . [ error SEMI RBRACE ]
 ## many_nonlocal_module_bindings -> many_nonlocal_module_bindings . and_nonlocal_module_bindings [ error SEMI RBRACE AND ]
@@ -7665,16 +7665,16 @@ implementation: INCLUDE LBRACE LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT A
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1089, spurious reduction of production post_item_attributes ->
-## In state 1090, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2030, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
+## In state 1098, spurious reduction of production post_item_attributes ->
+## In state 1099, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2039, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE REC WITH
 ##
-## Ends in an error in state: 2028.
+## Ends in an error in state: 2037.
 ##
 ## many_nonlocal_module_bindings -> LET MODULE REC . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7686,7 +7686,7 @@ implementation: INCLUDE LBRACE LET MODULE REC WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2015.
+## Ends in an error in state: 2024.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
@@ -7700,19 +7700,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2014.
+## Ends in an error in state: 2023.
 ##
 ## module_binding_body_expr -> COLON module_type EQUAL . module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7724,7 +7724,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2013.
+## Ends in an error in state: 2022.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER EQUAL ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER EQUAL ]
@@ -7740,22 +7740,22 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 958, spurious reduction of production _simple_module_type -> mty_longident
-## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 967, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2012.
+## Ends in an error in state: 2021.
 ##
 ## module_binding_body_expr -> COLON . module_type EQUAL module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7767,7 +7767,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT COLON WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2011.
+## Ends in an error in state: 2020.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
@@ -7781,19 +7781,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1973.
+## Ends in an error in state: 1982.
 ##
 ## module_binding_body_expr -> EQUAL . module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7805,7 +7805,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2026.
+## Ends in an error in state: 2035.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER module_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
@@ -7819,19 +7819,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2025.
+## Ends in an error in state: 2034.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER . module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7843,7 +7843,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUA
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2024.
+## Ends in an error in state: 2033.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type . EQUALGREATER module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _module_type -> non_arrowed_module_type . [ WITH LBRACKETAT EQUALGREATER ]
@@ -7857,19 +7857,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 958, spurious reduction of production _simple_module_type -> mty_longident
-## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 967, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON WITH
 ##
-## Ends in an error in state: 2023.
+## Ends in an error in state: 2032.
 ##
 ## _module_binding_body_functor -> functor_args COLON . non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7881,7 +7881,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2022.
+## Ends in an error in state: 2031.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER module_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
@@ -7895,19 +7895,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2021.
+## Ends in an error in state: 2030.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER . module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7919,7 +7919,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2020.
+## Ends in an error in state: 2029.
 ##
 ## _module_binding_body_functor -> functor_args . EQUALGREATER module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _module_binding_body_functor -> functor_args . COLON non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7933,7 +7933,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1972.
+## Ends in an error in state: 1981.
 ##
 ## nonlocal_module_binding_details -> UIDENT . module_binding_body [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7945,7 +7945,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT WITH
 
 implementation: INCLUDE LBRACE LET MODULE WITH
 ##
-## Ends in an error in state: 1971.
+## Ends in an error in state: 1980.
 ##
 ## _structure_item_without_item_extension_sugar -> LET MODULE . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE ]
 ## many_nonlocal_module_bindings -> LET MODULE . REC nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE AND ]
@@ -7958,7 +7958,7 @@ implementation: INCLUDE LBRACE LET MODULE WITH
 
 implementation: INCLUDE LBRACE LET WITH
 ##
-## Ends in an error in state: 1970.
+## Ends in an error in state: 1979.
 ##
 ## _structure_item_without_item_extension_sugar -> LET . MODULE nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ error SEMI RBRACE AND ]
@@ -7972,7 +7972,7 @@ implementation: INCLUDE LBRACE LET WITH
 
 implementation: INCLUDE LBRACE MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1906.
+## Ends in an error in state: 1915.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7984,7 +7984,7 @@ implementation: INCLUDE LBRACE MODULE TYPE UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE MODULE TYPE WITH
 ##
-## Ends in an error in state: 1904.
+## Ends in an error in state: 1913.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE . ident post_item_attributes [ error SEMI RBRACE ]
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ error SEMI RBRACE ]
@@ -7997,7 +7997,7 @@ implementation: INCLUDE LBRACE MODULE TYPE WITH
 
 implementation: INCLUDE LBRACE MODULE WITH
 ##
-## Ends in an error in state: 1903.
+## Ends in an error in state: 1912.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident post_item_attributes [ error SEMI RBRACE ]
 ## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ error SEMI RBRACE ]
@@ -8010,7 +8010,7 @@ implementation: INCLUDE LBRACE MODULE WITH
 
 implementation: INCLUDE LBRACE OPEN BANG WITH
 ##
-## Ends in an error in state: 1900.
+## Ends in an error in state: 1909.
 ##
 ## open_statement -> OPEN override_flag . mod_longident post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8022,7 +8022,7 @@ implementation: INCLUDE LBRACE OPEN BANG WITH
 
 implementation: INCLUDE LBRACE OPEN WITH
 ##
-## Ends in an error in state: 1899.
+## Ends in an error in state: 1908.
 ##
 ## open_statement -> OPEN . override_flag mod_longident post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8034,7 +8034,7 @@ implementation: INCLUDE LBRACE OPEN WITH
 
 implementation: INCLUDE LBRACE STRING WITH
 ##
-## Ends in an error in state: 2134.
+## Ends in an error in state: 2143.
 ##
 ## structure -> structure_item . [ error RBRACE ]
 ## structure -> structure_item . SEMI structure [ error RBRACE ]
@@ -8046,24 +8046,24 @@ implementation: INCLUDE LBRACE STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2177, spurious reduction of production post_item_attributes ->
-## In state 2178, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 2179, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 2140, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 2133, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 2180, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 2141, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2186, spurious reduction of production post_item_attributes ->
+## In state 2187, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 2188, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 2149, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 2142, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 2189, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 2150, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT AND LIDENT WITH
 ##
-## Ends in an error in state: 2145.
+## Ends in an error in state: 2154.
 ##
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -8074,14 +8074,14 @@ implementation: INCLUDE LBRACE TYPE LIDENT AND LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2144, spurious reduction of production optional_type_parameters ->
+## In state 2153, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT AND WITH
 ##
-## Ends in an error in state: 2143.
+## Ends in an error in state: 2152.
 ##
 ## and_type_declaration -> AND . type_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -8093,7 +8093,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT AND WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 522.
+## Ends in an error in state: 531.
 ##
 ## constrain -> core_type EQUAL . core_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER CONSTRAINT AND ]
 ##
@@ -8105,7 +8105,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 521.
+## Ends in an error in state: 530.
 ##
 ## constrain -> core_type . EQUAL core_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER CONSTRAINT AND ]
 ##
@@ -8128,7 +8128,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT WITH
 ##
-## Ends in an error in state: 520.
+## Ends in an error in state: 529.
 ##
 ## constraints -> constraints CONSTRAINT . constrain [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER CONSTRAINT AND ]
 ##
@@ -8140,7 +8140,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL DOTDOT WITH
 ##
-## Ends in an error in state: 519.
+## Ends in an error in state: 528.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ## type_declaration_details -> LIDENT optional_type_parameters type_kind constraints . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -8153,7 +8153,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL DOTDOT WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 499.
+## Ends in an error in state: 507.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8165,17 +8165,17 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LBRACE LIDENT COLON LESSDOTDOTG
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 494, spurious reduction of production attributes ->
-## In state 495, spurious reduction of production attributes -> attribute attributes
-## In state 493, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 504, spurious reduction of production label_declarations -> label_declaration
+## In state 502, spurious reduction of production attributes ->
+## In state 503, spurious reduction of production attributes -> attribute attributes
+## In state 501, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 512, spurious reduction of production label_declarations -> label_declaration
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 482.
+## Ends in an error in state: 490.
 ##
 ## type_kind -> EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ##
@@ -8187,10 +8187,11 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LBRACE WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 252.
+## Ends in an error in state: 464.
 ##
-## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
-## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
+## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ error SEMI RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT AS AND ]
+## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ error SEMI RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT AS AND ]
+## constr_ident2 -> LPAREN . RPAREN [ error UNDERSCORE UIDENT SHARP SEMI RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET CONSTRAINT COLON BAR AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -8200,7 +8201,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LPAREN WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 462.
+## Ends in an error in state: 463.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL PRIVATE . core_type [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8214,7 +8215,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL PRIVATE WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UIDENT BAR WITH
 ##
-## Ends in an error in state: 463.
+## Ends in an error in state: 468.
 ##
 ## constructor_declaration_leading_bar -> BAR . constr_ident generalized_constructor_arguments attributes [ error SEMI RBRACE LBRACKETATAT CONSTRAINT BAR AND ]
 ##
@@ -8226,7 +8227,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UIDENT BAR WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 477.
+## Ends in an error in state: 482.
 ##
 ## constructor_declarations -> constructor_declaration_no_leading_bar . [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ## constructor_declarations -> constructor_declaration_no_leading_bar . constructor_declarations_leading_bar [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8267,7 +8268,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UIDENT WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 513.
+## Ends in an error in state: 522.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8279,17 +8280,17 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 494, spurious reduction of production attributes ->
-## In state 495, spurious reduction of production attributes -> attribute attributes
-## In state 493, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 504, spurious reduction of production label_declarations -> label_declaration
+## In state 502, spurious reduction of production attributes ->
+## In state 503, spurious reduction of production attributes -> attribute attributes
+## In state 501, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 512, spurious reduction of production label_declarations -> label_declaration
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 512.
+## Ends in an error in state: 521.
 ##
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ##
@@ -8301,7 +8302,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 ##
-## Ends in an error in state: 508.
+## Ends in an error in state: 516.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL core_type EQUAL PRIVATE . constructor_declarations [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8314,7 +8315,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 506.
+## Ends in an error in state: 514.
 ##
 ## type_kind -> EQUAL core_type EQUAL . constructor_declarations [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type EQUAL . PRIVATE constructor_declarations [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8329,7 +8330,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 505.
+## Ends in an error in state: 513.
 ##
 ## type_kind -> EQUAL core_type . [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type . EQUAL constructor_declarations [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8377,7 +8378,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT LBRACKETATAT WITH RBRACKET WITH
 ##
-## Ends in an error in state: 2142.
+## Ends in an error in state: 2151.
 ##
 ## _structure_item_without_item_extension_sugar -> many_type_declarations . [ error SEMI RBRACE ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ error SEMI RBRACE AND ]
@@ -8389,9 +8390,9 @@ implementation: INCLUDE LBRACE TYPE LIDENT LBRACKETATAT WITH RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1089, spurious reduction of production post_item_attributes ->
-## In state 1090, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2353, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 1098, spurious reduction of production post_item_attributes ->
+## In state 1099, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2362, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
@@ -8448,7 +8449,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUS WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 2357.
+## Ends in an error in state: 2366.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . str_extension_constructors post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8460,7 +8461,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ BAR WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 2356.
+## Ends in an error in state: 2365.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8472,7 +8473,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ PRIVATE BANG
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 2359.
+## Ends in an error in state: 2368.
 ##
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_declaration [ error SEMI RBRACE LBRACKETATAT BAR ]
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_rebind [ error SEMI RBRACE LBRACKETATAT BAR ]
@@ -8485,7 +8486,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 2355.
+## Ends in an error in state: 2364.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8521,7 +8522,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 525, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 534, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
 ##
 
 <SYNTAX ERROR>
@@ -8547,7 +8548,7 @@ implementation: INCLUDE LBRACE TYPE WITH
 
 implementation: INCLUDE LBRACE UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2135.
+## Ends in an error in state: 2144.
 ##
 ## structure -> structure_item SEMI . structure [ error RBRACE ]
 ##
@@ -8572,7 +8573,7 @@ implementation: INCLUDE LBRACE WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1978.
+## Ends in an error in state: 1987.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER module_expr . [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8587,7 +8588,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHIL
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1976.
+## Ends in an error in state: 1985.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER . module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8599,7 +8600,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1975.
+## Ends in an error in state: 1984.
 ##
 ## _module_expr -> FUN functor_args . EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## functor_args -> functor_args . functor_arg [ LPAREN EQUALGREATER ]
@@ -8612,7 +8613,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 
 implementation: INCLUDE LPAREN FUN WITH
 ##
-## Ends in an error in state: 1974.
+## Ends in an error in state: 1983.
 ##
 ## _module_expr -> FUN . functor_args EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8624,7 +8625,7 @@ implementation: INCLUDE LPAREN FUN WITH
 
 implementation: INCLUDE LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 1898.
+## Ends in an error in state: 1907.
 ##
 ## _module_expr -> LBRACE . structure error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LBRACE . structure RBRACE [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8637,7 +8638,7 @@ implementation: INCLUDE LPAREN LBRACE WITH
 
 implementation: INCLUDE LPAREN LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2000.
+## Ends in an error in state: 2009.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -8653,23 +8654,23 @@ implementation: INCLUDE LPAREN LPAREN UIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 234, spurious reduction of production ident -> UIDENT
-## In state 643, spurious reduction of production mty_longident -> ident
-## In state 1914, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1958, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1954, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1912, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1959, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1955, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1913, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1960, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1956, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 652, spurious reduction of production mty_longident -> ident
+## In state 1923, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1967, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1963, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1921, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1968, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1964, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1922, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1969, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1965, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1999.
+## Ends in an error in state: 2008.
 ##
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8682,7 +8683,7 @@ implementation: INCLUDE LPAREN LPAREN UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2308.
+## Ends in an error in state: 2317.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -8699,19 +8700,19 @@ implementation: INCLUDE LPAREN LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1990.
+## Ends in an error in state: 1999.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8731,7 +8732,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDEN
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1989.
+## Ends in an error in state: 1998.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8743,7 +8744,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 2306.
+## Ends in an error in state: 2315.
 ##
 ## _module_expr -> LPAREN VAL expr COLON . error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8757,7 +8758,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1984.
+## Ends in an error in state: 1993.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8777,7 +8778,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATE
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 2304.
+## Ends in an error in state: 2313.
 ##
 ## _module_expr -> LPAREN VAL expr COLONGREATER . error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8790,7 +8791,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 2302.
+## Ends in an error in state: 2311.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -8830,21 +8831,21 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN LPAREN VAL WITH
 ##
-## Ends in an error in state: 550.
+## Ends in an error in state: 559.
 ##
 ## _module_expr -> LPAREN VAL . expr COLON error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _module_expr -> LPAREN VAL . expr COLONGREATER error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8862,7 +8863,7 @@ implementation: INCLUDE LPAREN LPAREN VAL WITH
 
 implementation: INCLUDE LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 549.
+## Ends in an error in state: 558.
 ##
 ## _module_expr -> LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _module_expr -> LPAREN . VAL expr COLON error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8885,7 +8886,7 @@ implementation: INCLUDE LPAREN LPAREN WITH
 
 implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2187.
+## Ends in an error in state: 2196.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -8901,23 +8902,23 @@ implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 234, spurious reduction of production ident -> UIDENT
-## In state 643, spurious reduction of production mty_longident -> ident
-## In state 1914, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1958, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1954, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1912, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1959, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1955, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1913, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1960, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1956, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 652, spurious reduction of production mty_longident -> ident
+## In state 1923, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1967, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1963, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1921, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1968, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1964, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1922, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1969, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1965, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 2186.
+## Ends in an error in state: 2195.
 ##
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -8930,7 +8931,7 @@ implementation: INCLUDE LPAREN UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN UIDENT LBRACE UIDENT EOF
 ##
-## Ends in an error in state: 1997.
+## Ends in an error in state: 2006.
 ##
 ## _simple_module_expr -> LBRACE structure . RBRACE [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8941,29 +8942,29 @@ implementation: INCLUDE LPAREN UIDENT LBRACE UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1513, spurious reduction of production post_item_attributes ->
-## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1115, spurious reduction of production structure -> structure_item
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1522, spurious reduction of production post_item_attributes ->
+## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1124, spurious reduction of production structure -> structure_item
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 1996.
+## Ends in an error in state: 2005.
 ##
 ## _simple_module_expr -> LBRACE . structure RBRACE [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8975,7 +8976,7 @@ implementation: INCLUDE LPAREN UIDENT LBRACE WITH
 
 implementation: INCLUDE LPAREN UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1993.
+## Ends in an error in state: 2002.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -8992,19 +8993,19 @@ implementation: INCLUDE LPAREN UIDENT LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 1986.
+## Ends in an error in state: 1995.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type COLONGREATER package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -9017,7 +9018,7 @@ implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1983.
+## Ends in an error in state: 1992.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -9029,7 +9030,7 @@ implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 1981.
+## Ends in an error in state: 1990.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -9066,21 +9067,21 @@ implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT LPAREN VAL WITH
 ##
-## Ends in an error in state: 1980.
+## Ends in an error in state: 1989.
 ##
 ## _simple_module_expr -> LPAREN VAL . expr RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN VAL . expr COLON package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -9095,7 +9096,7 @@ implementation: INCLUDE LPAREN UIDENT LPAREN VAL WITH
 
 implementation: INCLUDE LPAREN UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1979.
+## Ends in an error in state: 1988.
 ##
 ## _module_expr -> module_expr LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN . module_expr COLON module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -9115,7 +9116,7 @@ implementation: INCLUDE LPAREN UIDENT LPAREN WITH
 
 implementation: INCLUDE LPAREN UIDENT WHILE
 ##
-## Ends in an error in state: 2004.
+## Ends in an error in state: 2013.
 ##
 ## _simple_module_expr -> mod_longident . [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER DOT COLON AND ]
@@ -9128,7 +9129,7 @@ implementation: INCLUDE LPAREN UIDENT WHILE
 
 implementation: INCLUDE LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2397.
+## Ends in an error in state: 2406.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -9145,19 +9146,19 @@ implementation: INCLUDE LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1895.
+## Ends in an error in state: 1904.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER package_type . RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9177,7 +9178,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLON
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1894.
+## Ends in an error in state: 1903.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER . package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9189,7 +9190,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 2395.
+## Ends in an error in state: 2404.
 ##
 ## _module_expr -> LPAREN VAL expr COLON . error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9203,7 +9204,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1889.
+## Ends in an error in state: 1898.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER package_type . RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9223,7 +9224,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 2393.
+## Ends in an error in state: 2402.
 ##
 ## _module_expr -> LPAREN VAL expr COLONGREATER . error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9236,7 +9237,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 2391.
+## Ends in an error in state: 2400.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -9276,14 +9277,14 @@ implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -9331,7 +9332,7 @@ implementation: INCLUDE LPAREN WITH
 
 implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ##
-## Ends in an error in state: 1777.
+## Ends in an error in state: 1786.
 ##
 ## _simple_module_expr -> LBRACE structure . RBRACE [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9342,29 +9343,29 @@ implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1513, spurious reduction of production post_item_attributes ->
-## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1115, spurious reduction of production structure -> structure_item
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1522, spurious reduction of production post_item_attributes ->
+## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1124, spurious reduction of production structure -> structure_item
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 903.
+## Ends in an error in state: 912.
 ##
 ## _simple_module_expr -> LBRACE . structure RBRACE [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9376,7 +9377,7 @@ implementation: INCLUDE UIDENT LBRACE WITH
 
 implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2183.
+## Ends in an error in state: 2192.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -9393,19 +9394,19 @@ implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2013, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2017, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2014, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1986, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2019, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2018, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 1891.
+## Ends in an error in state: 1900.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type COLONGREATER package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9418,7 +9419,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1888.
+## Ends in an error in state: 1897.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9430,7 +9431,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 1886.
+## Ends in an error in state: 1895.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -9467,21 +9468,21 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL WITH
 ##
-## Ends in an error in state: 855.
+## Ends in an error in state: 864.
 ##
 ## _simple_module_expr -> LPAREN VAL . expr RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL . expr COLON package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9496,7 +9497,7 @@ implementation: INCLUDE UIDENT LPAREN VAL WITH
 
 implementation: INCLUDE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 854.
+## Ends in an error in state: 863.
 ##
 ## _module_expr -> module_expr LPAREN . module_expr error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN . module_expr COLON module_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9516,7 +9517,7 @@ implementation: INCLUDE UIDENT LPAREN WITH
 
 implementation: INCLUDE UIDENT WHILE
 ##
-## Ends in an error in state: 910.
+## Ends in an error in state: 919.
 ##
 ## _simple_module_expr -> mod_longident . [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF DOT COLON AND ]
@@ -9529,7 +9530,7 @@ implementation: INCLUDE UIDENT WHILE
 
 implementation: INCLUDE WITH
 ##
-## Ends in an error in state: 1033.
+## Ends in an error in state: 1042.
 ##
 ## _structure_item_without_item_extension_sugar -> INCLUDE . module_expr post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -9541,7 +9542,7 @@ implementation: INCLUDE WITH
 
 implementation: LAZY WITH
 ##
-## Ends in an error in state: 556.
+## Ends in an error in state: 565.
 ##
 ## _expr -> LAZY . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -9553,7 +9554,7 @@ implementation: LAZY WITH
 
 implementation: LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1339.
+## Ends in an error in state: 1348.
 ##
 ## class_self_pattern_and_structure -> class_self_pattern . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -9565,7 +9566,7 @@ implementation: LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: LBRACE AS UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1328.
+## Ends in an error in state: 1337.
 ##
 ## _class_self_pattern -> AS pattern . SEMI [ error VAL RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ## _or_pattern -> pattern . BAR pattern [ SEMI BAR ]
@@ -9577,14 +9578,14 @@ implementation: LBRACE AS UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 782, spurious reduction of production pattern -> pattern_without_or
+## In state 791, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE AS WITH
 ##
-## Ends in an error in state: 1327.
+## Ends in an error in state: 1336.
 ##
 ## _class_self_pattern -> AS . pattern SEMI [ error VAL RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ##
@@ -9596,7 +9597,7 @@ implementation: LBRACE AS WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1530.
+## Ends in an error in state: 1539.
 ##
 ## constrain_field -> core_type EQUAL . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -9608,7 +9609,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1529.
+## Ends in an error in state: 1538.
 ##
 ## constrain_field -> core_type . EQUAL core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -9631,7 +9632,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 
 implementation: LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1528.
+## Ends in an error in state: 1537.
 ##
 ## _class_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -9643,7 +9644,7 @@ implementation: LBRACE CONSTRAINT WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1826.
+## Ends in an error in state: 1835.
 ##
 ## record_expr -> DOTDOTDOT expr_optional_constraint COMMA . lbl_expr_list [ error RBRACE ]
 ##
@@ -9655,7 +9656,7 @@ implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ##
-## Ends in an error in state: 1825.
+## Ends in an error in state: 1834.
 ##
 ## record_expr -> DOTDOTDOT expr_optional_constraint . COMMA lbl_expr_list [ error RBRACE ]
 ##
@@ -9666,22 +9667,22 @@ implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1810, spurious reduction of production expr_optional_constraint -> expr
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1819, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE DOTDOTDOT WITH
 ##
-## Ends in an error in state: 1824.
+## Ends in an error in state: 1833.
 ##
 ## record_expr -> DOTDOTDOT . expr_optional_constraint COMMA lbl_expr_list [ error RBRACE ]
 ##
@@ -9693,7 +9694,7 @@ implementation: LBRACE DOTDOTDOT WITH
 
 implementation: LBRACE INHERIT BANG WITH
 ##
-## Ends in an error in state: 1522.
+## Ends in an error in state: 1531.
 ##
 ## _class_field -> INHERIT override_flag . class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -9705,7 +9706,7 @@ implementation: LBRACE INHERIT BANG WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1298.
+## Ends in an error in state: 1307.
 ##
 ## _class_expr -> CLASS class_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET COLON AS AND ]
@@ -9718,7 +9719,7 @@ implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1297.
+## Ends in an error in state: 1306.
 ##
 ## _class_expr -> CLASS class_longident . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## _class_expr -> CLASS class_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
@@ -9731,7 +9732,7 @@ implementation: LBRACE INHERIT CLASS LIDENT WITH
 
 implementation: LBRACE INHERIT CLASS WITH
 ##
-## Ends in an error in state: 1296.
+## Ends in an error in state: 1305.
 ##
 ## _class_expr -> CLASS . class_longident [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## _class_expr -> CLASS . class_longident non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
@@ -9744,7 +9745,7 @@ implementation: LBRACE INHERIT CLASS WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1320.
+## Ends in an error in state: 1329.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER class_expr . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
@@ -9757,7 +9758,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND R
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1295.
+## Ends in an error in state: 1304.
 ##
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER . class_expr [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ##
@@ -9769,7 +9770,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1294.
+## Ends in an error in state: 1303.
 ##
 ## _class_fun_def -> labeled_simple_pattern . EQUALGREATER class_expr [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern . class_fun_def [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
@@ -9782,7 +9783,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 
 implementation: LBRACE INHERIT FUN WITH
 ##
-## Ends in an error in state: 1292.
+## Ends in an error in state: 1301.
 ##
 ## _class_expr -> FUN . class_fun_def [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ##
@@ -9794,7 +9795,7 @@ implementation: LBRACE INHERIT FUN WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 1333.
+## Ends in an error in state: 1342.
 ##
 ## _class_expr_lets_and_rest -> let_bindings SEMI . class_expr_lets_and_rest [ error RBRACE ]
 ##
@@ -9806,7 +9807,7 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ##
-## Ends in an error in state: 1332.
+## Ends in an error in state: 1341.
 ##
 ## _class_expr_lets_and_rest -> let_bindings . SEMI class_expr_lets_and_rest [ error RBRACE ]
 ## let_bindings -> let_bindings . and_let_binding [ SEMI AND ]
@@ -9818,22 +9819,22 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1289, spurious reduction of production let_binding_body -> pattern EQUAL expr
-## In state 1290, spurious reduction of production post_item_attributes ->
-## In state 1291, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
-## In state 1334, spurious reduction of production let_binding -> let_binding_impl
-## In state 1335, spurious reduction of production let_bindings -> let_binding
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1298, spurious reduction of production let_binding_body -> pattern EQUAL expr
+## In state 1299, spurious reduction of production post_item_attributes ->
+## In state 1300, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
+## In state 1343, spurious reduction of production let_binding -> let_binding_impl
+## In state 1344, spurious reduction of production let_bindings -> let_binding
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE LET WITH
 ##
-## Ends in an error in state: 1156.
+## Ends in an error in state: 1165.
 ##
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI AND ]
 ##
@@ -9845,7 +9846,7 @@ implementation: LBRACE INHERIT LBRACE LET WITH
 
 implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ##
-## Ends in an error in state: 1544.
+## Ends in an error in state: 1553.
 ##
 ## _class_expr -> class_expr . attribute [ error RBRACE LBRACKETAT ]
 ## _class_expr_lets_and_rest -> class_expr . [ error RBRACE ]
@@ -9857,16 +9858,16 @@ implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1302, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1323, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1300, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1311, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1332, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1309, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 ##
-## Ends in an error in state: 1336.
+## Ends in an error in state: 1345.
 ##
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI AND ]
 ##
@@ -9885,7 +9886,7 @@ implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 
 implementation: LBRACE INHERIT LBRACE WITH
 ##
-## Ends in an error in state: 1155.
+## Ends in an error in state: 1164.
 ##
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest RBRACE [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest error [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
@@ -9898,7 +9899,7 @@ implementation: LBRACE INHERIT LBRACE WITH
 
 implementation: LBRACE INHERIT LIDENT AS WITH
 ##
-## Ends in an error in state: 1524.
+## Ends in an error in state: 1533.
 ##
 ## parent_binder -> AS . LIDENT [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -9910,7 +9911,7 @@ implementation: LBRACE INHERIT LIDENT AS WITH
 
 implementation: LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1523.
+## Ends in an error in state: 1532.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AS ]
 ## _class_field -> INHERIT override_flag class_expr . parent_binder post_item_attributes [ error SEMI RBRACE ]
@@ -9922,16 +9923,16 @@ implementation: LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1302, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1323, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1300, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1311, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1332, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1309, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT SEMI WITH
 ##
-## Ends in an error in state: 1540.
+## Ends in an error in state: 1549.
 ##
 ## semi_terminated_class_fields -> class_field SEMI . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -9943,7 +9944,7 @@ implementation: LBRACE INHERIT LIDENT SEMI WITH
 
 implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ##
-## Ends in an error in state: 1314.
+## Ends in an error in state: 1323.
 ##
 ## _class_expr -> class_simple_expr simple_labeled_expr_list . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## simple_labeled_expr_list -> simple_labeled_expr_list . labeled_simple_expr [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
@@ -9955,20 +9956,20 @@ implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1309, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1305, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1315, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
-## In state 1318, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1318, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1314, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1324, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
+## In state 1327, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT WITH
 ##
-## Ends in an error in state: 1302.
+## Ends in an error in state: 1311.
 ##
 ## _class_expr -> class_simple_expr . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## _class_expr -> class_simple_expr . simple_labeled_expr_list [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
@@ -9981,7 +9982,7 @@ implementation: LBRACE INHERIT LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1582.
+## Ends in an error in state: 1591.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -9993,7 +9994,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE 
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1581.
+## Ends in an error in state: 1590.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -10006,7 +10007,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE 
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1580.
+## Ends in an error in state: 1589.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -10018,7 +10019,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1573.
+## Ends in an error in state: 1582.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -10030,7 +10031,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 1572.
+## Ends in an error in state: 1581.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -10043,7 +10044,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1571.
+## Ends in an error in state: 1580.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -10055,7 +10056,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1574.
+## Ends in an error in state: 1583.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -10067,7 +10068,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1570, spurious reduction of production type_longident -> LIDENT
+## In state 1579, spurious reduction of production type_longident -> LIDENT
 ## In state 261, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
 ## In state 266, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
 ## In state 264, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
@@ -10078,7 +10079,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 ##
-## Ends in an error in state: 1556.
+## Ends in an error in state: 1565.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT AND ]
@@ -10091,7 +10092,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1567.
+## Ends in an error in state: 1576.
 ##
 ## _class_constructor_type -> NEW class_instance_type . [ error RPAREN ]
 ## _class_instance_type -> class_instance_type . attribute [ error RPAREN LBRACKETAT ]
@@ -10103,16 +10104,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1565, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1569, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1563, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1574, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1578, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1572, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1566.
+## Ends in an error in state: 1575.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET AND ]
@@ -10125,7 +10126,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 ##
-## Ends in an error in state: 1565.
+## Ends in an error in state: 1574.
 ##
 ## _class_instance_type -> clty_longident . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT AND ]
@@ -10138,7 +10139,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 ##
-## Ends in an error in state: 1561.
+## Ends in an error in state: 1570.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -10152,7 +10153,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 ##
-## Ends in an error in state: 1560.
+## Ends in an error in state: 1569.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -10172,7 +10173,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1554.
+## Ends in an error in state: 1563.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ error RPAREN ]
 ##
@@ -10184,7 +10185,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1575.
+## Ends in an error in state: 1584.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -10196,7 +10197,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 ##
-## Ends in an error in state: 1553.
+## Ends in an error in state: 1562.
 ##
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
@@ -10209,7 +10210,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ##
-## Ends in an error in state: 1550.
+## Ends in an error in state: 1559.
 ##
 ## _class_expr -> class_expr . attribute [ error RPAREN LBRACKETAT COLON ]
 ## _class_simple_expr -> LPAREN class_expr . COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
@@ -10224,16 +10225,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1302, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1323, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1300, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1311, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1332, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1309, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN WITH
 ##
-## Ends in an error in state: 1154.
+## Ends in an error in state: 1163.
 ##
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
@@ -10248,7 +10249,7 @@ implementation: LBRACE INHERIT LPAREN WITH
 
 implementation: LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1521.
+## Ends in an error in state: 1530.
 ##
 ## _class_field -> INHERIT . override_flag class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -10260,7 +10261,7 @@ implementation: LBRACE INHERIT WITH
 
 implementation: LBRACE INITIALIZER EQUALGREATER WITH
 ##
-## Ends in an error in state: 1518.
+## Ends in an error in state: 1527.
 ##
 ## _class_field -> INITIALIZER EQUALGREATER . expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -10272,7 +10273,7 @@ implementation: LBRACE INITIALIZER EQUALGREATER WITH
 
 implementation: LBRACE INITIALIZER WITH
 ##
-## Ends in an error in state: 1517.
+## Ends in an error in state: 1526.
 ##
 ## _class_field -> INITIALIZER . EQUALGREATER expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -10284,7 +10285,7 @@ implementation: LBRACE INITIALIZER WITH
 
 implementation: LBRACE LBRACKETATATAT UNDERSCORE
 ##
-## Ends in an error in state: 1498.
+## Ends in an error in state: 1507.
 ##
 ## floating_attribute -> LBRACKETATATAT . attr_id payload RBRACKET [ error SEMI RBRACE ]
 ##
@@ -10296,7 +10297,7 @@ implementation: LBRACE LBRACKETATATAT UNDERSCORE
 
 implementation: LBRACE LBRACKETATATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 1501.
+## Ends in an error in state: 1510.
 ##
 ## floating_attribute -> LBRACKETATATAT attr_id payload . RBRACKET [ error SEMI RBRACE ]
 ##
@@ -10307,30 +10308,30 @@ implementation: LBRACE LBRACKETATATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1513, spurious reduction of production post_item_attributes ->
-## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1115, spurious reduction of production structure -> structure_item
-## In state 1500, spurious reduction of production payload -> structure
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1522, spurious reduction of production post_item_attributes ->
+## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1124, spurious reduction of production structure -> structure_item
+## In state 1509, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LBRACKETPERCENTPERCENT UNDERSCORE
 ##
-## Ends in an error in state: 1112.
+## Ends in an error in state: 1121.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT . attr_id payload RBRACKET [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -10342,7 +10343,7 @@ implementation: LBRACE LBRACKETPERCENTPERCENT UNDERSCORE
 
 implementation: LBRACE LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 1679.
+## Ends in an error in state: 1688.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT attr_id payload . RBRACKET [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -10353,30 +10354,30 @@ implementation: LBRACE LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1513, spurious reduction of production post_item_attributes ->
-## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1115, spurious reduction of production structure -> structure_item
-## In state 1500, spurious reduction of production payload -> structure
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1522, spurious reduction of production post_item_attributes ->
+## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1124, spurious reduction of production structure -> structure_item
+## In state 1509, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET CHAR EQUAL CHAR AND WITH
 ##
-## Ends in an error in state: 2165.
+## Ends in an error in state: 2174.
 ##
 ## and_let_binding -> AND . let_binding_body post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -10388,7 +10389,7 @@ implementation: LBRACE LET CHAR EQUAL CHAR AND WITH
 
 implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 2431.
+## Ends in an error in state: 2440.
 ##
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . RBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -10400,17 +10401,17 @@ implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2256, spurious reduction of production opt_semi -> SEMI
-## In state 2267, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
-## In state 2265, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2254, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2265, spurious reduction of production opt_semi -> SEMI
+## In state 2276, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
+## In state 2274, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2263, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
 ##
 
 Expecting "}" to finish the block
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 2049.
+## Ends in an error in state: 2058.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -10444,21 +10445,21 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2053.
+## Ends in an error in state: 2062.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10470,7 +10471,7 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2052.
+## Ends in an error in state: 2061.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10493,7 +10494,7 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 2051.
+## Ends in an error in state: 2060.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10505,7 +10506,7 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2050.
+## Ends in an error in state: 2059.
 ##
 ## let_binding_body -> val_ident COLON typevar_list . DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -10518,7 +10519,7 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 
 implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2047.
+## Ends in an error in state: 2056.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10530,7 +10531,7 @@ implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2046.
+## Ends in an error in state: 2055.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10553,7 +10554,7 @@ implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 2045.
+## Ends in an error in state: 2054.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10565,7 +10566,7 @@ implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LBRACE LET LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 2043.
+## Ends in an error in state: 2052.
 ##
 ## let_binding_body -> val_ident COLON TYPE . lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10577,7 +10578,7 @@ implementation: LBRACE LET LIDENT COLON TYPE WITH
 
 implementation: LBRACE LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 2042.
+## Ends in an error in state: 2051.
 ##
 ## let_binding_body -> val_ident COLON . typevar_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ## let_binding_body -> val_ident COLON . TYPE lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -10591,7 +10592,7 @@ implementation: LBRACE LET LIDENT COLON WITH
 
 implementation: LBRACE LET LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 ##
-## Ends in an error in state: 2056.
+## Ends in an error in state: 2065.
 ##
 ## let_binding_body -> val_ident type_constraint EQUAL . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10603,7 +10604,7 @@ implementation: LBRACE LET LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 
 implementation: LBRACE LET LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2055.
+## Ends in an error in state: 2064.
 ##
 ## let_binding_body -> val_ident type_constraint . EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10620,14 +10621,14 @@ implementation: LBRACE LET LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1254, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1263, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2040.
+## Ends in an error in state: 2049.
 ##
 ## _curried_binding_return_typed -> EQUALGREATER . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10639,7 +10640,7 @@ implementation: LBRACE LET LIDENT EQUALGREATER WITH
 
 implementation: LBRACE LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2038.
+## Ends in an error in state: 2047.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10651,7 +10652,7 @@ implementation: LBRACE LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LBRACE LET LIDENT LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 2037.
+## Ends in an error in state: 2046.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10663,7 +10664,7 @@ implementation: LBRACE LET LIDENT LPAREN TYPE LIDENT WITH
 
 implementation: LBRACE LET LIDENT LPAREN TYPE WITH
 ##
-## Ends in an error in state: 2036.
+## Ends in an error in state: 2045.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10675,7 +10676,7 @@ implementation: LBRACE LET LIDENT LPAREN TYPE WITH
 
 implementation: LBRACE LET LIDENT LPAREN WITH
 ##
-## Ends in an error in state: 2035.
+## Ends in an error in state: 2044.
 ##
 ## _curried_binding_return_typed -> LPAREN . TYPE LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -10698,7 +10699,7 @@ implementation: LBRACE LET LIDENT LPAREN WITH
 
 implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1478.
+## Ends in an error in state: 1487.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -10732,21 +10733,21 @@ implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1477.
+## Ends in an error in state: 1486.
 ##
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type EQUALGREATER . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10758,7 +10759,7 @@ implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1476.
+## Ends in an error in state: 1485.
 ##
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type . EQUALGREATER expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -10771,7 +10772,7 @@ implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE WITH
 
 implementation: LBRACE LET LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1475.
+## Ends in an error in state: 1484.
 ##
 ## curried_binding_return_typed_ -> COLON . non_arrowed_core_type EQUALGREATER expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10783,7 +10784,7 @@ implementation: LBRACE LET LIDENT UNDERSCORE COLON WITH
 
 implementation: LBRACE LET LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2059.
+## Ends in an error in state: 2068.
 ##
 ## _curried_binding_return_typed -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10795,7 +10796,7 @@ implementation: LBRACE LET LIDENT UNDERSCORE WITH
 
 implementation: LBRACE LET LIDENT WITH
 ##
-## Ends in an error in state: 2034.
+## Ends in an error in state: 2043.
 ##
 ## _simple_pattern -> val_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> val_ident . type_constraint EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -10811,7 +10812,7 @@ implementation: LBRACE LET LIDENT WITH
 
 implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT RBRACKET
 ##
-## Ends in an error in state: 2271.
+## Ends in an error in state: 2280.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes . SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10822,22 +10823,22 @@ implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 852, spurious reduction of production _module_expr -> simple_module_expr
-## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
-## In state 908, spurious reduction of production module_binding_body_expr -> EQUAL module_expr
-## In state 1758, spurious reduction of production module_binding_body -> module_binding_body_expr
-## In state 2270, spurious reduction of production post_item_attributes ->
+## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 861, spurious reduction of production _module_expr -> simple_module_expr
+## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 917, spurious reduction of production module_binding_body_expr -> EQUAL module_expr
+## In state 1767, spurious reduction of production module_binding_body -> module_binding_body_expr
+## In state 2279, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2272.
+## Ends in an error in state: 2281.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10849,7 +10850,7 @@ implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 
 implementation: LBRACE LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2269.
+## Ends in an error in state: 2278.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10861,7 +10862,7 @@ implementation: LBRACE LET MODULE UIDENT WITH
 
 implementation: LBRACE LET MODULE WITH
 ##
-## Ends in an error in state: 2268.
+## Ends in an error in state: 2277.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10873,7 +10874,7 @@ implementation: LBRACE LET MODULE WITH
 
 implementation: LBRACE LET OPEN BANG WITH
 ##
-## Ends in an error in state: 585.
+## Ends in an error in state: 594.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10885,7 +10886,7 @@ implementation: LBRACE LET OPEN BANG WITH
 
 implementation: LBRACE LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 589.
+## Ends in an error in state: 598.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10897,7 +10898,7 @@ implementation: LBRACE LET OPEN UIDENT SEMI WITH
 
 implementation: LBRACE LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 588.
+## Ends in an error in state: 597.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10908,14 +10909,14 @@ implementation: LBRACE LET OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 586, spurious reduction of production post_item_attributes ->
+## In state 595, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET OPEN WITH
 ##
-## Ends in an error in state: 584.
+## Ends in an error in state: 593.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10927,7 +10928,7 @@ implementation: LBRACE LET OPEN WITH
 
 implementation: LBRACE LET REC ASSERT
 ##
-## Ends in an error in state: 2033.
+## Ends in an error in state: 2042.
 ##
 ## let_binding_impl -> LET rec_flag . let_binding_body post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -10939,7 +10940,7 @@ implementation: LBRACE LET REC ASSERT
 
 implementation: LBRACE LET UIDENT UNDERSCORE WHEN
 ##
-## Ends in an error in state: 2068.
+## Ends in an error in state: 2077.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EQUAL BAR ]
 ## let_binding_body -> pattern . EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -10951,17 +10952,17 @@ implementation: LBRACE LET UIDENT UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 778, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
-## In state 781, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
-## In state 776, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
-## In state 782, spurious reduction of production pattern -> pattern_without_or
+## In state 787, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
+## In state 790, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
+## In state 785, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
+## In state 791, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2066.
+## Ends in an error in state: 2075.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10973,7 +10974,7 @@ implementation: LBRACE LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 
 implementation: LBRACE LET UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2065.
+## Ends in an error in state: 2074.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10996,7 +10997,7 @@ implementation: LBRACE LET UNDERSCORE COLON UNDERSCORE WITH
 
 implementation: LBRACE LET UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2064.
+## Ends in an error in state: 2073.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON . core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11008,7 +11009,7 @@ implementation: LBRACE LET UNDERSCORE COLON WITH
 
 implementation: LBRACE LET UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2069.
+## Ends in an error in state: 2078.
 ##
 ## let_binding_body -> pattern EQUAL . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11020,7 +11021,7 @@ implementation: LBRACE LET UNDERSCORE EQUAL WITH
 
 implementation: LBRACE LET UNDERSCORE WITH
 ##
-## Ends in an error in state: 2063.
+## Ends in an error in state: 2072.
 ##
 ## _simple_pattern -> simple_pattern_not_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> simple_pattern_not_ident . COLON core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -11033,7 +11034,7 @@ implementation: LBRACE LET UNDERSCORE WITH
 
 implementation: LBRACE LET WITH
 ##
-## Ends in an error in state: 582.
+## Ends in an error in state: 591.
 ##
 ## _semi_terminated_seq_expr_row -> LET . MODULE UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ## _semi_terminated_seq_expr_row -> LET . OPEN override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
@@ -11047,7 +11048,7 @@ implementation: LBRACE LET WITH
 
 implementation: LBRACE LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1844.
+## Ends in an error in state: 1853.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11082,21 +11083,21 @@ implementation: LBRACE LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1843.
+## Ends in an error in state: 1852.
 ##
 ## lbl_expr -> label_longident COLON . expr [ COMMA ]
 ## non_punned_lbl_expression -> label_longident COLON . expr [ error RBRACE ]
@@ -11109,7 +11110,7 @@ implementation: LBRACE LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1833.
+## Ends in an error in state: 1842.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11143,21 +11144,21 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 ##
-## Ends in an error in state: 1832.
+## Ends in an error in state: 1841.
 ##
 ## lbl_expr -> label_longident COLON . expr [ error RBRACE COMMA ]
 ##
@@ -11169,7 +11170,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 ##
-## Ends in an error in state: 1829.
+## Ends in an error in state: 1838.
 ##
 ## lbl_expr_list -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ## lbl_expr_list -> lbl_expr COMMA . [ error RBRACE ]
@@ -11182,7 +11183,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT WITH
 ##
-## Ends in an error in state: 1831.
+## Ends in an error in state: 1840.
 ##
 ## lbl_expr -> label_longident . COLON expr [ error RBRACE COMMA ]
 ## lbl_expr -> label_longident . [ error RBRACE COMMA ]
@@ -11195,7 +11196,7 @@ implementation: LBRACE LIDENT COMMA LIDENT WITH
 
 implementation: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 1840.
+## Ends in an error in state: 1849.
 ##
 ## lbl_expr_list_that_is_not_a_single_punned_field -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ##
@@ -11207,7 +11208,7 @@ implementation: LBRACE LIDENT COMMA WITH
 
 implementation: LBRACE METHOD BANG WITH
 ##
-## Ends in an error in state: 1456.
+## Ends in an error in state: 1465.
 ##
 ## method_ -> override_flag . PRIVATE VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag . VIRTUAL private_flag label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -11224,7 +11225,7 @@ implementation: LBRACE METHOD BANG WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1491.
+## Ends in an error in state: 1500.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11258,21 +11259,21 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1490.
+## Ends in an error in state: 1499.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT core_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11284,7 +11285,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1489.
+## Ends in an error in state: 1498.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT core_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11307,7 +11308,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1488.
+## Ends in an error in state: 1497.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT . core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11319,7 +11320,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 1486.
+## Ends in an error in state: 1495.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE . lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11331,7 +11332,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE WITH
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1494.
+## Ends in an error in state: 1503.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11365,21 +11366,21 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1493.
+## Ends in an error in state: 1502.
 ##
 ## method_ -> override_flag private_flag label COLON poly_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11391,7 +11392,7 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1492.
+## Ends in an error in state: 1501.
 ##
 ## method_ -> override_flag private_flag label COLON poly_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11408,16 +11409,16 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 497, spurious reduction of production _poly_type -> core_type
-## In state 498, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 496, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 505, spurious reduction of production _poly_type -> core_type
+## In state 506, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 504, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON WITH
 ##
-## Ends in an error in state: 1485.
+## Ends in an error in state: 1494.
 ##
 ## method_ -> override_flag private_flag label COLON . poly_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag private_flag label COLON . TYPE lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -11430,7 +11431,7 @@ implementation: LBRACE METHOD LIDENT COLON WITH
 
 implementation: LBRACE METHOD LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1484.
+## Ends in an error in state: 1493.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11464,21 +11465,21 @@ implementation: LBRACE METHOD LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1483.
+## Ends in an error in state: 1492.
 ##
 ## method_ -> override_flag private_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11490,7 +11491,7 @@ implementation: LBRACE METHOD LIDENT EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1539.
+## Ends in an error in state: 1548.
 ##
 ## semi_terminated_class_fields -> class_field . [ error RBRACE ]
 ## semi_terminated_class_fields -> class_field . SEMI semi_terminated_class_fields [ error RBRACE ]
@@ -11502,27 +11503,27 @@ implementation: LBRACE METHOD LIDENT EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1474, spurious reduction of production curried_binding -> EQUALGREATER expr
-## In state 1495, spurious reduction of production method_ -> override_flag private_flag label curried_binding
-## In state 1496, spurious reduction of production post_item_attributes ->
-## In state 1497, spurious reduction of production _class_field -> METHOD method_ post_item_attributes
-## In state 1542, spurious reduction of production mark_position_cf(_class_field) -> _class_field
-## In state 1535, spurious reduction of production class_field -> mark_position_cf(_class_field)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1483, spurious reduction of production curried_binding -> EQUALGREATER expr
+## In state 1504, spurious reduction of production method_ -> override_flag private_flag label curried_binding
+## In state 1505, spurious reduction of production post_item_attributes ->
+## In state 1506, spurious reduction of production _class_field -> METHOD method_ post_item_attributes
+## In state 1551, spurious reduction of production mark_position_cf(_class_field) -> _class_field
+## In state 1544, spurious reduction of production class_field -> mark_position_cf(_class_field)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1473.
+## Ends in an error in state: 1482.
 ##
 ## curried_binding -> EQUALGREATER . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11534,7 +11535,7 @@ implementation: LBRACE METHOD LIDENT EQUALGREATER WITH
 
 implementation: LBRACE METHOD LIDENT LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1472.
+## Ends in an error in state: 1481.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11546,7 +11547,7 @@ implementation: LBRACE METHOD LIDENT LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LBRACE METHOD LIDENT LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1471.
+## Ends in an error in state: 1480.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11558,7 +11559,7 @@ implementation: LBRACE METHOD LIDENT LPAREN TYPE LIDENT WITH
 
 implementation: LBRACE METHOD LIDENT LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1470.
+## Ends in an error in state: 1479.
 ##
 ## curried_binding -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11570,7 +11571,7 @@ implementation: LBRACE METHOD LIDENT LPAREN TYPE WITH
 
 implementation: LBRACE METHOD LIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1469.
+## Ends in an error in state: 1478.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -11593,7 +11594,7 @@ implementation: LBRACE METHOD LIDENT LPAREN WITH
 
 implementation: LBRACE METHOD LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1479.
+## Ends in an error in state: 1488.
 ##
 ## curried_binding -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11605,7 +11606,7 @@ implementation: LBRACE METHOD LIDENT UNDERSCORE WITH
 
 implementation: LBRACE METHOD LIDENT WITH
 ##
-## Ends in an error in state: 1468.
+## Ends in an error in state: 1477.
 ##
 ## method_ -> override_flag private_flag label . curried_binding [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag private_flag label . COLON poly_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -11620,7 +11621,7 @@ implementation: LBRACE METHOD LIDENT WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1465.
+## Ends in an error in state: 1474.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11632,7 +11633,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1464.
+## Ends in an error in state: 1473.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11644,7 +11645,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL WITH
 ##
-## Ends in an error in state: 1463.
+## Ends in an error in state: 1472.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11656,7 +11657,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL WITH
 
 implementation: LBRACE METHOD PRIVATE WITH
 ##
-## Ends in an error in state: 1462.
+## Ends in an error in state: 1471.
 ##
 ## method_ -> override_flag PRIVATE . VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## private_flag -> PRIVATE . [ LIDENT ]
@@ -11669,7 +11670,7 @@ implementation: LBRACE METHOD PRIVATE WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1105.
+## Ends in an error in state: 1114.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11681,7 +11682,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1104.
+## Ends in an error in state: 1113.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -11694,7 +11695,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WIT
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE WITH
 ##
-## Ends in an error in state: 1102.
+## Ends in an error in state: 1111.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ error SEMI RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AS ]
 ## typevar_list -> QUOTE . ident [ QUOTE DOT ]
@@ -11707,7 +11708,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1460.
+## Ends in an error in state: 1469.
 ##
 ## method_ -> override_flag VIRTUAL private_flag label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11719,7 +11720,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1459.
+## Ends in an error in state: 1468.
 ##
 ## method_ -> override_flag VIRTUAL private_flag label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11731,7 +11732,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT WITH
 
 implementation: LBRACE METHOD VIRTUAL PRIVATE LET
 ##
-## Ends in an error in state: 1458.
+## Ends in an error in state: 1467.
 ##
 ## method_ -> override_flag VIRTUAL private_flag . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11743,7 +11744,7 @@ implementation: LBRACE METHOD VIRTUAL PRIVATE LET
 
 implementation: LBRACE METHOD VIRTUAL WITH
 ##
-## Ends in an error in state: 1457.
+## Ends in an error in state: 1466.
 ##
 ## method_ -> override_flag VIRTUAL . private_flag label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11755,7 +11756,7 @@ implementation: LBRACE METHOD VIRTUAL WITH
 
 implementation: LBRACE METHOD WITH
 ##
-## Ends in an error in state: 1455.
+## Ends in an error in state: 1464.
 ##
 ## _class_field -> METHOD . method_ post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -11767,7 +11768,7 @@ implementation: LBRACE METHOD WITH
 
 implementation: LBRACE PERCENT WITH TYPE
 ##
-## Ends in an error in state: 2258.
+## Ends in an error in state: 2267.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ error RBRACE ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ error SEMI RBRACE AND ]
@@ -11787,7 +11788,7 @@ implementation: LBRACE PERCENT WITH TYPE
 
 implementation: LBRACE UIDENT DOT WITH
 ##
-## Ends in an error in state: 2281.
+## Ends in an error in state: 2290.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
@@ -11812,7 +11813,7 @@ implementation: LBRACE UIDENT DOT WITH
 
 implementation: LBRACE UIDENT LBRACKETATAT UNDERSCORE
 ##
-## Ends in an error in state: 534.
+## Ends in an error in state: 543.
 ##
 ## item_attribute -> LBRACKETATAT . attr_id payload RBRACKET [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11824,7 +11825,7 @@ implementation: LBRACE UIDENT LBRACKETATAT UNDERSCORE
 
 implementation: LBRACE UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2351.
+## Ends in an error in state: 2360.
 ##
 ## item_attribute -> LBRACKETATAT attr_id payload . RBRACKET [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11835,30 +11836,30 @@ implementation: LBRACE UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1513, spurious reduction of production post_item_attributes ->
-## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1115, spurious reduction of production structure -> structure_item
-## In state 1500, spurious reduction of production payload -> structure
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1522, spurious reduction of production post_item_attributes ->
+## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1124, spurious reduction of production structure -> structure_item
+## In state 1509, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL BANG WITH
 ##
-## Ends in an error in state: 1349.
+## Ends in an error in state: 1358.
 ##
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -11873,7 +11874,7 @@ implementation: LBRACE VAL BANG WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1454.
+## Ends in an error in state: 1463.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11907,21 +11908,21 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL UIDENT RP
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 ##
-## Ends in an error in state: 1453.
+## Ends in an error in state: 1462.
 ##
 ## value -> override_flag mutable_flag label type_constraint EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11933,7 +11934,7 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1452.
+## Ends in an error in state: 1461.
 ##
 ## value -> override_flag mutable_flag label type_constraint . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11950,14 +11951,14 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1254, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1263, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1450.
+## Ends in an error in state: 1459.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11991,21 +11992,21 @@ implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1358.
+## Ends in an error in state: 1367.
 ##
 ## value -> override_flag mutable_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -12017,7 +12018,7 @@ implementation: LBRACE VAL LIDENT EQUAL WITH
 
 implementation: LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1357.
+## Ends in an error in state: 1366.
 ##
 ## value -> override_flag mutable_flag label . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag mutable_flag label . type_constraint EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -12030,7 +12031,7 @@ implementation: LBRACE VAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1354.
+## Ends in an error in state: 1363.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12054,7 +12055,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1353.
+## Ends in an error in state: 1362.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12067,7 +12068,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1352.
+## Ends in an error in state: 1361.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12080,7 +12081,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 ##
-## Ends in an error in state: 1351.
+## Ends in an error in state: 1360.
 ##
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12093,7 +12094,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 
 implementation: LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1350.
+## Ends in an error in state: 1359.
 ##
 ## mutable_flag -> MUTABLE . [ LIDENT ]
 ## value -> override_flag MUTABLE . VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -12107,7 +12108,7 @@ implementation: LBRACE VAL MUTABLE WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1345.
+## Ends in an error in state: 1354.
 ##
 ## value -> VIRTUAL mutable_flag label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12131,7 +12132,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1344.
+## Ends in an error in state: 1353.
 ##
 ## value -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12144,7 +12145,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1343.
+## Ends in an error in state: 1352.
 ##
 ## value -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12157,7 +12158,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1342.
+## Ends in an error in state: 1351.
 ##
 ## value -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12170,7 +12171,7 @@ implementation: LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1341.
+## Ends in an error in state: 1350.
 ##
 ## value -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL . mutable_flag label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12183,7 +12184,7 @@ implementation: LBRACE VAL VIRTUAL WITH
 
 implementation: LBRACE VAL WITH
 ##
-## Ends in an error in state: 1340.
+## Ends in an error in state: 1349.
 ##
 ## _class_field -> VAL . value post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -12212,7 +12213,7 @@ implementation: LBRACE WITH
 
 implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2482.
+## Ends in an error in state: 2491.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -12246,14 +12247,14 @@ implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -12272,7 +12273,7 @@ implementation: LBRACELESS LIDENT COLON WITH
 
 implementation: LBRACELESS LIDENT COMMA WITH
 ##
-## Ends in an error in state: 574.
+## Ends in an error in state: 583.
 ##
 ## field_expr_list -> field_expr_list COMMA . field_expr [ error GREATERRBRACE COMMA ]
 ## opt_comma -> COMMA . [ error GREATERRBRACE ]
@@ -12312,7 +12313,7 @@ implementation: LBRACELESS WITH
 
 implementation: LBRACKET DOTDOTDOT UIDENT COMMA
 ##
-## Ends in an error in state: 2204.
+## Ends in an error in state: 2213.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT expr_optional_constraint . RBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -12323,22 +12324,22 @@ implementation: LBRACKET DOTDOTDOT UIDENT COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1810, spurious reduction of production expr_optional_constraint -> expr
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1819, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKET DOTDOTDOT WITH
 ##
-## Ends in an error in state: 2203.
+## Ends in an error in state: 2212.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT . expr_optional_constraint RBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -12350,7 +12351,7 @@ implementation: LBRACKET DOTDOTDOT WITH
 
 implementation: LBRACKET UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2207.
+## Ends in an error in state: 2216.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint COMMA . expr_comma_seq_extension [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## opt_comma -> COMMA . [ RBRACKET ]
@@ -12363,7 +12364,7 @@ implementation: LBRACKET UIDENT COMMA WITH
 
 implementation: LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2206.
+## Ends in an error in state: 2215.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint . opt_comma RBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## expr_comma_seq_extension -> expr_optional_constraint . COMMA expr_comma_seq_extension [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -12375,15 +12376,15 @@ implementation: LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1810, spurious reduction of production expr_optional_constraint -> expr
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1819, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 Expecting one of the following:
@@ -12408,7 +12409,7 @@ Expecting one of the following:
 
 implementation: LBRACKETATATAT UNDERSCORE
 ##
-## Ends in an error in state: 1031.
+## Ends in an error in state: 1040.
 ##
 ## floating_attribute -> LBRACKETATATAT . attr_id payload RBRACKET [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12420,7 +12421,7 @@ implementation: LBRACKETATATAT UNDERSCORE
 
 implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 1703.
+## Ends in an error in state: 1712.
 ##
 ## floating_attribute -> LBRACKETATATAT attr_id payload . RBRACKET [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12431,30 +12432,30 @@ implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1513, spurious reduction of production post_item_attributes ->
-## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1115, spurious reduction of production structure -> structure_item
-## In state 1500, spurious reduction of production payload -> structure
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1522, spurious reduction of production post_item_attributes ->
+## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1124, spurious reduction of production structure -> structure_item
+## In state 1509, spurious reduction of production payload -> structure
 ##
 
 Expecting "]" to finish current floating attribute
 
 implementation: LBRACKETBAR BANG WITH
 ##
-## Ends in an error in state: 597.
+## Ends in an error in state: 606.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12466,7 +12467,7 @@ implementation: LBRACKETBAR BANG WITH
 
 implementation: LBRACKETBAR MINUSDOT WITH
 ##
-## Ends in an error in state: 1361.
+## Ends in an error in state: 1370.
 ##
 ## _expr -> subtractive . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12478,7 +12479,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR PLUSDOT WITH
 ##
-## Ends in an error in state: 1385.
+## Ends in an error in state: 1394.
 ##
 ## _expr -> additive . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12502,7 +12503,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1800.
+## Ends in an error in state: 1809.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -12514,7 +12515,7 @@ Expecting a type name
 
 implementation: LBRACKETBAR UIDENT COLON WITH
 ##
-## Ends in an error in state: 1797.
+## Ends in an error in state: 1806.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -12526,7 +12527,7 @@ implementation: LBRACKETBAR UIDENT COLON WITH
 
 implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1795.
+## Ends in an error in state: 1804.
 ##
 ## type_constraint -> COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -12538,7 +12539,7 @@ implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 
 implementation: LBRACKETBAR UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1792.
+## Ends in an error in state: 1801.
 ##
 ## expr_comma_seq -> expr_comma_seq COMMA . expr_optional_constraint [ error COMMA BARRBRACKET ]
 ## opt_comma -> COMMA . [ error BARRBRACKET ]
@@ -12551,7 +12552,7 @@ implementation: LBRACKETBAR UIDENT COMMA WITH
 
 implementation: LBRACKETBAR UIDENT SEMI
 ##
-## Ends in an error in state: 2500.
+## Ends in an error in state: 2509.
 ##
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -12564,16 +12565,16 @@ implementation: LBRACKETBAR UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1794, spurious reduction of production expr_optional_constraint -> expr
-## In state 1790, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1803, spurious reduction of production expr_optional_constraint -> expr
+## In state 1799, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
@@ -12606,7 +12607,7 @@ implementation: LBRACKETPERCENT UNDERSCORE
 
 implementation: LBRACKETPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2593.
+## Ends in an error in state: 2611.
 ##
 ## extension -> LBRACKETPERCENT attr_id payload . RBRACKET [ WITH WHEN UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR OPTIONAL_NO_DEFAULT NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 IN GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOWNTO DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12617,30 +12618,30 @@ implementation: LBRACKETPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1513, spurious reduction of production post_item_attributes ->
-## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1115, spurious reduction of production structure -> structure_item
-## In state 1500, spurious reduction of production payload -> structure
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1522, spurious reduction of production post_item_attributes ->
+## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1124, spurious reduction of production structure -> structure_item
+## In state 1509, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 ##
-## Ends in an error in state: 1029.
+## Ends in an error in state: 1038.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT . attr_id payload RBRACKET [ SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -12652,7 +12653,7 @@ implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH COLON WITH
 ##
-## Ends in an error in state: 1056.
+## Ends in an error in state: 1065.
 ##
 ## payload -> COLON . core_type [ RBRACKET ]
 ##
@@ -12676,7 +12677,7 @@ implementation: LBRACKETPERCENTPERCENT WITH DOT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ##
-## Ends in an error in state: 2425.
+## Ends in an error in state: 2434.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN RBRACKET BAR ]
 ## payload -> QUESTION pattern . [ RBRACKET ]
@@ -12689,14 +12690,14 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 782, spurious reduction of production pattern -> pattern_without_or
+## In state 791, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2427.
+## Ends in an error in state: 2436.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -12730,21 +12731,21 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2426.
+## Ends in an error in state: 2435.
 ##
 ## payload -> QUESTION pattern WHEN . expr [ RBRACKET ]
 ##
@@ -12769,7 +12770,7 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION WITH
 
 implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 1705.
+## Ends in an error in state: 1714.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT attr_id payload . RBRACKET [ SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -12780,23 +12781,23 @@ implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1513, spurious reduction of production post_item_attributes ->
-## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1115, spurious reduction of production structure -> structure_item
-## In state 1500, spurious reduction of production payload -> structure
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1522, spurious reduction of production post_item_attributes ->
+## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1124, spurious reduction of production structure -> structure_item
+## In state 1509, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
@@ -12816,7 +12817,7 @@ implementation: LBRACKETPERCENTPERCENT WITH WITH
 
 implementation: LET CHAR EQUAL CHAR AND WITH
 ##
-## Ends in an error in state: 1504.
+## Ends in an error in state: 1513.
 ##
 ## and_let_binding -> AND . let_binding_body post_item_attributes [ SEMI RBRACKET RBRACE EOF BAR AND ]
 ##
@@ -12828,7 +12829,7 @@ implementation: LET CHAR EQUAL CHAR AND WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1264.
+## Ends in an error in state: 1273.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -12862,21 +12863,21 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1268.
+## Ends in an error in state: 1277.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type EQUAL . mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12888,7 +12889,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1267.
+## Ends in an error in state: 1276.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type . EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12911,7 +12912,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1266.
+## Ends in an error in state: 1275.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT . core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12923,7 +12924,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1265.
+## Ends in an error in state: 1274.
 ##
 ## let_binding_body -> val_ident COLON typevar_list . DOT core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -12936,7 +12937,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1262.
+## Ends in an error in state: 1271.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type EQUAL . mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12948,7 +12949,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1261.
+## Ends in an error in state: 1270.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type . EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12971,7 +12972,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1260.
+## Ends in an error in state: 1269.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT . core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12983,7 +12984,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1257.
+## Ends in an error in state: 1266.
 ##
 ## lident_list -> LIDENT . [ DOT ]
 ## lident_list -> LIDENT . lident_list [ DOT ]
@@ -12996,7 +12997,7 @@ implementation: LET LIDENT COLON TYPE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 1256.
+## Ends in an error in state: 1265.
 ##
 ## let_binding_body -> val_ident COLON TYPE . lident_list DOT core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13008,7 +13009,7 @@ implementation: LET LIDENT COLON TYPE WITH
 
 implementation: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 1255.
+## Ends in an error in state: 1264.
 ##
 ## let_binding_body -> val_ident COLON . typevar_list DOT core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ## let_binding_body -> val_ident COLON . TYPE lident_list DOT core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
@@ -13022,7 +13023,7 @@ implementation: LET LIDENT COLON WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1275.
+## Ends in an error in state: 1284.
 ##
 ## let_binding_body -> val_ident type_constraint EQUAL . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13034,7 +13035,7 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 1274.
+## Ends in an error in state: 1283.
 ##
 ## let_binding_body -> val_ident type_constraint . EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13051,14 +13052,14 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1254, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1263, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1251.
+## Ends in an error in state: 1260.
 ##
 ## _curried_binding_return_typed -> EQUALGREATER . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13070,7 +13071,7 @@ implementation: LET LIDENT EQUALGREATER WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1162.
+## Ends in an error in state: 1171.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13082,7 +13083,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1161.
+## Ends in an error in state: 1170.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13094,7 +13095,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1160.
+## Ends in an error in state: 1169.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13106,7 +13107,7 @@ implementation: LET LIDENT LPAREN TYPE WITH
 
 implementation: LET LIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1159.
+## Ends in an error in state: 1168.
 ##
 ## _curried_binding_return_typed -> LPAREN . TYPE LIDENT RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -13129,7 +13130,7 @@ implementation: LET LIDENT LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1244.
+## Ends in an error in state: 1253.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -13163,21 +13164,21 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1243.
+## Ends in an error in state: 1252.
 ##
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type EQUALGREATER . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13189,7 +13190,7 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1242.
+## Ends in an error in state: 1251.
 ##
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type . EQUALGREATER expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
@@ -13203,7 +13204,7 @@ Expecting "=>" to start the function body
 
 implementation: LET LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1241.
+## Ends in an error in state: 1250.
 ##
 ## curried_binding_return_typed_ -> COLON . non_arrowed_core_type EQUALGREATER expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13215,7 +13216,7 @@ implementation: LET LIDENT UNDERSCORE COLON WITH
 
 implementation: LET LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1167.
+## Ends in an error in state: 1176.
 ##
 ## curried_binding -> EQUALGREATER . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13227,7 +13228,7 @@ Expecting an expression as function body
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1166.
+## Ends in an error in state: 1175.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13239,7 +13240,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1165.
+## Ends in an error in state: 1174.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13251,7 +13252,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1164.
+## Ends in an error in state: 1173.
 ##
 ## curried_binding -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13263,7 +13264,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 1163.
+## Ends in an error in state: 1172.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -13286,7 +13287,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 1246.
+## Ends in an error in state: 1255.
 ##
 ## curried_binding -> labeled_simple_pattern . curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13298,7 +13299,7 @@ implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 
 implementation: LET LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1278.
+## Ends in an error in state: 1287.
 ##
 ## _curried_binding_return_typed -> labeled_simple_pattern . curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13314,7 +13315,7 @@ Expecting one of the following:
 
 implementation: LET LIDENT WITH
 ##
-## Ends in an error in state: 1158.
+## Ends in an error in state: 1167.
 ##
 ## _simple_pattern -> val_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> val_ident . type_constraint EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
@@ -13330,7 +13331,7 @@ implementation: LET LIDENT WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 ##
-## Ends in an error in state: 1136.
+## Ends in an error in state: 1145.
 ##
 ## and_nonlocal_module_bindings -> AND . nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -13342,7 +13343,7 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1135.
+## Ends in an error in state: 1144.
 ##
 ## _structure_item_without_item_extension_sugar -> many_nonlocal_module_bindings . [ SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> many_nonlocal_module_bindings . and_nonlocal_module_bindings [ SEMI RBRACKET RBRACE EOF AND ]
@@ -13354,16 +13355,16 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WIT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 923, spurious reduction of production post_item_attributes ->
-## In state 924, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1774, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
+## In state 932, spurious reduction of production post_item_attributes ->
+## In state 933, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1783, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE REC WITH
 ##
-## Ends in an error in state: 1772.
+## Ends in an error in state: 1781.
 ##
 ## many_nonlocal_module_bindings -> LET MODULE REC . nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -13375,7 +13376,7 @@ implementation: LET MODULE REC WITH
 
 implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 1756.
+## Ends in an error in state: 1765.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -13389,19 +13390,19 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 852, spurious reduction of production _module_expr -> simple_module_expr
-## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 861, spurious reduction of production _module_expr -> simple_module_expr
+## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1755.
+## Ends in an error in state: 1764.
 ##
 ## module_binding_body_expr -> COLON module_type EQUAL . module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13413,7 +13414,7 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
 
 implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1754.
+## Ends in an error in state: 1763.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER EQUAL ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER EQUAL ]
@@ -13429,22 +13430,22 @@ implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 958, spurious reduction of production _simple_module_type -> mty_longident
-## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 967, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 966, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 917.
+## Ends in an error in state: 926.
 ##
 ## module_binding_body_expr -> COLON . module_type EQUAL module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13456,7 +13457,7 @@ implementation: LET MODULE UIDENT COLON WITH
 
 implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 908.
+## Ends in an error in state: 917.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -13470,19 +13471,19 @@ implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 852, spurious reduction of production _module_expr -> simple_module_expr
-## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 861, spurious reduction of production _module_expr -> simple_module_expr
+## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 907.
+## Ends in an error in state: 916.
 ##
 ## module_binding_body_expr -> EQUAL . module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13494,7 +13495,7 @@ implementation: LET MODULE UIDENT EQUAL WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 1767.
+## Ends in an error in state: 1776.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER module_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -13508,19 +13509,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 852, spurious reduction of production _module_expr -> simple_module_expr
-## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 861, spurious reduction of production _module_expr -> simple_module_expr
+## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1766.
+## Ends in an error in state: 1775.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER . module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13532,7 +13533,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1765.
+## Ends in an error in state: 1774.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type . EQUALGREATER module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_type -> non_arrowed_module_type . [ WITH LBRACKETAT EQUALGREATER ]
@@ -13546,19 +13547,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 958, spurious reduction of production _simple_module_type -> mty_longident
-## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 967, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 965, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER SEMI
 ##
-## Ends in an error in state: 1768.
+## Ends in an error in state: 1777.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER ]
@@ -13577,18 +13578,18 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT CO
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 967, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 986, spurious reduction of production with_constraints -> with_constraint
-## In state 983, spurious reduction of production _module_type -> module_type WITH with_constraints
-## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 976, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 995, spurious reduction of production with_constraints -> with_constraint
+## In state 992, spurious reduction of production _module_type -> module_type WITH with_constraints
+## In state 1005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1001, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
 ##
-## Ends in an error in state: 1764.
+## Ends in an error in state: 1773.
 ##
 ## _module_binding_body_functor -> functor_args COLON . non_arrowed_module_type EQUALGREATER module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13600,7 +13601,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 1763.
+## Ends in an error in state: 1772.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER module_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -13614,19 +13615,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 852, spurious reduction of production _module_expr -> simple_module_expr
-## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 861, spurious reduction of production _module_expr -> simple_module_expr
+## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1762.
+## Ends in an error in state: 1771.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER . module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13638,7 +13639,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1761.
+## Ends in an error in state: 1770.
 ##
 ## _module_binding_body_functor -> functor_args . EQUALGREATER module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_binding_body_functor -> functor_args . COLON non_arrowed_module_type EQUALGREATER module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -13652,7 +13653,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 
 implementation: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 906.
+## Ends in an error in state: 915.
 ##
 ## nonlocal_module_binding_details -> UIDENT . module_binding_body [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13664,7 +13665,7 @@ implementation: LET MODULE UIDENT WITH
 
 implementation: LET MODULE WITH
 ##
-## Ends in an error in state: 905.
+## Ends in an error in state: 914.
 ##
 ## _structure_item_without_item_extension_sugar -> LET MODULE . nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> LET MODULE . REC nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
@@ -13677,7 +13678,7 @@ implementation: LET MODULE WITH
 
 implementation: LET REC ASSERT
 ##
-## Ends in an error in state: 1157.
+## Ends in an error in state: 1166.
 ##
 ## let_binding_impl -> LET rec_flag . let_binding_body post_item_attributes [ SEMI RBRACKET RBRACE EOF BAR AND ]
 ##
@@ -13689,7 +13690,7 @@ implementation: LET REC ASSERT
 
 implementation: LET UIDENT UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1287.
+## Ends in an error in state: 1296.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EQUAL BAR ]
 ## let_binding_body -> pattern . EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
@@ -13701,17 +13702,17 @@ implementation: LET UIDENT UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 778, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
-## In state 781, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
-## In state 776, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
-## In state 782, spurious reduction of production pattern -> pattern_without_or
+## In state 787, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
+## In state 790, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
+## In state 785, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
+## In state 791, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1285.
+## Ends in an error in state: 1294.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type EQUAL . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13723,7 +13724,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1284.
+## Ends in an error in state: 1293.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type . EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13746,7 +13747,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 
 implementation: LET UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1283.
+## Ends in an error in state: 1292.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON . core_type EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13758,7 +13759,7 @@ implementation: LET UNDERSCORE COLON WITH
 
 implementation: LET UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1288.
+## Ends in an error in state: 1297.
 ##
 ## let_binding_body -> pattern EQUAL . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13770,7 +13771,7 @@ implementation: LET UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE WITH
 ##
-## Ends in an error in state: 1282.
+## Ends in an error in state: 1291.
 ##
 ## _simple_pattern -> simple_pattern_not_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> simple_pattern_not_ident . COLON core_type EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
@@ -13783,7 +13784,7 @@ implementation: LET UNDERSCORE WITH
 
 implementation: LET WITH
 ##
-## Ends in an error in state: 904.
+## Ends in an error in state: 913.
 ##
 ## _structure_item_without_item_extension_sugar -> LET . MODULE nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
@@ -13797,7 +13798,7 @@ Incomplete let binding
 
 implementation: LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1181.
+## Ends in an error in state: 1190.
 ##
 ## _expr -> label EQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13809,7 +13810,7 @@ implementation: LIDENT EQUAL WITH
 
 implementation: LPAREN ASSERT WITH
 ##
-## Ends in an error in state: 1359.
+## Ends in an error in state: 1368.
 ##
 ## _expr -> ASSERT . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13821,7 +13822,7 @@ implementation: LPAREN ASSERT WITH
 
 implementation: LPAREN BACKQUOTE WITH
 ##
-## Ends in an error in state: 598.
+## Ends in an error in state: 607.
 ##
 ## name_tag -> BACKQUOTE . ident [ error UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -13833,7 +13834,7 @@ implementation: LPAREN BACKQUOTE WITH
 
 implementation: LPAREN BANG WITH
 ##
-## Ends in an error in state: 1785.
+## Ends in an error in state: 1794.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SHARP RPAREN QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## operator -> BANG . [ RPAREN ]
@@ -13846,7 +13847,7 @@ implementation: LPAREN BANG WITH
 
 implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ##
-## Ends in an error in state: 2336.
+## Ends in an error in state: 2345.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr . RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13880,21 +13881,21 @@ implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2335.
+## Ends in an error in state: 2344.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA . expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13906,7 +13907,7 @@ implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2334.
+## Ends in an error in state: 2343.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr . COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13940,21 +13941,21 @@ implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2333.
+## Ends in an error in state: 2342.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN . expr COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13966,7 +13967,7 @@ implementation: LPAREN COLONCOLON RPAREN LPAREN WITH
 
 implementation: LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2332.
+## Ends in an error in state: 2341.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN . LPAREN expr COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13978,7 +13979,7 @@ implementation: LPAREN COLONCOLON RPAREN WITH
 
 implementation: LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2331.
+## Ends in an error in state: 2340.
 ##
 ## _expr -> LPAREN COLONCOLON . RPAREN LPAREN expr COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13990,7 +13991,7 @@ implementation: LPAREN COLONCOLON WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ##
-## Ends in an error in state: 895.
+## Ends in an error in state: 904.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag simple_expr . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -14008,17 +14009,17 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 881, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 890, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 ##
-## Ends in an error in state: 894.
+## Ends in an error in state: 903.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag . simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14030,7 +14031,7 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ##
-## Ends in an error in state: 893.
+## Ends in an error in state: 902.
 ##
 ## _expr -> FOR pattern IN simple_expr . direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ TO SHARP DOWNTO DOT ]
@@ -14048,17 +14049,17 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 881, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 890, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FOR UNDERSCORE IN WITH
 ##
-## Ends in an error in state: 892.
+## Ends in an error in state: 901.
 ##
 ## _expr -> FOR pattern IN . simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14070,7 +14071,7 @@ implementation: LPAREN FOR UNDERSCORE IN WITH
 
 implementation: LPAREN FOR UNDERSCORE WHEN
 ##
-## Ends in an error in state: 891.
+## Ends in an error in state: 900.
 ##
 ## _expr -> FOR pattern . IN simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _or_pattern -> pattern . BAR pattern [ IN BAR ]
@@ -14082,14 +14083,14 @@ implementation: LPAREN FOR UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 782, spurious reduction of production pattern -> pattern_without_or
+## In state 791, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FOR WITH
 ##
-## Ends in an error in state: 890.
+## Ends in an error in state: 899.
 ##
 ## _expr -> FOR . pattern IN simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14101,7 +14102,7 @@ implementation: LPAREN FOR WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2236.
+## Ends in an error in state: 2245.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14135,17 +14136,17 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2235.
+## Ends in an error in state: 2244.
 ##
 ## leading_bar_match_case -> bar_located_pattern EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14157,7 +14158,7 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2234.
+## Ends in an error in state: 2243.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14191,17 +14192,17 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2233.
+## Ends in an error in state: 2242.
 ##
 ## leading_bar_match_case -> bar_located_pattern WHEN expr EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14213,7 +14214,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2232.
+## Ends in an error in state: 2241.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -14247,21 +14248,21 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2231.
+## Ends in an error in state: 2240.
 ##
 ## leading_bar_match_case -> bar_located_pattern WHEN . expr EQUALGREATER expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14273,7 +14274,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 616.
+## Ends in an error in state: 625.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14285,7 +14286,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 615.
+## Ends in an error in state: 624.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14297,7 +14298,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN LPAREN TYPE WITH
 ##
-## Ends in an error in state: 614.
+## Ends in an error in state: 623.
 ##
 ## _expr -> FUN LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14309,7 +14310,7 @@ implementation: LPAREN FUN LPAREN TYPE WITH
 
 implementation: LPAREN FUN LPAREN WITH
 ##
-## Ends in an error in state: 613.
+## Ends in an error in state: 622.
 ##
 ## _expr -> FUN LPAREN . TYPE LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
@@ -14332,7 +14333,7 @@ implementation: LPAREN FUN LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2223.
+## Ends in an error in state: 2232.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14366,17 +14367,17 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2222.
+## Ends in an error in state: 2231.
 ##
 ## fun_def -> EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14388,7 +14389,7 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 620.
+## Ends in an error in state: 629.
 ##
 ## fun_def -> LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14400,7 +14401,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 619.
+## Ends in an error in state: 628.
 ##
 ## fun_def -> LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14412,7 +14413,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 618.
+## Ends in an error in state: 627.
 ##
 ## fun_def -> LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14424,7 +14425,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 617.
+## Ends in an error in state: 626.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
@@ -14447,7 +14448,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 2224.
+## Ends in an error in state: 2233.
 ##
 ## fun_def -> labeled_simple_pattern . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14459,7 +14460,7 @@ implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 
 implementation: LPAREN FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2238.
+## Ends in an error in state: 2247.
 ##
 ## _expr -> FUN labeled_simple_pattern . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14471,7 +14472,7 @@ implementation: LPAREN FUN UNDERSCORE WITH
 
 implementation: LPAREN FUN WITH
 ##
-## Ends in an error in state: 612.
+## Ends in an error in state: 621.
 ##
 ## _expr -> FUN . labeled_simple_pattern fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> FUN . LPAREN TYPE LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14485,7 +14486,7 @@ implementation: LPAREN FUN WITH
 
 implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 ##
-## Ends in an error in state: 611.
+## Ends in an error in state: 620.
 ##
 ## _expr -> IF simple_expr simple_expr ELSE . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14497,7 +14498,7 @@ implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 
 implementation: LPAREN IF UIDENT WITH
 ##
-## Ends in an error in state: 609.
+## Ends in an error in state: 618.
 ##
 ## _expr -> IF simple_expr . simple_expr ELSE expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF simple_expr . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14516,17 +14517,17 @@ implementation: LPAREN IF UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 881, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 890, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN IF WITH
 ##
-## Ends in an error in state: 608.
+## Ends in an error in state: 617.
 ##
 ## _expr -> IF . simple_expr simple_expr ELSE expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF . simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14539,7 +14540,7 @@ implementation: LPAREN IF WITH
 
 implementation: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 590.
+## Ends in an error in state: 599.
 ##
 ## _expr -> LAZY . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14551,7 +14552,7 @@ implementation: LPAREN LAZY WITH
 
 implementation: LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 580.
+## Ends in an error in state: 589.
 ##
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14568,7 +14569,7 @@ implementation: LPAREN LBRACE WITH
 
 implementation: LPAREN LBRACELESS WITH
 ##
-## Ends in an error in state: 571.
+## Ends in an error in state: 580.
 ##
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14582,7 +14583,7 @@ implementation: LPAREN LBRACELESS WITH
 
 implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ##
-## Ends in an error in state: 1808.
+## Ends in an error in state: 1817.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT expr_optional_constraint . RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -14593,22 +14594,22 @@ implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1810, spurious reduction of production expr_optional_constraint -> expr
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1819, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKET DOTDOTDOT WITH
 ##
-## Ends in an error in state: 1807.
+## Ends in an error in state: 1816.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT . expr_optional_constraint RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -14620,7 +14621,7 @@ implementation: LPAREN LBRACKET DOTDOTDOT WITH
 
 implementation: LPAREN LBRACKET UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1812.
+## Ends in an error in state: 1821.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint . opt_comma RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## expr_comma_seq_extension -> expr_optional_constraint . COMMA expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14638,15 +14639,15 @@ implementation: LPAREN LBRACKET UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1254, spurious reduction of production type_constraint -> COLONGREATER core_type
-## In state 1811, spurious reduction of production expr_optional_constraint -> expr type_constraint
+## In state 1263, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1820, spurious reduction of production expr_optional_constraint -> expr type_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKET UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1813.
+## Ends in an error in state: 1822.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint COMMA . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## opt_comma -> COMMA . [ RBRACKET ]
@@ -14659,7 +14660,7 @@ implementation: LPAREN LBRACKET UIDENT COMMA WITH
 
 implementation: LPAREN LBRACKET WITH
 ##
-## Ends in an error in state: 553.
+## Ends in an error in state: 562.
 ##
 ## _simple_expr -> LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## constr_longident -> LBRACKET . RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14672,7 +14673,7 @@ implementation: LPAREN LBRACKET WITH
 
 implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2298.
+## Ends in an error in state: 2307.
 ##
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14685,23 +14686,23 @@ implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1794, spurious reduction of production expr_optional_constraint -> expr
-## In state 1790, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1803, spurious reduction of production expr_optional_constraint -> expr
+## In state 1799, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKETBAR WITH
 ##
-## Ends in an error in state: 552.
+## Ends in an error in state: 561.
 ##
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14727,7 +14728,7 @@ implementation: LPAREN LBRACKETPERCENT UNDERSCORE
 
 implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2428.
+## Ends in an error in state: 2437.
 ##
 ## extension -> LBRACKETPERCENT attr_id payload . RBRACKET [ error WITH UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUALGREATER EQUAL ELSE DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -14738,30 +14739,30 @@ implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1513, spurious reduction of production post_item_attributes ->
-## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1115, spurious reduction of production structure -> structure_item
-## In state 1500, spurious reduction of production payload -> structure
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1522, spurious reduction of production post_item_attributes ->
+## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1124, spurious reduction of production structure -> structure_item
+## In state 1509, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1371.
+## Ends in an error in state: 1380.
 ##
 ## _expr -> label EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14773,7 +14774,7 @@ implementation: LPAREN LIDENT EQUAL WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ##
-## Ends in an error in state: 2381.
+## Ends in an error in state: 2390.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr . RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -14807,21 +14808,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2380.
+## Ends in an error in state: 2389.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA . expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14833,7 +14834,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2379.
+## Ends in an error in state: 2388.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr . COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -14867,21 +14868,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2378.
+## Ends in an error in state: 2387.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN . expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14893,7 +14894,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2377.
+## Ends in an error in state: 2386.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN . LPAREN expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14905,7 +14906,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2376.
+## Ends in an error in state: 2385.
 ##
 ## _expr -> LPAREN COLONCOLON . RPAREN LPAREN expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14917,7 +14918,7 @@ implementation: LPAREN LPAREN COLONCOLON WITH
 
 implementation: LPAREN LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2374.
+## Ends in an error in state: 2383.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -14937,7 +14938,7 @@ implementation: LPAREN LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: LPAREN LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2372.
+## Ends in an error in state: 2381.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14950,7 +14951,7 @@ implementation: LPAREN LPAREN MODULE UIDENT COLON WITH
 
 implementation: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2370.
+## Ends in an error in state: 2379.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -14966,12 +14967,12 @@ implementation: LPAREN LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 852, spurious reduction of production _module_expr -> simple_module_expr
-## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 861, spurious reduction of production _module_expr -> simple_module_expr
+## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
@@ -14992,7 +14993,7 @@ Expecting a module expression
 
 implementation: LPAREN LPAREN STAR WITH
 ##
-## Ends in an error in state: 717.
+## Ends in an error in state: 726.
 ##
 ## val_ident -> LPAREN operator . RPAREN [ error UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15004,7 +15005,7 @@ implementation: LPAREN LPAREN STAR WITH
 
 implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ##
-## Ends in an error in state: 2383.
+## Ends in an error in state: 2392.
 ##
 ## _simple_expr -> LPAREN expr_comma_list . RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN expr_comma_list . error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15017,12 +15018,12 @@ implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1794, spurious reduction of production expr_optional_constraint -> expr
-## In state 2340, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1803, spurious reduction of production expr_optional_constraint -> expr
+## In state 2349, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
@@ -15056,7 +15057,7 @@ Expecting one of the following:
 
 implementation: LPAREN MINUS WITH
 ##
-## Ends in an error in state: 1784.
+## Ends in an error in state: 1793.
 ##
 ## operator -> MINUS . [ RPAREN ]
 ## subtractive -> MINUS . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
@@ -15069,7 +15070,7 @@ implementation: LPAREN MINUS WITH
 
 implementation: LPAREN MINUSDOT WITH
 ##
-## Ends in an error in state: 1783.
+## Ends in an error in state: 1792.
 ##
 ## operator -> MINUSDOT . [ RPAREN ]
 ## subtractive -> MINUSDOT . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
@@ -15082,7 +15083,7 @@ implementation: LPAREN MINUSDOT WITH
 
 implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2329.
+## Ends in an error in state: 2338.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON package_type . RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -15102,7 +15103,7 @@ implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2327.
+## Ends in an error in state: 2336.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON . package_type RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE module_expr COLON . error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15115,7 +15116,7 @@ implementation: LPAREN MODULE UIDENT COLON WITH
 
 implementation: LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2325.
+## Ends in an error in state: 2334.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -15131,19 +15132,19 @@ implementation: LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 852, spurious reduction of production _module_expr -> simple_module_expr
-## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 861, spurious reduction of production _module_expr -> simple_module_expr
+## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN MODULE WITH
 ##
-## Ends in an error in state: 537.
+## Ends in an error in state: 546.
 ##
 ## _simple_expr -> LPAREN MODULE . module_expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE . module_expr COLON package_type RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15234,7 +15235,7 @@ implementation: LPAREN PREFIXOP WITH
 
 implementation: LPAREN STAR WITH
 ##
-## Ends in an error in state: 789.
+## Ends in an error in state: 798.
 ##
 ## val_ident -> LPAREN operator . RPAREN [ WITH WHEN UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR OPTIONAL_NO_DEFAULT NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 IN GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15246,7 +15247,7 @@ implementation: LPAREN STAR WITH
 
 implementation: LPAREN STRING LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1312.
+## Ends in an error in state: 1321.
 ##
 ## label_expr -> LIDENT COLONCOLON . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15258,7 +15259,7 @@ implementation: LPAREN STRING LIDENT COLONCOLON WITH
 
 implementation: LPAREN STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1304.
+## Ends in an error in state: 1313.
 ##
 ## label_expr -> LIDENT EXPLICITLY_PASSED_OPTIONAL . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15270,7 +15271,7 @@ implementation: LPAREN STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: LPAREN SWITCH UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2441.
+## Ends in an error in state: 2450.
 ##
 ## _expr -> SWITCH simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15282,7 +15283,7 @@ implementation: LPAREN SWITCH UIDENT LBRACE WITH
 
 implementation: LPAREN SWITCH UIDENT WITH
 ##
-## Ends in an error in state: 2440.
+## Ends in an error in state: 2449.
 ##
 ## _expr -> SWITCH simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ SHARP LBRACE DOT ]
@@ -15300,10 +15301,10 @@ implementation: LPAREN SWITCH UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 881, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 890, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -15322,7 +15323,7 @@ implementation: LPAREN SWITCH WITH
 
 implementation: LPAREN TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 ##
-## Ends in an error in state: 1444.
+## Ends in an error in state: 1453.
 ##
 ## _expr -> simple_expr DOT LBRACE expr RBRACE EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15334,7 +15335,7 @@ implementation: LPAREN TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 
 implementation: LPAREN TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 1442.
+## Ends in an error in state: 1451.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -15369,21 +15370,21 @@ implementation: LPAREN TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 1441.
+## Ends in an error in state: 1450.
 ##
 ## _expr -> simple_expr DOT LBRACE . expr RBRACE EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15396,7 +15397,7 @@ implementation: LPAREN TRUE DOT LBRACE WITH
 
 implementation: LPAREN TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 ##
-## Ends in an error in state: 1439.
+## Ends in an error in state: 1448.
 ##
 ## _expr -> simple_expr DOT LBRACKET expr RBRACKET EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15408,7 +15409,7 @@ implementation: LPAREN TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 
 implementation: LPAREN TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 1436.
+## Ends in an error in state: 1445.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -15444,21 +15445,21 @@ implementation: LPAREN TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1435.
+## Ends in an error in state: 1444.
 ##
 ## _expr -> simple_expr DOT LBRACKET . expr RBRACKET EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15472,7 +15473,7 @@ implementation: LPAREN TRUE DOT LBRACKET WITH
 
 implementation: LPAREN TRUE DOT LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1447.
+## Ends in an error in state: 1456.
 ##
 ## _expr -> simple_expr DOT label_longident EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15484,7 +15485,7 @@ implementation: LPAREN TRUE DOT LIDENT EQUAL WITH
 
 implementation: LPAREN TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 ##
-## Ends in an error in state: 1429.
+## Ends in an error in state: 1438.
 ##
 ## _expr -> simple_expr DOT LPAREN expr RPAREN EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15496,7 +15497,7 @@ implementation: LPAREN TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 
 implementation: LPAREN TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1426.
+## Ends in an error in state: 1435.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -15532,21 +15533,21 @@ implementation: LPAREN TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 1364.
+## Ends in an error in state: 1373.
 ##
 ## _expr -> simple_expr DOT LPAREN . expr RPAREN EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15560,7 +15561,7 @@ implementation: LPAREN TRUE DOT LPAREN WITH
 
 implementation: LPAREN TRUE DOT WITH
 ##
-## Ends in an error in state: 1363.
+## Ends in an error in state: 1372.
 ##
 ## _expr -> simple_expr DOT . label_longident EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> simple_expr DOT . LPAREN expr RPAREN EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -15581,7 +15582,7 @@ implementation: LPAREN TRUE DOT WITH
 
 implementation: LPAREN TRY UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2496.
+## Ends in an error in state: 2505.
 ##
 ## _expr -> TRY simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15593,7 +15594,7 @@ implementation: LPAREN TRY UIDENT LBRACE WITH
 
 implementation: LPAREN TRY UIDENT UNDERSCORE
 ##
-## Ends in an error in state: 2493.
+## Ends in an error in state: 2502.
 ##
 ## _expr -> TRY simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> TRY simple_expr . WITH error [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -15612,17 +15613,17 @@ implementation: LPAREN TRY UIDENT UNDERSCORE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 881, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 890, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN TRY UIDENT WITH WITH
 ##
-## Ends in an error in state: 2494.
+## Ends in an error in state: 2503.
 ##
 ## _expr -> TRY simple_expr WITH . error [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15647,7 +15648,7 @@ implementation: LPAREN TRY WITH
 
 implementation: LPAREN UIDENT AMPERAMPER WITH
 ##
-## Ends in an error in state: 1422.
+## Ends in an error in state: 1431.
 ##
 ## _expr -> expr AMPERAMPER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15659,7 +15660,7 @@ implementation: LPAREN UIDENT AMPERAMPER WITH
 
 implementation: LPAREN UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 1420.
+## Ends in an error in state: 1429.
 ##
 ## _expr -> expr AMPERSAND . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15671,7 +15672,7 @@ implementation: LPAREN UIDENT AMPERSAND WITH
 
 implementation: LPAREN UIDENT BARBAR WITH
 ##
-## Ends in an error in state: 1418.
+## Ends in an error in state: 1427.
 ##
 ## _expr -> expr BARBAR . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15683,7 +15684,7 @@ implementation: LPAREN UIDENT BARBAR WITH
 
 implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1272.
+## Ends in an error in state: 1281.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ RPAREN RBRACKET EQUAL COMMA ]
 ##
@@ -15695,7 +15696,7 @@ implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 
 implementation: LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1451.
+## Ends in an error in state: 1460.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ RPAREN RBRACKET EQUAL COMMA ]
 ##
@@ -15707,7 +15708,7 @@ implementation: LPAREN UIDENT COLON WITH
 
 implementation: LPAREN UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1424.
+## Ends in an error in state: 1433.
 ##
 ## _expr -> expr COLONEQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15719,7 +15720,7 @@ implementation: LPAREN UIDENT COLONEQUAL WITH
 
 implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2338.
+## Ends in an error in state: 2347.
 ##
 ## expr_comma_list -> expr_optional_constraint . COMMA expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -15736,15 +15737,15 @@ implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1254, spurious reduction of production type_constraint -> COLONGREATER core_type
-## In state 2349, spurious reduction of production expr_optional_constraint -> expr type_constraint
+## In state 1263, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 2358, spurious reduction of production expr_optional_constraint -> expr type_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1253.
+## Ends in an error in state: 1262.
 ##
 ## type_constraint -> COLONGREATER . core_type [ RPAREN RBRACKET EQUAL COMMA ]
 ##
@@ -15756,7 +15757,7 @@ implementation: LPAREN UIDENT COLONGREATER WITH
 
 implementation: LPAREN UIDENT COMMA CHAR BARRBRACKET
 ##
-## Ends in an error in state: 2341.
+## Ends in an error in state: 2350.
 ##
 ## _simple_expr -> LPAREN expr_comma_list . RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN expr_comma_list . error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15769,19 +15770,19 @@ implementation: LPAREN UIDENT COMMA CHAR BARRBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1794, spurious reduction of production expr_optional_constraint -> expr
-## In state 2340, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1803, spurious reduction of production expr_optional_constraint -> expr
+## In state 2349, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 2344.
+## Ends in an error in state: 2353.
 ##
 ## expr_comma_list -> expr_comma_list COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -15793,7 +15794,7 @@ implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 
 implementation: LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2339.
+## Ends in an error in state: 2348.
 ##
 ## expr_comma_list -> expr_optional_constraint COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -15805,7 +15806,7 @@ implementation: LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN UIDENT DOT LBRACE WITH
 ##
-## Ends in an error in state: 1823.
+## Ends in an error in state: 1832.
 ##
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15818,7 +15819,7 @@ implementation: LPAREN UIDENT DOT LBRACE WITH
 
 implementation: LPAREN UIDENT DOT LBRACELESS WITH
 ##
-## Ends in an error in state: 1818.
+## Ends in an error in state: 1827.
 ##
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15831,7 +15832,7 @@ implementation: LPAREN UIDENT DOT LBRACELESS WITH
 
 implementation: LPAREN UIDENT DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1806.
+## Ends in an error in state: 1815.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15843,7 +15844,7 @@ implementation: LPAREN UIDENT DOT LBRACKET WITH
 
 implementation: LPAREN UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 1791.
+## Ends in an error in state: 1800.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15856,23 +15857,23 @@ implementation: LPAREN UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1794, spurious reduction of production expr_optional_constraint -> expr
-## In state 1790, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1803, spurious reduction of production expr_optional_constraint -> expr
+## In state 1799, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT DOT LBRACKETBAR WITH
 ##
-## Ends in an error in state: 1789.
+## Ends in an error in state: 1798.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15885,7 +15886,7 @@ implementation: LPAREN UIDENT DOT LBRACKETBAR WITH
 
 implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1781.
+## Ends in an error in state: 1790.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15905,7 +15906,7 @@ implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 1779.
+## Ends in an error in state: 1788.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15918,7 +15919,7 @@ implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 
 implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 902.
+## Ends in an error in state: 911.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -15933,19 +15934,19 @@ implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 852, spurious reduction of production _module_expr -> simple_module_expr
-## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 861, spurious reduction of production _module_expr -> simple_module_expr
+## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT DOT LPAREN MODULE WITH
 ##
-## Ends in an error in state: 901.
+## Ends in an error in state: 910.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON package_type RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15958,7 +15959,7 @@ implementation: LPAREN UIDENT DOT LPAREN MODULE WITH
 
 implementation: LPAREN UIDENT DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1786.
+## Ends in an error in state: 1795.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -15993,21 +15994,21 @@ implementation: LPAREN UIDENT DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT DOT LPAREN WITH
 ##
-## Ends in an error in state: 900.
+## Ends in an error in state: 909.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN . expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16023,7 +16024,7 @@ implementation: LPAREN UIDENT DOT LPAREN WITH
 
 implementation: LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 899.
+## Ends in an error in state: 908.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16047,7 +16048,7 @@ implementation: LPAREN UIDENT DOT WITH
 
 implementation: LPAREN UIDENT GREATER WITH
 ##
-## Ends in an error in state: 1416.
+## Ends in an error in state: 1425.
 ##
 ## _expr -> expr GREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16059,7 +16060,7 @@ implementation: LPAREN UIDENT GREATER WITH
 
 implementation: LPAREN UIDENT INFIXOP0 WITH
 ##
-## Ends in an error in state: 1414.
+## Ends in an error in state: 1423.
 ##
 ## _expr -> expr INFIXOP0 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16071,7 +16072,7 @@ implementation: LPAREN UIDENT INFIXOP0 WITH
 
 implementation: LPAREN UIDENT INFIXOP1 WITH
 ##
-## Ends in an error in state: 1408.
+## Ends in an error in state: 1417.
 ##
 ## _expr -> expr INFIXOP1 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16083,7 +16084,7 @@ implementation: LPAREN UIDENT INFIXOP1 WITH
 
 implementation: LPAREN UIDENT INFIXOP2 WITH
 ##
-## Ends in an error in state: 1406.
+## Ends in an error in state: 1415.
 ##
 ## _expr -> expr INFIXOP2 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16095,7 +16096,7 @@ implementation: LPAREN UIDENT INFIXOP2 WITH
 
 implementation: LPAREN UIDENT INFIXOP3 WITH
 ##
-## Ends in an error in state: 1392.
+## Ends in an error in state: 1401.
 ##
 ## _expr -> expr INFIXOP3 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16107,7 +16108,7 @@ implementation: LPAREN UIDENT INFIXOP3 WITH
 
 implementation: LPAREN UIDENT INFIXOP4 WITH
 ##
-## Ends in an error in state: 1375.
+## Ends in an error in state: 1384.
 ##
 ## _expr -> expr INFIXOP4 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16131,7 +16132,7 @@ implementation: LPAREN UIDENT LBRACKETAT UNDERSCORE
 
 implementation: LPAREN UIDENT LBRACKETAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2406.
+## Ends in an error in state: 2415.
 ##
 ## attribute -> LBRACKETAT attr_id payload . RBRACKET [ error WITH UIDENT STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARRBRACKET BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -16142,30 +16143,30 @@ implementation: LPAREN UIDENT LBRACKETAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1513, spurious reduction of production post_item_attributes ->
-## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1115, spurious reduction of production structure -> structure_item
-## In state 1500, spurious reduction of production payload -> structure
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1522, spurious reduction of production post_item_attributes ->
+## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1124, spurious reduction of production structure -> structure_item
+## In state 1509, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT LESS WITH
 ##
-## Ends in an error in state: 1412.
+## Ends in an error in state: 1421.
 ##
 ## _expr -> expr LESS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16177,7 +16178,7 @@ implementation: LPAREN UIDENT LESS WITH
 
 implementation: LPAREN UIDENT LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1410.
+## Ends in an error in state: 1419.
 ##
 ## _expr -> expr LESSDOTDOTGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16189,7 +16190,7 @@ implementation: LPAREN UIDENT LESSDOTDOTGREATER WITH
 
 implementation: LPAREN UIDENT LESSGREATER WITH
 ##
-## Ends in an error in state: 1404.
+## Ends in an error in state: 1413.
 ##
 ## _expr -> expr LESSGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16222,7 +16223,7 @@ implementation: LPAREN UIDENT LPAREN WITH
 
 implementation: LPAREN UIDENT MINUS WITH
 ##
-## Ends in an error in state: 1402.
+## Ends in an error in state: 1411.
 ##
 ## _expr -> expr MINUS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16234,7 +16235,7 @@ implementation: LPAREN UIDENT MINUS WITH
 
 implementation: LPAREN UIDENT MINUSDOT WITH
 ##
-## Ends in an error in state: 1400.
+## Ends in an error in state: 1409.
 ##
 ## _expr -> expr MINUSDOT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16246,7 +16247,7 @@ implementation: LPAREN UIDENT MINUSDOT WITH
 
 implementation: LPAREN UIDENT OR WITH
 ##
-## Ends in an error in state: 1398.
+## Ends in an error in state: 1407.
 ##
 ## _expr -> expr OR . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16258,7 +16259,7 @@ implementation: LPAREN UIDENT OR WITH
 
 implementation: LPAREN UIDENT PERCENT WITH
 ##
-## Ends in an error in state: 1390.
+## Ends in an error in state: 1399.
 ##
 ## _expr -> expr PERCENT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16270,7 +16271,7 @@ implementation: LPAREN UIDENT PERCENT WITH
 
 implementation: LPAREN UIDENT PLUS WITH
 ##
-## Ends in an error in state: 1396.
+## Ends in an error in state: 1405.
 ##
 ## _expr -> expr PLUS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16282,7 +16283,7 @@ implementation: LPAREN UIDENT PLUS WITH
 
 implementation: LPAREN UIDENT PLUSDOT WITH
 ##
-## Ends in an error in state: 1394.
+## Ends in an error in state: 1403.
 ##
 ## _expr -> expr PLUSDOT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16294,7 +16295,7 @@ implementation: LPAREN UIDENT PLUSDOT WITH
 
 implementation: LPAREN UIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 1388.
+## Ends in an error in state: 1397.
 ##
 ## _expr -> expr PLUSEQ . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16306,7 +16307,7 @@ implementation: LPAREN UIDENT PLUSEQ WITH
 
 implementation: LPAREN UIDENT QUESTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1433.
+## Ends in an error in state: 1442.
 ##
 ## _expr -> expr QUESTION expr COLON . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16318,7 +16319,7 @@ implementation: LPAREN UIDENT QUESTION UIDENT COLON WITH
 
 implementation: LPAREN UIDENT QUESTION UIDENT SEMI
 ##
-## Ends in an error in state: 1432.
+## Ends in an error in state: 1441.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -16352,21 +16353,21 @@ implementation: LPAREN UIDENT QUESTION UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT QUESTION WITH
 ##
-## Ends in an error in state: 1431.
+## Ends in an error in state: 1440.
 ##
 ## _expr -> expr QUESTION . expr COLON expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16378,7 +16379,7 @@ implementation: LPAREN UIDENT QUESTION WITH
 
 implementation: LPAREN UIDENT SHARP WITH
 ##
-## Ends in an error in state: 603.
+## Ends in an error in state: 612.
 ##
 ## _simple_expr -> simple_expr SHARP . label [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -16390,7 +16391,7 @@ implementation: LPAREN UIDENT SHARP WITH
 
 implementation: LPAREN UIDENT STAR WITH
 ##
-## Ends in an error in state: 1373.
+## Ends in an error in state: 1382.
 ##
 ## _expr -> expr STAR . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16402,7 +16403,7 @@ implementation: LPAREN UIDENT STAR WITH
 
 implementation: LPAREN UIDENT TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 2247.
+## Ends in an error in state: 2256.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -16436,21 +16437,21 @@ implementation: LPAREN UIDENT TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 2246.
+## Ends in an error in state: 2255.
 ##
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -16462,7 +16463,7 @@ implementation: LPAREN UIDENT TRUE DOT LBRACE WITH
 
 implementation: LPAREN UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2244.
+## Ends in an error in state: 2253.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -16497,21 +16498,21 @@ implementation: LPAREN UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2243.
+## Ends in an error in state: 2252.
 ##
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16524,7 +16525,7 @@ implementation: LPAREN UIDENT TRUE DOT LBRACKET WITH
 
 implementation: LPAREN UIDENT TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2241.
+## Ends in an error in state: 2250.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -16559,21 +16560,21 @@ implementation: LPAREN UIDENT TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 607.
+## Ends in an error in state: 616.
 ##
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16586,7 +16587,7 @@ implementation: LPAREN UIDENT TRUE DOT LPAREN WITH
 
 implementation: LPAREN UIDENT TRUE DOT WITH
 ##
-## Ends in an error in state: 606.
+## Ends in an error in state: 615.
 ##
 ## _simple_expr -> simple_expr DOT . label_longident [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16603,7 +16604,7 @@ implementation: LPAREN UIDENT TRUE DOT WITH
 
 implementation: LPAREN WHILE UIDENT WITH
 ##
-## Ends in an error in state: 2595.
+## Ends in an error in state: 2613.
 ##
 ## _expr -> WHILE simple_expr . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -16621,10 +16622,10 @@ implementation: LPAREN WHILE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 881, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 890, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -16643,7 +16644,7 @@ implementation: LPAREN WHILE WITH
 
 implementation: LPAREN WITH
 ##
-## Ends in an error in state: 536.
+## Ends in an error in state: 545.
 ##
 ## _expr -> LPAREN . COLONCOLON RPAREN LPAREN expr COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . expr RPAREN [ UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -16665,7 +16666,7 @@ implementation: LPAREN WITH
 
 implementation: MINUSDOT WITH
 ##
-## Ends in an error in state: 886.
+## Ends in an error in state: 895.
 ##
 ## _expr -> subtractive . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16788,7 +16789,7 @@ implementation: PERCENT WITH WITH
 
 implementation: PLUSDOT WITH
 ##
-## Ends in an error in state: 1195.
+## Ends in an error in state: 1204.
 ##
 ## _expr -> additive . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16812,7 +16813,7 @@ implementation: PREFIXOP WITH
 
 implementation: STRING LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1173.
+## Ends in an error in state: 1182.
 ##
 ## label_expr -> LIDENT COLONCOLON . less_aggressive_simple_expression [ UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -16824,7 +16825,7 @@ implementation: STRING LIDENT COLONCOLON WITH
 
 implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1170.
+## Ends in an error in state: 1179.
 ##
 ## label_expr -> LIDENT EXPLICITLY_PASSED_OPTIONAL . less_aggressive_simple_expression [ UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -16836,7 +16837,7 @@ implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: STRING WITH
 ##
-## Ends in an error in state: 1115.
+## Ends in an error in state: 1124.
 ##
 ## structure -> structure_item . [ RBRACKET RBRACE EOF ]
 ## structure -> structure_item . SEMI structure [ RBRACKET RBRACE EOF ]
@@ -16848,24 +16849,24 @@ implementation: STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1513, spurious reduction of production post_item_attributes ->
-## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1522, spurious reduction of production post_item_attributes ->
+## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 Incomplete module item, forgetting a ";"?
 
 implementation: SWITCH UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2489.
+## Ends in an error in state: 2498.
 ##
 ## _expr -> SWITCH simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16877,7 +16878,7 @@ implementation: SWITCH UIDENT LBRACE WITH
 
 implementation: SWITCH UIDENT WITH
 ##
-## Ends in an error in state: 2488.
+## Ends in an error in state: 2497.
 ##
 ## _expr -> SWITCH simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ SHARP LBRACE DOT ]
@@ -16895,10 +16896,10 @@ implementation: SWITCH UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 881, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 890, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -16917,7 +16918,7 @@ implementation: SWITCH WITH
 
 implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 ##
-## Ends in an error in state: 1860.
+## Ends in an error in state: 1869.
 ##
 ## _expr -> simple_expr DOT LBRACE expr RBRACE EQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16929,7 +16930,7 @@ implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 
 implementation: TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 1858.
+## Ends in an error in state: 1867.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -16964,21 +16965,21 @@ implementation: TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 1857.
+## Ends in an error in state: 1866.
 ##
 ## _expr -> simple_expr DOT LBRACE . expr RBRACE EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -16991,7 +16992,7 @@ implementation: TRUE DOT LBRACE WITH
 
 implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 ##
-## Ends in an error in state: 1855.
+## Ends in an error in state: 1864.
 ##
 ## _expr -> simple_expr DOT LBRACKET expr RBRACKET EQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17003,7 +17004,7 @@ implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 
 implementation: TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 1852.
+## Ends in an error in state: 1861.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -17039,21 +17040,21 @@ implementation: TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1851.
+## Ends in an error in state: 1860.
 ##
 ## _expr -> simple_expr DOT LBRACKET . expr RBRACKET EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -17067,7 +17068,7 @@ implementation: TRUE DOT LBRACKET WITH
 
 implementation: TRUE DOT LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1863.
+## Ends in an error in state: 1872.
 ##
 ## _expr -> simple_expr DOT label_longident EQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17079,7 +17080,7 @@ implementation: TRUE DOT LIDENT EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 ##
-## Ends in an error in state: 1849.
+## Ends in an error in state: 1858.
 ##
 ## _expr -> simple_expr DOT LPAREN expr RPAREN EQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17091,7 +17092,7 @@ implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1846.
+## Ends in an error in state: 1855.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -17127,21 +17128,21 @@ implementation: TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 889.
+## Ends in an error in state: 898.
 ##
 ## _expr -> simple_expr DOT LPAREN . expr RPAREN EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -17181,7 +17182,7 @@ implementation: TRUE DOT UIDENT WITH
 
 implementation: TRUE DOT WITH
 ##
-## Ends in an error in state: 888.
+## Ends in an error in state: 897.
 ##
 ## _expr -> simple_expr DOT . label_longident EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> simple_expr DOT . LPAREN expr RPAREN EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -17202,7 +17203,7 @@ implementation: TRUE DOT WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER CHAR BAR WITH
 ##
-## Ends in an error in state: 1871.
+## Ends in an error in state: 1880.
 ##
 ## bar_located_pattern -> BAR . pattern [ WHEN EQUALGREATER ]
 ##
@@ -17214,7 +17215,7 @@ Expecting a match case
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT RBRACKET
 ##
-## Ends in an error in state: 2475.
+## Ends in an error in state: 2484.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes . SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17225,22 +17226,22 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 852, spurious reduction of production _module_expr -> simple_module_expr
-## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
-## In state 908, spurious reduction of production module_binding_body_expr -> EQUAL module_expr
-## In state 1758, spurious reduction of production module_binding_body -> module_binding_body_expr
-## In state 2474, spurious reduction of production post_item_attributes ->
+## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 861, spurious reduction of production _module_expr -> simple_module_expr
+## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 917, spurious reduction of production module_binding_body_expr -> EQUAL module_expr
+## In state 1767, spurious reduction of production module_binding_body -> module_binding_body_expr
+## In state 2483, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2476.
+## Ends in an error in state: 2485.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17252,7 +17253,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2473.
+## Ends in an error in state: 2482.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17264,7 +17265,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 ##
-## Ends in an error in state: 2472.
+## Ends in an error in state: 2481.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17276,7 +17277,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 ##
-## Ends in an error in state: 2451.
+## Ends in an error in state: 2460.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17288,7 +17289,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2454.
+## Ends in an error in state: 2463.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17300,7 +17301,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2453.
+## Ends in an error in state: 2462.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17311,14 +17312,14 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2452, spurious reduction of production post_item_attributes ->
+## In state 2461, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 ##
-## Ends in an error in state: 2450.
+## Ends in an error in state: 2459.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17330,7 +17331,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 ##
-## Ends in an error in state: 2449.
+## Ends in an error in state: 2458.
 ##
 ## _semi_terminated_seq_expr_row -> LET . MODULE UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ## _semi_terminated_seq_expr_row -> LET . OPEN override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
@@ -17344,7 +17345,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 ##
-## Ends in an error in state: 2462.
+## Ends in an error in state: 2471.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ RBRACE BAR ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI RBRACE BAR AND ]
@@ -17364,7 +17365,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 2508.
+## Ends in an error in state: 2517.
 ##
 ## _expr -> TRY simple_expr LBRACE leading_bar_match_cases_to_sequence_body . RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## leading_bar_match_cases_to_sequence_body -> leading_bar_match_cases_to_sequence_body . leading_bar_match_case_to_sequence_body [ RBRACE BAR ]
@@ -17376,24 +17377,24 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2464, spurious reduction of production post_item_attributes ->
-## In state 2465, spurious reduction of production opt_semi ->
-## In state 2470, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
-## In state 2468, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
-## In state 2457, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
-## In state 2455, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
-## In state 2469, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2458, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
-## In state 2480, spurious reduction of production leading_bar_match_case_to_sequence_body -> bar_located_pattern EQUALGREATER semi_terminated_seq_expr
-## In state 2481, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2473, spurious reduction of production post_item_attributes ->
+## In state 2474, spurious reduction of production opt_semi ->
+## In state 2479, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
+## In state 2477, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
+## In state 2466, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
+## In state 2464, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
+## In state 2478, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2467, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2489, spurious reduction of production leading_bar_match_case_to_sequence_body -> bar_located_pattern EQUALGREATER semi_terminated_seq_expr
+## In state 2490, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
 ##
 
 Expecting one of the following:
@@ -17402,7 +17403,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2479.
+## Ends in an error in state: 2488.
 ##
 ## leading_bar_match_case_to_sequence_body -> bar_located_pattern EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17414,7 +17415,7 @@ Expecting the body of the matched pattern
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ##
-## Ends in an error in state: 1872.
+## Ends in an error in state: 1881.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN EQUALGREATER BAR ]
 ## bar_located_pattern -> BAR pattern . [ WHEN EQUALGREATER ]
@@ -17426,7 +17427,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 782, spurious reduction of production pattern -> pattern_without_or
+## In state 791, spurious reduction of production pattern -> pattern_without_or
 ##
 
 Expecting one of the following:
@@ -17436,7 +17437,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2448.
+## Ends in an error in state: 2457.
 ##
 ## leading_bar_match_case_to_sequence_body -> bar_located_pattern WHEN expr EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17448,7 +17449,7 @@ Expecting a sequence item
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2447.
+## Ends in an error in state: 2456.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -17482,21 +17483,21 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2446.
+## Ends in an error in state: 2455.
 ##
 ## leading_bar_match_case_to_sequence_body -> bar_located_pattern WHEN . expr EQUALGREATER semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17508,7 +17509,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 
 implementation: TRY UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2507.
+## Ends in an error in state: 2516.
 ##
 ## _expr -> TRY simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17520,7 +17521,7 @@ implementation: TRY UIDENT LBRACE WITH
 
 implementation: TRY UIDENT UNDERSCORE
 ##
-## Ends in an error in state: 2504.
+## Ends in an error in state: 2513.
 ##
 ## _expr -> TRY simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> TRY simple_expr . WITH error [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -17539,17 +17540,17 @@ implementation: TRY UIDENT UNDERSCORE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 881, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 890, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT WITH WITH
 ##
-## Ends in an error in state: 2505.
+## Ends in an error in state: 2514.
 ##
 ## _expr -> TRY simple_expr WITH . error [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17574,7 +17575,7 @@ implementation: TRY WITH
 
 implementation: TYPE LIDENT AND LIDENT WITH
 ##
-## Ends in an error in state: 1129.
+## Ends in an error in state: 1138.
 ##
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -17585,14 +17586,14 @@ implementation: TYPE LIDENT AND LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1128, spurious reduction of production optional_type_parameters ->
+## In state 1137, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT AND WITH
 ##
-## Ends in an error in state: 1127.
+## Ends in an error in state: 1136.
 ##
 ## and_type_declaration -> AND . type_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -17604,7 +17605,7 @@ implementation: TYPE LIDENT AND WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 973.
+## Ends in an error in state: 982.
 ##
 ## constrain -> core_type EQUAL . core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ##
@@ -17616,7 +17617,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 972.
+## Ends in an error in state: 981.
 ##
 ## constrain -> core_type . EQUAL core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ##
@@ -17639,7 +17640,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 
 implementation: TYPE LIDENT CONSTRAINT WITH
 ##
-## Ends in an error in state: 971.
+## Ends in an error in state: 980.
 ##
 ## constraints -> constraints CONSTRAINT . constrain [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ##
@@ -17651,7 +17652,7 @@ implementation: TYPE LIDENT CONSTRAINT WITH
 
 implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2557.
+## Ends in an error in state: 2571.
 ##
 ## constructor_declarations -> constructor_declarations_leading_bar . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations_leading_bar -> constructor_declarations_leading_bar . constructor_declaration_leading_bar [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
@@ -17663,17 +17664,17 @@ implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 494, spurious reduction of production attributes ->
-## In state 495, spurious reduction of production attributes -> attribute attributes
-## In state 2555, spurious reduction of production constructor_declaration_leading_bar -> BAR constr_ident generalized_constructor_arguments attributes
-## In state 2562, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
+## In state 502, spurious reduction of production attributes ->
+## In state 503, spurious reduction of production attributes -> attribute attributes
+## In state 2569, spurious reduction of production constructor_declaration_leading_bar -> BAR constr_ident generalized_constructor_arguments attributes
+## In state 2576, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 ##
-## Ends in an error in state: 1131.
+## Ends in an error in state: 1140.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_declaration_details -> LIDENT optional_type_parameters type_kind constraints . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -17686,7 +17687,7 @@ implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 ##
-## Ends in an error in state: 500.
+## Ends in an error in state: 508.
 ##
 ## label_declarations -> label_declarations COMMA . label_declaration [ RBRACE COMMA ]
 ## opt_comma -> COMMA . [ RBRACE ]
@@ -17701,7 +17702,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2566.
+## Ends in an error in state: 2583.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17719,12 +17720,12 @@ implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 497, spurious reduction of production _poly_type -> core_type
-## In state 498, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 496, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 492, spurious reduction of production attributes ->
-## In state 493, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 504, spurious reduction of production label_declarations -> label_declaration
+## In state 505, spurious reduction of production _poly_type -> core_type
+## In state 506, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 504, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 500, spurious reduction of production attributes ->
+## In state 501, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 512, spurious reduction of production label_declarations -> label_declaration
 ##
 
 Expecting one of the following:
@@ -17733,7 +17734,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 486.
+## Ends in an error in state: 494.
 ##
 ## label_declaration -> mutable_flag LIDENT COLON . poly_type attributes [ RBRACE COMMA ]
 ##
@@ -17745,7 +17746,7 @@ Expecting a type name describing this field
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 485.
+## Ends in an error in state: 493.
 ##
 ## label_declaration -> mutable_flag LIDENT . COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -17758,7 +17759,7 @@ Expecting ":"
 
 implementation: TYPE LIDENT EQUAL LBRACE MUTABLE LET
 ##
-## Ends in an error in state: 484.
+## Ends in an error in state: 492.
 ##
 ## label_declaration -> mutable_flag . LIDENT COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -17771,7 +17772,7 @@ Expecting a type field definition in the form of:
 
 implementation: TYPE LIDENT EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2565.
+## Ends in an error in state: 2582.
 ##
 ## type_kind -> EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -17784,10 +17785,11 @@ Expecting at least one type field definition in the form of:
 
     implementation: TYPE LIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 115.
+## Ends in an error in state: 2562.
 ##
-## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
-## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
+## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
+## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
+## constr_ident2 -> LPAREN . RPAREN [ UNDERSCORE UIDENT SHARP SEMI RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF CONSTRAINT COLON BAR AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -17797,7 +17799,7 @@ Expecting at least one type field definition in the form of:
 
 implementation: TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 2551.
+## Ends in an error in state: 2561.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL PRIVATE . core_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17825,7 +17827,7 @@ implementation: TYPE LIDENT EQUAL UIDENT WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 ##
-## Ends in an error in state: 2552.
+## Ends in an error in state: 2566.
 ##
 ## constructor_declaration_leading_bar -> BAR . constr_ident generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
 ##
@@ -17837,7 +17839,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 2577.
+## Ends in an error in state: 2595.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17849,17 +17851,17 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDO
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 494, spurious reduction of production attributes ->
-## In state 495, spurious reduction of production attributes -> attribute attributes
-## In state 493, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 504, spurious reduction of production label_declarations -> label_declaration
+## In state 502, spurious reduction of production attributes ->
+## In state 503, spurious reduction of production attributes -> attribute attributes
+## In state 501, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 512, spurious reduction of production label_declarations -> label_declaration
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2576.
+## Ends in an error in state: 2594.
 ##
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -17871,7 +17873,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 ##
-## Ends in an error in state: 2572.
+## Ends in an error in state: 2589.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL core_type EQUAL PRIVATE . constructor_declarations [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17884,7 +17886,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2560.
+## Ends in an error in state: 2574.
 ##
 ## constructor_declarations -> constructor_declaration_no_leading_bar . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations -> constructor_declaration_no_leading_bar . constructor_declarations_leading_bar [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17896,16 +17898,16 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 494, spurious reduction of production attributes ->
-## In state 495, spurious reduction of production attributes -> attribute attributes
-## In state 2550, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
+## In state 502, spurious reduction of production attributes ->
+## In state 503, spurious reduction of production attributes -> attribute attributes
+## In state 2559, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2570.
+## Ends in an error in state: 2587.
 ##
 ## type_kind -> EQUAL core_type EQUAL . constructor_declarations [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type EQUAL . PRIVATE constructor_declarations [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17920,7 +17922,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 2569.
+## Ends in an error in state: 2586.
 ##
 ## type_kind -> EQUAL core_type . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type . EQUAL constructor_declarations [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17968,7 +17970,7 @@ implementation: TYPE LIDENT EQUAL WITH
 
 implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1126.
+## Ends in an error in state: 1135.
 ##
 ## _structure_item_without_item_extension_sugar -> many_type_declarations . [ SEMI RBRACKET RBRACE EOF ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ SEMI RBRACKET RBRACE EOF AND ]
@@ -17980,9 +17982,9 @@ implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 923, spurious reduction of production post_item_attributes ->
-## In state 924, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 922, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 932, spurious reduction of production post_item_attributes ->
+## In state 933, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 931, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
@@ -18039,7 +18041,7 @@ implementation: TYPE LIDENT PLUS WITH
 
 implementation: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 2585.
+## Ends in an error in state: 2603.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . str_extension_constructors post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -18051,7 +18053,7 @@ implementation: TYPE LIDENT PLUSEQ BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 2584.
+## Ends in an error in state: 2602.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar str_extension_constructors post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -18063,7 +18065,7 @@ implementation: TYPE LIDENT PLUSEQ PRIVATE BANG
 
 implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 2587.
+## Ends in an error in state: 2605.
 ##
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_declaration [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_rebind [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -18076,7 +18078,7 @@ implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 2583.
+## Ends in an error in state: 2601.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar str_extension_constructors post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -18124,7 +18126,7 @@ Expecting one of the following:
 
 implementation: TYPE UIDENT DOT WITH
 ##
-## Ends in an error in state: 950.
+## Ends in an error in state: 959.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -18138,7 +18140,7 @@ implementation: TYPE UIDENT DOT WITH
 
 implementation: TYPE UIDENT WITH
 ##
-## Ends in an error in state: 949.
+## Ends in an error in state: 958.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -18177,7 +18179,7 @@ implementation: TYPE WITH
 
 implementation: UIDENT AMPERAMPER WITH
 ##
-## Ends in an error in state: 1232.
+## Ends in an error in state: 1241.
 ##
 ## _expr -> expr AMPERAMPER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18189,7 +18191,7 @@ implementation: UIDENT AMPERAMPER WITH
 
 implementation: UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 1230.
+## Ends in an error in state: 1239.
 ##
 ## _expr -> expr AMPERSAND . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18201,7 +18203,7 @@ implementation: UIDENT AMPERSAND WITH
 
 implementation: UIDENT BARBAR WITH
 ##
-## Ends in an error in state: 1228.
+## Ends in an error in state: 1237.
 ##
 ## _expr -> expr BARBAR . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18213,7 +18215,7 @@ implementation: UIDENT BARBAR WITH
 
 implementation: UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1234.
+## Ends in an error in state: 1243.
 ##
 ## _expr -> expr COLONEQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18225,7 +18227,7 @@ implementation: UIDENT COLONEQUAL WITH
 
 implementation: UIDENT DOT LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 1842.
+## Ends in an error in state: 1851.
 ##
 ## lbl_expr -> label_longident . COLON expr [ COMMA ]
 ## lbl_expr -> label_longident . [ COMMA ]
@@ -18239,7 +18241,7 @@ implementation: UIDENT DOT LBRACE LIDENT WITH
 
 implementation: UIDENT DOT LBRACE WITH
 ##
-## Ends in an error in state: 2217.
+## Ends in an error in state: 2226.
 ##
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr RBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18252,7 +18254,7 @@ implementation: UIDENT DOT LBRACE WITH
 
 implementation: UIDENT DOT LBRACELESS WITH
 ##
-## Ends in an error in state: 2212.
+## Ends in an error in state: 2221.
 ##
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18265,7 +18267,7 @@ implementation: UIDENT DOT LBRACELESS WITH
 
 implementation: UIDENT DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2202.
+## Ends in an error in state: 2211.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKET . expr_comma_seq_extension [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -18277,7 +18279,7 @@ implementation: UIDENT DOT LBRACKET WITH
 
 implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2198.
+## Ends in an error in state: 2207.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18290,23 +18292,23 @@ implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1794, spurious reduction of production expr_optional_constraint -> expr
-## In state 1790, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1803, spurious reduction of production expr_optional_constraint -> expr
+## In state 1799, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LBRACKETBAR WITH
 ##
-## Ends in an error in state: 2197.
+## Ends in an error in state: 2206.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18319,7 +18321,7 @@ implementation: UIDENT DOT LBRACKETBAR WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2192.
+## Ends in an error in state: 2201.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON package_type . RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -18339,7 +18341,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2190.
+## Ends in an error in state: 2199.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . package_type RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18352,7 +18354,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 853.
+## Ends in an error in state: 862.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -18367,19 +18369,19 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 852, spurious reduction of production _module_expr -> simple_module_expr
-## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 919, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 923, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 920, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 861, spurious reduction of production _module_expr -> simple_module_expr
+## In state 925, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 924, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN MODULE WITH
 ##
-## Ends in an error in state: 851.
+## Ends in an error in state: 860.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON package_type RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18392,7 +18394,7 @@ implementation: UIDENT DOT LPAREN MODULE WITH
 
 implementation: UIDENT DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2194.
+## Ends in an error in state: 2203.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -18427,21 +18429,21 @@ implementation: UIDENT DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN WITH
 ##
-## Ends in an error in state: 850.
+## Ends in an error in state: 859.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN . expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN . expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18457,7 +18459,7 @@ implementation: UIDENT DOT LPAREN WITH
 
 implementation: UIDENT DOT WITH
 ##
-## Ends in an error in state: 849.
+## Ends in an error in state: 858.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18481,7 +18483,7 @@ implementation: UIDENT DOT WITH
 
 implementation: UIDENT GREATER WITH
 ##
-## Ends in an error in state: 1226.
+## Ends in an error in state: 1235.
 ##
 ## _expr -> expr GREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18493,7 +18495,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP0 WITH
 ##
-## Ends in an error in state: 1224.
+## Ends in an error in state: 1233.
 ##
 ## _expr -> expr INFIXOP0 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18505,7 +18507,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP1 WITH
 ##
-## Ends in an error in state: 1218.
+## Ends in an error in state: 1227.
 ##
 ## _expr -> expr INFIXOP1 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18517,7 +18519,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP2 WITH
 ##
-## Ends in an error in state: 1216.
+## Ends in an error in state: 1225.
 ##
 ## _expr -> expr INFIXOP2 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18529,7 +18531,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP3 WITH
 ##
-## Ends in an error in state: 1202.
+## Ends in an error in state: 1211.
 ##
 ## _expr -> expr INFIXOP3 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18541,7 +18543,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP4 WITH
 ##
-## Ends in an error in state: 1185.
+## Ends in an error in state: 1194.
 ##
 ## _expr -> expr INFIXOP4 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18565,7 +18567,7 @@ Expecting an attribute id
 
 implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2510.
+## Ends in an error in state: 2519.
 ##
 ## attribute -> LBRACKETAT attr_id payload . RBRACKET [ WITH WHEN UIDENT STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 IN GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -18576,23 +18578,23 @@ implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1513, spurious reduction of production post_item_attributes ->
-## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1115, spurious reduction of production structure -> structure_item
-## In state 1500, spurious reduction of production payload -> structure
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1522, spurious reduction of production post_item_attributes ->
+## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1124, spurious reduction of production structure -> structure_item
+## In state 1509, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
@@ -18611,7 +18613,7 @@ Expecting an attributed id
 
 implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2403.
+## Ends in an error in state: 2412.
 ##
 ## item_attribute -> LBRACKETATAT attr_id payload . RBRACKET [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -18622,30 +18624,30 @@ implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1513, spurious reduction of production post_item_attributes ->
-## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1115, spurious reduction of production structure -> structure_item
-## In state 1500, spurious reduction of production payload -> structure
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1522, spurious reduction of production post_item_attributes ->
+## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1124, spurious reduction of production structure -> structure_item
+## In state 1509, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
 
 implementation: UIDENT LESS WITH
 ##
-## Ends in an error in state: 1222.
+## Ends in an error in state: 1231.
 ##
 ## _expr -> expr LESS . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18657,7 +18659,7 @@ Expecting an expression
 
 implementation: UIDENT LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1220.
+## Ends in an error in state: 1229.
 ##
 ## _expr -> expr LESSDOTDOTGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18669,7 +18671,7 @@ Expecting an expression
 
 implementation: UIDENT LESSGREATER WITH
 ##
-## Ends in an error in state: 1214.
+## Ends in an error in state: 1223.
 ##
 ## _expr -> expr LESSGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18706,7 +18708,7 @@ Expecting one of the following:
 
 implementation: UIDENT MINUS WITH
 ##
-## Ends in an error in state: 1212.
+## Ends in an error in state: 1221.
 ##
 ## _expr -> expr MINUS . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18718,7 +18720,7 @@ Expecting an expression
 
 implementation: UIDENT MINUSDOT WITH
 ##
-## Ends in an error in state: 1210.
+## Ends in an error in state: 1219.
 ##
 ## _expr -> expr MINUSDOT . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18730,7 +18732,7 @@ Expecting an expression
 
 implementation: UIDENT OR WITH
 ##
-## Ends in an error in state: 1208.
+## Ends in an error in state: 1217.
 ##
 ## _expr -> expr OR . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18742,7 +18744,7 @@ Expecting an expression
 
 implementation: UIDENT PERCENT WITH
 ##
-## Ends in an error in state: 1200.
+## Ends in an error in state: 1209.
 ##
 ## _expr -> expr PERCENT . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18754,7 +18756,7 @@ Expecting an expression
 
 implementation: UIDENT PLUS WITH
 ##
-## Ends in an error in state: 1206.
+## Ends in an error in state: 1215.
 ##
 ## _expr -> expr PLUS . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18766,7 +18768,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSDOT WITH
 ##
-## Ends in an error in state: 1204.
+## Ends in an error in state: 1213.
 ##
 ## _expr -> expr PLUSDOT . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18778,7 +18780,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 1198.
+## Ends in an error in state: 1207.
 ##
 ## _expr -> expr PLUSEQ . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18790,7 +18792,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1239.
+## Ends in an error in state: 1248.
 ##
 ## _expr -> expr QUESTION expr COLON . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18802,7 +18804,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT SEMI
 ##
-## Ends in an error in state: 1238.
+## Ends in an error in state: 1247.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -18836,14 +18838,14 @@ implementation: UIDENT QUESTION UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -18852,7 +18854,7 @@ Expecting one of the following:
 
 implementation: UIDENT QUESTION WITH
 ##
-## Ends in an error in state: 1237.
+## Ends in an error in state: 1246.
 ##
 ## _expr -> expr QUESTION . expr COLON expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18864,7 +18866,7 @@ Expecting an expression
 
 implementation: UIDENT RBRACKET
 ##
-## Ends in an error in state: 2603.
+## Ends in an error in state: 2621.
 ##
 ## implementation -> structure . EOF [ # ]
 ##
@@ -18875,29 +18877,29 @@ implementation: UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1513, spurious reduction of production post_item_attributes ->
-## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1115, spurious reduction of production structure -> structure_item
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1522, spurious reduction of production post_item_attributes ->
+## In state 1523, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1524, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1132, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1123, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1525, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1133, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1124, spurious reduction of production structure -> structure_item
 ##
 
 Invalid token
 
 implementation: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 1116.
+## Ends in an error in state: 1125.
 ##
 ## structure -> structure_item SEMI . structure [ RBRACKET RBRACE EOF ]
 ##
@@ -18909,7 +18911,7 @@ Expecting a structure item
 
 implementation: UIDENT SHARP WITH
 ##
-## Ends in an error in state: 567.
+## Ends in an error in state: 576.
 ##
 ## _simple_expr -> simple_expr SHARP . label [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -18921,7 +18923,7 @@ Expecting an identifier
 
 implementation: UIDENT STAR WITH
 ##
-## Ends in an error in state: 1183.
+## Ends in an error in state: 1192.
 ##
 ## _expr -> expr STAR . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18933,7 +18935,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 2292.
+## Ends in an error in state: 2301.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -18967,14 +18969,14 @@ implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 1188, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 1197, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 896, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1177, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1206, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1134, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -18983,7 +18985,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 2291.
+## Ends in an error in state: 2300.
 ##
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -18995,7 +18997,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2289.
+## Ends in an error in state: 2298.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -19030,14 +19032,14 @@ implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -19046,7 +19048,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2288.
+## Ends in an error in state: 2297.
 ##
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -19059,7 +19061,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2286.
+## Ends in an error in state: 2295.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -19094,14 +19096,14 @@ implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 898, spurious reduction of production constr_longident -> mod_longident
-## In state 1378, spurious reduction of production _simple_expr -> constr_longident
-## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1362, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 907, spurious reduction of production constr_longident -> mod_longident
+## In state 1387, spurious reduction of production _simple_expr -> constr_longident
+## In state 1320, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1315, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1371, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1377, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1396, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1376, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -19110,7 +19112,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 570.
+## Ends in an error in state: 579.
 ##
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -19123,7 +19125,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT WITH
 ##
-## Ends in an error in state: 569.
+## Ends in an error in state: 578.
 ##
 ## _simple_expr -> simple_expr DOT . label_longident [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT . LPAREN expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -19144,7 +19146,7 @@ Expecting one of the following:
 
 implementation: WHILE UIDENT WITH
 ##
-## Ends in an error in state: 2598.
+## Ends in an error in state: 2616.
 ##
 ## _expr -> WHILE simple_expr . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -19162,10 +19164,10 @@ implementation: WHILE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 848, spurious reduction of production constr_longident -> mod_longident
-## In state 881, spurious reduction of production _simple_expr -> constr_longident
-## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production constr_longident -> mod_longident
+## In state 890, spurious reduction of production _simple_expr -> constr_longident
+## In state 892, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 888, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>

--- a/src/reason_parser.messages
+++ b/src/reason_parser.messages
@@ -1,6 +1,6 @@
 use_file: SHARP LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2656.
+## Ends in an error in state: 2743.
 ##
 ## _use_file -> toplevel_directive SEMI . use_file [ # ]
 ##
@@ -12,7 +12,7 @@ use_file: SHARP LIDENT SEMI WITH
 
 use_file: SHARP LIDENT TRUE WITH
 ##
-## Ends in an error in state: 2655.
+## Ends in an error in state: 2742.
 ##
 ## _use_file -> toplevel_directive . SEMI use_file [ # ]
 ## _use_file -> toplevel_directive . EOF [ # ]
@@ -25,7 +25,7 @@ use_file: SHARP LIDENT TRUE WITH
 
 use_file: UIDENT RPAREN
 ##
-## Ends in an error in state: 2658.
+## Ends in an error in state: 2745.
 ##
 ## _use_file -> structure_item . SEMI use_file [ # ]
 ## _use_file -> structure_item . EOF [ # ]
@@ -37,28 +37,28 @@ use_file: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1519, spurious reduction of production post_item_attributes ->
-## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1558, spurious reduction of production post_item_attributes ->
+## In state 1559, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1560, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1168, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1159, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1561, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1169, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 use_file: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2659.
+## Ends in an error in state: 2746.
 ##
 ## _use_file -> structure_item SEMI . use_file [ # ]
 ##
@@ -70,7 +70,7 @@ use_file: UIDENT SEMI WITH
 
 use_file: WITH
 ##
-## Ends in an error in state: 2652.
+## Ends in an error in state: 2739.
 ##
 ## use_file' -> . use_file [ # ]
 ##
@@ -82,7 +82,7 @@ use_file: WITH
 
 toplevel_phrase: SHARP UIDENT EOF
 ##
-## Ends in an error in state: 2647.
+## Ends in an error in state: 2734.
 ##
 ## _toplevel_phrase -> toplevel_directive . SEMI [ # ]
 ##
@@ -93,14 +93,14 @@ toplevel_phrase: SHARP UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2637, spurious reduction of production toplevel_directive -> SHARP ident
+## In state 2724, spurious reduction of production toplevel_directive -> SHARP ident
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 ##
-## Ends in an error in state: 2644.
+## Ends in an error in state: 2731.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ SEMI EOF DOT ]
 ## val_longident -> mod_longident DOT . val_ident [ SEMI EOF ]
@@ -113,7 +113,7 @@ toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 
 toplevel_phrase: SHARP UIDENT UIDENT WITH
 ##
-## Ends in an error in state: 2643.
+## Ends in an error in state: 2730.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ SEMI EOF DOT ]
 ## toplevel_directive -> SHARP ident mod_longident . [ SEMI EOF ]
@@ -127,7 +127,7 @@ toplevel_phrase: SHARP UIDENT UIDENT WITH
 
 toplevel_phrase: SHARP UIDENT WITH
 ##
-## Ends in an error in state: 2637.
+## Ends in an error in state: 2724.
 ##
 ## toplevel_directive -> SHARP ident . [ SEMI EOF ]
 ## toplevel_directive -> SHARP ident . STRING [ SEMI EOF ]
@@ -145,7 +145,7 @@ toplevel_phrase: SHARP UIDENT WITH
 
 toplevel_phrase: SHARP WITH
 ##
-## Ends in an error in state: 2636.
+## Ends in an error in state: 2723.
 ##
 ## toplevel_directive -> SHARP . ident [ SEMI EOF ]
 ## toplevel_directive -> SHARP . ident STRING [ SEMI EOF ]
@@ -163,7 +163,7 @@ toplevel_phrase: SHARP WITH
 
 toplevel_phrase: UIDENT RPAREN
 ##
-## Ends in an error in state: 2649.
+## Ends in an error in state: 2736.
 ##
 ## _toplevel_phrase -> structure_item . SEMI [ # ]
 ##
@@ -174,28 +174,28 @@ toplevel_phrase: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1519, spurious reduction of production post_item_attributes ->
-## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1558, spurious reduction of production post_item_attributes ->
+## In state 1559, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1560, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1168, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1159, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1561, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1169, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: WITH
 ##
-## Ends in an error in state: 2635.
+## Ends in an error in state: 2722.
 ##
 ## toplevel_phrase' -> . toplevel_phrase [ # ]
 ##
@@ -207,7 +207,7 @@ toplevel_phrase: WITH
 
 parse_pattern: EXCEPTION UNDERSCORE WITH
 ##
-## Ends in an error in state: 777.
+## Ends in an error in state: 793.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -224,7 +224,7 @@ parse_pattern: EXCEPTION UNDERSCORE WITH
 
 parse_pattern: EXCEPTION WITH
 ##
-## Ends in an error in state: 775.
+## Ends in an error in state: 791.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -236,7 +236,7 @@ parse_pattern: EXCEPTION WITH
 
 parse_pattern: LAZY WITH
 ##
-## Ends in an error in state: 759.
+## Ends in an error in state: 775.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -248,7 +248,7 @@ parse_pattern: LAZY WITH
 
 parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ##
-## Ends in an error in state: 820.
+## Ends in an error in state: 836.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error RBRACE COMMA BAR ]
 ## lbl_pattern -> label_longident COLON pattern . [ error RBRACE COMMA ]
@@ -260,14 +260,14 @@ parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 713, spurious reduction of production pattern -> pattern_without_or
+## In state 729, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 671.
+## Ends in an error in state: 687.
 ##
 ## lbl_pattern -> label_longident COLON . pattern [ error RBRACE COMMA ]
 ##
@@ -279,7 +279,7 @@ parse_pattern: LBRACE LIDENT COLON WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 756.
+## Ends in an error in state: 772.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -292,7 +292,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 666.
+## Ends in an error in state: 682.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA UNDERSCORE . opt_comma [ error RBRACE ]
 ##
@@ -304,7 +304,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 
 parse_pattern: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 665.
+## Ends in an error in state: 681.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA . [ error RBRACE ]
 ## lbl_pattern_list -> lbl_pattern COMMA . UNDERSCORE opt_comma [ error RBRACE ]
@@ -318,7 +318,7 @@ parse_pattern: LBRACE LIDENT COMMA WITH
 
 parse_pattern: LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 670.
+## Ends in an error in state: 686.
 ##
 ## lbl_pattern -> label_longident . COLON pattern [ error RBRACE COMMA ]
 ## lbl_pattern -> label_longident . [ error RBRACE COMMA ]
@@ -331,7 +331,7 @@ parse_pattern: LBRACE LIDENT WITH
 
 parse_pattern: LBRACE UIDENT DOT WITH
 ##
-## Ends in an error in state: 659.
+## Ends in an error in state: 675.
 ##
 ## label_longident -> mod_longident DOT . LIDENT [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident DOT . UIDENT [ DOT ]
@@ -344,7 +344,7 @@ parse_pattern: LBRACE UIDENT DOT WITH
 
 parse_pattern: LBRACE UIDENT WITH
 ##
-## Ends in an error in state: 658.
+## Ends in an error in state: 674.
 ##
 ## label_longident -> mod_longident . DOT LIDENT [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident . DOT UIDENT [ DOT ]
@@ -357,7 +357,7 @@ parse_pattern: LBRACE UIDENT WITH
 
 parse_pattern: LBRACE WITH
 ##
-## Ends in an error in state: 755.
+## Ends in an error in state: 771.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -370,7 +370,7 @@ parse_pattern: LBRACE WITH
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 752.
+## Ends in an error in state: 768.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET BAR ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT pattern . [ error SEMI RBRACKET ]
@@ -382,14 +382,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 713, spurious reduction of production pattern -> pattern_without_or
+## In state 729, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT WITH
 ##
-## Ends in an error in state: 751.
+## Ends in an error in state: 767.
 ##
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT . pattern [ error SEMI RBRACKET ]
 ##
@@ -401,7 +401,7 @@ Expecting a valid list identifier
 
 parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 753.
+## Ends in an error in state: 769.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ COMMA ]
@@ -414,14 +414,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 713, spurious reduction of production pattern -> pattern_without_or
+## In state 729, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 750.
+## Ends in an error in state: 766.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ COMMA ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA . DOTDOTDOT pattern [ error SEMI RBRACKET ]
@@ -435,7 +435,7 @@ parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKET UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 754.
+## Ends in an error in state: 770.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern . [ COMMA ]
@@ -448,14 +448,14 @@ parse_pattern: LBRACKET UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 713, spurious reduction of production pattern -> pattern_without_or
+## In state 729, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 746.
+## Ends in an error in state: 762.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -468,7 +468,7 @@ parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LBRACKET WITH
 ##
-## Ends in an error in state: 743.
+## Ends in an error in state: 759.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -482,7 +482,7 @@ parse_pattern: LBRACKET WITH
 
 parse_pattern: LBRACKETBAR MINUS WITH
 ##
-## Ends in an error in state: 654.
+## Ends in an error in state: 670.
 ##
 ## signed_constant -> MINUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> MINUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -498,7 +498,7 @@ parse_pattern: LBRACKETBAR MINUS WITH
 
 parse_pattern: LBRACKETBAR PLUS WITH
 ##
-## Ends in an error in state: 653.
+## Ends in an error in state: 669.
 ##
 ## signed_constant -> PLUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> PLUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -514,7 +514,7 @@ parse_pattern: LBRACKETBAR PLUS WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 733.
+## Ends in an error in state: 749.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -526,14 +526,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 713, spurious reduction of production pattern -> pattern_without_or
+## In state 729, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 732.
+## Ends in an error in state: 748.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ error SEMI COMMA BARRBRACKET ]
 ##
@@ -545,7 +545,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 742.
+## Ends in an error in state: 758.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -557,14 +557,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 713, spurious reduction of production pattern -> pattern_without_or
+## In state 729, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 739.
+## Ends in an error in state: 755.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -577,7 +577,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LBRACKETBAR WITH
 ##
-## Ends in an error in state: 728.
+## Ends in an error in state: 744.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -591,7 +591,7 @@ parse_pattern: LBRACKETBAR WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 2428.
+## Ends in an error in state: 2492.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -609,7 +609,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 2427.
+## Ends in an error in state: 2491.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -622,7 +622,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2426.
+## Ends in an error in state: 2490.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -640,7 +640,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2425.
+## Ends in an error in state: 2489.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -653,7 +653,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2424.
+## Ends in an error in state: 2488.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -666,7 +666,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2423.
+## Ends in an error in state: 2487.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -679,7 +679,7 @@ parse_pattern: LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN EXCEPTION UNDERSCORE WITH
 ##
-## Ends in an error in state: 688.
+## Ends in an error in state: 704.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -696,7 +696,7 @@ parse_pattern: LPAREN EXCEPTION UNDERSCORE WITH
 
 parse_pattern: LPAREN EXCEPTION WITH
 ##
-## Ends in an error in state: 680.
+## Ends in an error in state: 696.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -708,7 +708,7 @@ parse_pattern: LPAREN EXCEPTION WITH
 
 parse_pattern: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 672.
+## Ends in an error in state: 688.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -720,7 +720,7 @@ parse_pattern: LPAREN LAZY WITH
 
 parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 661.
+## Ends in an error in state: 677.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -733,7 +733,7 @@ parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 656.
+## Ends in an error in state: 672.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -746,7 +746,7 @@ parse_pattern: LPAREN LBRACE WITH
 
 parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 822.
+## Ends in an error in state: 838.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -759,7 +759,7 @@ parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LPAREN LBRACKET WITH
 ##
-## Ends in an error in state: 655.
+## Ends in an error in state: 671.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -773,7 +773,7 @@ parse_pattern: LPAREN LBRACKET WITH
 
 parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 827.
+## Ends in an error in state: 843.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -786,7 +786,7 @@ parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LPAREN LBRACKETBAR WITH
 ##
-## Ends in an error in state: 652.
+## Ends in an error in state: 668.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -800,7 +800,7 @@ parse_pattern: LPAREN LBRACKETBAR WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 835.
+## Ends in an error in state: 851.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -818,7 +818,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCOR
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 834.
+## Ends in an error in state: 850.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -831,7 +831,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 833.
+## Ends in an error in state: 849.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -849,7 +849,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 832.
+## Ends in an error in state: 848.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -862,7 +862,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 831.
+## Ends in an error in state: 847.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -875,7 +875,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 830.
+## Ends in an error in state: 846.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -888,7 +888,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 640.
+## Ends in an error in state: 656.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -901,7 +901,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 638.
+## Ends in an error in state: 654.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -915,7 +915,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 
 parse_pattern: LPAREN LPAREN MODULE WITH
 ##
-## Ends in an error in state: 637.
+## Ends in an error in state: 653.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -929,7 +929,7 @@ parse_pattern: LPAREN LPAREN MODULE WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 814.
+## Ends in an error in state: 830.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -944,7 +944,7 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 725.
+## Ends in an error in state: 741.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -962,17 +962,17 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 800, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
-## In state 807, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 806, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 810, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 816, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
+## In state 823, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 822, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 826, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 636.
+## Ends in an error in state: 652.
 ##
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -996,7 +996,7 @@ parse_pattern: LPAREN LPAREN WITH
 
 parse_pattern: LPAREN MINUS WITH
 ##
-## Ends in an error in state: 630.
+## Ends in an error in state: 646.
 ##
 ## operator -> MINUS . [ RPAREN ]
 ## signed_constant -> MINUS . INT [ error RPAREN LBRACKETAT DOTDOT COMMA COLONCOLON COLON BAR AS ]
@@ -1026,7 +1026,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 234, spurious reduction of production ident -> UIDENT
-## In state 648, spurious reduction of production mty_longident -> ident
+## In state 664, spurious reduction of production mty_longident -> ident
 ##
 
 <SYNTAX ERROR>
@@ -1047,7 +1047,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WHILE
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2421.
+## Ends in an error in state: 2485.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ error RPAREN ]
 ##
@@ -1059,7 +1059,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2420.
+## Ends in an error in state: 2484.
 ##
 ## package_type_cstrs -> package_type_cstr . [ error RPAREN ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ error RPAREN ]
@@ -1077,7 +1077,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 ## In state 445, spurious reduction of production _core_type -> core_type2
 ## In state 454, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 444, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2418, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 2482, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
@@ -1236,7 +1236,7 @@ parse_pattern: LPAREN SHARP WITH
 
 parse_pattern: LPAREN STRING DOTDOT WITH
 ##
-## Ends in an error in state: 685.
+## Ends in an error in state: 701.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ##
@@ -1248,7 +1248,7 @@ parse_pattern: LPAREN STRING DOTDOT WITH
 
 parse_pattern: LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 694.
+## Ends in an error in state: 710.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ error WITH UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS AND ]
 ##
@@ -1260,7 +1260,7 @@ parse_pattern: LPAREN UIDENT DOT WITH
 
 parse_pattern: LPAREN UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 673.
+## Ends in an error in state: 689.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1282,7 +1282,7 @@ parse_pattern: LPAREN UIDENT LPAREN WITH
 
 parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 704.
+## Ends in an error in state: 720.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1295,7 +1295,7 @@ parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE AS LPAREN WITH
 ##
-## Ends in an error in state: 719.
+## Ends in an error in state: 735.
 ##
 ## val_ident -> LPAREN . operator RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -1307,7 +1307,7 @@ parse_pattern: LPAREN UNDERSCORE AS LPAREN WITH
 
 parse_pattern: LPAREN UNDERSCORE AS WITH
 ##
-## Ends in an error in state: 717.
+## Ends in an error in state: 733.
 ##
 ## _pattern_without_or -> pattern_without_or AS . val_ident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> pattern_without_or AS . error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -1320,7 +1320,7 @@ parse_pattern: LPAREN UNDERSCORE AS WITH
 
 parse_pattern: LPAREN UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 734.
+## Ends in an error in state: 750.
 ##
 ## _or_pattern -> pattern BAR . pattern [ error SEMI RPAREN RBRACKET RBRACE COMMA COLON BARRBRACKET BAR ]
 ##
@@ -1345,7 +1345,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BACKQUOTE LIDENT GREATER
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 160, spurious reduction of production attributes ->
-## In state 2525, spurious reduction of production tag_field -> name_tag attributes
+## In state 2589, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
@@ -1555,7 +1555,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LESS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2416.
+## Ends in an error in state: 2480.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1774,7 +1774,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 843.
+## Ends in an error in state: 859.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1789,7 +1789,7 @@ parse_pattern: LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 716.
+## Ends in an error in state: 732.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -1806,7 +1806,7 @@ parse_pattern: LPAREN UNDERSCORE COLONCOLON UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLONCOLON WITH
 ##
-## Ends in an error in state: 714.
+## Ends in an error in state: 730.
 ##
 ## _pattern_without_or -> pattern_without_or COLONCOLON . pattern_without_or [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> pattern_without_or COLONCOLON . error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -1819,7 +1819,7 @@ parse_pattern: LPAREN UNDERSCORE COLONCOLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 727.
+## Ends in an error in state: 743.
 ##
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1831,7 +1831,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 799.
+## Ends in an error in state: 815.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ RPAREN COMMA ]
 ##
@@ -1843,7 +1843,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ##
-## Ends in an error in state: 838.
+## Ends in an error in state: 854.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -1855,18 +1855,18 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 787, spurious reduction of production pattern -> pattern_without_or
-## In state 798, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 807, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 806, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 810, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 803, spurious reduction of production pattern -> pattern_without_or
+## In state 814, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 823, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 822, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 826, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 809.
+## Ends in an error in state: 825.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1878,7 +1878,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 808.
+## Ends in an error in state: 824.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint . COMMA pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1889,10 +1889,10 @@ parse_pattern: LPAREN UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 713, spurious reduction of production pattern -> pattern_without_or
-## In state 840, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 807, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 806, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 729, spurious reduction of production pattern -> pattern_without_or
+## In state 856, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 823, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 822, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
 ##
 
 <SYNTAX ERROR>
@@ -1967,7 +1967,7 @@ parse_pattern: SHARP WITH
 
 parse_pattern: STRING DOTDOT WITH
 ##
-## Ends in an error in state: 764.
+## Ends in an error in state: 780.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ##
@@ -1979,7 +1979,7 @@ parse_pattern: STRING DOTDOT WITH
 
 parse_pattern: UIDENT DOT WITH
 ##
-## Ends in an error in state: 592.
+## Ends in an error in state: 608.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ WITH WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS AND ]
 ##
@@ -1991,7 +1991,7 @@ parse_pattern: UIDENT DOT WITH
 
 parse_pattern: UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 628.
+## Ends in an error in state: 644.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -2013,7 +2013,7 @@ parse_pattern: UIDENT LPAREN WITH
 
 parse_pattern: UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 783.
+## Ends in an error in state: 799.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -2026,7 +2026,7 @@ parse_pattern: UIDENT UNDERSCORE WITH
 
 parse_pattern: UNDERSCORE AS WITH
 ##
-## Ends in an error in state: 791.
+## Ends in an error in state: 807.
 ##
 ## _pattern_without_or -> pattern_without_or AS . val_ident [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> pattern_without_or AS . error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -2039,7 +2039,7 @@ parse_pattern: UNDERSCORE AS WITH
 
 parse_pattern: UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 801.
+## Ends in an error in state: 817.
 ##
 ## _or_pattern -> pattern BAR . pattern [ WHEN SEMI RPAREN RBRACKET IN EQUALGREATER EQUAL EOF COMMA COLON BAR ]
 ##
@@ -2051,7 +2051,7 @@ parse_pattern: UNDERSCORE BAR WITH
 
 parse_pattern: UNDERSCORE COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 790.
+## Ends in an error in state: 806.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -2068,7 +2068,7 @@ parse_pattern: UNDERSCORE COLONCOLON UNDERSCORE WITH
 
 parse_pattern: UNDERSCORE COLONCOLON WITH
 ##
-## Ends in an error in state: 788.
+## Ends in an error in state: 804.
 ##
 ## _pattern_without_or -> pattern_without_or COLONCOLON . pattern_without_or [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> pattern_without_or COLONCOLON . error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -2081,7 +2081,7 @@ parse_pattern: UNDERSCORE COLONCOLON WITH
 
 parse_pattern: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2632.
+## Ends in an error in state: 2719.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EOF BAR ]
 ## parse_pattern -> pattern . EOF [ # ]
@@ -2093,14 +2093,14 @@ parse_pattern: UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 787, spurious reduction of production pattern -> pattern_without_or
+## In state 803, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: WITH
 ##
-## Ends in an error in state: 2631.
+## Ends in an error in state: 2718.
 ##
 ## parse_pattern' -> . parse_pattern [ # ]
 ##
@@ -2112,7 +2112,7 @@ parse_pattern: WITH
 
 parse_expression: UIDENT SEMI
 ##
-## Ends in an error in state: 2629.
+## Ends in an error in state: 2716.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -2146,21 +2146,21 @@ parse_expression: UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 parse_expression: WITH
 ##
-## Ends in an error in state: 2627.
+## Ends in an error in state: 2714.
 ##
 ## parse_expression' -> . parse_expression [ # ]
 ##
@@ -2172,7 +2172,7 @@ parse_expression: WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 2519.
+## Ends in an error in state: 2583.
 ##
 ## tag_field -> name_tag opt_ampersand . amper_type_list attributes [ RBRACKET GREATER BAR ]
 ##
@@ -2184,7 +2184,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 ##
-## Ends in an error in state: 2522.
+## Ends in an error in state: 2586.
 ##
 ## amper_type_list -> amper_type_list AMPERSAND . core_type [ RBRACKET LBRACKETAT GREATER BAR AMPERSAND ]
 ##
@@ -2196,7 +2196,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ##
-## Ends in an error in state: 2526.
+## Ends in an error in state: 2590.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET tag_field . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field -> tag_field . [ BAR ]
@@ -2209,7 +2209,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 160, spurious reduction of production attributes ->
-## In state 2525, spurious reduction of production tag_field -> name_tag attributes
+## In state 2589, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
@@ -2241,7 +2241,7 @@ parse_core_type: LBRACKET BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 2530.
+## Ends in an error in state: 2594.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2254,7 +2254,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 2529.
+## Ends in an error in state: 2593.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2266,7 +2266,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE WITH
 ##
-## Ends in an error in state: 2528.
+## Ends in an error in state: 2592.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field . BAR row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2304,7 +2304,7 @@ parse_core_type: LBRACKETGREATER BAR ASSERT
 
 parse_core_type: LBRACKETGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 2532.
+## Ends in an error in state: 2596.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2355,7 +2355,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2537.
+## Ends in an error in state: 2601.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER name_tag_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## name_tag_list -> name_tag_list . name_tag [ RBRACKET BACKQUOTE ]
@@ -2368,7 +2368,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 ##
-## Ends in an error in state: 2536.
+## Ends in an error in state: 2600.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER . name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2380,7 +2380,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE WITH
 ##
-## Ends in an error in state: 2534.
+## Ends in an error in state: 2598.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . GREATER name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2432,7 +2432,7 @@ parse_core_type: LESS LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 ##
-## Ends in an error in state: 495.
+## Ends in an error in state: 510.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ##
@@ -2444,7 +2444,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 492.
+## Ends in an error in state: 507.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -2457,7 +2457,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE WITH
 ##
-## Ends in an error in state: 493.
+## Ends in an error in state: 508.
 ##
 ## typevar_list -> typevar_list QUOTE . ident [ QUOTE DOT ]
 ##
@@ -2500,11 +2500,11 @@ parse_core_type: LESS LIDENT COLON UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 502, spurious reduction of production _poly_type -> core_type
-## In state 503, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 501, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 2539, spurious reduction of production attributes ->
-## In state 2540, spurious reduction of production field -> label COLON poly_type attributes
+## In state 517, spurious reduction of production _poly_type -> core_type
+## In state 518, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 516, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 2603, spurious reduction of production attributes ->
+## In state 2604, spurious reduction of production field -> label COLON poly_type attributes
 ##
 
 <SYNTAX ERROR>
@@ -2547,7 +2547,7 @@ parse_core_type: LESS WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2545.
+## Ends in an error in state: 2609.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2559,7 +2559,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 ##
-## Ends in an error in state: 2543.
+## Ends in an error in state: 2607.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2571,7 +2571,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 ##
-## Ends in an error in state: 2542.
+## Ends in an error in state: 2606.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION . EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2583,7 +2583,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2541.
+## Ends in an error in state: 2605.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . QUESTION EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2675,7 +2675,7 @@ parse_core_type: LPAREN MODULE UIDENT SEMI
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2550.
+## Ends in an error in state: 2614.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ RPAREN COLONGREATER ]
 ##
@@ -2687,7 +2687,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER A
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2549.
+## Ends in an error in state: 2613.
 ##
 ## package_type_cstrs -> package_type_cstr . [ RPAREN COLONGREATER ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ RPAREN COLONGREATER ]
@@ -2705,7 +2705,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER W
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2547, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 2611, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
@@ -2784,7 +2784,7 @@ parse_core_type: LPAREN UNDERSCORE COMMA WITH
 
 parse_core_type: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2552.
+## Ends in an error in state: 2616.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN core_type_comma_list . RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## core_type_comma_list -> core_type_comma_list . COMMA core_type [ RPAREN COMMA ]
@@ -2823,7 +2823,7 @@ parse_core_type: QUOTE WITH
 
 parse_core_type: SHARP LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 2554.
+## Ends in an error in state: 2618.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP class_longident non_arrowed_simple_core_type_list . [ WITH SEMI RPAREN RBRACKET RBRACE QUESTION LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2990,7 +2990,7 @@ parse_core_type: UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2625.
+## Ends in an error in state: 2712.
 ##
 ## parse_core_type -> core_type . EOF [ # ]
 ##
@@ -3013,7 +3013,7 @@ parse_core_type: UNDERSCORE WITH
 
 parse_core_type: WITH
 ##
-## Ends in an error in state: 2623.
+## Ends in an error in state: 2710.
 ##
 ## parse_core_type' -> . parse_core_type [ # ]
 ##
@@ -3025,7 +3025,7 @@ parse_core_type: WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 ##
-## Ends in an error in state: 1749.
+## Ends in an error in state: 1788.
 ##
 ## and_class_description -> AND . class_description_details post_item_attributes [ SEMI AND ]
 ##
@@ -3037,7 +3037,7 @@ interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ##
-## Ends in an error in state: 1748.
+## Ends in an error in state: 1787.
 ##
 ## _signature_item -> many_class_descriptions . [ SEMI ]
 ## many_class_descriptions -> many_class_descriptions . and_class_description [ SEMI AND ]
@@ -3049,22 +3049,22 @@ interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1632, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1636, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1630, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1634, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1645, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1643, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
-## In state 1731, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
-## In state 1732, spurious reduction of production post_item_attributes ->
-## In state 1733, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
+## In state 1671, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1675, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1669, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1673, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1684, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1682, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1770, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
+## In state 1771, spurious reduction of production post_item_attributes ->
+## In state 1772, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 1730.
+## Ends in an error in state: 1769.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters COLON . class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -3076,7 +3076,7 @@ interface: CLASS LIDENT COLON WITH
 
 interface: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1654.
+## Ends in an error in state: 1693.
 ##
 ## type_parameter -> type_variance . type_variable [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLON CHAR BACKQUOTE ]
 ##
@@ -3088,7 +3088,7 @@ interface: CLASS LIDENT PLUS WITH
 
 interface: CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1729.
+## Ends in an error in state: 1768.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters . COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS COLON ]
@@ -3101,7 +3101,7 @@ interface: CLASS LIDENT WITH
 
 interface: CLASS TYPE LIDENT EQUAL LIDENT RBRACKET
 ##
-## Ends in an error in state: 1747.
+## Ends in an error in state: 1786.
 ##
 ## _signature_item -> many_class_type_declarations . [ SEMI ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ SEMI AND ]
@@ -3113,19 +3113,19 @@ interface: CLASS TYPE LIDENT EQUAL LIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1632, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1636, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1630, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1704, spurious reduction of production class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type
-## In state 1705, spurious reduction of production post_item_attributes ->
-## In state 1706, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
+## In state 1671, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1675, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1669, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1743, spurious reduction of production class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type
+## In state 1744, spurious reduction of production post_item_attributes ->
+## In state 1745, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 1727.
+## Ends in an error in state: 1766.
 ##
 ## class_description_details -> virtual_flag . LIDENT class_type_parameters COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -3137,7 +3137,7 @@ interface: CLASS VIRTUAL LET
 
 interface: CLASS WITH
 ##
-## Ends in an error in state: 1726.
+## Ends in an error in state: 1765.
 ##
 ## many_class_descriptions -> CLASS . class_description_details post_item_attributes [ SEMI AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ SEMI AND ]
@@ -3150,19 +3150,19 @@ interface: CLASS WITH
 
 interface: EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 945.
+## Ends in an error in state: 951.
 ##
-## extension_constructor_declaration -> constr_ident . generalized_constructor_arguments attributes [ SEMI LBRACKETATAT BAR ]
+## extension_constructor_declaration -> UIDENT . generalized_constructor_arguments attributes [ SEMI LBRACKETATAT BAR ]
 ##
 ## The known suffix of the stack is as follows:
-## constr_ident
+## UIDENT
 ##
 
 <SYNTAX ERROR>
 
 interface: EXCEPTION WITH
 ##
-## Ends in an error in state: 1723.
+## Ends in an error in state: 1762.
 ##
 ## sig_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ SEMI ]
 ##
@@ -3174,7 +3174,7 @@ interface: EXCEPTION WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1720.
+## Ends in an error in state: 1759.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3186,7 +3186,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1719.
+## Ends in an error in state: 1758.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3209,7 +3209,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 interface: EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1718.
+## Ends in an error in state: 1757.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3221,7 +3221,7 @@ interface: EXTERNAL LIDENT COLON WITH
 
 interface: EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 1717.
+## Ends in an error in state: 1756.
 ##
 ## _signature_item -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3233,7 +3233,7 @@ interface: EXTERNAL LIDENT WITH
 
 interface: EXTERNAL WITH
 ##
-## Ends in an error in state: 1716.
+## Ends in an error in state: 1755.
 ##
 ## _signature_item -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3245,7 +3245,7 @@ interface: EXTERNAL WITH
 
 interface: INCLUDE LBRACE OPEN UIDENT WITH
 ##
-## Ends in an error in state: 1734.
+## Ends in an error in state: 1773.
 ##
 ## signature -> signature_item . SEMI signature [ error RBRACE ]
 ##
@@ -3257,17 +3257,17 @@ interface: INCLUDE LBRACE OPEN UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 402, spurious reduction of production post_item_attributes ->
-## In state 2411, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 1739, spurious reduction of production _signature_item -> open_statement
-## In state 1756, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 1740, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 2475, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 1778, spurious reduction of production _signature_item -> open_statement
+## In state 1795, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 1779, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 1735.
+## Ends in an error in state: 1774.
 ##
 ## signature -> signature_item SEMI . signature [ error RBRACE ]
 ##
@@ -3279,7 +3279,7 @@ interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 
 interface: INCLUDE LBRACE WITH
 ##
-## Ends in an error in state: 923.
+## Ends in an error in state: 939.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LBRACE . signature error [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3292,7 +3292,7 @@ interface: INCLUDE LBRACE WITH
 
 interface: INCLUDE LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 1914.
+## Ends in an error in state: 1953.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## _simple_module_type -> LBRACE . signature error [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3305,7 +3305,7 @@ interface: INCLUDE LPAREN LBRACE WITH
 
 interface: INCLUDE LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 2317.
+## Ends in an error in state: 2381.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3321,7 +3321,7 @@ interface: INCLUDE LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 1921.
+## Ends in an error in state: 1960.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3337,7 +3337,7 @@ interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 1972.
+## Ends in an error in state: 2011.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3352,7 +3352,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LID
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1971.
+## Ends in an error in state: 2010.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3364,7 +3364,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WIT
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1970.
+## Ends in an error in state: 2009.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3376,7 +3376,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1969.
+## Ends in an error in state: 2008.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3392,22 +3392,22 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 964, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 986, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1022, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1018, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 984, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1023, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1019, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 985, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1024, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1020, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1968.
+## Ends in an error in state: 2007.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3419,7 +3419,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1967.
+## Ends in an error in state: 2006.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3431,7 +3431,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 1913.
+## Ends in an error in state: 1952.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3445,7 +3445,7 @@ interface: INCLUDE LPAREN LPAREN WITH
 
 interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2316.
+## Ends in an error in state: 2380.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER ]
@@ -3459,19 +3459,19 @@ interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2049, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2053, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2050, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 2022, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2055, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2054, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN MODULE TYPE WITH
 ##
-## Ends in an error in state: 553.
+## Ends in an error in state: 569.
 ##
 ## _non_arrowed_module_type -> MODULE TYPE . module_expr [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3483,7 +3483,7 @@ interface: INCLUDE LPAREN MODULE TYPE WITH
 
 interface: INCLUDE LPAREN MODULE WITH
 ##
-## Ends in an error in state: 552.
+## Ends in an error in state: 568.
 ##
 ## _non_arrowed_module_type -> MODULE . TYPE module_expr [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3495,7 +3495,7 @@ interface: INCLUDE LPAREN MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 ##
-## Ends in an error in state: 646.
+## Ends in an error in state: 662.
 ##
 ## ident -> UIDENT . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## mod_ext2 -> mod_ext_longident DOT UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -3509,7 +3509,7 @@ interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 645.
+## Ends in an error in state: 661.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -3523,7 +3523,7 @@ interface: INCLUDE LPAREN UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 1958.
+## Ends in an error in state: 1997.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3538,7 +3538,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1957.
+## Ends in an error in state: 1996.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3550,7 +3550,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 644.
+## Ends in an error in state: 660.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -3570,7 +3570,7 @@ interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UIDENT WHILE
 ##
-## Ends in an error in state: 551.
+## Ends in an error in state: 567.
 ##
 ## functor_arg_name -> UIDENT . [ COLON ]
 ## ident -> UIDENT . [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3585,7 +3585,7 @@ interface: INCLUDE LPAREN UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 ##
-## Ends in an error in state: 1940.
+## Ends in an error in state: 1979.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
@@ -3598,7 +3598,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1937.
+## Ends in an error in state: 1976.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ RPAREN LPAREN DOT ]
 ## mod_ext2 -> UIDENT LPAREN mod_ext_longident . RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
@@ -3618,7 +3618,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UID
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1936.
+## Ends in an error in state: 1975.
 ##
 ## mod_ext2 -> UIDENT LPAREN . mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
 ##
@@ -3643,7 +3643,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WIT
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1934.
+## Ends in an error in state: 1973.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ##
@@ -3655,7 +3655,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 1949.
+## Ends in an error in state: 1988.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3668,7 +3668,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 ##
-## Ends in an error in state: 1935.
+## Ends in an error in state: 1974.
 ##
 ## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
 ## mod_ext_longident -> UIDENT . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
@@ -3681,7 +3681,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1950.
+## Ends in an error in state: 1989.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ##
@@ -3693,7 +3693,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1933.
+## Ends in an error in state: 1972.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3706,7 +3706,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 1932.
+## Ends in an error in state: 1971.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3719,7 +3719,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 1953.
+## Ends in an error in state: 1992.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ##
@@ -3731,7 +3731,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER A
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER EQUAL
 ##
-## Ends in an error in state: 1952.
+## Ends in an error in state: 1991.
 ##
 ## _module_type -> module_type WITH with_constraints . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## with_constraints -> with_constraints . AND with_constraint [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3749,15 +3749,15 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER E
 ## In state 445, spurious reduction of production _core_type -> core_type2
 ## In state 454, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 444, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1928, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1955, spurious reduction of production with_constraints -> with_constraint
+## In state 1967, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1994, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1927.
+## Ends in an error in state: 1966.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ##
@@ -3769,7 +3769,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1929.
+## Ends in an error in state: 1968.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ##
@@ -3781,7 +3781,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ##
-## Ends in an error in state: 1931.
+## Ends in an error in state: 1970.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3799,14 +3799,14 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ## In state 445, spurious reduction of production _core_type -> core_type2
 ## In state 454, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 444, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1930, spurious reduction of production constraints ->
+## In state 1969, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ##
-## Ends in an error in state: 1926.
+## Ends in an error in state: 1965.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3818,14 +3818,14 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 535, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 551, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 1924.
+## Ends in an error in state: 1963.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3838,7 +3838,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH WITH
 ##
-## Ends in an error in state: 1923.
+## Ends in an error in state: 1962.
 ##
 ## _module_type -> module_type WITH . with_constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3850,7 +3850,7 @@ interface: INCLUDE LPAREN UIDENT WITH WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2325.
+## Ends in an error in state: 2389.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3866,22 +3866,22 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COL
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 964, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 986, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1022, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1018, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 984, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1023, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1019, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 985, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1024, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1020, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2324.
+## Ends in an error in state: 2388.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3893,7 +3893,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2323.
+## Ends in an error in state: 2387.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3905,7 +3905,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2322.
+## Ends in an error in state: 2386.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3921,22 +3921,22 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 964, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 986, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1022, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1018, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 984, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1023, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1019, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 985, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1024, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1020, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2321.
+## Ends in an error in state: 2385.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3948,7 +3948,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2320.
+## Ends in an error in state: 2384.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3960,7 +3960,7 @@ interface: INCLUDE LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN WITH
 ##
-## Ends in an error in state: 550.
+## Ends in an error in state: 566.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3974,7 +3974,7 @@ interface: INCLUDE LPAREN WITH
 
 interface: INCLUDE MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2405.
+## Ends in an error in state: 2469.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
@@ -3988,12 +3988,12 @@ interface: INCLUDE MODULE TYPE UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 857, spurious reduction of production _module_expr -> simple_module_expr
-## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 931, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 935, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 932, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 873, spurious reduction of production _module_expr -> simple_module_expr
+## In state 937, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 936, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
@@ -4052,7 +4052,7 @@ interface: INCLUDE UIDENT DOT WITH
 
 interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 994.
+## Ends in an error in state: 1016.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4068,22 +4068,22 @@ interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 964, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 986, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1022, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1018, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 984, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1023, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1019, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 985, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1024, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1020, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 993.
+## Ends in an error in state: 1015.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4143,7 +4143,7 @@ interface: INCLUDE UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 984.
+## Ends in an error in state: 1006.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4155,7 +4155,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 986.
+## Ends in an error in state: 1008.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4181,7 +4181,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 987.
+## Ends in an error in state: 1009.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4193,7 +4193,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 983.
+## Ends in an error in state: 1005.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4206,7 +4206,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 982.
+## Ends in an error in state: 1004.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4219,7 +4219,7 @@ interface: INCLUDE UIDENT WITH MODULE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 990.
+## Ends in an error in state: 1012.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4231,7 +4231,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ##
-## Ends in an error in state: 989.
+## Ends in an error in state: 1011.
 ##
 ## _module_type -> module_type WITH with_constraints . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraints -> with_constraints . AND with_constraint [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4249,15 +4249,15 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 973, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 992, spurious reduction of production with_constraints -> with_constraint
+## In state 995, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1014, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 972.
+## Ends in an error in state: 994.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4269,7 +4269,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 974.
+## Ends in an error in state: 996.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4281,7 +4281,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ##
-## Ends in an error in state: 976.
+## Ends in an error in state: 998.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4299,14 +4299,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 975, spurious reduction of production constraints ->
+## In state 997, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 970.
+## Ends in an error in state: 992.
 ##
 ## with_type_binder -> EQUAL . [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
 ## with_type_binder -> EQUAL . PRIVATE [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
@@ -4319,7 +4319,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ##
-## Ends in an error in state: 969.
+## Ends in an error in state: 991.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4331,14 +4331,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 968, spurious reduction of production optional_type_parameters ->
+## In state 990, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 967.
+## Ends in an error in state: 989.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4351,7 +4351,7 @@ interface: INCLUDE UIDENT WITH TYPE WITH
 
 interface: INCLUDE UIDENT WITH WITH
 ##
-## Ends in an error in state: 966.
+## Ends in an error in state: 988.
 ##
 ## _module_type -> module_type WITH . with_constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4363,7 +4363,7 @@ interface: INCLUDE UIDENT WITH WITH
 
 interface: INCLUDE WITH
 ##
-## Ends in an error in state: 1713.
+## Ends in an error in state: 1752.
 ##
 ## _signature_item -> INCLUDE . module_type post_item_attributes [ SEMI ]
 ##
@@ -4375,7 +4375,7 @@ interface: INCLUDE WITH
 
 interface: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 1032.
+## Ends in an error in state: 1054.
 ##
 ## _signature_item -> LET val_ident COLON . core_type post_item_attributes [ SEMI ]
 ##
@@ -4387,7 +4387,7 @@ interface: LET LIDENT COLON WITH
 
 interface: LET LIDENT WITH
 ##
-## Ends in an error in state: 1031.
+## Ends in an error in state: 1053.
 ##
 ## _signature_item -> LET val_ident . COLON core_type post_item_attributes [ SEMI ]
 ##
@@ -4399,7 +4399,7 @@ interface: LET LIDENT WITH
 
 interface: LET LPAREN WITH
 ##
-## Ends in an error in state: 793.
+## Ends in an error in state: 809.
 ##
 ## val_ident -> LPAREN . operator RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -4411,7 +4411,7 @@ interface: LET LPAREN WITH
 
 interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
 ##
-## Ends in an error in state: 1743.
+## Ends in an error in state: 1782.
 ##
 ## and_module_rec_declaration -> AND . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4423,7 +4423,7 @@ interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
 
 interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1742.
+## Ends in an error in state: 1781.
 ##
 ## _signature_item -> many_module_rec_declarations . [ SEMI ]
 ## many_module_rec_declarations -> many_module_rec_declarations . and_module_rec_declaration [ SEMI AND ]
@@ -4435,16 +4435,16 @@ interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 928, spurious reduction of production post_item_attributes ->
-## In state 929, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1030, spurious reduction of production many_module_rec_declarations -> LET MODULE REC module_rec_declaration_details post_item_attributes
+## In state 944, spurious reduction of production post_item_attributes ->
+## In state 945, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1052, spurious reduction of production many_module_rec_declarations -> LET MODULE REC module_rec_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 1028.
+## Ends in an error in state: 1050.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -4460,22 +4460,22 @@ interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 964, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 986, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1022, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1018, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 984, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1023, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1019, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 985, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1024, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1020, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON WITH
 ##
-## Ends in an error in state: 1027.
+## Ends in an error in state: 1049.
 ##
 ## module_rec_declaration_details -> UIDENT COLON . module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4487,7 +4487,7 @@ interface: LET MODULE REC UIDENT COLON WITH
 
 interface: LET MODULE REC UIDENT WITH
 ##
-## Ends in an error in state: 1026.
+## Ends in an error in state: 1048.
 ##
 ## module_rec_declaration_details -> UIDENT . COLON module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4499,7 +4499,7 @@ interface: LET MODULE REC UIDENT WITH
 
 interface: LET MODULE REC WITH
 ##
-## Ends in an error in state: 1025.
+## Ends in an error in state: 1047.
 ##
 ## many_module_rec_declarations -> LET MODULE REC . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4511,7 +4511,7 @@ interface: LET MODULE REC WITH
 
 interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 1014.
+## Ends in an error in state: 1036.
 ##
 ## _module_declaration -> COLON module_type . [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -4527,22 +4527,22 @@ interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 964, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 986, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1022, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1018, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 984, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1023, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1019, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 985, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1024, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1020, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 1013.
+## Ends in an error in state: 1035.
 ##
 ## _module_declaration -> COLON . module_type [ SEMI LBRACKETATAT ]
 ##
@@ -4554,7 +4554,7 @@ interface: LET MODULE UIDENT COLON WITH
 
 interface: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1020.
+## Ends in an error in state: 1042.
 ##
 ## _signature_item -> LET MODULE UIDENT EQUAL . mod_longident post_item_attributes [ SEMI ]
 ##
@@ -4566,7 +4566,7 @@ interface: LET MODULE UIDENT EQUAL WITH
 
 interface: LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1018.
+## Ends in an error in state: 1040.
 ##
 ## _module_declaration -> LPAREN RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4578,7 +4578,7 @@ interface: LET MODULE UIDENT LPAREN RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1012.
+## Ends in an error in state: 1034.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4590,7 +4590,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1011.
+## Ends in an error in state: 1033.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type . RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -4606,22 +4606,22 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 964, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 986, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1022, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1018, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 984, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1023, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1019, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 985, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1024, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1020, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1010.
+## Ends in an error in state: 1032.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON . module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4633,7 +4633,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1009.
+## Ends in an error in state: 1031.
 ##
 ## _module_declaration -> LPAREN UIDENT . COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4645,7 +4645,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT WITH
 
 interface: LET MODULE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1008.
+## Ends in an error in state: 1030.
 ##
 ## _module_declaration -> LPAREN . UIDENT COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_declaration -> LPAREN . RPAREN module_declaration [ SEMI LBRACKETATAT ]
@@ -4658,7 +4658,7 @@ interface: LET MODULE UIDENT LPAREN WITH
 
 interface: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1007.
+## Ends in an error in state: 1029.
 ##
 ## _signature_item -> LET MODULE UIDENT . module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> LET MODULE UIDENT . EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4671,7 +4671,7 @@ interface: LET MODULE UIDENT WITH
 
 interface: LET MODULE WITH
 ##
-## Ends in an error in state: 1006.
+## Ends in an error in state: 1028.
 ##
 ## _signature_item -> LET MODULE . UIDENT module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> LET MODULE . UIDENT EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4685,7 +4685,7 @@ interface: LET MODULE WITH
 
 interface: LET WITH
 ##
-## Ends in an error in state: 1005.
+## Ends in an error in state: 1027.
 ##
 ## _signature_item -> LET . val_ident COLON core_type post_item_attributes [ SEMI ]
 ## _signature_item -> LET . MODULE UIDENT module_declaration post_item_attributes [ SEMI ]
@@ -4700,7 +4700,7 @@ interface: LET WITH
 
 interface: MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 961.
+## Ends in an error in state: 983.
 ##
 ## _signature_item -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ SEMI ]
 ##
@@ -4712,7 +4712,7 @@ interface: MODULE TYPE UIDENT EQUAL WITH
 
 interface: MODULE TYPE WITH
 ##
-## Ends in an error in state: 959.
+## Ends in an error in state: 981.
 ##
 ## _signature_item -> MODULE TYPE . ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4725,7 +4725,7 @@ interface: MODULE TYPE WITH
 
 interface: MODULE WITH
 ##
-## Ends in an error in state: 958.
+## Ends in an error in state: 980.
 ##
 ## _signature_item -> MODULE . TYPE ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4738,7 +4738,7 @@ interface: MODULE WITH
 
 interface: OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2617.
+## Ends in an error in state: 2704.
 ##
 ## signature -> signature_item . SEMI signature [ EOF ]
 ##
@@ -4750,17 +4750,17 @@ interface: OPEN UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 402, spurious reduction of production post_item_attributes ->
-## In state 2411, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 1739, spurious reduction of production _signature_item -> open_statement
-## In state 1756, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 1740, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 2475, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 1778, spurious reduction of production _signature_item -> open_statement
+## In state 1795, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 1779, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 934.
+## Ends in an error in state: 950.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4772,7 +4772,7 @@ interface: TYPE LIDENT PLUSEQ BAR WITH
 
 interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 933.
+## Ends in an error in state: 949.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4784,7 +4784,7 @@ interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 
 interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 942.
+## Ends in an error in state: 973.
 ##
 ## sig_extension_constructors -> sig_extension_constructors BAR . extension_constructor_declaration [ SEMI LBRACKETATAT BAR ]
 ##
@@ -4796,7 +4796,7 @@ interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 interface: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 931.
+## Ends in an error in state: 947.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4808,7 +4808,7 @@ interface: TYPE LIDENT PLUSEQ WITH
 
 interface: TYPE LIDENT RBRACKET
 ##
-## Ends in an error in state: 1741.
+## Ends in an error in state: 1780.
 ##
 ## _signature_item -> many_type_declarations . [ SEMI ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ SEMI AND ]
@@ -4822,17 +4822,17 @@ interface: TYPE LIDENT RBRACKET
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 89, spurious reduction of production optional_type_parameters ->
 ## In state 104, spurious reduction of production type_kind ->
-## In state 1136, spurious reduction of production constraints ->
-## In state 1137, spurious reduction of production type_declaration_details -> LIDENT optional_type_parameters type_kind constraints
-## In state 926, spurious reduction of production post_item_attributes ->
-## In state 927, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 1175, spurious reduction of production constraints ->
+## In state 1176, spurious reduction of production type_declaration_details -> LIDENT optional_type_parameters type_kind constraints
+## In state 942, spurious reduction of production post_item_attributes ->
+## In state 943, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2618.
+## Ends in an error in state: 2705.
 ##
 ## signature -> signature_item SEMI . signature [ EOF ]
 ##
@@ -4844,7 +4844,7 @@ interface: TYPE LIDENT SEMI WITH
 
 interface: TYPE NONREC LET
 ##
-## Ends in an error in state: 925.
+## Ends in an error in state: 941.
 ##
 ## many_type_declarations -> TYPE nonrec_flag . type_declaration_details post_item_attributes [ SEMI AND ]
 ## sig_type_extension -> TYPE nonrec_flag . potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
@@ -4857,7 +4857,7 @@ interface: TYPE NONREC LET
 
 interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ##
-## Ends in an error in state: 930.
+## Ends in an error in state: 946.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters . PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4868,15 +4868,15 @@ interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 535, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
-## In state 534, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
+## In state 551, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 550, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
 ##
 
 <SYNTAX ERROR>
 
 interface: WITH
 ##
-## Ends in an error in state: 2616.
+## Ends in an error in state: 2703.
 ##
 ## interface' -> . interface [ # ]
 ##
@@ -4888,7 +4888,7 @@ interface: WITH
 
 implementation: ASSERT WITH
 ##
-## Ends in an error in state: 889.
+## Ends in an error in state: 905.
 ##
 ## _expr -> ASSERT . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -4912,7 +4912,7 @@ implementation: BACKQUOTE WITH
 
 implementation: BANG WITH
 ##
-## Ends in an error in state: 568.
+## Ends in an error in state: 584.
 ##
 ## _simple_expr -> BANG . simple_expr [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -4924,7 +4924,7 @@ implementation: BANG WITH
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1649.
+## Ends in an error in state: 1688.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4936,7 +4936,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WIT
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1648.
+## Ends in an error in state: 1687.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4949,7 +4949,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE WITH
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1647.
+## Ends in an error in state: 1686.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4961,7 +4961,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON WITH
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1640.
+## Ends in an error in state: 1679.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4973,7 +4973,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE 
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 1639.
+## Ends in an error in state: 1678.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4986,7 +4986,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE 
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1638.
+## Ends in an error in state: 1677.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4998,7 +4998,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: CLASS LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1641.
+## Ends in an error in state: 1680.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -5010,7 +5010,7 @@ implementation: CLASS LIDENT COLON LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1637, spurious reduction of production type_longident -> LIDENT
+## In state 1676, spurious reduction of production type_longident -> LIDENT
 ## In state 261, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
 ## In state 266, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
 ## In state 264, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
@@ -5021,7 +5021,7 @@ implementation: CLASS LIDENT COLON LIDENT WITH
 
 implementation: CLASS LIDENT COLON NEW LIDENT EQUAL LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1653.
+## Ends in an error in state: 1692.
 ##
 ## _class_expr -> class_expr . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL class_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5034,7 +5034,7 @@ implementation: CLASS LIDENT COLON NEW LIDENT EQUAL LBRACKETPERCENT AND RBRACKET
 
 implementation: CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1652.
+## Ends in an error in state: 1691.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL . class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5046,7 +5046,7 @@ implementation: CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 
 implementation: CLASS LIDENT COLON NEW LIDENT RBRACKET
 ##
-## Ends in an error in state: 1634.
+## Ends in an error in state: 1673.
 ##
 ## _class_constructor_type -> NEW class_instance_type . [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _class_instance_type -> class_instance_type . attribute [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUAL AND ]
@@ -5058,16 +5058,16 @@ implementation: CLASS LIDENT COLON NEW LIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1632, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1636, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1630, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1671, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1675, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1669, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1651.
+## Ends in an error in state: 1690.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type . EQUAL class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5078,19 +5078,19 @@ implementation: CLASS LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1632, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1636, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1630, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1634, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1645, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1643, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1671, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1675, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1669, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1673, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1684, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1682, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1626.
+## Ends in an error in state: 1665.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -5102,7 +5102,7 @@ implementation: CLASS LIDENT COLON NEW WITH
 
 implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1642.
+## Ends in an error in state: 1681.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -5114,7 +5114,7 @@ implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 1625.
+## Ends in an error in state: 1664.
 ##
 ## _constrained_class_declaration -> COLON . class_constructor_type EQUAL class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5126,7 +5126,7 @@ implementation: CLASS LIDENT COLON WITH
 
 implementation: CLASS LIDENT EQUAL CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1610.
+## Ends in an error in state: 1649.
 ##
 ## _class_expr -> CLASS class_longident non_arrowed_simple_core_type_list . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ UNDERSCORE UIDENT SHARP SEMI RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
@@ -5139,7 +5139,7 @@ implementation: CLASS LIDENT EQUAL CLASS LIDENT UNDERSCORE WITH
 
 implementation: CLASS LIDENT EQUAL CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1609.
+## Ends in an error in state: 1648.
 ##
 ## _class_expr -> CLASS class_longident . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_expr -> CLASS class_longident . non_arrowed_simple_core_type_list [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -5152,7 +5152,7 @@ implementation: CLASS LIDENT EQUAL CLASS LIDENT WITH
 
 implementation: CLASS LIDENT EQUAL CLASS WITH
 ##
-## Ends in an error in state: 1608.
+## Ends in an error in state: 1647.
 ##
 ## _class_expr -> CLASS . class_longident [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_expr -> CLASS . class_longident non_arrowed_simple_core_type_list [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -5165,7 +5165,7 @@ implementation: CLASS LIDENT EQUAL CLASS WITH
 
 implementation: CLASS LIDENT EQUAL FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1617.
+## Ends in an error in state: 1656.
 ##
 ## _class_expr -> class_expr . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER class_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -5178,7 +5178,7 @@ implementation: CLASS LIDENT EQUAL FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT A
 
 implementation: CLASS LIDENT EQUAL FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1607.
+## Ends in an error in state: 1646.
 ##
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER . class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ##
@@ -5190,7 +5190,7 @@ implementation: CLASS LIDENT EQUAL FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT EQUAL FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1606.
+## Ends in an error in state: 1645.
 ##
 ## _class_fun_def -> labeled_simple_pattern . EQUALGREATER class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_fun_def -> labeled_simple_pattern . class_fun_def [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -5203,7 +5203,7 @@ implementation: CLASS LIDENT EQUAL FUN UNDERSCORE WITH
 
 implementation: CLASS LIDENT EQUAL FUN WITH
 ##
-## Ends in an error in state: 1604.
+## Ends in an error in state: 1643.
 ##
 ## _class_expr -> FUN . class_fun_def [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ##
@@ -5215,7 +5215,7 @@ implementation: CLASS LIDENT EQUAL FUN WITH
 
 implementation: CLASS LIDENT EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 1600.
+## Ends in an error in state: 1639.
 ##
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest RBRACE [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest error [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
@@ -5228,7 +5228,7 @@ implementation: CLASS LIDENT EQUAL LBRACE WITH
 
 implementation: CLASS LIDENT EQUAL LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1624.
+## Ends in an error in state: 1663.
 ##
 ## _class_expr -> class_expr . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5241,7 +5241,7 @@ implementation: CLASS LIDENT EQUAL LBRACKETPERCENT AND RBRACKET WITH
 
 implementation: CLASS LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1152.
+## Ends in an error in state: 1191.
 ##
 ## and_class_declaration -> AND . class_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5253,7 +5253,7 @@ implementation: CLASS LIDENT EQUAL LIDENT AND WITH
 
 implementation: CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1151.
+## Ends in an error in state: 1190.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_declarations . [ SEMI RBRACKET RBRACE EOF ]
 ## many_class_declarations -> many_class_declarations . and_class_declaration [ SEMI RBRACKET RBRACE EOF AND ]
@@ -5265,16 +5265,16 @@ implementation: CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 928, spurious reduction of production post_item_attributes ->
-## In state 929, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1708, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
+## In state 944, spurious reduction of production post_item_attributes ->
+## In state 945, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1747, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT EQUAL LIDENT UIDENT WITH
 ##
-## Ends in an error in state: 1615.
+## Ends in an error in state: 1654.
 ##
 ## _class_expr -> class_simple_expr simple_labeled_expr_list . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## simple_labeled_expr_list -> simple_labeled_expr_list . labeled_simple_expr [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
@@ -5286,20 +5286,20 @@ implementation: CLASS LIDENT EQUAL LIDENT UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 886, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1177, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1182, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
-## In state 1185, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 902, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1216, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1221, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
+## In state 1224, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT EQUAL LIDENT WITH
 ##
-## Ends in an error in state: 1614.
+## Ends in an error in state: 1653.
 ##
 ## _class_expr -> class_simple_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_expr -> class_simple_expr . simple_labeled_expr_list [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -5312,7 +5312,7 @@ implementation: CLASS LIDENT EQUAL LIDENT WITH
 
 implementation: CLASS LIDENT EQUAL LPAREN LIDENT COLON WITH
 ##
-## Ends in an error in state: 1596.
+## Ends in an error in state: 1635.
 ##
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type RPAREN [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type error [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
@@ -5325,7 +5325,7 @@ implementation: CLASS LIDENT EQUAL LPAREN LIDENT COLON WITH
 
 implementation: CLASS LIDENT EQUAL LPAREN LIDENT SEMI
 ##
-## Ends in an error in state: 1593.
+## Ends in an error in state: 1632.
 ##
 ## _class_expr -> class_expr . attribute [ error RPAREN LBRACKETAT COLON ]
 ## _class_simple_expr -> LPAREN class_expr . COLON class_constructor_type RPAREN [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
@@ -5340,16 +5340,16 @@ implementation: CLASS LIDENT EQUAL LPAREN LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1308, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1329, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1306, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1347, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1368, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1345, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 1159.
+## Ends in an error in state: 1198.
 ##
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type RPAREN [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type error [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
@@ -5364,7 +5364,7 @@ implementation: CLASS LIDENT EQUAL LPAREN WITH
 
 implementation: CLASS LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1158.
+## Ends in an error in state: 1197.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5376,7 +5376,7 @@ implementation: CLASS LIDENT EQUAL WITH
 
 implementation: CLASS LIDENT MINUS WITH
 ##
-## Ends in an error in state: 1157.
+## Ends in an error in state: 1196.
 ##
 ## signed_constant -> MINUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> MINUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -5393,7 +5393,7 @@ implementation: CLASS LIDENT MINUS WITH
 
 implementation: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1156.
+## Ends in an error in state: 1195.
 ##
 ## signed_constant -> PLUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> PLUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -5410,7 +5410,7 @@ implementation: CLASS LIDENT PLUS WITH
 
 implementation: CLASS LIDENT QUOTE WITH
 ##
-## Ends in an error in state: 1655.
+## Ends in an error in state: 1694.
 ##
 ## _type_variable -> QUOTE . ident [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLON CHAR BACKQUOTE ]
 ##
@@ -5422,7 +5422,7 @@ implementation: CLASS LIDENT QUOTE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1081.
+## Ends in an error in state: 1120.
 ##
 ## class_sig_body -> class_self_type . class_sig_fields opt_semi [ error RBRACE ]
 ##
@@ -5434,7 +5434,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 ##
-## Ends in an error in state: 1076.
+## Ends in an error in state: 1115.
 ##
 ## class_self_type -> AS core_type . SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -5457,7 +5457,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 ##
-## Ends in an error in state: 1075.
+## Ends in an error in state: 1114.
 ##
 ## class_self_type -> AS . core_type SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -5469,7 +5469,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1691.
+## Ends in an error in state: 1730.
 ##
 ## _class_sig_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5481,7 +5481,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1688.
+## Ends in an error in state: 1727.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT ]
 ## _class_sig_field -> INHERIT class_instance_type . [ error SEMI RBRACE ]
@@ -5494,16 +5494,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1571, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1575, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1569, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1610, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1614, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1608, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1687.
+## Ends in an error in state: 1726.
 ##
 ## _class_sig_field -> INHERIT . class_instance_type [ error SEMI RBRACE ]
 ## _class_sig_field -> INHERIT . class_instance_type item_attribute post_item_attributes [ error SEMI RBRACE ]
@@ -5516,7 +5516,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH RBRACKET WITH
 ##
-## Ends in an error in state: 1078.
+## Ends in an error in state: 1117.
 ##
 ## _class_instance_type -> LBRACE class_sig_body . RBRACE [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE class_sig_body . error [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5528,20 +5528,20 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1695, spurious reduction of production post_item_attributes ->
-## In state 1696, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
-## In state 1701, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
-## In state 1694, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
-## In state 1703, spurious reduction of production class_sig_fields -> class_sig_field
-## In state 1698, spurious reduction of production opt_semi ->
-## In state 1702, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
+## In state 1734, spurious reduction of production post_item_attributes ->
+## In state 1735, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
+## In state 1740, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
+## In state 1733, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
+## In state 1742, spurious reduction of production class_sig_fields -> class_sig_field
+## In state 1737, spurious reduction of production opt_semi ->
+## In state 1741, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 ##
-## Ends in an error in state: 1107.
+## Ends in an error in state: 1146.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label COLON . poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5553,7 +5553,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 ##
-## Ends in an error in state: 1106.
+## Ends in an error in state: 1145.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label . COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5565,7 +5565,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 ##
-## Ends in an error in state: 1103.
+## Ends in an error in state: 1142.
 ##
 ## private_virtual_flags -> PRIVATE . [ LIDENT ]
 ## private_virtual_flags -> PRIVATE . VIRTUAL [ LIDENT ]
@@ -5578,7 +5578,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1105.
+## Ends in an error in state: 1144.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags . label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5590,7 +5590,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 ##
-## Ends in an error in state: 1101.
+## Ends in an error in state: 1140.
 ##
 ## private_virtual_flags -> VIRTUAL . [ LIDENT ]
 ## private_virtual_flags -> VIRTUAL . PRIVATE [ LIDENT ]
@@ -5603,7 +5603,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 ##
-## Ends in an error in state: 1100.
+## Ends in an error in state: 1139.
 ##
 ## _class_sig_field -> METHOD . private_virtual_flags label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5615,7 +5615,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1098.
+## Ends in an error in state: 1137.
 ##
 ## value_type -> label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5627,7 +5627,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1097.
+## Ends in an error in state: 1136.
 ##
 ## value_type -> label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5639,7 +5639,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1091.
+## Ends in an error in state: 1130.
 ##
 ## value_type -> MUTABLE virtual_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5651,7 +5651,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 ##
-## Ends in an error in state: 1090.
+## Ends in an error in state: 1129.
 ##
 ## value_type -> MUTABLE virtual_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5663,7 +5663,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 ##
-## Ends in an error in state: 1089.
+## Ends in an error in state: 1128.
 ##
 ## value_type -> MUTABLE virtual_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5675,7 +5675,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1088.
+## Ends in an error in state: 1127.
 ##
 ## value_type -> MUTABLE . virtual_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5687,7 +5687,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1086.
+## Ends in an error in state: 1125.
 ##
 ## value_type -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5699,7 +5699,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1085.
+## Ends in an error in state: 1124.
 ##
 ## value_type -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5711,7 +5711,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1084.
+## Ends in an error in state: 1123.
 ##
 ## value_type -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5723,7 +5723,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1083.
+## Ends in an error in state: 1122.
 ##
 ## value_type -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5735,7 +5735,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 ##
-## Ends in an error in state: 1082.
+## Ends in an error in state: 1121.
 ##
 ## _class_sig_field -> VAL . value_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5747,7 +5747,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 ##
-## Ends in an error in state: 1074.
+## Ends in an error in state: 1113.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5760,7 +5760,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1672.
+## Ends in an error in state: 1711.
 ##
 ## _class_expr -> class_expr . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER class_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5773,7 +5773,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER LBRACKETPERCEN
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1671.
+## Ends in an error in state: 1710.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER . class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5785,7 +5785,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ##
-## Ends in an error in state: 1674.
+## Ends in an error in state: 1713.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## _non_arrowed_class_constructor_type -> class_instance_type . [ EQUALGREATER ]
@@ -5797,16 +5797,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1632, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1636, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1630, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1671, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1675, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1669, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1633.
+## Ends in an error in state: 1672.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
@@ -5819,7 +5819,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 ##
-## Ends in an error in state: 1632.
+## Ends in an error in state: 1671.
 ##
 ## _class_instance_type -> clty_longident . [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5832,7 +5832,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1670.
+## Ends in an error in state: 1709.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type . EQUALGREATER class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5844,7 +5844,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT RPAREN WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1668.
+## Ends in an error in state: 1707.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN class_constructor_type . RPAREN [ EQUALGREATER ]
 ##
@@ -5855,19 +5855,19 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1632, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1636, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1630, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1634, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1645, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1643, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1671, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1675, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1669, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1673, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1684, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1682, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 ##
-## Ends in an error in state: 1667.
+## Ends in an error in state: 1706.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN . class_constructor_type RPAREN [ EQUALGREATER ]
 ##
@@ -5879,7 +5879,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 ##
-## Ends in an error in state: 1628.
+## Ends in an error in state: 1667.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5893,7 +5893,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 ##
-## Ends in an error in state: 1627.
+## Ends in an error in state: 1666.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5913,7 +5913,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1666.
+## Ends in an error in state: 1705.
 ##
 ## class_fun_return -> COLON . non_arrowed_class_constructor_type EQUALGREATER class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5925,7 +5925,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1665.
+## Ends in an error in state: 1704.
 ##
 ## _class_expr -> class_expr . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> EQUALGREATER class_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5938,7 +5938,7 @@ implementation: CLASS LIDENT UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKE
 
 implementation: CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1664.
+## Ends in an error in state: 1703.
 ##
 ## class_fun_return -> EQUALGREATER . class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5950,7 +5950,7 @@ implementation: CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1663.
+## Ends in an error in state: 1702.
 ##
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_binding [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_return [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5963,7 +5963,7 @@ implementation: CLASS LIDENT UNDERSCORE WITH
 
 implementation: CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1155.
+## Ends in an error in state: 1194.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . class_fun_binding [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . constrained_class_declaration [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5978,7 +5978,7 @@ implementation: CLASS LIDENT WITH
 
 implementation: CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1147.
+## Ends in an error in state: 1186.
 ##
 ## and_class_type_declaration -> AND . class_type_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5990,7 +5990,7 @@ implementation: CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 
 implementation: CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1146.
+## Ends in an error in state: 1185.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_type_declarations . [ SEMI RBRACKET RBRACE EOF ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ SEMI RBRACKET RBRACE EOF AND ]
@@ -6002,16 +6002,16 @@ implementation: CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 928, spurious reduction of production post_item_attributes ->
-## In state 929, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1706, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
+## In state 944, spurious reduction of production post_item_attributes ->
+## In state 945, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1745, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1704.
+## Ends in an error in state: 1743.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -6023,16 +6023,16 @@ implementation: CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1632, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1636, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1630, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1671, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1675, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1669, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1072.
+## Ends in an error in state: 1111.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_instance_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -6044,7 +6044,7 @@ implementation: CLASS TYPE LIDENT EQUAL WITH
 
 implementation: CLASS TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1069.
+## Ends in an error in state: 1108.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters . EQUAL class_instance_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS EQUAL ]
@@ -6057,7 +6057,7 @@ implementation: CLASS TYPE LIDENT WITH
 
 implementation: CLASS TYPE VIRTUAL LET
 ##
-## Ends in an error in state: 1067.
+## Ends in an error in state: 1106.
 ##
 ## class_type_declaration_details -> virtual_flag . LIDENT class_type_parameters EQUAL class_instance_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -6069,7 +6069,7 @@ implementation: CLASS TYPE VIRTUAL LET
 
 implementation: CLASS TYPE WITH
 ##
-## Ends in an error in state: 1066.
+## Ends in an error in state: 1105.
 ##
 ## many_class_type_declarations -> CLASS TYPE . class_type_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -6081,7 +6081,7 @@ implementation: CLASS TYPE WITH
 
 implementation: CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 1153.
+## Ends in an error in state: 1192.
 ##
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters class_fun_binding [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters constrained_class_declaration [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -6095,7 +6095,7 @@ implementation: CLASS VIRTUAL LET
 
 implementation: CLASS WITH
 ##
-## Ends in an error in state: 1064.
+## Ends in an error in state: 1103.
 ##
 ## many_class_declarations -> CLASS . class_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
@@ -6108,9 +6108,10 @@ implementation: CLASS WITH
 
 implementation: EXCEPTION LPAREN WITH
 ##
-## Ends in an error in state: 937.
+## Ends in an error in state: 1084.
 ##
-## constr_ident2 -> LPAREN . RPAREN [ UNDERSCORE UIDENT SHARP SEMI RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUAL EOF CONSTRAINT COLON BAR AND ]
+## extension_constructor_declaration -> LPAREN . RPAREN generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
+## extension_constructor_rebind -> LPAREN . RPAREN EQUAL constr_longident attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -6120,7 +6121,7 @@ implementation: EXCEPTION LPAREN WITH
 
 implementation: EXCEPTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 946.
+## Ends in an error in state: 952.
 ##
 ## generalized_constructor_arguments -> COLON . core_type [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -6132,7 +6133,7 @@ implementation: EXCEPTION UIDENT COLON WITH
 
 implementation: EXCEPTION UIDENT EQUAL LBRACKET WITH
 ##
-## Ends in an error in state: 1059.
+## Ends in an error in state: 1077.
 ##
 ## constr_longident -> LBRACKET . RBRACKET [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -6144,7 +6145,7 @@ implementation: EXCEPTION UIDENT EQUAL LBRACKET WITH
 
 implementation: EXCEPTION UIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 1058.
+## Ends in an error in state: 1076.
 ##
 ## constr_longident -> LPAREN . RPAREN [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -6156,19 +6157,19 @@ implementation: EXCEPTION UIDENT EQUAL LPAREN WITH
 
 implementation: EXCEPTION UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1057.
+## Ends in an error in state: 1075.
 ##
-## extension_constructor_rebind -> constr_ident EQUAL . constr_longident attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
+## extension_constructor_rebind -> UIDENT EQUAL . constr_longident attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ##
 ## The known suffix of the stack is as follows:
-## constr_ident EQUAL
+## UIDENT EQUAL
 ##
 
 <SYNTAX ERROR>
 
 implementation: EXCEPTION UIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 949.
+## Ends in an error in state: 955.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list COLON . core_type [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -6180,7 +6181,7 @@ implementation: EXCEPTION UIDENT UNDERSCORE COLON WITH
 
 implementation: EXCEPTION UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 948.
+## Ends in an error in state: 954.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . COLON core_type [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
@@ -6194,20 +6195,20 @@ implementation: EXCEPTION UIDENT UNDERSCORE WITH
 
 implementation: EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1056.
+## Ends in an error in state: 1074.
 ##
-## extension_constructor_declaration -> constr_ident . generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
-## extension_constructor_rebind -> constr_ident . EQUAL constr_longident attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
+## extension_constructor_declaration -> UIDENT . generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
+## extension_constructor_rebind -> UIDENT . EQUAL constr_longident attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ##
 ## The known suffix of the stack is as follows:
-## constr_ident
+## UIDENT
 ##
 
 <SYNTAX ERROR>
 
 implementation: EXCEPTION WITH
 ##
-## Ends in an error in state: 1051.
+## Ends in an error in state: 1073.
 ##
 ## str_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ## str_exception_declaration -> EXCEPTION . extension_constructor_rebind post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
@@ -6220,7 +6221,7 @@ implementation: EXCEPTION WITH
 
 implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 ##
-## Ends in an error in state: 1047.
+## Ends in an error in state: 1069.
 ##
 ## primitive_declaration -> STRING . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ## primitive_declaration -> STRING . primitive_declaration [ SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
@@ -6233,7 +6234,7 @@ implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 
 implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1046.
+## Ends in an error in state: 1068.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6245,7 +6246,7 @@ implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1045.
+## Ends in an error in state: 1067.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6268,7 +6269,7 @@ implementation: EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 implementation: EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1044.
+## Ends in an error in state: 1066.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6280,7 +6281,7 @@ implementation: EXTERNAL LIDENT COLON WITH
 
 implementation: EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 1043.
+## Ends in an error in state: 1065.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6292,7 +6293,7 @@ implementation: EXTERNAL LIDENT WITH
 
 implementation: EXTERNAL WITH
 ##
-## Ends in an error in state: 1042.
+## Ends in an error in state: 1064.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6304,7 +6305,7 @@ implementation: EXTERNAL WITH
 
 implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ##
-## Ends in an error in state: 882.
+## Ends in an error in state: 898.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag simple_expr . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -6322,17 +6323,17 @@ implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 886, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 902, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FOR UNDERSCORE IN UIDENT TO WITH
 ##
-## Ends in an error in state: 881.
+## Ends in an error in state: 897.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag . simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6344,7 +6345,7 @@ implementation: FOR UNDERSCORE IN UIDENT TO WITH
 
 implementation: FOR UNDERSCORE IN UIDENT WITH
 ##
-## Ends in an error in state: 878.
+## Ends in an error in state: 894.
 ##
 ## _expr -> FOR pattern IN simple_expr . direction_flag simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ TO SHARP DOWNTO DOT ]
@@ -6362,17 +6363,17 @@ implementation: FOR UNDERSCORE IN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 886, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 902, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FOR UNDERSCORE IN WITH
 ##
-## Ends in an error in state: 877.
+## Ends in an error in state: 893.
 ##
 ## _expr -> FOR pattern IN . simple_expr direction_flag simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6384,7 +6385,7 @@ implementation: FOR UNDERSCORE IN WITH
 
 implementation: FOR UNDERSCORE WHEN
 ##
-## Ends in an error in state: 876.
+## Ends in an error in state: 892.
 ##
 ## _expr -> FOR pattern . IN simple_expr direction_flag simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _or_pattern -> pattern . BAR pattern [ IN BAR ]
@@ -6396,14 +6397,14 @@ implementation: FOR UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 787, spurious reduction of production pattern -> pattern_without_or
+## In state 803, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: FOR WITH
 ##
-## Ends in an error in state: 875.
+## Ends in an error in state: 891.
 ##
 ## _expr -> FOR . pattern IN simple_expr direction_flag simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6415,7 +6416,7 @@ implementation: FOR WITH
 
 implementation: FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 1887.
+## Ends in an error in state: 1926.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6449,17 +6450,17 @@ implementation: FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1886.
+## Ends in an error in state: 1925.
 ##
 ## leading_bar_match_case -> bar_located_pattern EQUALGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6471,7 +6472,7 @@ implementation: FUN BAR UNDERSCORE EQUALGREATER WITH
 
 implementation: FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 1885.
+## Ends in an error in state: 1924.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6505,17 +6506,17 @@ implementation: FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1884.
+## Ends in an error in state: 1923.
 ##
 ## leading_bar_match_case -> bar_located_pattern WHEN expr EQUALGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6527,7 +6528,7 @@ implementation: FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 
 implementation: FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 1883.
+## Ends in an error in state: 1922.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -6561,21 +6562,21 @@ implementation: FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 1882.
+## Ends in an error in state: 1921.
 ##
 ## leading_bar_match_case -> bar_located_pattern WHEN . expr EQUALGREATER expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6587,7 +6588,7 @@ implementation: FUN BAR UNDERSCORE WHEN WITH
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 851.
+## Ends in an error in state: 867.
 ##
 ## _simple_expr -> simple_expr . DOT label_longident [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
 ## _simple_expr -> simple_expr . DOT LPAREN expr RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
@@ -6605,17 +6606,17 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 886, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 902, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 850.
+## Ends in an error in state: 866.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern EQUAL . simple_expr [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ##
@@ -6627,7 +6628,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 848.
+## Ends in an error in state: 864.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -6641,7 +6642,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 
 implementation: FUN LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 627.
+## Ends in an error in state: 643.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -6655,7 +6656,7 @@ implementation: FUN LIDENT COLONCOLON WITH
 
 implementation: FUN LIDENT WITH
 ##
-## Ends in an error in state: 1889.
+## Ends in an error in state: 1928.
 ##
 ## _expr -> FUN labeled_simple_pattern . fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6666,18 +6667,18 @@ implementation: FUN LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 626, spurious reduction of production val_ident -> LIDENT
-## In state 760, spurious reduction of production _simple_pattern -> val_ident
-## In state 774, spurious reduction of production mark_position_pat(_simple_pattern) -> _simple_pattern
-## In state 770, spurious reduction of production simple_pattern -> mark_position_pat(_simple_pattern)
-## In state 1251, spurious reduction of production labeled_simple_pattern -> simple_pattern
+## In state 642, spurious reduction of production val_ident -> LIDENT
+## In state 776, spurious reduction of production _simple_pattern -> val_ident
+## In state 790, spurious reduction of production mark_position_pat(_simple_pattern) -> _simple_pattern
+## In state 786, spurious reduction of production simple_pattern -> mark_position_pat(_simple_pattern)
+## In state 1290, spurious reduction of production labeled_simple_pattern -> simple_pattern
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 869.
+## Ends in an error in state: 885.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT RPAREN . fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6689,7 +6690,7 @@ implementation: FUN LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: FUN LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 868.
+## Ends in an error in state: 884.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT . RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6701,7 +6702,7 @@ implementation: FUN LPAREN TYPE LIDENT WITH
 
 implementation: FUN LPAREN TYPE WITH
 ##
-## Ends in an error in state: 867.
+## Ends in an error in state: 883.
 ##
 ## _expr -> FUN LPAREN TYPE . LIDENT RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6713,7 +6714,7 @@ implementation: FUN LPAREN TYPE WITH
 
 implementation: FUN LPAREN WITH
 ##
-## Ends in an error in state: 866.
+## Ends in an error in state: 882.
 ##
 ## _expr -> FUN LPAREN . TYPE LIDENT RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
@@ -6736,7 +6737,7 @@ implementation: FUN LPAREN WITH
 
 implementation: FUN UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 1872.
+## Ends in an error in state: 1911.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6770,17 +6771,17 @@ implementation: FUN UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 874.
+## Ends in an error in state: 890.
 ##
 ## fun_def -> EQUALGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6792,7 +6793,7 @@ implementation: FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 873.
+## Ends in an error in state: 889.
 ##
 ## fun_def -> LPAREN TYPE LIDENT RPAREN . fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6804,7 +6805,7 @@ implementation: FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 872.
+## Ends in an error in state: 888.
 ##
 ## fun_def -> LPAREN TYPE LIDENT . RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6816,7 +6817,7 @@ implementation: FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: FUN UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 871.
+## Ends in an error in state: 887.
 ##
 ## fun_def -> LPAREN TYPE . LIDENT RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6828,7 +6829,7 @@ implementation: FUN UNDERSCORE LPAREN TYPE WITH
 
 implementation: FUN UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 870.
+## Ends in an error in state: 886.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
@@ -6851,7 +6852,7 @@ implementation: FUN UNDERSCORE LPAREN WITH
 
 implementation: FUN UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 1873.
+## Ends in an error in state: 1912.
 ##
 ## fun_def -> labeled_simple_pattern . fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6863,7 +6864,7 @@ implementation: FUN UNDERSCORE UNDERSCORE WITH
 
 implementation: FUN WITH
 ##
-## Ends in an error in state: 865.
+## Ends in an error in state: 881.
 ##
 ## _expr -> FUN . labeled_simple_pattern fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> FUN . LPAREN TYPE LIDENT RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6877,7 +6878,7 @@ implementation: FUN WITH
 
 implementation: IF UIDENT UIDENT ELSE WITH
 ##
-## Ends in an error in state: 864.
+## Ends in an error in state: 880.
 ##
 ## _expr -> IF simple_expr simple_expr ELSE . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6889,7 +6890,7 @@ implementation: IF UIDENT UIDENT ELSE WITH
 
 implementation: IF UIDENT WITH
 ##
-## Ends in an error in state: 862.
+## Ends in an error in state: 878.
 ##
 ## _expr -> IF simple_expr . simple_expr ELSE expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF simple_expr . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6908,17 +6909,17 @@ implementation: IF UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 886, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 902, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: IF WITH
 ##
-## Ends in an error in state: 861.
+## Ends in an error in state: 877.
 ##
 ## _expr -> IF . simple_expr simple_expr ELSE expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF . simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6931,7 +6932,7 @@ implementation: IF WITH
 
 implementation: INCLUDE FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 2330.
+## Ends in an error in state: 2394.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER module_expr . [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _module_expr -> module_expr . simple_module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -6946,7 +6947,7 @@ implementation: INCLUDE FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 
 implementation: INCLUDE FUN LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2329.
+## Ends in an error in state: 2393.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER . module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -6958,7 +6959,7 @@ implementation: INCLUDE FUN LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE FUN LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2328.
+## Ends in an error in state: 2392.
 ##
 ## _module_expr -> FUN functor_args . EQUALGREATER module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## functor_args -> functor_args . functor_arg [ LPAREN EQUALGREATER ]
@@ -6971,7 +6972,7 @@ implementation: INCLUDE FUN LPAREN RPAREN WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2326.
+## Ends in an error in state: 2390.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -6987,22 +6988,22 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 964, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 986, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1022, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1018, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 984, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1023, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1019, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 985, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1024, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1020, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 549.
+## Ends in an error in state: 565.
 ##
 ## functor_arg -> LPAREN functor_arg_name COLON . module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -7014,7 +7015,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 548.
+## Ends in an error in state: 564.
 ##
 ## functor_arg -> LPAREN functor_arg_name . COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -7026,7 +7027,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 
 implementation: INCLUDE FUN LPAREN WITH
 ##
-## Ends in an error in state: 544.
+## Ends in an error in state: 560.
 ##
 ## functor_arg -> LPAREN . RPAREN [ LPAREN EQUALGREATER COLON ]
 ## functor_arg -> LPAREN . functor_arg_name COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
@@ -7039,7 +7040,7 @@ implementation: INCLUDE FUN LPAREN WITH
 
 implementation: INCLUDE FUN WITH
 ##
-## Ends in an error in state: 543.
+## Ends in an error in state: 559.
 ##
 ## _module_expr -> FUN . functor_args EQUALGREATER module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -7051,7 +7052,7 @@ implementation: INCLUDE FUN WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 2121.
+## Ends in an error in state: 2185.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL class_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7063,16 +7064,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1308, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1329, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1306, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1347, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1368, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1345, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2120.
+## Ends in an error in state: 2184.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL . class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7084,7 +7085,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 2119.
+## Ends in an error in state: 2183.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type . EQUAL class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7095,19 +7096,19 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1632, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1636, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1630, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1634, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1645, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1643, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1671, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1675, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1669, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1673, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1684, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1682, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 2118.
+## Ends in an error in state: 2182.
 ##
 ## _constrained_class_declaration -> COLON . class_constructor_type EQUAL class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7119,7 +7120,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 2166.
+## Ends in an error in state: 2230.
 ##
 ## and_class_declaration -> AND . class_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7131,7 +7132,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2165.
+## Ends in an error in state: 2229.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_declarations . [ error SEMI RBRACE ]
 ## many_class_declarations -> many_class_declarations . and_class_declaration [ error SEMI RBRACE AND ]
@@ -7143,16 +7144,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1095, spurious reduction of production post_item_attributes ->
-## In state 1096, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2138, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
+## In state 1134, spurious reduction of production post_item_attributes ->
+## In state 1135, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2202, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 2117.
+## Ends in an error in state: 2181.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7164,16 +7165,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1308, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1329, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1306, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1347, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1368, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1345, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2116.
+## Ends in an error in state: 2180.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7185,7 +7186,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 2130.
+## Ends in an error in state: 2194.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER class_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7197,16 +7198,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1308, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1329, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1306, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1347, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1368, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1345, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2129.
+## Ends in an error in state: 2193.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER . class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7218,7 +7219,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2128.
+## Ends in an error in state: 2192.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type . EQUALGREATER class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7230,7 +7231,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT R
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2127.
+## Ends in an error in state: 2191.
 ##
 ## class_fun_return -> COLON . non_arrowed_class_constructor_type EQUALGREATER class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7242,7 +7243,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 2126.
+## Ends in an error in state: 2190.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## class_fun_return -> EQUALGREATER class_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7254,16 +7255,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1308, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1329, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1306, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1347, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1368, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1345, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2125.
+## Ends in an error in state: 2189.
 ##
 ## class_fun_return -> EQUALGREATER . class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7275,7 +7276,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2124.
+## Ends in an error in state: 2188.
 ##
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_binding [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_return [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7288,7 +7289,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT WITH
 ##
-## Ends in an error in state: 2115.
+## Ends in an error in state: 2179.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . class_fun_binding [ error SEMI RBRACE LBRACKETATAT AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . constrained_class_declaration [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7303,7 +7304,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 2161.
+## Ends in an error in state: 2225.
 ##
 ## and_class_type_declaration -> AND . class_type_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7315,7 +7316,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2160.
+## Ends in an error in state: 2224.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_type_declarations . [ error SEMI RBRACE ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ error SEMI RBRACE AND ]
@@ -7327,16 +7328,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND R
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1095, spurious reduction of production post_item_attributes ->
-## In state 1096, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2112, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
+## In state 1134, spurious reduction of production post_item_attributes ->
+## In state 1135, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2176, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 2110.
+## Ends in an error in state: 2174.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7348,16 +7349,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1571, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1575, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1569, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1610, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1614, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1608, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2109.
+## Ends in an error in state: 2173.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_instance_type [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7369,7 +7370,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 ##
-## Ends in an error in state: 2108.
+## Ends in an error in state: 2172.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters . EQUAL class_instance_type [ error SEMI RBRACE LBRACKETATAT AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS EQUAL ]
@@ -7382,7 +7383,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 ##
-## Ends in an error in state: 2106.
+## Ends in an error in state: 2170.
 ##
 ## class_type_declaration_details -> virtual_flag . LIDENT class_type_parameters EQUAL class_instance_type [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7394,7 +7395,7 @@ implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE WITH
 ##
-## Ends in an error in state: 2105.
+## Ends in an error in state: 2169.
 ##
 ## many_class_type_declarations -> CLASS TYPE . class_type_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7406,7 +7407,7 @@ implementation: INCLUDE LBRACE CLASS TYPE WITH
 
 implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 2113.
+## Ends in an error in state: 2177.
 ##
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters class_fun_binding [ error SEMI RBRACE LBRACKETATAT AND ]
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters constrained_class_declaration [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7420,7 +7421,7 @@ implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 
 implementation: INCLUDE LBRACE CLASS WITH
 ##
-## Ends in an error in state: 2104.
+## Ends in an error in state: 2168.
 ##
 ## many_class_declarations -> CLASS . class_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
@@ -7433,9 +7434,10 @@ implementation: INCLUDE LBRACE CLASS WITH
 
 implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 ##
-## Ends in an error in state: 470.
+## Ends in an error in state: 2145.
 ##
-## constr_ident2 -> LPAREN . RPAREN [ error UNDERSCORE UIDENT SHARP SEMI RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUAL CONSTRAINT COLON BAR AND ]
+## extension_constructor_declaration -> LPAREN . RPAREN generalized_constructor_arguments attributes [ error SEMI RBRACE LBRACKETATAT BAR ]
+## extension_constructor_rebind -> LPAREN . RPAREN EQUAL constr_longident attributes [ error SEMI RBRACE LBRACKETATAT BAR ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -7457,7 +7459,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 ##
-## Ends in an error in state: 2099.
+## Ends in an error in state: 2134.
 ##
 ## constr_longident -> LBRACKET . RBRACKET [ error SEMI RBRACE LBRACKETATAT LBRACKETAT BAR ]
 ##
@@ -7469,7 +7471,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 2098.
+## Ends in an error in state: 2133.
 ##
 ## constr_longident -> LPAREN . RPAREN [ error SEMI RBRACE LBRACKETATAT LBRACKETAT BAR ]
 ##
@@ -7481,12 +7483,12 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2097.
+## Ends in an error in state: 2132.
 ##
-## extension_constructor_rebind -> constr_ident EQUAL . constr_longident attributes [ error SEMI RBRACE LBRACKETATAT BAR ]
+## extension_constructor_rebind -> UIDENT EQUAL . constr_longident attributes [ error SEMI RBRACE LBRACKETATAT BAR ]
 ##
 ## The known suffix of the stack is as follows:
-## constr_ident EQUAL
+## UIDENT EQUAL
 ##
 
 <SYNTAX ERROR>
@@ -7519,20 +7521,20 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 2096.
+## Ends in an error in state: 2131.
 ##
-## extension_constructor_declaration -> constr_ident . generalized_constructor_arguments attributes [ error SEMI RBRACE LBRACKETATAT BAR ]
-## extension_constructor_rebind -> constr_ident . EQUAL constr_longident attributes [ error SEMI RBRACE LBRACKETATAT BAR ]
+## extension_constructor_declaration -> UIDENT . generalized_constructor_arguments attributes [ error SEMI RBRACE LBRACKETATAT BAR ]
+## extension_constructor_rebind -> UIDENT . EQUAL constr_longident attributes [ error SEMI RBRACE LBRACKETATAT BAR ]
 ##
 ## The known suffix of the stack is as follows:
-## constr_ident
+## UIDENT
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE EXCEPTION WITH
 ##
-## Ends in an error in state: 2091.
+## Ends in an error in state: 2130.
 ##
 ## str_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ error SEMI RBRACE ]
 ## str_exception_declaration -> EXCEPTION . extension_constructor_rebind post_item_attributes [ error SEMI RBRACE ]
@@ -7545,7 +7547,7 @@ implementation: INCLUDE LBRACE EXCEPTION WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 ##
-## Ends in an error in state: 2087.
+## Ends in an error in state: 2126.
 ##
 ## primitive_declaration -> STRING . [ error SEMI RBRACE LBRACKETATAT ]
 ## primitive_declaration -> STRING . primitive_declaration [ error SEMI RBRACE LBRACKETATAT ]
@@ -7558,7 +7560,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WIT
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2086.
+## Ends in an error in state: 2125.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7570,7 +7572,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2085.
+## Ends in an error in state: 2124.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7593,7 +7595,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 2084.
+## Ends in an error in state: 2123.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7605,7 +7607,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 2083.
+## Ends in an error in state: 2122.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7617,7 +7619,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 
 implementation: INCLUDE LBRACE EXTERNAL WITH
 ##
-## Ends in an error in state: 2082.
+## Ends in an error in state: 2121.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7629,7 +7631,7 @@ implementation: INCLUDE LBRACE EXTERNAL WITH
 
 implementation: INCLUDE LBRACE INCLUDE WITH
 ##
-## Ends in an error in state: 2079.
+## Ends in an error in state: 2118.
 ##
 ## _structure_item_without_item_extension_sugar -> INCLUDE . module_expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7641,7 +7643,7 @@ implementation: INCLUDE LBRACE INCLUDE WITH
 
 implementation: INCLUDE LBRACE LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 ##
-## Ends in an error in state: 2156.
+## Ends in an error in state: 2220.
 ##
 ## and_nonlocal_module_bindings -> AND . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7653,7 +7655,7 @@ implementation: INCLUDE LBRACE LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 
 implementation: INCLUDE LBRACE LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2155.
+## Ends in an error in state: 2219.
 ##
 ## _structure_item_without_item_extension_sugar -> many_nonlocal_module_bindings . [ error SEMI RBRACE ]
 ## many_nonlocal_module_bindings -> many_nonlocal_module_bindings . and_nonlocal_module_bindings [ error SEMI RBRACE AND ]
@@ -7665,16 +7667,16 @@ implementation: INCLUDE LBRACE LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT A
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1095, spurious reduction of production post_item_attributes ->
-## In state 1096, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2036, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
+## In state 1134, spurious reduction of production post_item_attributes ->
+## In state 1135, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2075, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE REC WITH
 ##
-## Ends in an error in state: 2034.
+## Ends in an error in state: 2073.
 ##
 ## many_nonlocal_module_bindings -> LET MODULE REC . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7686,7 +7688,7 @@ implementation: INCLUDE LBRACE LET MODULE REC WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2021.
+## Ends in an error in state: 2060.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
@@ -7700,19 +7702,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2049, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2053, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2050, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 2022, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2055, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2054, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2020.
+## Ends in an error in state: 2059.
 ##
 ## module_binding_body_expr -> COLON module_type EQUAL . module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7724,7 +7726,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2019.
+## Ends in an error in state: 2058.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER EQUAL ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER EQUAL ]
@@ -7740,22 +7742,22 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 964, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 986, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1022, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1018, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 984, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1023, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1019, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 985, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1024, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1020, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2018.
+## Ends in an error in state: 2057.
 ##
 ## module_binding_body_expr -> COLON . module_type EQUAL module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7767,7 +7769,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT COLON WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2017.
+## Ends in an error in state: 2056.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
@@ -7781,19 +7783,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2049, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2053, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2050, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 2022, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2055, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2054, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1979.
+## Ends in an error in state: 2018.
 ##
 ## module_binding_body_expr -> EQUAL . module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7805,7 +7807,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2032.
+## Ends in an error in state: 2071.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER module_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
@@ -7819,19 +7821,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2049, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2053, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2050, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 2022, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2055, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2054, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2031.
+## Ends in an error in state: 2070.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER . module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7843,7 +7845,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUA
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2030.
+## Ends in an error in state: 2069.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type . EQUALGREATER module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _module_type -> non_arrowed_module_type . [ WITH LBRACKETAT EQUALGREATER ]
@@ -7857,19 +7859,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 964, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 986, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1022, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1018, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 984, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1023, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1019, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON WITH
 ##
-## Ends in an error in state: 2029.
+## Ends in an error in state: 2068.
 ##
 ## _module_binding_body_functor -> functor_args COLON . non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7881,7 +7883,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2028.
+## Ends in an error in state: 2067.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER module_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
@@ -7895,19 +7897,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2049, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2053, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2050, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 2022, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2055, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2054, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2027.
+## Ends in an error in state: 2066.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER . module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7919,7 +7921,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2026.
+## Ends in an error in state: 2065.
 ##
 ## _module_binding_body_functor -> functor_args . EQUALGREATER module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _module_binding_body_functor -> functor_args . COLON non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7933,7 +7935,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1978.
+## Ends in an error in state: 2017.
 ##
 ## nonlocal_module_binding_details -> UIDENT . module_binding_body [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7945,7 +7947,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT WITH
 
 implementation: INCLUDE LBRACE LET MODULE WITH
 ##
-## Ends in an error in state: 1977.
+## Ends in an error in state: 2016.
 ##
 ## _structure_item_without_item_extension_sugar -> LET MODULE . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE ]
 ## many_nonlocal_module_bindings -> LET MODULE . REC nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE AND ]
@@ -7958,7 +7960,7 @@ implementation: INCLUDE LBRACE LET MODULE WITH
 
 implementation: INCLUDE LBRACE LET WITH
 ##
-## Ends in an error in state: 1976.
+## Ends in an error in state: 2015.
 ##
 ## _structure_item_without_item_extension_sugar -> LET . MODULE nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ error SEMI RBRACE AND ]
@@ -7972,7 +7974,7 @@ implementation: INCLUDE LBRACE LET WITH
 
 implementation: INCLUDE LBRACE MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1912.
+## Ends in an error in state: 1951.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7984,7 +7986,7 @@ implementation: INCLUDE LBRACE MODULE TYPE UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE MODULE TYPE WITH
 ##
-## Ends in an error in state: 1910.
+## Ends in an error in state: 1949.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE . ident post_item_attributes [ error SEMI RBRACE ]
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ error SEMI RBRACE ]
@@ -7997,7 +7999,7 @@ implementation: INCLUDE LBRACE MODULE TYPE WITH
 
 implementation: INCLUDE LBRACE MODULE WITH
 ##
-## Ends in an error in state: 1909.
+## Ends in an error in state: 1948.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident post_item_attributes [ error SEMI RBRACE ]
 ## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ error SEMI RBRACE ]
@@ -8010,7 +8012,7 @@ implementation: INCLUDE LBRACE MODULE WITH
 
 implementation: INCLUDE LBRACE OPEN BANG WITH
 ##
-## Ends in an error in state: 1906.
+## Ends in an error in state: 1945.
 ##
 ## open_statement -> OPEN override_flag . mod_longident post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8022,7 +8024,7 @@ implementation: INCLUDE LBRACE OPEN BANG WITH
 
 implementation: INCLUDE LBRACE OPEN WITH
 ##
-## Ends in an error in state: 1905.
+## Ends in an error in state: 1944.
 ##
 ## open_statement -> OPEN . override_flag mod_longident post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8034,7 +8036,7 @@ implementation: INCLUDE LBRACE OPEN WITH
 
 implementation: INCLUDE LBRACE STRING WITH
 ##
-## Ends in an error in state: 2140.
+## Ends in an error in state: 2204.
 ##
 ## structure -> structure_item . [ error RBRACE ]
 ## structure -> structure_item . SEMI structure [ error RBRACE ]
@@ -8046,24 +8048,24 @@ implementation: INCLUDE LBRACE STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2183, spurious reduction of production post_item_attributes ->
-## In state 2184, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 2185, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 2146, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 2139, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 2186, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 2147, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2247, spurious reduction of production post_item_attributes ->
+## In state 2248, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 2249, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 2210, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 2203, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 2250, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 2211, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT AND LIDENT WITH
 ##
-## Ends in an error in state: 2151.
+## Ends in an error in state: 2215.
 ##
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -8074,14 +8076,14 @@ implementation: INCLUDE LBRACE TYPE LIDENT AND LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2150, spurious reduction of production optional_type_parameters ->
+## In state 2214, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT AND WITH
 ##
-## Ends in an error in state: 2149.
+## Ends in an error in state: 2213.
 ##
 ## and_type_declaration -> AND . type_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -8093,7 +8095,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT AND WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 527.
+## Ends in an error in state: 543.
 ##
 ## constrain -> core_type EQUAL . core_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER CONSTRAINT AND ]
 ##
@@ -8105,7 +8107,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 526.
+## Ends in an error in state: 542.
 ##
 ## constrain -> core_type . EQUAL core_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER CONSTRAINT AND ]
 ##
@@ -8128,7 +8130,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT WITH
 ##
-## Ends in an error in state: 525.
+## Ends in an error in state: 541.
 ##
 ## constraints -> constraints CONSTRAINT . constrain [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER CONSTRAINT AND ]
 ##
@@ -8140,7 +8142,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL DOTDOT WITH
 ##
-## Ends in an error in state: 524.
+## Ends in an error in state: 540.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ## type_declaration_details -> LIDENT optional_type_parameters type_kind constraints . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -8153,7 +8155,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL DOTDOT WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 504.
+## Ends in an error in state: 519.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8165,17 +8167,17 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LBRACE LIDENT COLON LESSDOTDOTG
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 499, spurious reduction of production attributes ->
-## In state 500, spurious reduction of production attributes -> attribute attributes
-## In state 498, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 509, spurious reduction of production label_declarations -> label_declaration
+## In state 514, spurious reduction of production attributes ->
+## In state 515, spurious reduction of production attributes -> attribute attributes
+## In state 513, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 524, spurious reduction of production label_declarations -> label_declaration
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 487.
+## Ends in an error in state: 502.
 ##
 ## type_kind -> EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ##
@@ -8187,11 +8189,11 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LBRACE WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 464.
+## Ends in an error in state: 466.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ error SEMI RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT AS AND ]
 ## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ error SEMI RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT AS AND ]
-## constr_ident2 -> LPAREN . RPAREN [ error UNDERSCORE UIDENT SHARP SEMI RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET CONSTRAINT COLON BAR AND ]
+## constructor_declaration_no_leading_bar -> LPAREN . RPAREN generalized_constructor_arguments attributes [ error SEMI RBRACE LBRACKETATAT CONSTRAINT BAR AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -8201,7 +8203,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LPAREN WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 463.
+## Ends in an error in state: 465.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL PRIVATE . core_type [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8215,9 +8217,13 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL PRIVATE WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UIDENT BAR WITH
 ##
-## Ends in an error in state: 468.
+## Ends in an error in state: 476.
 ##
-## constructor_declaration_leading_bar -> BAR . constr_ident generalized_constructor_arguments attributes [ error SEMI RBRACE LBRACKETATAT CONSTRAINT BAR AND ]
+## constructor_declaration_leading_bar -> BAR . UIDENT generalized_constructor_arguments attributes [ error SEMI RBRACE LBRACKETATAT CONSTRAINT BAR AND ]
+## constructor_declaration_leading_bar -> BAR . LPAREN RPAREN generalized_constructor_arguments attributes [ error SEMI RBRACE LBRACKETATAT CONSTRAINT BAR AND ]
+## constructor_declaration_leading_bar -> BAR . COLONCOLON generalized_constructor_arguments attributes [ error SEMI RBRACE LBRACKETATAT CONSTRAINT BAR AND ]
+## constructor_declaration_leading_bar -> BAR . FALSE generalized_constructor_arguments attributes [ error SEMI RBRACE LBRACKETATAT CONSTRAINT BAR AND ]
+## constructor_declaration_leading_bar -> BAR . TRUE generalized_constructor_arguments attributes [ error SEMI RBRACE LBRACKETATAT CONSTRAINT BAR AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## BAR
@@ -8227,7 +8233,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UIDENT BAR WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 479.
+## Ends in an error in state: 497.
 ##
 ## constructor_declarations -> constructor_declaration_no_leading_bar . [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ## constructor_declarations -> constructor_declaration_no_leading_bar . constructor_declarations_leading_bar [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8268,7 +8274,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UIDENT WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 518.
+## Ends in an error in state: 534.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8280,17 +8286,17 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 499, spurious reduction of production attributes ->
-## In state 500, spurious reduction of production attributes -> attribute attributes
-## In state 498, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 509, spurious reduction of production label_declarations -> label_declaration
+## In state 514, spurious reduction of production attributes ->
+## In state 515, spurious reduction of production attributes -> attribute attributes
+## In state 513, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 524, spurious reduction of production label_declarations -> label_declaration
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 517.
+## Ends in an error in state: 533.
 ##
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ##
@@ -8302,7 +8308,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 ##
-## Ends in an error in state: 513.
+## Ends in an error in state: 528.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL core_type EQUAL PRIVATE . constructor_declarations [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8315,7 +8321,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 511.
+## Ends in an error in state: 526.
 ##
 ## type_kind -> EQUAL core_type EQUAL . constructor_declarations [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type EQUAL . PRIVATE constructor_declarations [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8330,7 +8336,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 510.
+## Ends in an error in state: 525.
 ##
 ## type_kind -> EQUAL core_type . [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type . EQUAL constructor_declarations [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8378,7 +8384,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT LBRACKETATAT WITH RBRACKET WITH
 ##
-## Ends in an error in state: 2148.
+## Ends in an error in state: 2212.
 ##
 ## _structure_item_without_item_extension_sugar -> many_type_declarations . [ error SEMI RBRACE ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ error SEMI RBRACE AND ]
@@ -8390,9 +8396,9 @@ implementation: INCLUDE LBRACE TYPE LIDENT LBRACKETATAT WITH RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1095, spurious reduction of production post_item_attributes ->
-## In state 1096, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2359, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 1134, spurious reduction of production post_item_attributes ->
+## In state 1135, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2423, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
@@ -8449,7 +8455,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUS WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 2363.
+## Ends in an error in state: 2427.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . str_extension_constructors post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8461,7 +8467,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ BAR WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 2362.
+## Ends in an error in state: 2426.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8473,7 +8479,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ PRIVATE BANG
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 2365.
+## Ends in an error in state: 2429.
 ##
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_declaration [ error SEMI RBRACE LBRACKETATAT BAR ]
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_rebind [ error SEMI RBRACE LBRACKETATAT BAR ]
@@ -8486,7 +8492,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 2361.
+## Ends in an error in state: 2425.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8522,7 +8528,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 530, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 546, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
 ##
 
 <SYNTAX ERROR>
@@ -8548,7 +8554,7 @@ implementation: INCLUDE LBRACE TYPE WITH
 
 implementation: INCLUDE LBRACE UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2141.
+## Ends in an error in state: 2205.
 ##
 ## structure -> structure_item SEMI . structure [ error RBRACE ]
 ##
@@ -8573,7 +8579,7 @@ implementation: INCLUDE LBRACE WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1984.
+## Ends in an error in state: 2023.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER module_expr . [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8588,7 +8594,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHIL
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1982.
+## Ends in an error in state: 2021.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER . module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8600,7 +8606,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1981.
+## Ends in an error in state: 2020.
 ##
 ## _module_expr -> FUN functor_args . EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## functor_args -> functor_args . functor_arg [ LPAREN EQUALGREATER ]
@@ -8613,7 +8619,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 
 implementation: INCLUDE LPAREN FUN WITH
 ##
-## Ends in an error in state: 1980.
+## Ends in an error in state: 2019.
 ##
 ## _module_expr -> FUN . functor_args EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8625,7 +8631,7 @@ implementation: INCLUDE LPAREN FUN WITH
 
 implementation: INCLUDE LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 1904.
+## Ends in an error in state: 1943.
 ##
 ## _module_expr -> LBRACE . structure error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LBRACE . structure RBRACE [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8638,7 +8644,7 @@ implementation: INCLUDE LPAREN LBRACE WITH
 
 implementation: INCLUDE LPAREN LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2006.
+## Ends in an error in state: 2045.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -8654,23 +8660,23 @@ implementation: INCLUDE LPAREN LPAREN UIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 234, spurious reduction of production ident -> UIDENT
-## In state 648, spurious reduction of production mty_longident -> ident
-## In state 1920, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1964, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1960, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1918, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1965, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1961, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1919, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1966, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1962, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 664, spurious reduction of production mty_longident -> ident
+## In state 1959, spurious reduction of production _simple_module_type -> mty_longident
+## In state 2003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1957, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 2004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 2000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1958, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 2005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 2001, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 2005.
+## Ends in an error in state: 2044.
 ##
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8683,7 +8689,7 @@ implementation: INCLUDE LPAREN LPAREN UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2314.
+## Ends in an error in state: 2378.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -8700,19 +8706,19 @@ implementation: INCLUDE LPAREN LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2049, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2053, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2050, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 2022, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2055, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2054, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1996.
+## Ends in an error in state: 2035.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8732,7 +8738,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDEN
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1995.
+## Ends in an error in state: 2034.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8744,7 +8750,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 2312.
+## Ends in an error in state: 2376.
 ##
 ## _module_expr -> LPAREN VAL expr COLON . error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8758,7 +8764,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1990.
+## Ends in an error in state: 2029.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8778,7 +8784,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATE
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 2310.
+## Ends in an error in state: 2374.
 ##
 ## _module_expr -> LPAREN VAL expr COLONGREATER . error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8791,7 +8797,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 2308.
+## Ends in an error in state: 2372.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -8831,21 +8837,21 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN LPAREN VAL WITH
 ##
-## Ends in an error in state: 555.
+## Ends in an error in state: 571.
 ##
 ## _module_expr -> LPAREN VAL . expr COLON error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _module_expr -> LPAREN VAL . expr COLONGREATER error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8863,7 +8869,7 @@ implementation: INCLUDE LPAREN LPAREN VAL WITH
 
 implementation: INCLUDE LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 554.
+## Ends in an error in state: 570.
 ##
 ## _module_expr -> LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _module_expr -> LPAREN . VAL expr COLON error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8886,7 +8892,7 @@ implementation: INCLUDE LPAREN LPAREN WITH
 
 implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2193.
+## Ends in an error in state: 2257.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -8902,23 +8908,23 @@ implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 234, spurious reduction of production ident -> UIDENT
-## In state 648, spurious reduction of production mty_longident -> ident
-## In state 1920, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1964, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1960, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1918, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1965, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1961, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1919, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1966, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1962, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 664, spurious reduction of production mty_longident -> ident
+## In state 1959, spurious reduction of production _simple_module_type -> mty_longident
+## In state 2003, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1999, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1957, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 2004, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 2000, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1958, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 2005, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 2001, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 2192.
+## Ends in an error in state: 2256.
 ##
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -8931,7 +8937,7 @@ implementation: INCLUDE LPAREN UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN UIDENT LBRACE UIDENT EOF
 ##
-## Ends in an error in state: 2003.
+## Ends in an error in state: 2042.
 ##
 ## _simple_module_expr -> LBRACE structure . RBRACE [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8942,29 +8948,29 @@ implementation: INCLUDE LPAREN UIDENT LBRACE UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1519, spurious reduction of production post_item_attributes ->
-## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1121, spurious reduction of production structure -> structure_item
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1558, spurious reduction of production post_item_attributes ->
+## In state 1559, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1560, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1168, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1159, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1561, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1169, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1160, spurious reduction of production structure -> structure_item
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2002.
+## Ends in an error in state: 2041.
 ##
 ## _simple_module_expr -> LBRACE . structure RBRACE [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8976,7 +8982,7 @@ implementation: INCLUDE LPAREN UIDENT LBRACE WITH
 
 implementation: INCLUDE LPAREN UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1999.
+## Ends in an error in state: 2038.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -8993,19 +8999,19 @@ implementation: INCLUDE LPAREN UIDENT LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2049, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2053, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2050, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 2022, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2055, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2054, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 1992.
+## Ends in an error in state: 2031.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type COLONGREATER package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -9018,7 +9024,7 @@ implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1989.
+## Ends in an error in state: 2028.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -9030,7 +9036,7 @@ implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 1987.
+## Ends in an error in state: 2026.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -9067,21 +9073,21 @@ implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT LPAREN VAL WITH
 ##
-## Ends in an error in state: 1986.
+## Ends in an error in state: 2025.
 ##
 ## _simple_module_expr -> LPAREN VAL . expr RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN VAL . expr COLON package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -9096,7 +9102,7 @@ implementation: INCLUDE LPAREN UIDENT LPAREN VAL WITH
 
 implementation: INCLUDE LPAREN UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1985.
+## Ends in an error in state: 2024.
 ##
 ## _module_expr -> module_expr LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN . module_expr COLON module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -9116,7 +9122,7 @@ implementation: INCLUDE LPAREN UIDENT LPAREN WITH
 
 implementation: INCLUDE LPAREN UIDENT WHILE
 ##
-## Ends in an error in state: 2010.
+## Ends in an error in state: 2049.
 ##
 ## _simple_module_expr -> mod_longident . [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER DOT COLON AND ]
@@ -9129,7 +9135,7 @@ implementation: INCLUDE LPAREN UIDENT WHILE
 
 implementation: INCLUDE LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2403.
+## Ends in an error in state: 2467.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -9146,19 +9152,19 @@ implementation: INCLUDE LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2049, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2053, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2050, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 2022, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2055, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2054, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1901.
+## Ends in an error in state: 1940.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER package_type . RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9178,7 +9184,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLON
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1900.
+## Ends in an error in state: 1939.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER . package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9190,7 +9196,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 2401.
+## Ends in an error in state: 2465.
 ##
 ## _module_expr -> LPAREN VAL expr COLON . error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9204,7 +9210,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1895.
+## Ends in an error in state: 1934.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER package_type . RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9224,7 +9230,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 2399.
+## Ends in an error in state: 2463.
 ##
 ## _module_expr -> LPAREN VAL expr COLONGREATER . error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9237,7 +9243,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 2397.
+## Ends in an error in state: 2461.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -9277,14 +9283,14 @@ implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -9332,7 +9338,7 @@ implementation: INCLUDE LPAREN WITH
 
 implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ##
-## Ends in an error in state: 1783.
+## Ends in an error in state: 1822.
 ##
 ## _simple_module_expr -> LBRACE structure . RBRACE [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9343,29 +9349,29 @@ implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1519, spurious reduction of production post_item_attributes ->
-## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1121, spurious reduction of production structure -> structure_item
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1558, spurious reduction of production post_item_attributes ->
+## In state 1559, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1560, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1168, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1159, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1561, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1169, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1160, spurious reduction of production structure -> structure_item
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 908.
+## Ends in an error in state: 924.
 ##
 ## _simple_module_expr -> LBRACE . structure RBRACE [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9377,7 +9383,7 @@ implementation: INCLUDE UIDENT LBRACE WITH
 
 implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2189.
+## Ends in an error in state: 2253.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -9394,19 +9400,19 @@ implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1983, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2049, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2053, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2050, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 2022, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2055, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2054, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 1897.
+## Ends in an error in state: 1936.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type COLONGREATER package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9419,7 +9425,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1894.
+## Ends in an error in state: 1933.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9431,7 +9437,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 1892.
+## Ends in an error in state: 1931.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -9468,21 +9474,21 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL WITH
 ##
-## Ends in an error in state: 860.
+## Ends in an error in state: 876.
 ##
 ## _simple_module_expr -> LPAREN VAL . expr RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL . expr COLON package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9497,7 +9503,7 @@ implementation: INCLUDE UIDENT LPAREN VAL WITH
 
 implementation: INCLUDE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 859.
+## Ends in an error in state: 875.
 ##
 ## _module_expr -> module_expr LPAREN . module_expr error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN . module_expr COLON module_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9517,7 +9523,7 @@ implementation: INCLUDE UIDENT LPAREN WITH
 
 implementation: INCLUDE UIDENT WHILE
 ##
-## Ends in an error in state: 915.
+## Ends in an error in state: 931.
 ##
 ## _simple_module_expr -> mod_longident . [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF DOT COLON AND ]
@@ -9530,7 +9536,7 @@ implementation: INCLUDE UIDENT WHILE
 
 implementation: INCLUDE WITH
 ##
-## Ends in an error in state: 1039.
+## Ends in an error in state: 1061.
 ##
 ## _structure_item_without_item_extension_sugar -> INCLUDE . module_expr post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -9542,7 +9548,7 @@ implementation: INCLUDE WITH
 
 implementation: LAZY WITH
 ##
-## Ends in an error in state: 561.
+## Ends in an error in state: 577.
 ##
 ## _expr -> LAZY . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -9554,7 +9560,7 @@ implementation: LAZY WITH
 
 implementation: LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1345.
+## Ends in an error in state: 1384.
 ##
 ## class_self_pattern_and_structure -> class_self_pattern . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -9566,7 +9572,7 @@ implementation: LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: LBRACE AS UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1334.
+## Ends in an error in state: 1373.
 ##
 ## _class_self_pattern -> AS pattern . SEMI [ error VAL RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ## _or_pattern -> pattern . BAR pattern [ SEMI BAR ]
@@ -9578,14 +9584,14 @@ implementation: LBRACE AS UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 787, spurious reduction of production pattern -> pattern_without_or
+## In state 803, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE AS WITH
 ##
-## Ends in an error in state: 1333.
+## Ends in an error in state: 1372.
 ##
 ## _class_self_pattern -> AS . pattern SEMI [ error VAL RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ##
@@ -9597,7 +9603,7 @@ implementation: LBRACE AS WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1536.
+## Ends in an error in state: 1575.
 ##
 ## constrain_field -> core_type EQUAL . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -9609,7 +9615,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1535.
+## Ends in an error in state: 1574.
 ##
 ## constrain_field -> core_type . EQUAL core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -9632,7 +9638,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 
 implementation: LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1534.
+## Ends in an error in state: 1573.
 ##
 ## _class_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -9644,7 +9650,7 @@ implementation: LBRACE CONSTRAINT WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1832.
+## Ends in an error in state: 1871.
 ##
 ## record_expr -> DOTDOTDOT expr_optional_constraint COMMA . lbl_expr_list [ error RBRACE ]
 ##
@@ -9656,7 +9662,7 @@ implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ##
-## Ends in an error in state: 1831.
+## Ends in an error in state: 1870.
 ##
 ## record_expr -> DOTDOTDOT expr_optional_constraint . COMMA lbl_expr_list [ error RBRACE ]
 ##
@@ -9667,22 +9673,22 @@ implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1816, spurious reduction of production expr_optional_constraint -> expr
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1855, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE DOTDOTDOT WITH
 ##
-## Ends in an error in state: 1830.
+## Ends in an error in state: 1869.
 ##
 ## record_expr -> DOTDOTDOT . expr_optional_constraint COMMA lbl_expr_list [ error RBRACE ]
 ##
@@ -9694,7 +9700,7 @@ implementation: LBRACE DOTDOTDOT WITH
 
 implementation: LBRACE INHERIT BANG WITH
 ##
-## Ends in an error in state: 1528.
+## Ends in an error in state: 1567.
 ##
 ## _class_field -> INHERIT override_flag . class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -9706,7 +9712,7 @@ implementation: LBRACE INHERIT BANG WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1304.
+## Ends in an error in state: 1343.
 ##
 ## _class_expr -> CLASS class_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET COLON AS AND ]
@@ -9719,7 +9725,7 @@ implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1303.
+## Ends in an error in state: 1342.
 ##
 ## _class_expr -> CLASS class_longident . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## _class_expr -> CLASS class_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
@@ -9732,7 +9738,7 @@ implementation: LBRACE INHERIT CLASS LIDENT WITH
 
 implementation: LBRACE INHERIT CLASS WITH
 ##
-## Ends in an error in state: 1302.
+## Ends in an error in state: 1341.
 ##
 ## _class_expr -> CLASS . class_longident [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## _class_expr -> CLASS . class_longident non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
@@ -9745,7 +9751,7 @@ implementation: LBRACE INHERIT CLASS WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1326.
+## Ends in an error in state: 1365.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER class_expr . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
@@ -9758,7 +9764,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND R
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1301.
+## Ends in an error in state: 1340.
 ##
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER . class_expr [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ##
@@ -9770,7 +9776,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1300.
+## Ends in an error in state: 1339.
 ##
 ## _class_fun_def -> labeled_simple_pattern . EQUALGREATER class_expr [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern . class_fun_def [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
@@ -9783,7 +9789,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 
 implementation: LBRACE INHERIT FUN WITH
 ##
-## Ends in an error in state: 1298.
+## Ends in an error in state: 1337.
 ##
 ## _class_expr -> FUN . class_fun_def [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ##
@@ -9795,7 +9801,7 @@ implementation: LBRACE INHERIT FUN WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 1339.
+## Ends in an error in state: 1378.
 ##
 ## _class_expr_lets_and_rest -> let_bindings SEMI . class_expr_lets_and_rest [ error RBRACE ]
 ##
@@ -9807,7 +9813,7 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ##
-## Ends in an error in state: 1338.
+## Ends in an error in state: 1377.
 ##
 ## _class_expr_lets_and_rest -> let_bindings . SEMI class_expr_lets_and_rest [ error RBRACE ]
 ## let_bindings -> let_bindings . and_let_binding [ SEMI AND ]
@@ -9819,22 +9825,22 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1295, spurious reduction of production let_binding_body -> pattern EQUAL expr
-## In state 1296, spurious reduction of production post_item_attributes ->
-## In state 1297, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
-## In state 1340, spurious reduction of production let_binding -> let_binding_impl
-## In state 1341, spurious reduction of production let_bindings -> let_binding
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1334, spurious reduction of production let_binding_body -> pattern EQUAL expr
+## In state 1335, spurious reduction of production post_item_attributes ->
+## In state 1336, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
+## In state 1379, spurious reduction of production let_binding -> let_binding_impl
+## In state 1380, spurious reduction of production let_bindings -> let_binding
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE LET WITH
 ##
-## Ends in an error in state: 1162.
+## Ends in an error in state: 1201.
 ##
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI AND ]
 ##
@@ -9846,7 +9852,7 @@ implementation: LBRACE INHERIT LBRACE LET WITH
 
 implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ##
-## Ends in an error in state: 1550.
+## Ends in an error in state: 1589.
 ##
 ## _class_expr -> class_expr . attribute [ error RBRACE LBRACKETAT ]
 ## _class_expr_lets_and_rest -> class_expr . [ error RBRACE ]
@@ -9858,16 +9864,16 @@ implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1308, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1329, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1306, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1347, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1368, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1345, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 ##
-## Ends in an error in state: 1342.
+## Ends in an error in state: 1381.
 ##
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI AND ]
 ##
@@ -9886,7 +9892,7 @@ implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 
 implementation: LBRACE INHERIT LBRACE WITH
 ##
-## Ends in an error in state: 1161.
+## Ends in an error in state: 1200.
 ##
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest RBRACE [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest error [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
@@ -9899,7 +9905,7 @@ implementation: LBRACE INHERIT LBRACE WITH
 
 implementation: LBRACE INHERIT LIDENT AS WITH
 ##
-## Ends in an error in state: 1530.
+## Ends in an error in state: 1569.
 ##
 ## parent_binder -> AS . LIDENT [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -9911,7 +9917,7 @@ implementation: LBRACE INHERIT LIDENT AS WITH
 
 implementation: LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1529.
+## Ends in an error in state: 1568.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AS ]
 ## _class_field -> INHERIT override_flag class_expr . parent_binder post_item_attributes [ error SEMI RBRACE ]
@@ -9923,16 +9929,16 @@ implementation: LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1308, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1329, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1306, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1347, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1368, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1345, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT SEMI WITH
 ##
-## Ends in an error in state: 1546.
+## Ends in an error in state: 1585.
 ##
 ## semi_terminated_class_fields -> class_field SEMI . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -9944,7 +9950,7 @@ implementation: LBRACE INHERIT LIDENT SEMI WITH
 
 implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ##
-## Ends in an error in state: 1320.
+## Ends in an error in state: 1359.
 ##
 ## _class_expr -> class_simple_expr simple_labeled_expr_list . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## simple_labeled_expr_list -> simple_labeled_expr_list . labeled_simple_expr [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
@@ -9956,20 +9962,20 @@ implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1315, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1311, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1321, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
-## In state 1324, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1354, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1350, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1360, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
+## In state 1363, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT WITH
 ##
-## Ends in an error in state: 1308.
+## Ends in an error in state: 1347.
 ##
 ## _class_expr -> class_simple_expr . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
 ## _class_expr -> class_simple_expr . simple_labeled_expr_list [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT COLON AS AND ]
@@ -9982,7 +9988,7 @@ implementation: LBRACE INHERIT LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1588.
+## Ends in an error in state: 1627.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -9994,7 +10000,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE 
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1587.
+## Ends in an error in state: 1626.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -10007,7 +10013,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE 
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1586.
+## Ends in an error in state: 1625.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -10019,7 +10025,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1579.
+## Ends in an error in state: 1618.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -10031,7 +10037,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 1578.
+## Ends in an error in state: 1617.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -10044,7 +10050,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1577.
+## Ends in an error in state: 1616.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -10056,7 +10062,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1580.
+## Ends in an error in state: 1619.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -10068,7 +10074,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1576, spurious reduction of production type_longident -> LIDENT
+## In state 1615, spurious reduction of production type_longident -> LIDENT
 ## In state 261, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
 ## In state 266, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
 ## In state 264, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
@@ -10079,7 +10085,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 ##
-## Ends in an error in state: 1562.
+## Ends in an error in state: 1601.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT AND ]
@@ -10092,7 +10098,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1573.
+## Ends in an error in state: 1612.
 ##
 ## _class_constructor_type -> NEW class_instance_type . [ error RPAREN ]
 ## _class_instance_type -> class_instance_type . attribute [ error RPAREN LBRACKETAT ]
@@ -10104,16 +10110,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1571, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1575, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1569, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1610, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1614, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1608, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1572.
+## Ends in an error in state: 1611.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET AND ]
@@ -10126,7 +10132,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 ##
-## Ends in an error in state: 1571.
+## Ends in an error in state: 1610.
 ##
 ## _class_instance_type -> clty_longident . [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT AND ]
@@ -10139,7 +10145,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 ##
-## Ends in an error in state: 1567.
+## Ends in an error in state: 1606.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -10153,7 +10159,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 ##
-## Ends in an error in state: 1566.
+## Ends in an error in state: 1605.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -10173,7 +10179,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1560.
+## Ends in an error in state: 1599.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ error RPAREN ]
 ##
@@ -10185,7 +10191,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1581.
+## Ends in an error in state: 1620.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -10197,7 +10203,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 ##
-## Ends in an error in state: 1559.
+## Ends in an error in state: 1598.
 ##
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
@@ -10210,7 +10216,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ##
-## Ends in an error in state: 1556.
+## Ends in an error in state: 1595.
 ##
 ## _class_expr -> class_expr . attribute [ error RPAREN LBRACKETAT COLON ]
 ## _class_simple_expr -> LPAREN class_expr . COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
@@ -10225,16 +10231,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1308, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1329, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1306, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1347, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1368, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1345, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN WITH
 ##
-## Ends in an error in state: 1160.
+## Ends in an error in state: 1199.
 ##
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
@@ -10249,7 +10255,7 @@ implementation: LBRACE INHERIT LPAREN WITH
 
 implementation: LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1527.
+## Ends in an error in state: 1566.
 ##
 ## _class_field -> INHERIT . override_flag class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -10261,7 +10267,7 @@ implementation: LBRACE INHERIT WITH
 
 implementation: LBRACE INITIALIZER EQUALGREATER WITH
 ##
-## Ends in an error in state: 1524.
+## Ends in an error in state: 1563.
 ##
 ## _class_field -> INITIALIZER EQUALGREATER . expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -10273,7 +10279,7 @@ implementation: LBRACE INITIALIZER EQUALGREATER WITH
 
 implementation: LBRACE INITIALIZER WITH
 ##
-## Ends in an error in state: 1523.
+## Ends in an error in state: 1562.
 ##
 ## _class_field -> INITIALIZER . EQUALGREATER expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -10285,7 +10291,7 @@ implementation: LBRACE INITIALIZER WITH
 
 implementation: LBRACE LBRACKETATATAT UNDERSCORE
 ##
-## Ends in an error in state: 1504.
+## Ends in an error in state: 1543.
 ##
 ## floating_attribute -> LBRACKETATATAT . attr_id payload RBRACKET [ error SEMI RBRACE ]
 ##
@@ -10297,7 +10303,7 @@ implementation: LBRACE LBRACKETATATAT UNDERSCORE
 
 implementation: LBRACE LBRACKETATATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 1507.
+## Ends in an error in state: 1546.
 ##
 ## floating_attribute -> LBRACKETATATAT attr_id payload . RBRACKET [ error SEMI RBRACE ]
 ##
@@ -10308,30 +10314,30 @@ implementation: LBRACE LBRACKETATATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1519, spurious reduction of production post_item_attributes ->
-## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1121, spurious reduction of production structure -> structure_item
-## In state 1506, spurious reduction of production payload -> structure
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1558, spurious reduction of production post_item_attributes ->
+## In state 1559, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1560, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1168, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1159, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1561, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1169, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1160, spurious reduction of production structure -> structure_item
+## In state 1545, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LBRACKETPERCENTPERCENT UNDERSCORE
 ##
-## Ends in an error in state: 1118.
+## Ends in an error in state: 1157.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT . attr_id payload RBRACKET [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -10343,7 +10349,7 @@ implementation: LBRACE LBRACKETPERCENTPERCENT UNDERSCORE
 
 implementation: LBRACE LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 1685.
+## Ends in an error in state: 1724.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT attr_id payload . RBRACKET [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -10354,30 +10360,30 @@ implementation: LBRACE LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1519, spurious reduction of production post_item_attributes ->
-## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1121, spurious reduction of production structure -> structure_item
-## In state 1506, spurious reduction of production payload -> structure
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1558, spurious reduction of production post_item_attributes ->
+## In state 1559, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1560, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1168, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1159, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1561, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1169, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1160, spurious reduction of production structure -> structure_item
+## In state 1545, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET CHAR EQUAL CHAR AND WITH
 ##
-## Ends in an error in state: 2171.
+## Ends in an error in state: 2235.
 ##
 ## and_let_binding -> AND . let_binding_body post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -10389,7 +10395,7 @@ implementation: LBRACE LET CHAR EQUAL CHAR AND WITH
 
 implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 2437.
+## Ends in an error in state: 2501.
 ##
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . RBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -10401,17 +10407,17 @@ implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2262, spurious reduction of production opt_semi -> SEMI
-## In state 2273, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
-## In state 2271, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2260, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2326, spurious reduction of production opt_semi -> SEMI
+## In state 2337, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
+## In state 2335, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2324, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
 ##
 
 Expecting "}" to finish the block
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 2055.
+## Ends in an error in state: 2094.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -10445,21 +10451,21 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2059.
+## Ends in an error in state: 2098.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10471,7 +10477,7 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2058.
+## Ends in an error in state: 2097.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10494,7 +10500,7 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 2057.
+## Ends in an error in state: 2096.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10506,7 +10512,7 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2056.
+## Ends in an error in state: 2095.
 ##
 ## let_binding_body -> val_ident COLON typevar_list . DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -10519,7 +10525,7 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 
 implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2053.
+## Ends in an error in state: 2092.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10531,7 +10537,7 @@ implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2052.
+## Ends in an error in state: 2091.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10554,7 +10560,7 @@ implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 2051.
+## Ends in an error in state: 2090.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10566,7 +10572,7 @@ implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LBRACE LET LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 2049.
+## Ends in an error in state: 2088.
 ##
 ## let_binding_body -> val_ident COLON TYPE . lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10578,7 +10584,7 @@ implementation: LBRACE LET LIDENT COLON TYPE WITH
 
 implementation: LBRACE LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 2048.
+## Ends in an error in state: 2087.
 ##
 ## let_binding_body -> val_ident COLON . typevar_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ## let_binding_body -> val_ident COLON . TYPE lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -10592,7 +10598,7 @@ implementation: LBRACE LET LIDENT COLON WITH
 
 implementation: LBRACE LET LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 ##
-## Ends in an error in state: 2062.
+## Ends in an error in state: 2101.
 ##
 ## let_binding_body -> val_ident type_constraint EQUAL . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10604,7 +10610,7 @@ implementation: LBRACE LET LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 
 implementation: LBRACE LET LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2061.
+## Ends in an error in state: 2100.
 ##
 ## let_binding_body -> val_ident type_constraint . EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10621,14 +10627,14 @@ implementation: LBRACE LET LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1260, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1299, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2046.
+## Ends in an error in state: 2085.
 ##
 ## _curried_binding_return_typed -> EQUALGREATER . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10640,7 +10646,7 @@ implementation: LBRACE LET LIDENT EQUALGREATER WITH
 
 implementation: LBRACE LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2044.
+## Ends in an error in state: 2083.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10652,7 +10658,7 @@ implementation: LBRACE LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LBRACE LET LIDENT LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 2043.
+## Ends in an error in state: 2082.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10664,7 +10670,7 @@ implementation: LBRACE LET LIDENT LPAREN TYPE LIDENT WITH
 
 implementation: LBRACE LET LIDENT LPAREN TYPE WITH
 ##
-## Ends in an error in state: 2042.
+## Ends in an error in state: 2081.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10676,7 +10682,7 @@ implementation: LBRACE LET LIDENT LPAREN TYPE WITH
 
 implementation: LBRACE LET LIDENT LPAREN WITH
 ##
-## Ends in an error in state: 2041.
+## Ends in an error in state: 2080.
 ##
 ## _curried_binding_return_typed -> LPAREN . TYPE LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -10699,7 +10705,7 @@ implementation: LBRACE LET LIDENT LPAREN WITH
 
 implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1484.
+## Ends in an error in state: 1523.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -10733,21 +10739,21 @@ implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1483.
+## Ends in an error in state: 1522.
 ##
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type EQUALGREATER . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10759,7 +10765,7 @@ implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1482.
+## Ends in an error in state: 1521.
 ##
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type . EQUALGREATER expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -10772,7 +10778,7 @@ implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE WITH
 
 implementation: LBRACE LET LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1481.
+## Ends in an error in state: 1520.
 ##
 ## curried_binding_return_typed_ -> COLON . non_arrowed_core_type EQUALGREATER expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10784,7 +10790,7 @@ implementation: LBRACE LET LIDENT UNDERSCORE COLON WITH
 
 implementation: LBRACE LET LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2065.
+## Ends in an error in state: 2104.
 ##
 ## _curried_binding_return_typed -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10796,7 +10802,7 @@ implementation: LBRACE LET LIDENT UNDERSCORE WITH
 
 implementation: LBRACE LET LIDENT WITH
 ##
-## Ends in an error in state: 2040.
+## Ends in an error in state: 2079.
 ##
 ## _simple_pattern -> val_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> val_ident . type_constraint EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -10812,7 +10818,7 @@ implementation: LBRACE LET LIDENT WITH
 
 implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT RBRACKET
 ##
-## Ends in an error in state: 2277.
+## Ends in an error in state: 2341.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes . SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10823,22 +10829,22 @@ implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 857, spurious reduction of production _module_expr -> simple_module_expr
-## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
-## In state 913, spurious reduction of production module_binding_body_expr -> EQUAL module_expr
-## In state 1764, spurious reduction of production module_binding_body -> module_binding_body_expr
-## In state 2276, spurious reduction of production post_item_attributes ->
+## In state 931, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 935, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 932, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 873, spurious reduction of production _module_expr -> simple_module_expr
+## In state 937, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 936, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 929, spurious reduction of production module_binding_body_expr -> EQUAL module_expr
+## In state 1803, spurious reduction of production module_binding_body -> module_binding_body_expr
+## In state 2340, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2278.
+## Ends in an error in state: 2342.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10850,7 +10856,7 @@ implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 
 implementation: LBRACE LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2275.
+## Ends in an error in state: 2339.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10862,7 +10868,7 @@ implementation: LBRACE LET MODULE UIDENT WITH
 
 implementation: LBRACE LET MODULE WITH
 ##
-## Ends in an error in state: 2274.
+## Ends in an error in state: 2338.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10874,7 +10880,7 @@ implementation: LBRACE LET MODULE WITH
 
 implementation: LBRACE LET OPEN BANG WITH
 ##
-## Ends in an error in state: 590.
+## Ends in an error in state: 606.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10886,7 +10892,7 @@ implementation: LBRACE LET OPEN BANG WITH
 
 implementation: LBRACE LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 594.
+## Ends in an error in state: 610.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10898,7 +10904,7 @@ implementation: LBRACE LET OPEN UIDENT SEMI WITH
 
 implementation: LBRACE LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 593.
+## Ends in an error in state: 609.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10909,14 +10915,14 @@ implementation: LBRACE LET OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 591, spurious reduction of production post_item_attributes ->
+## In state 607, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET OPEN WITH
 ##
-## Ends in an error in state: 589.
+## Ends in an error in state: 605.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10928,7 +10934,7 @@ implementation: LBRACE LET OPEN WITH
 
 implementation: LBRACE LET REC ASSERT
 ##
-## Ends in an error in state: 2039.
+## Ends in an error in state: 2078.
 ##
 ## let_binding_impl -> LET rec_flag . let_binding_body post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -10940,7 +10946,7 @@ implementation: LBRACE LET REC ASSERT
 
 implementation: LBRACE LET UIDENT UNDERSCORE WHEN
 ##
-## Ends in an error in state: 2074.
+## Ends in an error in state: 2113.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EQUAL BAR ]
 ## let_binding_body -> pattern . EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -10952,17 +10958,17 @@ implementation: LBRACE LET UIDENT UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 783, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
-## In state 786, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
-## In state 781, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
-## In state 787, spurious reduction of production pattern -> pattern_without_or
+## In state 799, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
+## In state 802, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
+## In state 797, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
+## In state 803, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2072.
+## Ends in an error in state: 2111.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10974,7 +10980,7 @@ implementation: LBRACE LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 
 implementation: LBRACE LET UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2071.
+## Ends in an error in state: 2110.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10997,7 +11003,7 @@ implementation: LBRACE LET UNDERSCORE COLON UNDERSCORE WITH
 
 implementation: LBRACE LET UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2070.
+## Ends in an error in state: 2109.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON . core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11009,7 +11015,7 @@ implementation: LBRACE LET UNDERSCORE COLON WITH
 
 implementation: LBRACE LET UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2075.
+## Ends in an error in state: 2114.
 ##
 ## let_binding_body -> pattern EQUAL . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11021,7 +11027,7 @@ implementation: LBRACE LET UNDERSCORE EQUAL WITH
 
 implementation: LBRACE LET UNDERSCORE WITH
 ##
-## Ends in an error in state: 2069.
+## Ends in an error in state: 2108.
 ##
 ## _simple_pattern -> simple_pattern_not_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> simple_pattern_not_ident . COLON core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -11034,7 +11040,7 @@ implementation: LBRACE LET UNDERSCORE WITH
 
 implementation: LBRACE LET WITH
 ##
-## Ends in an error in state: 587.
+## Ends in an error in state: 603.
 ##
 ## _semi_terminated_seq_expr_row -> LET . MODULE UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ## _semi_terminated_seq_expr_row -> LET . OPEN override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
@@ -11048,7 +11054,7 @@ implementation: LBRACE LET WITH
 
 implementation: LBRACE LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1850.
+## Ends in an error in state: 1889.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11083,21 +11089,21 @@ implementation: LBRACE LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1849.
+## Ends in an error in state: 1888.
 ##
 ## lbl_expr -> label_longident COLON . expr [ COMMA ]
 ## non_punned_lbl_expression -> label_longident COLON . expr [ error RBRACE ]
@@ -11110,7 +11116,7 @@ implementation: LBRACE LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1839.
+## Ends in an error in state: 1878.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11144,21 +11150,21 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 ##
-## Ends in an error in state: 1838.
+## Ends in an error in state: 1877.
 ##
 ## lbl_expr -> label_longident COLON . expr [ error RBRACE COMMA ]
 ##
@@ -11170,7 +11176,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 ##
-## Ends in an error in state: 1835.
+## Ends in an error in state: 1874.
 ##
 ## lbl_expr_list -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ## lbl_expr_list -> lbl_expr COMMA . [ error RBRACE ]
@@ -11183,7 +11189,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT WITH
 ##
-## Ends in an error in state: 1837.
+## Ends in an error in state: 1876.
 ##
 ## lbl_expr -> label_longident . COLON expr [ error RBRACE COMMA ]
 ## lbl_expr -> label_longident . [ error RBRACE COMMA ]
@@ -11196,7 +11202,7 @@ implementation: LBRACE LIDENT COMMA LIDENT WITH
 
 implementation: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 1846.
+## Ends in an error in state: 1885.
 ##
 ## lbl_expr_list_that_is_not_a_single_punned_field -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ##
@@ -11208,7 +11214,7 @@ implementation: LBRACE LIDENT COMMA WITH
 
 implementation: LBRACE METHOD BANG WITH
 ##
-## Ends in an error in state: 1462.
+## Ends in an error in state: 1501.
 ##
 ## method_ -> override_flag . PRIVATE VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag . VIRTUAL private_flag label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -11225,7 +11231,7 @@ implementation: LBRACE METHOD BANG WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1497.
+## Ends in an error in state: 1536.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11259,21 +11265,21 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1496.
+## Ends in an error in state: 1535.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT core_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11285,7 +11291,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1495.
+## Ends in an error in state: 1534.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT core_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11308,7 +11314,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1494.
+## Ends in an error in state: 1533.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT . core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11320,7 +11326,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 1492.
+## Ends in an error in state: 1531.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE . lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11332,7 +11338,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE WITH
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1500.
+## Ends in an error in state: 1539.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11366,21 +11372,21 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1499.
+## Ends in an error in state: 1538.
 ##
 ## method_ -> override_flag private_flag label COLON poly_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11392,7 +11398,7 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1498.
+## Ends in an error in state: 1537.
 ##
 ## method_ -> override_flag private_flag label COLON poly_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11409,16 +11415,16 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 502, spurious reduction of production _poly_type -> core_type
-## In state 503, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 501, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 517, spurious reduction of production _poly_type -> core_type
+## In state 518, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 516, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON WITH
 ##
-## Ends in an error in state: 1491.
+## Ends in an error in state: 1530.
 ##
 ## method_ -> override_flag private_flag label COLON . poly_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag private_flag label COLON . TYPE lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -11431,7 +11437,7 @@ implementation: LBRACE METHOD LIDENT COLON WITH
 
 implementation: LBRACE METHOD LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1490.
+## Ends in an error in state: 1529.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11465,21 +11471,21 @@ implementation: LBRACE METHOD LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1489.
+## Ends in an error in state: 1528.
 ##
 ## method_ -> override_flag private_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11491,7 +11497,7 @@ implementation: LBRACE METHOD LIDENT EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1545.
+## Ends in an error in state: 1584.
 ##
 ## semi_terminated_class_fields -> class_field . [ error RBRACE ]
 ## semi_terminated_class_fields -> class_field . SEMI semi_terminated_class_fields [ error RBRACE ]
@@ -11503,27 +11509,27 @@ implementation: LBRACE METHOD LIDENT EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1480, spurious reduction of production curried_binding -> EQUALGREATER expr
-## In state 1501, spurious reduction of production method_ -> override_flag private_flag label curried_binding
-## In state 1502, spurious reduction of production post_item_attributes ->
-## In state 1503, spurious reduction of production _class_field -> METHOD method_ post_item_attributes
-## In state 1548, spurious reduction of production mark_position_cf(_class_field) -> _class_field
-## In state 1541, spurious reduction of production class_field -> mark_position_cf(_class_field)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1519, spurious reduction of production curried_binding -> EQUALGREATER expr
+## In state 1540, spurious reduction of production method_ -> override_flag private_flag label curried_binding
+## In state 1541, spurious reduction of production post_item_attributes ->
+## In state 1542, spurious reduction of production _class_field -> METHOD method_ post_item_attributes
+## In state 1587, spurious reduction of production mark_position_cf(_class_field) -> _class_field
+## In state 1580, spurious reduction of production class_field -> mark_position_cf(_class_field)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1479.
+## Ends in an error in state: 1518.
 ##
 ## curried_binding -> EQUALGREATER . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11535,7 +11541,7 @@ implementation: LBRACE METHOD LIDENT EQUALGREATER WITH
 
 implementation: LBRACE METHOD LIDENT LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1478.
+## Ends in an error in state: 1517.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11547,7 +11553,7 @@ implementation: LBRACE METHOD LIDENT LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LBRACE METHOD LIDENT LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1477.
+## Ends in an error in state: 1516.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11559,7 +11565,7 @@ implementation: LBRACE METHOD LIDENT LPAREN TYPE LIDENT WITH
 
 implementation: LBRACE METHOD LIDENT LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1476.
+## Ends in an error in state: 1515.
 ##
 ## curried_binding -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11571,7 +11577,7 @@ implementation: LBRACE METHOD LIDENT LPAREN TYPE WITH
 
 implementation: LBRACE METHOD LIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1475.
+## Ends in an error in state: 1514.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -11594,7 +11600,7 @@ implementation: LBRACE METHOD LIDENT LPAREN WITH
 
 implementation: LBRACE METHOD LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1485.
+## Ends in an error in state: 1524.
 ##
 ## curried_binding -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11606,7 +11612,7 @@ implementation: LBRACE METHOD LIDENT UNDERSCORE WITH
 
 implementation: LBRACE METHOD LIDENT WITH
 ##
-## Ends in an error in state: 1474.
+## Ends in an error in state: 1513.
 ##
 ## method_ -> override_flag private_flag label . curried_binding [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag private_flag label . COLON poly_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -11621,7 +11627,7 @@ implementation: LBRACE METHOD LIDENT WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1471.
+## Ends in an error in state: 1510.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11633,7 +11639,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1470.
+## Ends in an error in state: 1509.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11645,7 +11651,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL WITH
 ##
-## Ends in an error in state: 1469.
+## Ends in an error in state: 1508.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11657,7 +11663,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL WITH
 
 implementation: LBRACE METHOD PRIVATE WITH
 ##
-## Ends in an error in state: 1468.
+## Ends in an error in state: 1507.
 ##
 ## method_ -> override_flag PRIVATE . VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## private_flag -> PRIVATE . [ LIDENT ]
@@ -11670,7 +11676,7 @@ implementation: LBRACE METHOD PRIVATE WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1111.
+## Ends in an error in state: 1150.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11682,7 +11688,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1110.
+## Ends in an error in state: 1149.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -11695,7 +11701,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WIT
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE WITH
 ##
-## Ends in an error in state: 1108.
+## Ends in an error in state: 1147.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ error SEMI RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AS ]
 ## typevar_list -> QUOTE . ident [ QUOTE DOT ]
@@ -11708,7 +11714,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1466.
+## Ends in an error in state: 1505.
 ##
 ## method_ -> override_flag VIRTUAL private_flag label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11720,7 +11726,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1465.
+## Ends in an error in state: 1504.
 ##
 ## method_ -> override_flag VIRTUAL private_flag label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11732,7 +11738,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT WITH
 
 implementation: LBRACE METHOD VIRTUAL PRIVATE LET
 ##
-## Ends in an error in state: 1464.
+## Ends in an error in state: 1503.
 ##
 ## method_ -> override_flag VIRTUAL private_flag . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11744,7 +11750,7 @@ implementation: LBRACE METHOD VIRTUAL PRIVATE LET
 
 implementation: LBRACE METHOD VIRTUAL WITH
 ##
-## Ends in an error in state: 1463.
+## Ends in an error in state: 1502.
 ##
 ## method_ -> override_flag VIRTUAL . private_flag label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11756,7 +11762,7 @@ implementation: LBRACE METHOD VIRTUAL WITH
 
 implementation: LBRACE METHOD WITH
 ##
-## Ends in an error in state: 1461.
+## Ends in an error in state: 1500.
 ##
 ## _class_field -> METHOD . method_ post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -11768,7 +11774,7 @@ implementation: LBRACE METHOD WITH
 
 implementation: LBRACE PERCENT WITH TYPE
 ##
-## Ends in an error in state: 2264.
+## Ends in an error in state: 2328.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ error RBRACE ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ error SEMI RBRACE AND ]
@@ -11788,7 +11794,7 @@ implementation: LBRACE PERCENT WITH TYPE
 
 implementation: LBRACE UIDENT DOT WITH
 ##
-## Ends in an error in state: 2287.
+## Ends in an error in state: 2351.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
@@ -11813,7 +11819,7 @@ implementation: LBRACE UIDENT DOT WITH
 
 implementation: LBRACE UIDENT LBRACKETATAT UNDERSCORE
 ##
-## Ends in an error in state: 539.
+## Ends in an error in state: 555.
 ##
 ## item_attribute -> LBRACKETATAT . attr_id payload RBRACKET [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11825,7 +11831,7 @@ implementation: LBRACE UIDENT LBRACKETATAT UNDERSCORE
 
 implementation: LBRACE UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2357.
+## Ends in an error in state: 2421.
 ##
 ## item_attribute -> LBRACKETATAT attr_id payload . RBRACKET [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11836,30 +11842,30 @@ implementation: LBRACE UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1519, spurious reduction of production post_item_attributes ->
-## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1121, spurious reduction of production structure -> structure_item
-## In state 1506, spurious reduction of production payload -> structure
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1558, spurious reduction of production post_item_attributes ->
+## In state 1559, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1560, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1168, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1159, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1561, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1169, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1160, spurious reduction of production structure -> structure_item
+## In state 1545, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL BANG WITH
 ##
-## Ends in an error in state: 1355.
+## Ends in an error in state: 1394.
 ##
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -11874,7 +11880,7 @@ implementation: LBRACE VAL BANG WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1460.
+## Ends in an error in state: 1499.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11908,21 +11914,21 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL UIDENT RP
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 ##
-## Ends in an error in state: 1459.
+## Ends in an error in state: 1498.
 ##
 ## value -> override_flag mutable_flag label type_constraint EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11934,7 +11940,7 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1458.
+## Ends in an error in state: 1497.
 ##
 ## value -> override_flag mutable_flag label type_constraint . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11951,14 +11957,14 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1260, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1299, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1456.
+## Ends in an error in state: 1495.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11992,21 +11998,21 @@ implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1364.
+## Ends in an error in state: 1403.
 ##
 ## value -> override_flag mutable_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -12018,7 +12024,7 @@ implementation: LBRACE VAL LIDENT EQUAL WITH
 
 implementation: LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1363.
+## Ends in an error in state: 1402.
 ##
 ## value -> override_flag mutable_flag label . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag mutable_flag label . type_constraint EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -12031,7 +12037,7 @@ implementation: LBRACE VAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1360.
+## Ends in an error in state: 1399.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12055,7 +12061,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1359.
+## Ends in an error in state: 1398.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12068,7 +12074,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1358.
+## Ends in an error in state: 1397.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12081,7 +12087,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 ##
-## Ends in an error in state: 1357.
+## Ends in an error in state: 1396.
 ##
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12094,7 +12100,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 
 implementation: LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1356.
+## Ends in an error in state: 1395.
 ##
 ## mutable_flag -> MUTABLE . [ LIDENT ]
 ## value -> override_flag MUTABLE . VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -12108,7 +12114,7 @@ implementation: LBRACE VAL MUTABLE WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1351.
+## Ends in an error in state: 1390.
 ##
 ## value -> VIRTUAL mutable_flag label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12132,7 +12138,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1350.
+## Ends in an error in state: 1389.
 ##
 ## value -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12145,7 +12151,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1349.
+## Ends in an error in state: 1388.
 ##
 ## value -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12158,7 +12164,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1348.
+## Ends in an error in state: 1387.
 ##
 ## value -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12171,7 +12177,7 @@ implementation: LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1347.
+## Ends in an error in state: 1386.
 ##
 ## value -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL . mutable_flag label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -12184,7 +12190,7 @@ implementation: LBRACE VAL VIRTUAL WITH
 
 implementation: LBRACE VAL WITH
 ##
-## Ends in an error in state: 1346.
+## Ends in an error in state: 1385.
 ##
 ## _class_field -> VAL . value post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -12213,7 +12219,7 @@ implementation: LBRACE WITH
 
 implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2488.
+## Ends in an error in state: 2552.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -12247,14 +12253,14 @@ implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -12273,7 +12279,7 @@ implementation: LBRACELESS LIDENT COLON WITH
 
 implementation: LBRACELESS LIDENT COMMA WITH
 ##
-## Ends in an error in state: 579.
+## Ends in an error in state: 595.
 ##
 ## field_expr_list -> field_expr_list COMMA . field_expr [ error GREATERRBRACE COMMA ]
 ## opt_comma -> COMMA . [ error GREATERRBRACE ]
@@ -12313,7 +12319,7 @@ implementation: LBRACELESS WITH
 
 implementation: LBRACKET DOTDOTDOT UIDENT COMMA
 ##
-## Ends in an error in state: 2210.
+## Ends in an error in state: 2274.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT expr_optional_constraint . RBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -12324,22 +12330,22 @@ implementation: LBRACKET DOTDOTDOT UIDENT COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1816, spurious reduction of production expr_optional_constraint -> expr
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1855, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKET DOTDOTDOT WITH
 ##
-## Ends in an error in state: 2209.
+## Ends in an error in state: 2273.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT . expr_optional_constraint RBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -12351,7 +12357,7 @@ implementation: LBRACKET DOTDOTDOT WITH
 
 implementation: LBRACKET UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2213.
+## Ends in an error in state: 2277.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint COMMA . expr_comma_seq_extension [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## opt_comma -> COMMA . [ RBRACKET ]
@@ -12364,7 +12370,7 @@ implementation: LBRACKET UIDENT COMMA WITH
 
 implementation: LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2212.
+## Ends in an error in state: 2276.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint . opt_comma RBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## expr_comma_seq_extension -> expr_optional_constraint . COMMA expr_comma_seq_extension [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -12376,15 +12382,15 @@ implementation: LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1816, spurious reduction of production expr_optional_constraint -> expr
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1855, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 Expecting one of the following:
@@ -12409,7 +12415,7 @@ Expecting one of the following:
 
 implementation: LBRACKETATATAT UNDERSCORE
 ##
-## Ends in an error in state: 1037.
+## Ends in an error in state: 1059.
 ##
 ## floating_attribute -> LBRACKETATATAT . attr_id payload RBRACKET [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12421,7 +12427,7 @@ implementation: LBRACKETATATAT UNDERSCORE
 
 implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 1709.
+## Ends in an error in state: 1748.
 ##
 ## floating_attribute -> LBRACKETATATAT attr_id payload . RBRACKET [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12432,30 +12438,30 @@ implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1519, spurious reduction of production post_item_attributes ->
-## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1121, spurious reduction of production structure -> structure_item
-## In state 1506, spurious reduction of production payload -> structure
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1558, spurious reduction of production post_item_attributes ->
+## In state 1559, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1560, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1168, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1159, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1561, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1169, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1160, spurious reduction of production structure -> structure_item
+## In state 1545, spurious reduction of production payload -> structure
 ##
 
 Expecting "]" to finish current floating attribute
 
 implementation: LBRACKETBAR BANG WITH
 ##
-## Ends in an error in state: 602.
+## Ends in an error in state: 618.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12467,7 +12473,7 @@ implementation: LBRACKETBAR BANG WITH
 
 implementation: LBRACKETBAR MINUSDOT WITH
 ##
-## Ends in an error in state: 1367.
+## Ends in an error in state: 1406.
 ##
 ## _expr -> subtractive . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12479,7 +12485,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR PLUSDOT WITH
 ##
-## Ends in an error in state: 1391.
+## Ends in an error in state: 1430.
 ##
 ## _expr -> additive . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12503,7 +12509,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1806.
+## Ends in an error in state: 1845.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -12515,7 +12521,7 @@ Expecting a type name
 
 implementation: LBRACKETBAR UIDENT COLON WITH
 ##
-## Ends in an error in state: 1803.
+## Ends in an error in state: 1842.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -12527,7 +12533,7 @@ implementation: LBRACKETBAR UIDENT COLON WITH
 
 implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1801.
+## Ends in an error in state: 1840.
 ##
 ## type_constraint -> COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -12539,7 +12545,7 @@ implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 
 implementation: LBRACKETBAR UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1798.
+## Ends in an error in state: 1837.
 ##
 ## expr_comma_seq -> expr_comma_seq COMMA . expr_optional_constraint [ error COMMA BARRBRACKET ]
 ## opt_comma -> COMMA . [ error BARRBRACKET ]
@@ -12552,7 +12558,7 @@ implementation: LBRACKETBAR UIDENT COMMA WITH
 
 implementation: LBRACKETBAR UIDENT SEMI
 ##
-## Ends in an error in state: 2506.
+## Ends in an error in state: 2570.
 ##
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -12565,16 +12571,16 @@ implementation: LBRACKETBAR UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1800, spurious reduction of production expr_optional_constraint -> expr
-## In state 1796, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1839, spurious reduction of production expr_optional_constraint -> expr
+## In state 1835, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
@@ -12607,7 +12613,7 @@ implementation: LBRACKETPERCENT UNDERSCORE
 
 implementation: LBRACKETPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2603.
+## Ends in an error in state: 2690.
 ##
 ## extension -> LBRACKETPERCENT attr_id payload . RBRACKET [ WITH WHEN UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR OPTIONAL_NO_DEFAULT NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 IN GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOWNTO DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12618,30 +12624,30 @@ implementation: LBRACKETPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1519, spurious reduction of production post_item_attributes ->
-## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1121, spurious reduction of production structure -> structure_item
-## In state 1506, spurious reduction of production payload -> structure
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1558, spurious reduction of production post_item_attributes ->
+## In state 1559, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1560, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1168, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1159, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1561, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1169, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1160, spurious reduction of production structure -> structure_item
+## In state 1545, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 ##
-## Ends in an error in state: 1035.
+## Ends in an error in state: 1057.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT . attr_id payload RBRACKET [ SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -12653,7 +12659,7 @@ implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH COLON WITH
 ##
-## Ends in an error in state: 1062.
+## Ends in an error in state: 1101.
 ##
 ## payload -> COLON . core_type [ RBRACKET ]
 ##
@@ -12677,7 +12683,7 @@ implementation: LBRACKETPERCENTPERCENT WITH DOT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ##
-## Ends in an error in state: 2431.
+## Ends in an error in state: 2495.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN RBRACKET BAR ]
 ## payload -> QUESTION pattern . [ RBRACKET ]
@@ -12690,14 +12696,14 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 787, spurious reduction of production pattern -> pattern_without_or
+## In state 803, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2433.
+## Ends in an error in state: 2497.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -12731,21 +12737,21 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2432.
+## Ends in an error in state: 2496.
 ##
 ## payload -> QUESTION pattern WHEN . expr [ RBRACKET ]
 ##
@@ -12770,7 +12776,7 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION WITH
 
 implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 1711.
+## Ends in an error in state: 1750.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT attr_id payload . RBRACKET [ SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -12781,23 +12787,23 @@ implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1519, spurious reduction of production post_item_attributes ->
-## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1121, spurious reduction of production structure -> structure_item
-## In state 1506, spurious reduction of production payload -> structure
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1558, spurious reduction of production post_item_attributes ->
+## In state 1559, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1560, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1168, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1159, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1561, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1169, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1160, spurious reduction of production structure -> structure_item
+## In state 1545, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
@@ -12817,7 +12823,7 @@ implementation: LBRACKETPERCENTPERCENT WITH WITH
 
 implementation: LET CHAR EQUAL CHAR AND WITH
 ##
-## Ends in an error in state: 1510.
+## Ends in an error in state: 1549.
 ##
 ## and_let_binding -> AND . let_binding_body post_item_attributes [ SEMI RBRACKET RBRACE EOF BAR AND ]
 ##
@@ -12829,7 +12835,7 @@ implementation: LET CHAR EQUAL CHAR AND WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1270.
+## Ends in an error in state: 1309.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -12863,21 +12869,21 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1274.
+## Ends in an error in state: 1313.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type EQUAL . mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12889,7 +12895,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1273.
+## Ends in an error in state: 1312.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type . EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12912,7 +12918,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1272.
+## Ends in an error in state: 1311.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT . core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12924,7 +12930,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1271.
+## Ends in an error in state: 1310.
 ##
 ## let_binding_body -> val_ident COLON typevar_list . DOT core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -12937,7 +12943,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1268.
+## Ends in an error in state: 1307.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type EQUAL . mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12949,7 +12955,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1267.
+## Ends in an error in state: 1306.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type . EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12972,7 +12978,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1266.
+## Ends in an error in state: 1305.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT . core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -12984,7 +12990,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1263.
+## Ends in an error in state: 1302.
 ##
 ## lident_list -> LIDENT . [ DOT ]
 ## lident_list -> LIDENT . lident_list [ DOT ]
@@ -12997,7 +13003,7 @@ implementation: LET LIDENT COLON TYPE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 1262.
+## Ends in an error in state: 1301.
 ##
 ## let_binding_body -> val_ident COLON TYPE . lident_list DOT core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13009,7 +13015,7 @@ implementation: LET LIDENT COLON TYPE WITH
 
 implementation: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 1261.
+## Ends in an error in state: 1300.
 ##
 ## let_binding_body -> val_ident COLON . typevar_list DOT core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ## let_binding_body -> val_ident COLON . TYPE lident_list DOT core_type EQUAL mark_position_exp(expr) [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
@@ -13023,7 +13029,7 @@ implementation: LET LIDENT COLON WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1281.
+## Ends in an error in state: 1320.
 ##
 ## let_binding_body -> val_ident type_constraint EQUAL . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13035,7 +13041,7 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 1280.
+## Ends in an error in state: 1319.
 ##
 ## let_binding_body -> val_ident type_constraint . EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13052,14 +13058,14 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1260, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1299, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1257.
+## Ends in an error in state: 1296.
 ##
 ## _curried_binding_return_typed -> EQUALGREATER . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13071,7 +13077,7 @@ implementation: LET LIDENT EQUALGREATER WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1168.
+## Ends in an error in state: 1207.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13083,7 +13089,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1167.
+## Ends in an error in state: 1206.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13095,7 +13101,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1166.
+## Ends in an error in state: 1205.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13107,7 +13113,7 @@ implementation: LET LIDENT LPAREN TYPE WITH
 
 implementation: LET LIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1165.
+## Ends in an error in state: 1204.
 ##
 ## _curried_binding_return_typed -> LPAREN . TYPE LIDENT RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -13130,7 +13136,7 @@ implementation: LET LIDENT LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1250.
+## Ends in an error in state: 1289.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -13164,21 +13170,21 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1249.
+## Ends in an error in state: 1288.
 ##
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type EQUALGREATER . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13190,7 +13196,7 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1248.
+## Ends in an error in state: 1287.
 ##
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type . EQUALGREATER expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
@@ -13204,7 +13210,7 @@ Expecting "=>" to start the function body
 
 implementation: LET LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1247.
+## Ends in an error in state: 1286.
 ##
 ## curried_binding_return_typed_ -> COLON . non_arrowed_core_type EQUALGREATER expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13216,7 +13222,7 @@ implementation: LET LIDENT UNDERSCORE COLON WITH
 
 implementation: LET LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1173.
+## Ends in an error in state: 1212.
 ##
 ## curried_binding -> EQUALGREATER . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13228,7 +13234,7 @@ Expecting an expression as function body
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1172.
+## Ends in an error in state: 1211.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13240,7 +13246,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1171.
+## Ends in an error in state: 1210.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13252,7 +13258,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1170.
+## Ends in an error in state: 1209.
 ##
 ## curried_binding -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13264,7 +13270,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 1169.
+## Ends in an error in state: 1208.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -13287,7 +13293,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 1252.
+## Ends in an error in state: 1291.
 ##
 ## curried_binding -> labeled_simple_pattern . curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13299,7 +13305,7 @@ implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 
 implementation: LET LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1284.
+## Ends in an error in state: 1323.
 ##
 ## _curried_binding_return_typed -> labeled_simple_pattern . curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13315,7 +13321,7 @@ Expecting one of the following:
 
 implementation: LET LIDENT WITH
 ##
-## Ends in an error in state: 1164.
+## Ends in an error in state: 1203.
 ##
 ## _simple_pattern -> val_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> val_ident . type_constraint EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
@@ -13331,7 +13337,7 @@ implementation: LET LIDENT WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 ##
-## Ends in an error in state: 1142.
+## Ends in an error in state: 1181.
 ##
 ## and_nonlocal_module_bindings -> AND . nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -13343,7 +13349,7 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1141.
+## Ends in an error in state: 1180.
 ##
 ## _structure_item_without_item_extension_sugar -> many_nonlocal_module_bindings . [ SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> many_nonlocal_module_bindings . and_nonlocal_module_bindings [ SEMI RBRACKET RBRACE EOF AND ]
@@ -13355,16 +13361,16 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WIT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 928, spurious reduction of production post_item_attributes ->
-## In state 929, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1780, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
+## In state 944, spurious reduction of production post_item_attributes ->
+## In state 945, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1819, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE REC WITH
 ##
-## Ends in an error in state: 1778.
+## Ends in an error in state: 1817.
 ##
 ## many_nonlocal_module_bindings -> LET MODULE REC . nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -13376,7 +13382,7 @@ implementation: LET MODULE REC WITH
 
 implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 1762.
+## Ends in an error in state: 1801.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -13390,19 +13396,19 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 857, spurious reduction of production _module_expr -> simple_module_expr
-## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 931, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 935, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 932, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 873, spurious reduction of production _module_expr -> simple_module_expr
+## In state 937, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 936, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1761.
+## Ends in an error in state: 1800.
 ##
 ## module_binding_body_expr -> COLON module_type EQUAL . module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13414,7 +13420,7 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
 
 implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1760.
+## Ends in an error in state: 1799.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER EQUAL ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER EQUAL ]
@@ -13430,22 +13436,22 @@ implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 964, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 963, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 986, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1022, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1018, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 984, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1023, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1019, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 985, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1024, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1020, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 922.
+## Ends in an error in state: 938.
 ##
 ## module_binding_body_expr -> COLON . module_type EQUAL module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13457,7 +13463,7 @@ implementation: LET MODULE UIDENT COLON WITH
 
 implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 913.
+## Ends in an error in state: 929.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -13471,19 +13477,19 @@ implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 857, spurious reduction of production _module_expr -> simple_module_expr
-## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 931, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 935, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 932, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 873, spurious reduction of production _module_expr -> simple_module_expr
+## In state 937, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 936, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 912.
+## Ends in an error in state: 928.
 ##
 ## module_binding_body_expr -> EQUAL . module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13495,7 +13501,7 @@ implementation: LET MODULE UIDENT EQUAL WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 1773.
+## Ends in an error in state: 1812.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER module_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -13509,19 +13515,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 857, spurious reduction of production _module_expr -> simple_module_expr
-## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 931, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 935, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 932, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 873, spurious reduction of production _module_expr -> simple_module_expr
+## In state 937, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 936, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1772.
+## Ends in an error in state: 1811.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER . module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13533,7 +13539,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1771.
+## Ends in an error in state: 1810.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type . EQUALGREATER module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_type -> non_arrowed_module_type . [ WITH LBRACKETAT EQUALGREATER ]
@@ -13547,19 +13553,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 117, spurious reduction of production ident -> UIDENT
 ## In state 260, spurious reduction of production mty_longident -> ident
-## In state 964, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1000, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 996, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1001, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 997, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 986, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1022, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1018, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 984, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1023, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1019, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER SEMI
 ##
-## Ends in an error in state: 1774.
+## Ends in an error in state: 1813.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER ]
@@ -13578,18 +13584,18 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT CO
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 973, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 992, spurious reduction of production with_constraints -> with_constraint
-## In state 989, spurious reduction of production _module_type -> module_type WITH with_constraints
-## In state 1002, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 998, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 995, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1014, spurious reduction of production with_constraints -> with_constraint
+## In state 1011, spurious reduction of production _module_type -> module_type WITH with_constraints
+## In state 1024, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1020, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
 ##
-## Ends in an error in state: 1770.
+## Ends in an error in state: 1809.
 ##
 ## _module_binding_body_functor -> functor_args COLON . non_arrowed_module_type EQUALGREATER module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13601,7 +13607,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 1769.
+## Ends in an error in state: 1808.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER module_expr . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -13615,19 +13621,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 857, spurious reduction of production _module_expr -> simple_module_expr
-## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 931, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 935, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 932, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 873, spurious reduction of production _module_expr -> simple_module_expr
+## In state 937, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 936, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1768.
+## Ends in an error in state: 1807.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER . module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13639,7 +13645,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1767.
+## Ends in an error in state: 1806.
 ##
 ## _module_binding_body_functor -> functor_args . EQUALGREATER module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_binding_body_functor -> functor_args . COLON non_arrowed_module_type EQUALGREATER module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -13653,7 +13659,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 
 implementation: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 911.
+## Ends in an error in state: 927.
 ##
 ## nonlocal_module_binding_details -> UIDENT . module_binding_body [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13665,7 +13671,7 @@ implementation: LET MODULE UIDENT WITH
 
 implementation: LET MODULE WITH
 ##
-## Ends in an error in state: 910.
+## Ends in an error in state: 926.
 ##
 ## _structure_item_without_item_extension_sugar -> LET MODULE . nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> LET MODULE . REC nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
@@ -13678,7 +13684,7 @@ implementation: LET MODULE WITH
 
 implementation: LET REC ASSERT
 ##
-## Ends in an error in state: 1163.
+## Ends in an error in state: 1202.
 ##
 ## let_binding_impl -> LET rec_flag . let_binding_body post_item_attributes [ SEMI RBRACKET RBRACE EOF BAR AND ]
 ##
@@ -13690,7 +13696,7 @@ implementation: LET REC ASSERT
 
 implementation: LET UIDENT UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1293.
+## Ends in an error in state: 1332.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EQUAL BAR ]
 ## let_binding_body -> pattern . EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
@@ -13702,17 +13708,17 @@ implementation: LET UIDENT UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 783, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
-## In state 786, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
-## In state 781, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
-## In state 787, spurious reduction of production pattern -> pattern_without_or
+## In state 799, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
+## In state 802, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
+## In state 797, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
+## In state 803, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1291.
+## Ends in an error in state: 1330.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type EQUAL . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13724,7 +13730,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1290.
+## Ends in an error in state: 1329.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type . EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13747,7 +13753,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 
 implementation: LET UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1289.
+## Ends in an error in state: 1328.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON . core_type EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13759,7 +13765,7 @@ implementation: LET UNDERSCORE COLON WITH
 
 implementation: LET UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1294.
+## Ends in an error in state: 1333.
 ##
 ## let_binding_body -> pattern EQUAL . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13771,7 +13777,7 @@ implementation: LET UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE WITH
 ##
-## Ends in an error in state: 1288.
+## Ends in an error in state: 1327.
 ##
 ## _simple_pattern -> simple_pattern_not_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> simple_pattern_not_ident . COLON core_type EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
@@ -13784,7 +13790,7 @@ implementation: LET UNDERSCORE WITH
 
 implementation: LET WITH
 ##
-## Ends in an error in state: 909.
+## Ends in an error in state: 925.
 ##
 ## _structure_item_without_item_extension_sugar -> LET . MODULE nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
@@ -13798,7 +13804,7 @@ Incomplete let binding
 
 implementation: LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1187.
+## Ends in an error in state: 1226.
 ##
 ## _expr -> label EQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13810,7 +13816,7 @@ implementation: LIDENT EQUAL WITH
 
 implementation: LPAREN ASSERT WITH
 ##
-## Ends in an error in state: 1365.
+## Ends in an error in state: 1404.
 ##
 ## _expr -> ASSERT . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13822,7 +13828,7 @@ implementation: LPAREN ASSERT WITH
 
 implementation: LPAREN BACKQUOTE WITH
 ##
-## Ends in an error in state: 603.
+## Ends in an error in state: 619.
 ##
 ## name_tag -> BACKQUOTE . ident [ error UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -13834,7 +13840,7 @@ implementation: LPAREN BACKQUOTE WITH
 
 implementation: LPAREN BANG WITH
 ##
-## Ends in an error in state: 1791.
+## Ends in an error in state: 1830.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SHARP RPAREN QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## operator -> BANG . [ RPAREN ]
@@ -13847,7 +13853,7 @@ implementation: LPAREN BANG WITH
 
 implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ##
-## Ends in an error in state: 2342.
+## Ends in an error in state: 2406.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr . RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13881,21 +13887,21 @@ implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2341.
+## Ends in an error in state: 2405.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA . expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13907,7 +13913,7 @@ implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2340.
+## Ends in an error in state: 2404.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr . COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13941,21 +13947,21 @@ implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2339.
+## Ends in an error in state: 2403.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN . expr COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13967,7 +13973,7 @@ implementation: LPAREN COLONCOLON RPAREN LPAREN WITH
 
 implementation: LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2338.
+## Ends in an error in state: 2402.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN . LPAREN expr COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13979,7 +13985,7 @@ implementation: LPAREN COLONCOLON RPAREN WITH
 
 implementation: LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2337.
+## Ends in an error in state: 2401.
 ##
 ## _expr -> LPAREN COLONCOLON . RPAREN LPAREN expr COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13991,7 +13997,7 @@ implementation: LPAREN COLONCOLON WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ##
-## Ends in an error in state: 900.
+## Ends in an error in state: 916.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag simple_expr . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -14009,17 +14015,17 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 886, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 902, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 ##
-## Ends in an error in state: 899.
+## Ends in an error in state: 915.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag . simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14031,7 +14037,7 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ##
-## Ends in an error in state: 898.
+## Ends in an error in state: 914.
 ##
 ## _expr -> FOR pattern IN simple_expr . direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ TO SHARP DOWNTO DOT ]
@@ -14049,17 +14055,17 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 886, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 902, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FOR UNDERSCORE IN WITH
 ##
-## Ends in an error in state: 897.
+## Ends in an error in state: 913.
 ##
 ## _expr -> FOR pattern IN . simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14071,7 +14077,7 @@ implementation: LPAREN FOR UNDERSCORE IN WITH
 
 implementation: LPAREN FOR UNDERSCORE WHEN
 ##
-## Ends in an error in state: 896.
+## Ends in an error in state: 912.
 ##
 ## _expr -> FOR pattern . IN simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _or_pattern -> pattern . BAR pattern [ IN BAR ]
@@ -14083,14 +14089,14 @@ implementation: LPAREN FOR UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 787, spurious reduction of production pattern -> pattern_without_or
+## In state 803, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FOR WITH
 ##
-## Ends in an error in state: 895.
+## Ends in an error in state: 911.
 ##
 ## _expr -> FOR . pattern IN simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14102,7 +14108,7 @@ implementation: LPAREN FOR WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2242.
+## Ends in an error in state: 2306.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14136,17 +14142,17 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2241.
+## Ends in an error in state: 2305.
 ##
 ## leading_bar_match_case -> bar_located_pattern EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14158,7 +14164,7 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2240.
+## Ends in an error in state: 2304.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14192,17 +14198,17 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2239.
+## Ends in an error in state: 2303.
 ##
 ## leading_bar_match_case -> bar_located_pattern WHEN expr EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14214,7 +14220,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2238.
+## Ends in an error in state: 2302.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -14248,21 +14254,21 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2237.
+## Ends in an error in state: 2301.
 ##
 ## leading_bar_match_case -> bar_located_pattern WHEN . expr EQUALGREATER expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14274,7 +14280,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 621.
+## Ends in an error in state: 637.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14286,7 +14292,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 620.
+## Ends in an error in state: 636.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14298,7 +14304,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN LPAREN TYPE WITH
 ##
-## Ends in an error in state: 619.
+## Ends in an error in state: 635.
 ##
 ## _expr -> FUN LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14310,7 +14316,7 @@ implementation: LPAREN FUN LPAREN TYPE WITH
 
 implementation: LPAREN FUN LPAREN WITH
 ##
-## Ends in an error in state: 618.
+## Ends in an error in state: 634.
 ##
 ## _expr -> FUN LPAREN . TYPE LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
@@ -14333,7 +14339,7 @@ implementation: LPAREN FUN LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2229.
+## Ends in an error in state: 2293.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14367,17 +14373,17 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2228.
+## Ends in an error in state: 2292.
 ##
 ## fun_def -> EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14389,7 +14395,7 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 625.
+## Ends in an error in state: 641.
 ##
 ## fun_def -> LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14401,7 +14407,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 624.
+## Ends in an error in state: 640.
 ##
 ## fun_def -> LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14413,7 +14419,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 623.
+## Ends in an error in state: 639.
 ##
 ## fun_def -> LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14425,7 +14431,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 622.
+## Ends in an error in state: 638.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
@@ -14448,7 +14454,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 2230.
+## Ends in an error in state: 2294.
 ##
 ## fun_def -> labeled_simple_pattern . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14460,7 +14466,7 @@ implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 
 implementation: LPAREN FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2244.
+## Ends in an error in state: 2308.
 ##
 ## _expr -> FUN labeled_simple_pattern . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14472,7 +14478,7 @@ implementation: LPAREN FUN UNDERSCORE WITH
 
 implementation: LPAREN FUN WITH
 ##
-## Ends in an error in state: 617.
+## Ends in an error in state: 633.
 ##
 ## _expr -> FUN . labeled_simple_pattern fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> FUN . LPAREN TYPE LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14486,7 +14492,7 @@ implementation: LPAREN FUN WITH
 
 implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 ##
-## Ends in an error in state: 616.
+## Ends in an error in state: 632.
 ##
 ## _expr -> IF simple_expr simple_expr ELSE . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14498,7 +14504,7 @@ implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 
 implementation: LPAREN IF UIDENT WITH
 ##
-## Ends in an error in state: 614.
+## Ends in an error in state: 630.
 ##
 ## _expr -> IF simple_expr . simple_expr ELSE expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF simple_expr . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14517,17 +14523,17 @@ implementation: LPAREN IF UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 886, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 902, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN IF WITH
 ##
-## Ends in an error in state: 613.
+## Ends in an error in state: 629.
 ##
 ## _expr -> IF . simple_expr simple_expr ELSE expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF . simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14540,7 +14546,7 @@ implementation: LPAREN IF WITH
 
 implementation: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 595.
+## Ends in an error in state: 611.
 ##
 ## _expr -> LAZY . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14552,7 +14558,7 @@ implementation: LPAREN LAZY WITH
 
 implementation: LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 585.
+## Ends in an error in state: 601.
 ##
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14569,7 +14575,7 @@ implementation: LPAREN LBRACE WITH
 
 implementation: LPAREN LBRACELESS WITH
 ##
-## Ends in an error in state: 576.
+## Ends in an error in state: 592.
 ##
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14583,7 +14589,7 @@ implementation: LPAREN LBRACELESS WITH
 
 implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ##
-## Ends in an error in state: 1814.
+## Ends in an error in state: 1853.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT expr_optional_constraint . RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -14594,22 +14600,22 @@ implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1816, spurious reduction of production expr_optional_constraint -> expr
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1855, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKET DOTDOTDOT WITH
 ##
-## Ends in an error in state: 1813.
+## Ends in an error in state: 1852.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT . expr_optional_constraint RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -14621,7 +14627,7 @@ implementation: LPAREN LBRACKET DOTDOTDOT WITH
 
 implementation: LPAREN LBRACKET UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1818.
+## Ends in an error in state: 1857.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint . opt_comma RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## expr_comma_seq_extension -> expr_optional_constraint . COMMA expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14639,15 +14645,15 @@ implementation: LPAREN LBRACKET UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1260, spurious reduction of production type_constraint -> COLONGREATER core_type
-## In state 1817, spurious reduction of production expr_optional_constraint -> expr type_constraint
+## In state 1299, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1856, spurious reduction of production expr_optional_constraint -> expr type_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKET UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1819.
+## Ends in an error in state: 1858.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint COMMA . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## opt_comma -> COMMA . [ RBRACKET ]
@@ -14660,7 +14666,7 @@ implementation: LPAREN LBRACKET UIDENT COMMA WITH
 
 implementation: LPAREN LBRACKET WITH
 ##
-## Ends in an error in state: 558.
+## Ends in an error in state: 574.
 ##
 ## _simple_expr -> LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## constr_longident -> LBRACKET . RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14673,7 +14679,7 @@ implementation: LPAREN LBRACKET WITH
 
 implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2304.
+## Ends in an error in state: 2368.
 ##
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14686,23 +14692,23 @@ implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1800, spurious reduction of production expr_optional_constraint -> expr
-## In state 1796, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1839, spurious reduction of production expr_optional_constraint -> expr
+## In state 1835, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKETBAR WITH
 ##
-## Ends in an error in state: 557.
+## Ends in an error in state: 573.
 ##
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14728,7 +14734,7 @@ implementation: LPAREN LBRACKETPERCENT UNDERSCORE
 
 implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2434.
+## Ends in an error in state: 2498.
 ##
 ## extension -> LBRACKETPERCENT attr_id payload . RBRACKET [ error WITH UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUALGREATER EQUAL ELSE DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -14739,30 +14745,30 @@ implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1519, spurious reduction of production post_item_attributes ->
-## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1121, spurious reduction of production structure -> structure_item
-## In state 1506, spurious reduction of production payload -> structure
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1558, spurious reduction of production post_item_attributes ->
+## In state 1559, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1560, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1168, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1159, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1561, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1169, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1160, spurious reduction of production structure -> structure_item
+## In state 1545, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1377.
+## Ends in an error in state: 1416.
 ##
 ## _expr -> label EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14774,7 +14780,7 @@ implementation: LPAREN LIDENT EQUAL WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ##
-## Ends in an error in state: 2387.
+## Ends in an error in state: 2451.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr . RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -14808,21 +14814,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2386.
+## Ends in an error in state: 2450.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA . expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14834,7 +14840,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2385.
+## Ends in an error in state: 2449.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr . COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -14868,21 +14874,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2384.
+## Ends in an error in state: 2448.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN . expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14894,7 +14900,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2383.
+## Ends in an error in state: 2447.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN . LPAREN expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14906,7 +14912,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2382.
+## Ends in an error in state: 2446.
 ##
 ## _expr -> LPAREN COLONCOLON . RPAREN LPAREN expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14918,7 +14924,7 @@ implementation: LPAREN LPAREN COLONCOLON WITH
 
 implementation: LPAREN LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2380.
+## Ends in an error in state: 2444.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -14938,7 +14944,7 @@ implementation: LPAREN LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: LPAREN LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2378.
+## Ends in an error in state: 2442.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14951,7 +14957,7 @@ implementation: LPAREN LPAREN MODULE UIDENT COLON WITH
 
 implementation: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2376.
+## Ends in an error in state: 2440.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -14967,12 +14973,12 @@ implementation: LPAREN LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 857, spurious reduction of production _module_expr -> simple_module_expr
-## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 931, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 935, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 932, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 873, spurious reduction of production _module_expr -> simple_module_expr
+## In state 937, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 936, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
@@ -14993,7 +14999,7 @@ Expecting a module expression
 
 implementation: LPAREN LPAREN STAR WITH
 ##
-## Ends in an error in state: 722.
+## Ends in an error in state: 738.
 ##
 ## val_ident -> LPAREN operator . RPAREN [ error UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15005,7 +15011,7 @@ implementation: LPAREN LPAREN STAR WITH
 
 implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ##
-## Ends in an error in state: 2389.
+## Ends in an error in state: 2453.
 ##
 ## _simple_expr -> LPAREN expr_comma_list . RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN expr_comma_list . error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15018,12 +15024,12 @@ implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1800, spurious reduction of production expr_optional_constraint -> expr
-## In state 2346, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1839, spurious reduction of production expr_optional_constraint -> expr
+## In state 2410, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
@@ -15057,7 +15063,7 @@ Expecting one of the following:
 
 implementation: LPAREN MINUS WITH
 ##
-## Ends in an error in state: 1790.
+## Ends in an error in state: 1829.
 ##
 ## operator -> MINUS . [ RPAREN ]
 ## subtractive -> MINUS . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
@@ -15070,7 +15076,7 @@ implementation: LPAREN MINUS WITH
 
 implementation: LPAREN MINUSDOT WITH
 ##
-## Ends in an error in state: 1789.
+## Ends in an error in state: 1828.
 ##
 ## operator -> MINUSDOT . [ RPAREN ]
 ## subtractive -> MINUSDOT . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
@@ -15083,7 +15089,7 @@ implementation: LPAREN MINUSDOT WITH
 
 implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2335.
+## Ends in an error in state: 2399.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON package_type . RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -15103,7 +15109,7 @@ implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2333.
+## Ends in an error in state: 2397.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON . package_type RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE module_expr COLON . error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15116,7 +15122,7 @@ implementation: LPAREN MODULE UIDENT COLON WITH
 
 implementation: LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2331.
+## Ends in an error in state: 2395.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -15132,19 +15138,19 @@ implementation: LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 857, spurious reduction of production _module_expr -> simple_module_expr
-## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 931, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 935, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 932, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 873, spurious reduction of production _module_expr -> simple_module_expr
+## In state 937, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 936, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN MODULE WITH
 ##
-## Ends in an error in state: 542.
+## Ends in an error in state: 558.
 ##
 ## _simple_expr -> LPAREN MODULE . module_expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE . module_expr COLON package_type RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15235,7 +15241,7 @@ implementation: LPAREN PREFIXOP WITH
 
 implementation: LPAREN STAR WITH
 ##
-## Ends in an error in state: 794.
+## Ends in an error in state: 810.
 ##
 ## val_ident -> LPAREN operator . RPAREN [ WITH WHEN UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR OPTIONAL_NO_DEFAULT NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 IN GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15247,7 +15253,7 @@ implementation: LPAREN STAR WITH
 
 implementation: LPAREN STRING LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1318.
+## Ends in an error in state: 1357.
 ##
 ## label_expr -> LIDENT COLONCOLON . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15259,7 +15265,7 @@ implementation: LPAREN STRING LIDENT COLONCOLON WITH
 
 implementation: LPAREN STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1310.
+## Ends in an error in state: 1349.
 ##
 ## label_expr -> LIDENT EXPLICITLY_PASSED_OPTIONAL . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15271,7 +15277,7 @@ implementation: LPAREN STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: LPAREN SWITCH UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2447.
+## Ends in an error in state: 2511.
 ##
 ## _expr -> SWITCH simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15283,7 +15289,7 @@ implementation: LPAREN SWITCH UIDENT LBRACE WITH
 
 implementation: LPAREN SWITCH UIDENT WITH
 ##
-## Ends in an error in state: 2446.
+## Ends in an error in state: 2510.
 ##
 ## _expr -> SWITCH simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ SHARP LBRACE DOT ]
@@ -15301,10 +15307,10 @@ implementation: LPAREN SWITCH UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 886, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 902, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -15323,7 +15329,7 @@ implementation: LPAREN SWITCH WITH
 
 implementation: LPAREN TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 ##
-## Ends in an error in state: 1450.
+## Ends in an error in state: 1489.
 ##
 ## _expr -> simple_expr DOT LBRACE expr RBRACE EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15335,7 +15341,7 @@ implementation: LPAREN TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 
 implementation: LPAREN TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 1448.
+## Ends in an error in state: 1487.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -15370,21 +15376,21 @@ implementation: LPAREN TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 1447.
+## Ends in an error in state: 1486.
 ##
 ## _expr -> simple_expr DOT LBRACE . expr RBRACE EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15397,7 +15403,7 @@ implementation: LPAREN TRUE DOT LBRACE WITH
 
 implementation: LPAREN TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 ##
-## Ends in an error in state: 1445.
+## Ends in an error in state: 1484.
 ##
 ## _expr -> simple_expr DOT LBRACKET expr RBRACKET EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15409,7 +15415,7 @@ implementation: LPAREN TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 
 implementation: LPAREN TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 1442.
+## Ends in an error in state: 1481.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -15445,21 +15451,21 @@ implementation: LPAREN TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1441.
+## Ends in an error in state: 1480.
 ##
 ## _expr -> simple_expr DOT LBRACKET . expr RBRACKET EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15473,7 +15479,7 @@ implementation: LPAREN TRUE DOT LBRACKET WITH
 
 implementation: LPAREN TRUE DOT LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1453.
+## Ends in an error in state: 1492.
 ##
 ## _expr -> simple_expr DOT label_longident EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15485,7 +15491,7 @@ implementation: LPAREN TRUE DOT LIDENT EQUAL WITH
 
 implementation: LPAREN TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 ##
-## Ends in an error in state: 1435.
+## Ends in an error in state: 1474.
 ##
 ## _expr -> simple_expr DOT LPAREN expr RPAREN EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15497,7 +15503,7 @@ implementation: LPAREN TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 
 implementation: LPAREN TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1432.
+## Ends in an error in state: 1471.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -15533,21 +15539,21 @@ implementation: LPAREN TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 1370.
+## Ends in an error in state: 1409.
 ##
 ## _expr -> simple_expr DOT LPAREN . expr RPAREN EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15561,7 +15567,7 @@ implementation: LPAREN TRUE DOT LPAREN WITH
 
 implementation: LPAREN TRUE DOT WITH
 ##
-## Ends in an error in state: 1369.
+## Ends in an error in state: 1408.
 ##
 ## _expr -> simple_expr DOT . label_longident EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> simple_expr DOT . LPAREN expr RPAREN EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -15582,7 +15588,7 @@ implementation: LPAREN TRUE DOT WITH
 
 implementation: LPAREN TRY UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2502.
+## Ends in an error in state: 2566.
 ##
 ## _expr -> TRY simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15594,7 +15600,7 @@ implementation: LPAREN TRY UIDENT LBRACE WITH
 
 implementation: LPAREN TRY UIDENT UNDERSCORE
 ##
-## Ends in an error in state: 2499.
+## Ends in an error in state: 2563.
 ##
 ## _expr -> TRY simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> TRY simple_expr . WITH error [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -15613,17 +15619,17 @@ implementation: LPAREN TRY UIDENT UNDERSCORE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 886, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 902, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN TRY UIDENT WITH WITH
 ##
-## Ends in an error in state: 2500.
+## Ends in an error in state: 2564.
 ##
 ## _expr -> TRY simple_expr WITH . error [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15648,7 +15654,7 @@ implementation: LPAREN TRY WITH
 
 implementation: LPAREN UIDENT AMPERAMPER WITH
 ##
-## Ends in an error in state: 1428.
+## Ends in an error in state: 1467.
 ##
 ## _expr -> expr AMPERAMPER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15660,7 +15666,7 @@ implementation: LPAREN UIDENT AMPERAMPER WITH
 
 implementation: LPAREN UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 1426.
+## Ends in an error in state: 1465.
 ##
 ## _expr -> expr AMPERSAND . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15672,7 +15678,7 @@ implementation: LPAREN UIDENT AMPERSAND WITH
 
 implementation: LPAREN UIDENT BARBAR WITH
 ##
-## Ends in an error in state: 1424.
+## Ends in an error in state: 1463.
 ##
 ## _expr -> expr BARBAR . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15684,7 +15690,7 @@ implementation: LPAREN UIDENT BARBAR WITH
 
 implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1278.
+## Ends in an error in state: 1317.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ RPAREN RBRACKET EQUAL COMMA ]
 ##
@@ -15696,7 +15702,7 @@ implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 
 implementation: LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1457.
+## Ends in an error in state: 1496.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ RPAREN RBRACKET EQUAL COMMA ]
 ##
@@ -15708,7 +15714,7 @@ implementation: LPAREN UIDENT COLON WITH
 
 implementation: LPAREN UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1430.
+## Ends in an error in state: 1469.
 ##
 ## _expr -> expr COLONEQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15720,7 +15726,7 @@ implementation: LPAREN UIDENT COLONEQUAL WITH
 
 implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2344.
+## Ends in an error in state: 2408.
 ##
 ## expr_comma_list -> expr_optional_constraint . COMMA expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -15737,15 +15743,15 @@ implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1260, spurious reduction of production type_constraint -> COLONGREATER core_type
-## In state 2355, spurious reduction of production expr_optional_constraint -> expr type_constraint
+## In state 1299, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 2419, spurious reduction of production expr_optional_constraint -> expr type_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1259.
+## Ends in an error in state: 1298.
 ##
 ## type_constraint -> COLONGREATER . core_type [ RPAREN RBRACKET EQUAL COMMA ]
 ##
@@ -15757,7 +15763,7 @@ implementation: LPAREN UIDENT COLONGREATER WITH
 
 implementation: LPAREN UIDENT COMMA CHAR BARRBRACKET
 ##
-## Ends in an error in state: 2347.
+## Ends in an error in state: 2411.
 ##
 ## _simple_expr -> LPAREN expr_comma_list . RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN expr_comma_list . error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15770,19 +15776,19 @@ implementation: LPAREN UIDENT COMMA CHAR BARRBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1800, spurious reduction of production expr_optional_constraint -> expr
-## In state 2346, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1839, spurious reduction of production expr_optional_constraint -> expr
+## In state 2410, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 2350.
+## Ends in an error in state: 2414.
 ##
 ## expr_comma_list -> expr_comma_list COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -15794,7 +15800,7 @@ implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 
 implementation: LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2345.
+## Ends in an error in state: 2409.
 ##
 ## expr_comma_list -> expr_optional_constraint COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -15806,7 +15812,7 @@ implementation: LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN UIDENT DOT LBRACE WITH
 ##
-## Ends in an error in state: 1829.
+## Ends in an error in state: 1868.
 ##
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15819,7 +15825,7 @@ implementation: LPAREN UIDENT DOT LBRACE WITH
 
 implementation: LPAREN UIDENT DOT LBRACELESS WITH
 ##
-## Ends in an error in state: 1824.
+## Ends in an error in state: 1863.
 ##
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15832,7 +15838,7 @@ implementation: LPAREN UIDENT DOT LBRACELESS WITH
 
 implementation: LPAREN UIDENT DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1812.
+## Ends in an error in state: 1851.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15844,7 +15850,7 @@ implementation: LPAREN UIDENT DOT LBRACKET WITH
 
 implementation: LPAREN UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 1797.
+## Ends in an error in state: 1836.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15857,23 +15863,23 @@ implementation: LPAREN UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1800, spurious reduction of production expr_optional_constraint -> expr
-## In state 1796, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1839, spurious reduction of production expr_optional_constraint -> expr
+## In state 1835, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT DOT LBRACKETBAR WITH
 ##
-## Ends in an error in state: 1795.
+## Ends in an error in state: 1834.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15886,7 +15892,7 @@ implementation: LPAREN UIDENT DOT LBRACKETBAR WITH
 
 implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1787.
+## Ends in an error in state: 1826.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15906,7 +15912,7 @@ implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 1785.
+## Ends in an error in state: 1824.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15919,7 +15925,7 @@ implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 
 implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 907.
+## Ends in an error in state: 923.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -15934,19 +15940,19 @@ implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 857, spurious reduction of production _module_expr -> simple_module_expr
-## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 931, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 935, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 932, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 873, spurious reduction of production _module_expr -> simple_module_expr
+## In state 937, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 936, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT DOT LPAREN MODULE WITH
 ##
-## Ends in an error in state: 906.
+## Ends in an error in state: 922.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON package_type RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15959,7 +15965,7 @@ implementation: LPAREN UIDENT DOT LPAREN MODULE WITH
 
 implementation: LPAREN UIDENT DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1792.
+## Ends in an error in state: 1831.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -15994,21 +16000,21 @@ implementation: LPAREN UIDENT DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT DOT LPAREN WITH
 ##
-## Ends in an error in state: 905.
+## Ends in an error in state: 921.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN . expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16024,7 +16030,7 @@ implementation: LPAREN UIDENT DOT LPAREN WITH
 
 implementation: LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 904.
+## Ends in an error in state: 920.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16048,7 +16054,7 @@ implementation: LPAREN UIDENT DOT WITH
 
 implementation: LPAREN UIDENT GREATER WITH
 ##
-## Ends in an error in state: 1422.
+## Ends in an error in state: 1461.
 ##
 ## _expr -> expr GREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16060,7 +16066,7 @@ implementation: LPAREN UIDENT GREATER WITH
 
 implementation: LPAREN UIDENT INFIXOP0 WITH
 ##
-## Ends in an error in state: 1420.
+## Ends in an error in state: 1459.
 ##
 ## _expr -> expr INFIXOP0 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16072,7 +16078,7 @@ implementation: LPAREN UIDENT INFIXOP0 WITH
 
 implementation: LPAREN UIDENT INFIXOP1 WITH
 ##
-## Ends in an error in state: 1414.
+## Ends in an error in state: 1453.
 ##
 ## _expr -> expr INFIXOP1 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16084,7 +16090,7 @@ implementation: LPAREN UIDENT INFIXOP1 WITH
 
 implementation: LPAREN UIDENT INFIXOP2 WITH
 ##
-## Ends in an error in state: 1412.
+## Ends in an error in state: 1451.
 ##
 ## _expr -> expr INFIXOP2 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16096,7 +16102,7 @@ implementation: LPAREN UIDENT INFIXOP2 WITH
 
 implementation: LPAREN UIDENT INFIXOP3 WITH
 ##
-## Ends in an error in state: 1398.
+## Ends in an error in state: 1437.
 ##
 ## _expr -> expr INFIXOP3 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16108,7 +16114,7 @@ implementation: LPAREN UIDENT INFIXOP3 WITH
 
 implementation: LPAREN UIDENT INFIXOP4 WITH
 ##
-## Ends in an error in state: 1381.
+## Ends in an error in state: 1420.
 ##
 ## _expr -> expr INFIXOP4 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16132,7 +16138,7 @@ implementation: LPAREN UIDENT LBRACKETAT UNDERSCORE
 
 implementation: LPAREN UIDENT LBRACKETAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2412.
+## Ends in an error in state: 2476.
 ##
 ## attribute -> LBRACKETAT attr_id payload . RBRACKET [ error WITH UIDENT STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARRBRACKET BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -16143,30 +16149,30 @@ implementation: LPAREN UIDENT LBRACKETAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1519, spurious reduction of production post_item_attributes ->
-## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1121, spurious reduction of production structure -> structure_item
-## In state 1506, spurious reduction of production payload -> structure
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1558, spurious reduction of production post_item_attributes ->
+## In state 1559, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1560, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1168, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1159, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1561, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1169, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1160, spurious reduction of production structure -> structure_item
+## In state 1545, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT LESS WITH
 ##
-## Ends in an error in state: 1418.
+## Ends in an error in state: 1457.
 ##
 ## _expr -> expr LESS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16178,7 +16184,7 @@ implementation: LPAREN UIDENT LESS WITH
 
 implementation: LPAREN UIDENT LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1416.
+## Ends in an error in state: 1455.
 ##
 ## _expr -> expr LESSDOTDOTGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16190,7 +16196,7 @@ implementation: LPAREN UIDENT LESSDOTDOTGREATER WITH
 
 implementation: LPAREN UIDENT LESSGREATER WITH
 ##
-## Ends in an error in state: 1410.
+## Ends in an error in state: 1449.
 ##
 ## _expr -> expr LESSGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16223,7 +16229,7 @@ implementation: LPAREN UIDENT LPAREN WITH
 
 implementation: LPAREN UIDENT MINUS WITH
 ##
-## Ends in an error in state: 1408.
+## Ends in an error in state: 1447.
 ##
 ## _expr -> expr MINUS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16235,7 +16241,7 @@ implementation: LPAREN UIDENT MINUS WITH
 
 implementation: LPAREN UIDENT MINUSDOT WITH
 ##
-## Ends in an error in state: 1406.
+## Ends in an error in state: 1445.
 ##
 ## _expr -> expr MINUSDOT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16247,7 +16253,7 @@ implementation: LPAREN UIDENT MINUSDOT WITH
 
 implementation: LPAREN UIDENT OR WITH
 ##
-## Ends in an error in state: 1404.
+## Ends in an error in state: 1443.
 ##
 ## _expr -> expr OR . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16259,7 +16265,7 @@ implementation: LPAREN UIDENT OR WITH
 
 implementation: LPAREN UIDENT PERCENT WITH
 ##
-## Ends in an error in state: 1396.
+## Ends in an error in state: 1435.
 ##
 ## _expr -> expr PERCENT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16271,7 +16277,7 @@ implementation: LPAREN UIDENT PERCENT WITH
 
 implementation: LPAREN UIDENT PLUS WITH
 ##
-## Ends in an error in state: 1402.
+## Ends in an error in state: 1441.
 ##
 ## _expr -> expr PLUS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16283,7 +16289,7 @@ implementation: LPAREN UIDENT PLUS WITH
 
 implementation: LPAREN UIDENT PLUSDOT WITH
 ##
-## Ends in an error in state: 1400.
+## Ends in an error in state: 1439.
 ##
 ## _expr -> expr PLUSDOT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16295,7 +16301,7 @@ implementation: LPAREN UIDENT PLUSDOT WITH
 
 implementation: LPAREN UIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 1394.
+## Ends in an error in state: 1433.
 ##
 ## _expr -> expr PLUSEQ . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16307,7 +16313,7 @@ implementation: LPAREN UIDENT PLUSEQ WITH
 
 implementation: LPAREN UIDENT QUESTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1439.
+## Ends in an error in state: 1478.
 ##
 ## _expr -> expr QUESTION expr COLON . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16319,7 +16325,7 @@ implementation: LPAREN UIDENT QUESTION UIDENT COLON WITH
 
 implementation: LPAREN UIDENT QUESTION UIDENT SEMI
 ##
-## Ends in an error in state: 1438.
+## Ends in an error in state: 1477.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -16353,21 +16359,21 @@ implementation: LPAREN UIDENT QUESTION UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT QUESTION WITH
 ##
-## Ends in an error in state: 1437.
+## Ends in an error in state: 1476.
 ##
 ## _expr -> expr QUESTION . expr COLON expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16379,7 +16385,7 @@ implementation: LPAREN UIDENT QUESTION WITH
 
 implementation: LPAREN UIDENT SHARP WITH
 ##
-## Ends in an error in state: 608.
+## Ends in an error in state: 624.
 ##
 ## _simple_expr -> simple_expr SHARP . label [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -16391,7 +16397,7 @@ implementation: LPAREN UIDENT SHARP WITH
 
 implementation: LPAREN UIDENT STAR WITH
 ##
-## Ends in an error in state: 1379.
+## Ends in an error in state: 1418.
 ##
 ## _expr -> expr STAR . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16403,7 +16409,7 @@ implementation: LPAREN UIDENT STAR WITH
 
 implementation: LPAREN UIDENT TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 2253.
+## Ends in an error in state: 2317.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -16437,21 +16443,21 @@ implementation: LPAREN UIDENT TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 2252.
+## Ends in an error in state: 2316.
 ##
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -16463,7 +16469,7 @@ implementation: LPAREN UIDENT TRUE DOT LBRACE WITH
 
 implementation: LPAREN UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2250.
+## Ends in an error in state: 2314.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -16498,21 +16504,21 @@ implementation: LPAREN UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2249.
+## Ends in an error in state: 2313.
 ##
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16525,7 +16531,7 @@ implementation: LPAREN UIDENT TRUE DOT LBRACKET WITH
 
 implementation: LPAREN UIDENT TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2247.
+## Ends in an error in state: 2311.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -16560,21 +16566,21 @@ implementation: LPAREN UIDENT TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 612.
+## Ends in an error in state: 628.
 ##
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16587,7 +16593,7 @@ implementation: LPAREN UIDENT TRUE DOT LPAREN WITH
 
 implementation: LPAREN UIDENT TRUE DOT WITH
 ##
-## Ends in an error in state: 611.
+## Ends in an error in state: 627.
 ##
 ## _simple_expr -> simple_expr DOT . label_longident [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16604,7 +16610,7 @@ implementation: LPAREN UIDENT TRUE DOT WITH
 
 implementation: LPAREN WHILE UIDENT WITH
 ##
-## Ends in an error in state: 2605.
+## Ends in an error in state: 2692.
 ##
 ## _expr -> WHILE simple_expr . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -16622,10 +16628,10 @@ implementation: LPAREN WHILE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 886, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 902, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -16644,7 +16650,7 @@ implementation: LPAREN WHILE WITH
 
 implementation: LPAREN WITH
 ##
-## Ends in an error in state: 541.
+## Ends in an error in state: 557.
 ##
 ## _expr -> LPAREN . COLONCOLON RPAREN LPAREN expr COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . expr RPAREN [ UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -16666,7 +16672,7 @@ implementation: LPAREN WITH
 
 implementation: MINUSDOT WITH
 ##
-## Ends in an error in state: 891.
+## Ends in an error in state: 907.
 ##
 ## _expr -> subtractive . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16789,7 +16795,7 @@ implementation: PERCENT WITH WITH
 
 implementation: PLUSDOT WITH
 ##
-## Ends in an error in state: 1201.
+## Ends in an error in state: 1240.
 ##
 ## _expr -> additive . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16813,7 +16819,7 @@ implementation: PREFIXOP WITH
 
 implementation: STRING LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1179.
+## Ends in an error in state: 1218.
 ##
 ## label_expr -> LIDENT COLONCOLON . less_aggressive_simple_expression [ UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -16825,7 +16831,7 @@ implementation: STRING LIDENT COLONCOLON WITH
 
 implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1176.
+## Ends in an error in state: 1215.
 ##
 ## label_expr -> LIDENT EXPLICITLY_PASSED_OPTIONAL . less_aggressive_simple_expression [ UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -16837,7 +16843,7 @@ implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: STRING WITH
 ##
-## Ends in an error in state: 1121.
+## Ends in an error in state: 1160.
 ##
 ## structure -> structure_item . [ RBRACKET RBRACE EOF ]
 ## structure -> structure_item . SEMI structure [ RBRACKET RBRACE EOF ]
@@ -16849,24 +16855,24 @@ implementation: STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1519, spurious reduction of production post_item_attributes ->
-## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1558, spurious reduction of production post_item_attributes ->
+## In state 1559, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1560, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1168, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1159, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1561, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1169, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 Incomplete module item, forgetting a ";"?
 
 implementation: SWITCH UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2495.
+## Ends in an error in state: 2559.
 ##
 ## _expr -> SWITCH simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16878,7 +16884,7 @@ implementation: SWITCH UIDENT LBRACE WITH
 
 implementation: SWITCH UIDENT WITH
 ##
-## Ends in an error in state: 2494.
+## Ends in an error in state: 2558.
 ##
 ## _expr -> SWITCH simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ SHARP LBRACE DOT ]
@@ -16896,10 +16902,10 @@ implementation: SWITCH UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 886, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 902, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -16918,7 +16924,7 @@ implementation: SWITCH WITH
 
 implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 ##
-## Ends in an error in state: 1866.
+## Ends in an error in state: 1905.
 ##
 ## _expr -> simple_expr DOT LBRACE expr RBRACE EQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16930,7 +16936,7 @@ implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 
 implementation: TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 1864.
+## Ends in an error in state: 1903.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -16965,21 +16971,21 @@ implementation: TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 1863.
+## Ends in an error in state: 1902.
 ##
 ## _expr -> simple_expr DOT LBRACE . expr RBRACE EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -16992,7 +16998,7 @@ implementation: TRUE DOT LBRACE WITH
 
 implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 ##
-## Ends in an error in state: 1861.
+## Ends in an error in state: 1900.
 ##
 ## _expr -> simple_expr DOT LBRACKET expr RBRACKET EQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17004,7 +17010,7 @@ implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 
 implementation: TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 1858.
+## Ends in an error in state: 1897.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -17040,21 +17046,21 @@ implementation: TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1857.
+## Ends in an error in state: 1896.
 ##
 ## _expr -> simple_expr DOT LBRACKET . expr RBRACKET EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -17068,7 +17074,7 @@ implementation: TRUE DOT LBRACKET WITH
 
 implementation: TRUE DOT LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1869.
+## Ends in an error in state: 1908.
 ##
 ## _expr -> simple_expr DOT label_longident EQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17080,7 +17086,7 @@ implementation: TRUE DOT LIDENT EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 ##
-## Ends in an error in state: 1855.
+## Ends in an error in state: 1894.
 ##
 ## _expr -> simple_expr DOT LPAREN expr RPAREN EQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17092,7 +17098,7 @@ implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1852.
+## Ends in an error in state: 1891.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -17128,21 +17134,21 @@ implementation: TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 894.
+## Ends in an error in state: 910.
 ##
 ## _expr -> simple_expr DOT LPAREN . expr RPAREN EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -17182,7 +17188,7 @@ implementation: TRUE DOT UIDENT WITH
 
 implementation: TRUE DOT WITH
 ##
-## Ends in an error in state: 893.
+## Ends in an error in state: 909.
 ##
 ## _expr -> simple_expr DOT . label_longident EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> simple_expr DOT . LPAREN expr RPAREN EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -17203,7 +17209,7 @@ implementation: TRUE DOT WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER CHAR BAR WITH
 ##
-## Ends in an error in state: 1877.
+## Ends in an error in state: 1916.
 ##
 ## bar_located_pattern -> BAR . pattern [ WHEN EQUALGREATER ]
 ##
@@ -17215,7 +17221,7 @@ Expecting a match case
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT RBRACKET
 ##
-## Ends in an error in state: 2481.
+## Ends in an error in state: 2545.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes . SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17226,22 +17232,22 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 857, spurious reduction of production _module_expr -> simple_module_expr
-## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
-## In state 913, spurious reduction of production module_binding_body_expr -> EQUAL module_expr
-## In state 1764, spurious reduction of production module_binding_body -> module_binding_body_expr
-## In state 2480, spurious reduction of production post_item_attributes ->
+## In state 931, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 935, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 932, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 873, spurious reduction of production _module_expr -> simple_module_expr
+## In state 937, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 936, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 929, spurious reduction of production module_binding_body_expr -> EQUAL module_expr
+## In state 1803, spurious reduction of production module_binding_body -> module_binding_body_expr
+## In state 2544, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2482.
+## Ends in an error in state: 2546.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17253,7 +17259,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2479.
+## Ends in an error in state: 2543.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17265,7 +17271,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 ##
-## Ends in an error in state: 2478.
+## Ends in an error in state: 2542.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17277,7 +17283,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 ##
-## Ends in an error in state: 2457.
+## Ends in an error in state: 2521.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17289,7 +17295,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2460.
+## Ends in an error in state: 2524.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17301,7 +17307,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2459.
+## Ends in an error in state: 2523.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17312,14 +17318,14 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2458, spurious reduction of production post_item_attributes ->
+## In state 2522, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 ##
-## Ends in an error in state: 2456.
+## Ends in an error in state: 2520.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17331,7 +17337,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 ##
-## Ends in an error in state: 2455.
+## Ends in an error in state: 2519.
 ##
 ## _semi_terminated_seq_expr_row -> LET . MODULE UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ## _semi_terminated_seq_expr_row -> LET . OPEN override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
@@ -17345,7 +17351,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 ##
-## Ends in an error in state: 2468.
+## Ends in an error in state: 2532.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ RBRACE BAR ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI RBRACE BAR AND ]
@@ -17365,7 +17371,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 2514.
+## Ends in an error in state: 2578.
 ##
 ## _expr -> TRY simple_expr LBRACE leading_bar_match_cases_to_sequence_body . RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## leading_bar_match_cases_to_sequence_body -> leading_bar_match_cases_to_sequence_body . leading_bar_match_case_to_sequence_body [ RBRACE BAR ]
@@ -17377,24 +17383,24 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2470, spurious reduction of production post_item_attributes ->
-## In state 2471, spurious reduction of production opt_semi ->
-## In state 2476, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
-## In state 2474, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
-## In state 2463, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
-## In state 2461, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
-## In state 2475, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2464, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
-## In state 2486, spurious reduction of production leading_bar_match_case_to_sequence_body -> bar_located_pattern EQUALGREATER semi_terminated_seq_expr
-## In state 2487, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2534, spurious reduction of production post_item_attributes ->
+## In state 2535, spurious reduction of production opt_semi ->
+## In state 2540, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
+## In state 2538, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
+## In state 2527, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
+## In state 2525, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
+## In state 2539, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2528, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2550, spurious reduction of production leading_bar_match_case_to_sequence_body -> bar_located_pattern EQUALGREATER semi_terminated_seq_expr
+## In state 2551, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
 ##
 
 Expecting one of the following:
@@ -17403,7 +17409,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2485.
+## Ends in an error in state: 2549.
 ##
 ## leading_bar_match_case_to_sequence_body -> bar_located_pattern EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17415,7 +17421,7 @@ Expecting the body of the matched pattern
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ##
-## Ends in an error in state: 1878.
+## Ends in an error in state: 1917.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN EQUALGREATER BAR ]
 ## bar_located_pattern -> BAR pattern . [ WHEN EQUALGREATER ]
@@ -17427,7 +17433,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 787, spurious reduction of production pattern -> pattern_without_or
+## In state 803, spurious reduction of production pattern -> pattern_without_or
 ##
 
 Expecting one of the following:
@@ -17437,7 +17443,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2454.
+## Ends in an error in state: 2518.
 ##
 ## leading_bar_match_case_to_sequence_body -> bar_located_pattern WHEN expr EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17449,7 +17455,7 @@ Expecting a sequence item
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2453.
+## Ends in an error in state: 2517.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -17483,21 +17489,21 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2452.
+## Ends in an error in state: 2516.
 ##
 ## leading_bar_match_case_to_sequence_body -> bar_located_pattern WHEN . expr EQUALGREATER semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17509,7 +17515,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 
 implementation: TRY UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2513.
+## Ends in an error in state: 2577.
 ##
 ## _expr -> TRY simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17521,7 +17527,7 @@ implementation: TRY UIDENT LBRACE WITH
 
 implementation: TRY UIDENT UNDERSCORE
 ##
-## Ends in an error in state: 2510.
+## Ends in an error in state: 2574.
 ##
 ## _expr -> TRY simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> TRY simple_expr . WITH error [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -17540,17 +17546,17 @@ implementation: TRY UIDENT UNDERSCORE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 886, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 902, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT WITH WITH
 ##
-## Ends in an error in state: 2511.
+## Ends in an error in state: 2575.
 ##
 ## _expr -> TRY simple_expr WITH . error [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17575,7 +17581,7 @@ implementation: TRY WITH
 
 implementation: TYPE LIDENT AND LIDENT WITH
 ##
-## Ends in an error in state: 1135.
+## Ends in an error in state: 1174.
 ##
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -17586,14 +17592,14 @@ implementation: TYPE LIDENT AND LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1134, spurious reduction of production optional_type_parameters ->
+## In state 1173, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT AND WITH
 ##
-## Ends in an error in state: 1133.
+## Ends in an error in state: 1172.
 ##
 ## and_type_declaration -> AND . type_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -17605,7 +17611,7 @@ implementation: TYPE LIDENT AND WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 979.
+## Ends in an error in state: 1001.
 ##
 ## constrain -> core_type EQUAL . core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ##
@@ -17617,7 +17623,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 978.
+## Ends in an error in state: 1000.
 ##
 ## constrain -> core_type . EQUAL core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ##
@@ -17640,7 +17646,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 
 implementation: TYPE LIDENT CONSTRAINT WITH
 ##
-## Ends in an error in state: 977.
+## Ends in an error in state: 999.
 ##
 ## constraints -> constraints CONSTRAINT . constrain [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ##
@@ -17652,7 +17658,7 @@ implementation: TYPE LIDENT CONSTRAINT WITH
 
 implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2564.
+## Ends in an error in state: 2653.
 ##
 ## constructor_declarations -> constructor_declarations_leading_bar . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations_leading_bar -> constructor_declarations_leading_bar . constructor_declaration_leading_bar [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
@@ -17664,17 +17670,17 @@ implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 499, spurious reduction of production attributes ->
-## In state 500, spurious reduction of production attributes -> attribute attributes
-## In state 2562, spurious reduction of production constructor_declaration_leading_bar -> BAR constr_ident generalized_constructor_arguments attributes
-## In state 2569, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
+## In state 514, spurious reduction of production attributes ->
+## In state 515, spurious reduction of production attributes -> attribute attributes
+## In state 2638, spurious reduction of production constructor_declaration_leading_bar -> BAR UIDENT generalized_constructor_arguments attributes
+## In state 2658, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 ##
-## Ends in an error in state: 1137.
+## Ends in an error in state: 1176.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_declaration_details -> LIDENT optional_type_parameters type_kind constraints . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -17687,7 +17693,7 @@ implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 ##
-## Ends in an error in state: 505.
+## Ends in an error in state: 520.
 ##
 ## label_declarations -> label_declarations COMMA . label_declaration [ RBRACE COMMA ]
 ## opt_comma -> COMMA . [ RBRACE ]
@@ -17702,7 +17708,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2576.
+## Ends in an error in state: 2662.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17720,12 +17726,12 @@ implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 502, spurious reduction of production _poly_type -> core_type
-## In state 503, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 501, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 497, spurious reduction of production attributes ->
-## In state 498, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 509, spurious reduction of production label_declarations -> label_declaration
+## In state 517, spurious reduction of production _poly_type -> core_type
+## In state 518, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 516, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 512, spurious reduction of production attributes ->
+## In state 513, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 524, spurious reduction of production label_declarations -> label_declaration
 ##
 
 Expecting one of the following:
@@ -17734,7 +17740,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 491.
+## Ends in an error in state: 506.
 ##
 ## label_declaration -> mutable_flag LIDENT COLON . poly_type attributes [ RBRACE COMMA ]
 ##
@@ -17746,7 +17752,7 @@ Expecting a type name describing this field
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 490.
+## Ends in an error in state: 505.
 ##
 ## label_declaration -> mutable_flag LIDENT . COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -17759,7 +17765,7 @@ Expecting ":"
 
 implementation: TYPE LIDENT EQUAL LBRACE MUTABLE LET
 ##
-## Ends in an error in state: 489.
+## Ends in an error in state: 504.
 ##
 ## label_declaration -> mutable_flag . LIDENT COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -17772,7 +17778,7 @@ Expecting a type field definition in the form of:
 
 implementation: TYPE LIDENT EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2575.
+## Ends in an error in state: 2661.
 ##
 ## type_kind -> EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -17785,11 +17791,11 @@ Expecting at least one type field definition in the form of:
 
     implementation: TYPE LIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 2558.
+## Ends in an error in state: 2625.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
 ## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
-## constr_ident2 -> LPAREN . RPAREN [ UNDERSCORE UIDENT SHARP SEMI RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF CONSTRAINT COLON BAR AND ]
+## constructor_declaration_no_leading_bar -> LPAREN . RPAREN generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -17799,7 +17805,7 @@ Expecting at least one type field definition in the form of:
 
 implementation: TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 2557.
+## Ends in an error in state: 2624.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL PRIVATE . core_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17827,9 +17833,13 @@ implementation: TYPE LIDENT EQUAL UIDENT WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 ##
-## Ends in an error in state: 2559.
+## Ends in an error in state: 2635.
 ##
-## constructor_declaration_leading_bar -> BAR . constr_ident generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
+## constructor_declaration_leading_bar -> BAR . UIDENT generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
+## constructor_declaration_leading_bar -> BAR . LPAREN RPAREN generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
+## constructor_declaration_leading_bar -> BAR . COLONCOLON generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
+## constructor_declaration_leading_bar -> BAR . FALSE generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
+## constructor_declaration_leading_bar -> BAR . TRUE generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## BAR
@@ -17839,7 +17849,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 2587.
+## Ends in an error in state: 2674.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17851,17 +17861,17 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDO
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 499, spurious reduction of production attributes ->
-## In state 500, spurious reduction of production attributes -> attribute attributes
-## In state 498, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 509, spurious reduction of production label_declarations -> label_declaration
+## In state 514, spurious reduction of production attributes ->
+## In state 515, spurious reduction of production attributes -> attribute attributes
+## In state 513, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 524, spurious reduction of production label_declarations -> label_declaration
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2586.
+## Ends in an error in state: 2673.
 ##
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -17873,7 +17883,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 ##
-## Ends in an error in state: 2582.
+## Ends in an error in state: 2668.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL core_type EQUAL PRIVATE . constructor_declarations [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17886,7 +17896,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2567.
+## Ends in an error in state: 2656.
 ##
 ## constructor_declarations -> constructor_declaration_no_leading_bar . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations -> constructor_declaration_no_leading_bar . constructor_declarations_leading_bar [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17898,16 +17908,16 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 499, spurious reduction of production attributes ->
-## In state 500, spurious reduction of production attributes -> attribute attributes
-## In state 2556, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
+## In state 514, spurious reduction of production attributes ->
+## In state 515, spurious reduction of production attributes -> attribute attributes
+## In state 2620, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2580.
+## Ends in an error in state: 2666.
 ##
 ## type_kind -> EQUAL core_type EQUAL . constructor_declarations [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type EQUAL . PRIVATE constructor_declarations [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17922,7 +17932,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 2579.
+## Ends in an error in state: 2665.
 ##
 ## type_kind -> EQUAL core_type . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type . EQUAL constructor_declarations [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17970,7 +17980,7 @@ implementation: TYPE LIDENT EQUAL WITH
 
 implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1132.
+## Ends in an error in state: 1171.
 ##
 ## _structure_item_without_item_extension_sugar -> many_type_declarations . [ SEMI RBRACKET RBRACE EOF ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ SEMI RBRACKET RBRACE EOF AND ]
@@ -17982,9 +17992,9 @@ implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 928, spurious reduction of production post_item_attributes ->
-## In state 929, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 927, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 944, spurious reduction of production post_item_attributes ->
+## In state 945, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 943, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
@@ -18041,7 +18051,7 @@ implementation: TYPE LIDENT PLUS WITH
 
 implementation: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 2595.
+## Ends in an error in state: 2682.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . str_extension_constructors post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -18053,7 +18063,7 @@ implementation: TYPE LIDENT PLUSEQ BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 2594.
+## Ends in an error in state: 2681.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar str_extension_constructors post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -18065,7 +18075,7 @@ implementation: TYPE LIDENT PLUSEQ PRIVATE BANG
 
 implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 2597.
+## Ends in an error in state: 2684.
 ##
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_declaration [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_rebind [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -18078,7 +18088,7 @@ implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 2593.
+## Ends in an error in state: 2680.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar str_extension_constructors post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -18126,7 +18136,7 @@ Expecting one of the following:
 
 implementation: TYPE UIDENT DOT WITH
 ##
-## Ends in an error in state: 956.
+## Ends in an error in state: 978.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -18140,7 +18150,7 @@ implementation: TYPE UIDENT DOT WITH
 
 implementation: TYPE UIDENT WITH
 ##
-## Ends in an error in state: 955.
+## Ends in an error in state: 977.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -18179,7 +18189,7 @@ implementation: TYPE WITH
 
 implementation: UIDENT AMPERAMPER WITH
 ##
-## Ends in an error in state: 1238.
+## Ends in an error in state: 1277.
 ##
 ## _expr -> expr AMPERAMPER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18191,7 +18201,7 @@ implementation: UIDENT AMPERAMPER WITH
 
 implementation: UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 1236.
+## Ends in an error in state: 1275.
 ##
 ## _expr -> expr AMPERSAND . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18203,7 +18213,7 @@ implementation: UIDENT AMPERSAND WITH
 
 implementation: UIDENT BARBAR WITH
 ##
-## Ends in an error in state: 1234.
+## Ends in an error in state: 1273.
 ##
 ## _expr -> expr BARBAR . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18215,7 +18225,7 @@ implementation: UIDENT BARBAR WITH
 
 implementation: UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1240.
+## Ends in an error in state: 1279.
 ##
 ## _expr -> expr COLONEQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18227,7 +18237,7 @@ implementation: UIDENT COLONEQUAL WITH
 
 implementation: UIDENT DOT LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 1848.
+## Ends in an error in state: 1887.
 ##
 ## lbl_expr -> label_longident . COLON expr [ COMMA ]
 ## lbl_expr -> label_longident . [ COMMA ]
@@ -18241,7 +18251,7 @@ implementation: UIDENT DOT LBRACE LIDENT WITH
 
 implementation: UIDENT DOT LBRACE WITH
 ##
-## Ends in an error in state: 2223.
+## Ends in an error in state: 2287.
 ##
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr RBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18254,7 +18264,7 @@ implementation: UIDENT DOT LBRACE WITH
 
 implementation: UIDENT DOT LBRACELESS WITH
 ##
-## Ends in an error in state: 2218.
+## Ends in an error in state: 2282.
 ##
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18267,7 +18277,7 @@ implementation: UIDENT DOT LBRACELESS WITH
 
 implementation: UIDENT DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2208.
+## Ends in an error in state: 2272.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKET . expr_comma_seq_extension [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -18279,7 +18289,7 @@ implementation: UIDENT DOT LBRACKET WITH
 
 implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2204.
+## Ends in an error in state: 2268.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18292,23 +18302,23 @@ implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1800, spurious reduction of production expr_optional_constraint -> expr
-## In state 1796, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1839, spurious reduction of production expr_optional_constraint -> expr
+## In state 1835, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LBRACKETBAR WITH
 ##
-## Ends in an error in state: 2203.
+## Ends in an error in state: 2267.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18321,7 +18331,7 @@ implementation: UIDENT DOT LBRACKETBAR WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2198.
+## Ends in an error in state: 2262.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON package_type . RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -18341,7 +18351,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2196.
+## Ends in an error in state: 2260.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . package_type RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18354,7 +18364,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 858.
+## Ends in an error in state: 874.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -18369,19 +18379,19 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 915, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 919, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 916, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 857, spurious reduction of production _module_expr -> simple_module_expr
-## In state 921, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 920, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 931, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 935, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 932, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 873, spurious reduction of production _module_expr -> simple_module_expr
+## In state 937, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 936, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN MODULE WITH
 ##
-## Ends in an error in state: 856.
+## Ends in an error in state: 872.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON package_type RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18394,7 +18404,7 @@ implementation: UIDENT DOT LPAREN MODULE WITH
 
 implementation: UIDENT DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2200.
+## Ends in an error in state: 2264.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -18429,21 +18439,21 @@ implementation: UIDENT DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN WITH
 ##
-## Ends in an error in state: 855.
+## Ends in an error in state: 871.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN . expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN . expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18459,7 +18469,7 @@ implementation: UIDENT DOT LPAREN WITH
 
 implementation: UIDENT DOT WITH
 ##
-## Ends in an error in state: 854.
+## Ends in an error in state: 870.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18483,7 +18493,7 @@ implementation: UIDENT DOT WITH
 
 implementation: UIDENT GREATER WITH
 ##
-## Ends in an error in state: 1232.
+## Ends in an error in state: 1271.
 ##
 ## _expr -> expr GREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18495,7 +18505,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP0 WITH
 ##
-## Ends in an error in state: 1230.
+## Ends in an error in state: 1269.
 ##
 ## _expr -> expr INFIXOP0 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18507,7 +18517,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP1 WITH
 ##
-## Ends in an error in state: 1224.
+## Ends in an error in state: 1263.
 ##
 ## _expr -> expr INFIXOP1 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18519,7 +18529,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP2 WITH
 ##
-## Ends in an error in state: 1222.
+## Ends in an error in state: 1261.
 ##
 ## _expr -> expr INFIXOP2 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18531,7 +18541,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP3 WITH
 ##
-## Ends in an error in state: 1208.
+## Ends in an error in state: 1247.
 ##
 ## _expr -> expr INFIXOP3 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18543,7 +18553,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP4 WITH
 ##
-## Ends in an error in state: 1191.
+## Ends in an error in state: 1230.
 ##
 ## _expr -> expr INFIXOP4 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18567,7 +18577,7 @@ Expecting an attribute id
 
 implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2516.
+## Ends in an error in state: 2580.
 ##
 ## attribute -> LBRACKETAT attr_id payload . RBRACKET [ WITH WHEN UIDENT STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 IN GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -18578,23 +18588,23 @@ implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1519, spurious reduction of production post_item_attributes ->
-## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1121, spurious reduction of production structure -> structure_item
-## In state 1506, spurious reduction of production payload -> structure
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1558, spurious reduction of production post_item_attributes ->
+## In state 1559, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1560, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1168, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1159, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1561, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1169, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1160, spurious reduction of production structure -> structure_item
+## In state 1545, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
@@ -18613,7 +18623,7 @@ Expecting an attributed id
 
 implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2409.
+## Ends in an error in state: 2473.
 ##
 ## item_attribute -> LBRACKETATAT attr_id payload . RBRACKET [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -18624,30 +18634,30 @@ implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1519, spurious reduction of production post_item_attributes ->
-## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1121, spurious reduction of production structure -> structure_item
-## In state 1506, spurious reduction of production payload -> structure
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1558, spurious reduction of production post_item_attributes ->
+## In state 1559, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1560, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1168, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1159, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1561, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1169, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1160, spurious reduction of production structure -> structure_item
+## In state 1545, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
 
 implementation: UIDENT LESS WITH
 ##
-## Ends in an error in state: 1228.
+## Ends in an error in state: 1267.
 ##
 ## _expr -> expr LESS . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18659,7 +18669,7 @@ Expecting an expression
 
 implementation: UIDENT LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1226.
+## Ends in an error in state: 1265.
 ##
 ## _expr -> expr LESSDOTDOTGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18671,7 +18681,7 @@ Expecting an expression
 
 implementation: UIDENT LESSGREATER WITH
 ##
-## Ends in an error in state: 1220.
+## Ends in an error in state: 1259.
 ##
 ## _expr -> expr LESSGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18708,7 +18718,7 @@ Expecting one of the following:
 
 implementation: UIDENT MINUS WITH
 ##
-## Ends in an error in state: 1218.
+## Ends in an error in state: 1257.
 ##
 ## _expr -> expr MINUS . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18720,7 +18730,7 @@ Expecting an expression
 
 implementation: UIDENT MINUSDOT WITH
 ##
-## Ends in an error in state: 1216.
+## Ends in an error in state: 1255.
 ##
 ## _expr -> expr MINUSDOT . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18732,7 +18742,7 @@ Expecting an expression
 
 implementation: UIDENT OR WITH
 ##
-## Ends in an error in state: 1214.
+## Ends in an error in state: 1253.
 ##
 ## _expr -> expr OR . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18744,7 +18754,7 @@ Expecting an expression
 
 implementation: UIDENT PERCENT WITH
 ##
-## Ends in an error in state: 1206.
+## Ends in an error in state: 1245.
 ##
 ## _expr -> expr PERCENT . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18756,7 +18766,7 @@ Expecting an expression
 
 implementation: UIDENT PLUS WITH
 ##
-## Ends in an error in state: 1212.
+## Ends in an error in state: 1251.
 ##
 ## _expr -> expr PLUS . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18768,7 +18778,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSDOT WITH
 ##
-## Ends in an error in state: 1210.
+## Ends in an error in state: 1249.
 ##
 ## _expr -> expr PLUSDOT . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18780,7 +18790,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 1204.
+## Ends in an error in state: 1243.
 ##
 ## _expr -> expr PLUSEQ . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18792,7 +18802,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1245.
+## Ends in an error in state: 1284.
 ##
 ## _expr -> expr QUESTION expr COLON . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18804,7 +18814,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT SEMI
 ##
-## Ends in an error in state: 1244.
+## Ends in an error in state: 1283.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -18838,14 +18848,14 @@ implementation: UIDENT QUESTION UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -18854,7 +18864,7 @@ Expecting one of the following:
 
 implementation: UIDENT QUESTION WITH
 ##
-## Ends in an error in state: 1243.
+## Ends in an error in state: 1282.
 ##
 ## _expr -> expr QUESTION . expr COLON expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18866,7 +18876,7 @@ Expecting an expression
 
 implementation: UIDENT RBRACKET
 ##
-## Ends in an error in state: 2613.
+## Ends in an error in state: 2700.
 ##
 ## implementation -> structure . EOF [ # ]
 ##
@@ -18877,29 +18887,29 @@ implementation: UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1519, spurious reduction of production post_item_attributes ->
-## In state 1520, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1521, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1129, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1120, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1522, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1130, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1121, spurious reduction of production structure -> structure_item
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1558, spurious reduction of production post_item_attributes ->
+## In state 1559, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1560, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1168, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1159, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1561, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1169, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1160, spurious reduction of production structure -> structure_item
 ##
 
 Invalid token
 
 implementation: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 1122.
+## Ends in an error in state: 1161.
 ##
 ## structure -> structure_item SEMI . structure [ RBRACKET RBRACE EOF ]
 ##
@@ -18911,7 +18921,7 @@ Expecting a structure item
 
 implementation: UIDENT SHARP WITH
 ##
-## Ends in an error in state: 572.
+## Ends in an error in state: 588.
 ##
 ## _simple_expr -> simple_expr SHARP . label [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -18923,7 +18933,7 @@ Expecting an identifier
 
 implementation: UIDENT STAR WITH
 ##
-## Ends in an error in state: 1189.
+## Ends in an error in state: 1228.
 ##
 ## _expr -> expr STAR . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18935,7 +18945,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 2298.
+## Ends in an error in state: 2362.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -18969,14 +18979,14 @@ implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 1194, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 892, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1174, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1203, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1131, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 1233, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 908, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1213, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1242, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1170, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -18985,7 +18995,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 2297.
+## Ends in an error in state: 2361.
 ##
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -18997,7 +19007,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2295.
+## Ends in an error in state: 2359.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -19032,14 +19042,14 @@ implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -19048,7 +19058,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2294.
+## Ends in an error in state: 2358.
 ##
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -19061,7 +19071,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2292.
+## Ends in an error in state: 2356.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -19096,14 +19106,14 @@ implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 903, spurious reduction of production constr_longident -> mod_longident
-## In state 1384, spurious reduction of production _simple_expr -> constr_longident
-## In state 1317, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 1312, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1368, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1374, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1393, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1373, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 919, spurious reduction of production constr_longident -> mod_longident
+## In state 1423, spurious reduction of production _simple_expr -> constr_longident
+## In state 1356, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 1351, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1407, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1413, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1432, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1412, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -19112,7 +19122,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 575.
+## Ends in an error in state: 591.
 ##
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -19125,7 +19135,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT WITH
 ##
-## Ends in an error in state: 574.
+## Ends in an error in state: 590.
 ##
 ## _simple_expr -> simple_expr DOT . label_longident [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT . LPAREN expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -19146,7 +19156,7 @@ Expecting one of the following:
 
 implementation: WHILE UIDENT WITH
 ##
-## Ends in an error in state: 2608.
+## Ends in an error in state: 2695.
 ##
 ## _expr -> WHILE simple_expr . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -19164,10 +19174,10 @@ implementation: WHILE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 853, spurious reduction of production constr_longident -> mod_longident
-## In state 886, spurious reduction of production _simple_expr -> constr_longident
-## In state 888, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 884, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 869, spurious reduction of production constr_longident -> mod_longident
+## In state 902, spurious reduction of production _simple_expr -> constr_longident
+## In state 904, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 900, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>

--- a/src/reason_parser.messages
+++ b/src/reason_parser.messages
@@ -1,6 +1,6 @@
 use_file: SHARP LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2638.
+## Ends in an error in state: 2646.
 ##
 ## _use_file -> toplevel_directive SEMI . use_file [ # ]
 ##
@@ -12,7 +12,7 @@ use_file: SHARP LIDENT SEMI WITH
 
 use_file: SHARP LIDENT TRUE WITH
 ##
-## Ends in an error in state: 2637.
+## Ends in an error in state: 2645.
 ##
 ## _use_file -> toplevel_directive . SEMI use_file [ # ]
 ## _use_file -> toplevel_directive . EOF [ # ]
@@ -25,7 +25,7 @@ use_file: SHARP LIDENT TRUE WITH
 
 use_file: UIDENT RPAREN
 ##
-## Ends in an error in state: 2640.
+## Ends in an error in state: 2648.
 ##
 ## _use_file -> structure_item . SEMI use_file [ # ]
 ## _use_file -> structure_item . EOF [ # ]
@@ -37,28 +37,28 @@ use_file: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1513, spurious reduction of production post_item_attributes ->
 ## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1122, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1113, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
 ## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1123, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 use_file: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2641.
+## Ends in an error in state: 2649.
 ##
 ## _use_file -> structure_item SEMI . use_file [ # ]
 ##
@@ -70,7 +70,7 @@ use_file: UIDENT SEMI WITH
 
 use_file: WITH
 ##
-## Ends in an error in state: 2634.
+## Ends in an error in state: 2642.
 ##
 ## use_file' -> . use_file [ # ]
 ##
@@ -82,7 +82,7 @@ use_file: WITH
 
 toplevel_phrase: SHARP UIDENT EOF
 ##
-## Ends in an error in state: 2629.
+## Ends in an error in state: 2637.
 ##
 ## _toplevel_phrase -> toplevel_directive . SEMI [ # ]
 ##
@@ -93,14 +93,14 @@ toplevel_phrase: SHARP UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2619, spurious reduction of production toplevel_directive -> SHARP ident
+## In state 2627, spurious reduction of production toplevel_directive -> SHARP ident
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 ##
-## Ends in an error in state: 2626.
+## Ends in an error in state: 2634.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ SEMI EOF DOT ]
 ## val_longident -> mod_longident DOT . val_ident [ SEMI EOF ]
@@ -113,7 +113,7 @@ toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 
 toplevel_phrase: SHARP UIDENT UIDENT WITH
 ##
-## Ends in an error in state: 2625.
+## Ends in an error in state: 2633.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ SEMI EOF DOT ]
 ## toplevel_directive -> SHARP ident mod_longident . [ SEMI EOF ]
@@ -127,7 +127,7 @@ toplevel_phrase: SHARP UIDENT UIDENT WITH
 
 toplevel_phrase: SHARP UIDENT WITH
 ##
-## Ends in an error in state: 2619.
+## Ends in an error in state: 2627.
 ##
 ## toplevel_directive -> SHARP ident . [ SEMI EOF ]
 ## toplevel_directive -> SHARP ident . STRING [ SEMI EOF ]
@@ -145,7 +145,7 @@ toplevel_phrase: SHARP UIDENT WITH
 
 toplevel_phrase: SHARP WITH
 ##
-## Ends in an error in state: 2618.
+## Ends in an error in state: 2626.
 ##
 ## toplevel_directive -> SHARP . ident [ SEMI EOF ]
 ## toplevel_directive -> SHARP . ident STRING [ SEMI EOF ]
@@ -163,7 +163,7 @@ toplevel_phrase: SHARP WITH
 
 toplevel_phrase: UIDENT RPAREN
 ##
-## Ends in an error in state: 2631.
+## Ends in an error in state: 2639.
 ##
 ## _toplevel_phrase -> structure_item . SEMI [ # ]
 ##
@@ -174,28 +174,28 @@ toplevel_phrase: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1513, spurious reduction of production post_item_attributes ->
 ## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1122, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1113, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
 ## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1123, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: WITH
 ##
-## Ends in an error in state: 2617.
+## Ends in an error in state: 2625.
 ##
 ## toplevel_phrase' -> . toplevel_phrase [ # ]
 ##
@@ -207,7 +207,7 @@ toplevel_phrase: WITH
 
 parse_pattern: EXCEPTION UNDERSCORE WITH
 ##
-## Ends in an error in state: 771.
+## Ends in an error in state: 772.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -224,7 +224,7 @@ parse_pattern: EXCEPTION UNDERSCORE WITH
 
 parse_pattern: EXCEPTION WITH
 ##
-## Ends in an error in state: 769.
+## Ends in an error in state: 770.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -236,7 +236,7 @@ parse_pattern: EXCEPTION WITH
 
 parse_pattern: LAZY WITH
 ##
-## Ends in an error in state: 753.
+## Ends in an error in state: 754.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -248,7 +248,7 @@ parse_pattern: LAZY WITH
 
 parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ##
-## Ends in an error in state: 814.
+## Ends in an error in state: 815.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error RBRACE COMMA BAR ]
 ## lbl_pattern -> label_longident COLON pattern . [ error RBRACE COMMA ]
@@ -260,14 +260,14 @@ parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 707, spurious reduction of production pattern -> pattern_without_or
+## In state 708, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 665.
+## Ends in an error in state: 666.
 ##
 ## lbl_pattern -> label_longident COLON . pattern [ error RBRACE COMMA ]
 ##
@@ -279,7 +279,7 @@ parse_pattern: LBRACE LIDENT COLON WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 750.
+## Ends in an error in state: 751.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -292,7 +292,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 660.
+## Ends in an error in state: 661.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA UNDERSCORE . opt_comma [ error RBRACE ]
 ##
@@ -304,7 +304,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 
 parse_pattern: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 659.
+## Ends in an error in state: 660.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA . [ error RBRACE ]
 ## lbl_pattern_list -> lbl_pattern COMMA . UNDERSCORE opt_comma [ error RBRACE ]
@@ -318,7 +318,7 @@ parse_pattern: LBRACE LIDENT COMMA WITH
 
 parse_pattern: LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 664.
+## Ends in an error in state: 665.
 ##
 ## lbl_pattern -> label_longident . COLON pattern [ error RBRACE COMMA ]
 ## lbl_pattern -> label_longident . [ error RBRACE COMMA ]
@@ -331,7 +331,7 @@ parse_pattern: LBRACE LIDENT WITH
 
 parse_pattern: LBRACE UIDENT DOT WITH
 ##
-## Ends in an error in state: 653.
+## Ends in an error in state: 654.
 ##
 ## label_longident -> mod_longident DOT . LIDENT [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident DOT . UIDENT [ DOT ]
@@ -344,7 +344,7 @@ parse_pattern: LBRACE UIDENT DOT WITH
 
 parse_pattern: LBRACE UIDENT WITH
 ##
-## Ends in an error in state: 652.
+## Ends in an error in state: 653.
 ##
 ## label_longident -> mod_longident . DOT LIDENT [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident . DOT UIDENT [ DOT ]
@@ -357,7 +357,7 @@ parse_pattern: LBRACE UIDENT WITH
 
 parse_pattern: LBRACE WITH
 ##
-## Ends in an error in state: 749.
+## Ends in an error in state: 750.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -370,7 +370,7 @@ parse_pattern: LBRACE WITH
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 746.
+## Ends in an error in state: 747.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET BAR ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT pattern . [ error SEMI RBRACKET ]
@@ -382,14 +382,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 707, spurious reduction of production pattern -> pattern_without_or
+## In state 708, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT WITH
 ##
-## Ends in an error in state: 745.
+## Ends in an error in state: 746.
 ##
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT . pattern [ error SEMI RBRACKET ]
 ##
@@ -401,7 +401,7 @@ Expecting a valid list identifier
 
 parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 747.
+## Ends in an error in state: 748.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ COMMA ]
@@ -414,14 +414,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 707, spurious reduction of production pattern -> pattern_without_or
+## In state 708, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 744.
+## Ends in an error in state: 745.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ COMMA ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA . DOTDOTDOT pattern [ error SEMI RBRACKET ]
@@ -435,7 +435,7 @@ parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKET UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 748.
+## Ends in an error in state: 749.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern . [ COMMA ]
@@ -448,14 +448,14 @@ parse_pattern: LBRACKET UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 707, spurious reduction of production pattern -> pattern_without_or
+## In state 708, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 740.
+## Ends in an error in state: 741.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -468,7 +468,7 @@ parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LBRACKET WITH
 ##
-## Ends in an error in state: 737.
+## Ends in an error in state: 738.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -482,7 +482,7 @@ parse_pattern: LBRACKET WITH
 
 parse_pattern: LBRACKETBAR MINUS WITH
 ##
-## Ends in an error in state: 648.
+## Ends in an error in state: 649.
 ##
 ## signed_constant -> MINUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> MINUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -498,7 +498,7 @@ parse_pattern: LBRACKETBAR MINUS WITH
 
 parse_pattern: LBRACKETBAR PLUS WITH
 ##
-## Ends in an error in state: 647.
+## Ends in an error in state: 648.
 ##
 ## signed_constant -> PLUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> PLUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -514,7 +514,7 @@ parse_pattern: LBRACKETBAR PLUS WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 727.
+## Ends in an error in state: 728.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -526,14 +526,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 707, spurious reduction of production pattern -> pattern_without_or
+## In state 708, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 726.
+## Ends in an error in state: 727.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ error SEMI COMMA BARRBRACKET ]
 ##
@@ -545,7 +545,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 736.
+## Ends in an error in state: 737.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -557,14 +557,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 707, spurious reduction of production pattern -> pattern_without_or
+## In state 708, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 733.
+## Ends in an error in state: 734.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -577,7 +577,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LBRACKETBAR WITH
 ##
-## Ends in an error in state: 722.
+## Ends in an error in state: 723.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -591,7 +591,7 @@ parse_pattern: LBRACKETBAR WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 2415.
+## Ends in an error in state: 2422.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -609,7 +609,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 2414.
+## Ends in an error in state: 2421.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -622,7 +622,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2413.
+## Ends in an error in state: 2420.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -640,7 +640,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2412.
+## Ends in an error in state: 2419.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -653,7 +653,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2411.
+## Ends in an error in state: 2418.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -666,7 +666,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2410.
+## Ends in an error in state: 2417.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -679,7 +679,7 @@ parse_pattern: LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN EXCEPTION UNDERSCORE WITH
 ##
-## Ends in an error in state: 682.
+## Ends in an error in state: 683.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -696,7 +696,7 @@ parse_pattern: LPAREN EXCEPTION UNDERSCORE WITH
 
 parse_pattern: LPAREN EXCEPTION WITH
 ##
-## Ends in an error in state: 674.
+## Ends in an error in state: 675.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -708,7 +708,7 @@ parse_pattern: LPAREN EXCEPTION WITH
 
 parse_pattern: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 666.
+## Ends in an error in state: 667.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -720,7 +720,7 @@ parse_pattern: LPAREN LAZY WITH
 
 parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 655.
+## Ends in an error in state: 656.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -733,7 +733,7 @@ parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 650.
+## Ends in an error in state: 651.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -746,7 +746,7 @@ parse_pattern: LPAREN LBRACE WITH
 
 parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 816.
+## Ends in an error in state: 817.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -759,7 +759,7 @@ parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LPAREN LBRACKET WITH
 ##
-## Ends in an error in state: 649.
+## Ends in an error in state: 650.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -773,7 +773,7 @@ parse_pattern: LPAREN LBRACKET WITH
 
 parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 821.
+## Ends in an error in state: 822.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -786,7 +786,7 @@ parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LPAREN LBRACKETBAR WITH
 ##
-## Ends in an error in state: 646.
+## Ends in an error in state: 647.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -800,7 +800,7 @@ parse_pattern: LPAREN LBRACKETBAR WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 829.
+## Ends in an error in state: 830.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -818,7 +818,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCOR
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 828.
+## Ends in an error in state: 829.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -831,7 +831,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 827.
+## Ends in an error in state: 828.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -849,7 +849,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 826.
+## Ends in an error in state: 827.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -862,7 +862,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 825.
+## Ends in an error in state: 826.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -875,7 +875,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 824.
+## Ends in an error in state: 825.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -888,7 +888,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 634.
+## Ends in an error in state: 635.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -901,7 +901,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 632.
+## Ends in an error in state: 633.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -915,7 +915,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 
 parse_pattern: LPAREN LPAREN MODULE WITH
 ##
-## Ends in an error in state: 631.
+## Ends in an error in state: 632.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -929,7 +929,7 @@ parse_pattern: LPAREN LPAREN MODULE WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 808.
+## Ends in an error in state: 809.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -944,7 +944,7 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 719.
+## Ends in an error in state: 720.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -956,23 +956,23 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 794, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
-## In state 801, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 800, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 804, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 795, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
+## In state 802, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 801, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 805, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 630.
+## Ends in an error in state: 631.
 ##
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -996,7 +996,7 @@ parse_pattern: LPAREN LPAREN WITH
 
 parse_pattern: LPAREN MINUS WITH
 ##
-## Ends in an error in state: 624.
+## Ends in an error in state: 625.
 ##
 ## operator -> MINUS . [ RPAREN ]
 ## signed_constant -> MINUS . INT [ error RPAREN LBRACKETAT DOTDOT COMMA COLONCOLON COLON BAR AS ]
@@ -1013,7 +1013,7 @@ parse_pattern: LPAREN MINUS WITH
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 246.
+## Ends in an error in state: 239.
 ##
 ## package_type -> mty_longident . [ error RPAREN ]
 ## package_type -> mty_longident . WITH package_type_cstrs [ error RPAREN ]
@@ -1025,18 +1025,19 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 241, spurious reduction of production ident -> UIDENT
-## In state 642, spurious reduction of production mty_longident -> ident
+## In state 234, spurious reduction of production ident -> UIDENT
+## In state 643, spurious reduction of production mty_longident -> ident
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WHILE
 ##
-## Ends in an error in state: 241.
+## Ends in an error in state: 234.
 ##
 ## ident -> UIDENT . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
-## mod_ext_longident -> UIDENT . [ LPAREN DOT ]
+## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> UIDENT . [ DOT ]
 ##
 ## The known suffix of the stack is as follows:
 ## UIDENT
@@ -1046,7 +1047,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WHILE
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2408.
+## Ends in an error in state: 2415.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ error RPAREN ]
 ##
@@ -1058,7 +1059,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2407.
+## Ends in an error in state: 2414.
 ##
 ## package_type_cstrs -> package_type_cstr . [ error RPAREN ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ error RPAREN ]
@@ -1070,20 +1071,20 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 457, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 451, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 453, spurious reduction of production _core_type -> core_type2
-## In state 462, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 452, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2405, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 339, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 449, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 443, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 445, spurious reduction of production _core_type -> core_type2
+## In state 454, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 444, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 2412, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 250.
+## Ends in an error in state: 243.
 ##
 ## package_type_cstr -> TYPE label_longident EQUAL . core_type [ error RPAREN AND ]
 ##
@@ -1095,7 +1096,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL WITH
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT WITH
 ##
-## Ends in an error in state: 249.
+## Ends in an error in state: 242.
 ##
 ## package_type_cstr -> TYPE label_longident . EQUAL core_type [ error RPAREN AND ]
 ##
@@ -1107,7 +1108,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT WITH
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 248.
+## Ends in an error in state: 241.
 ##
 ## package_type_cstr -> TYPE . label_longident EQUAL core_type [ error RPAREN AND ]
 ##
@@ -1119,7 +1120,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE WITH
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH WITH
 ##
-## Ends in an error in state: 247.
+## Ends in an error in state: 240.
 ##
 ## package_type -> mty_longident WITH . package_type_cstrs [ error RPAREN ]
 ##
@@ -1131,7 +1132,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH WITH
 
 parse_pattern: LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 240.
+## Ends in an error in state: 233.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1144,7 +1145,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON WITH
 
 parse_pattern: LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 238.
+## Ends in an error in state: 231.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . COLON package_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1158,7 +1159,7 @@ parse_pattern: LPAREN MODULE UIDENT WITH
 
 parse_pattern: LPAREN MODULE WITH
 ##
-## Ends in an error in state: 237.
+## Ends in an error in state: 230.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT COLON package_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1172,7 +1173,7 @@ parse_pattern: LPAREN MODULE WITH
 
 parse_pattern: LPAREN PLUS WITH
 ##
-## Ends in an error in state: 229.
+## Ends in an error in state: 222.
 ##
 ## operator -> PLUS . [ RPAREN ]
 ## signed_constant -> PLUS . INT [ error RPAREN LBRACKETAT DOTDOT COMMA COLONCOLON COLON BAR AS ]
@@ -1189,9 +1190,10 @@ parse_pattern: LPAREN PLUS WITH
 
 parse_pattern: LPAREN SHARP UIDENT DOT WITH
 ##
-## Ends in an error in state: 223.
+## Ends in an error in state: 216.
 ##
-## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ LPAREN DOT ]
+## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
 ## type_longident -> mod_ext_longident DOT . LIDENT [ error WITH UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS AND ]
 ##
 ## The known suffix of the stack is as follows:
@@ -1202,21 +1204,27 @@ parse_pattern: LPAREN SHARP UIDENT DOT WITH
 
 parse_pattern: LPAREN SHARP UIDENT WITH
 ##
-## Ends in an error in state: 222.
+## Ends in an error in state: 215.
 ##
-## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ LPAREN DOT ]
-## mod_ext_longident -> mod_ext_longident . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
 ## type_longident -> mod_ext_longident . DOT LIDENT [ error WITH UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## mod_ext_longident
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 76, spurious reduction of production mod_ext_longident -> UIDENT
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN SHARP WITH
 ##
-## Ends in an error in state: 219.
+## Ends in an error in state: 212.
 ##
 ## _simple_pattern_not_ident -> SHARP . type_longident [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ##
@@ -1228,7 +1236,7 @@ parse_pattern: LPAREN SHARP WITH
 
 parse_pattern: LPAREN STRING DOTDOT WITH
 ##
-## Ends in an error in state: 679.
+## Ends in an error in state: 680.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ##
@@ -1240,7 +1248,7 @@ parse_pattern: LPAREN STRING DOTDOT WITH
 
 parse_pattern: LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 688.
+## Ends in an error in state: 689.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ error WITH UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS AND ]
 ##
@@ -1252,7 +1260,7 @@ parse_pattern: LPAREN UIDENT DOT WITH
 
 parse_pattern: LPAREN UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 667.
+## Ends in an error in state: 668.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1274,7 +1282,7 @@ parse_pattern: LPAREN UIDENT LPAREN WITH
 
 parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 698.
+## Ends in an error in state: 699.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1287,7 +1295,7 @@ parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE AS LPAREN WITH
 ##
-## Ends in an error in state: 713.
+## Ends in an error in state: 714.
 ##
 ## val_ident -> LPAREN . operator RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -1299,7 +1307,7 @@ parse_pattern: LPAREN UNDERSCORE AS LPAREN WITH
 
 parse_pattern: LPAREN UNDERSCORE AS WITH
 ##
-## Ends in an error in state: 711.
+## Ends in an error in state: 712.
 ##
 ## _pattern_without_or -> pattern_without_or AS . val_ident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> pattern_without_or AS . error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -1312,7 +1320,7 @@ parse_pattern: LPAREN UNDERSCORE AS WITH
 
 parse_pattern: LPAREN UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 728.
+## Ends in an error in state: 729.
 ##
 ## _or_pattern -> pattern BAR . pattern [ error SEMI RPAREN RBRACKET RBRACE COMMA COLON BARRBRACKET BAR ]
 ##
@@ -1324,7 +1332,7 @@ parse_pattern: LPAREN UNDERSCORE BAR WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BACKQUOTE LIDENT GREATER
 ##
-## Ends in an error in state: 313.
+## Ends in an error in state: 317.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET tag_field . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## row_field -> tag_field . [ BAR ]
@@ -1336,15 +1344,15 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BACKQUOTE LIDENT GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 149, spurious reduction of production attributes ->
-## In state 2510, spurious reduction of production tag_field -> name_tag attributes
+## In state 160, spurious reduction of production attributes ->
+## In state 2519, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 311.
+## Ends in an error in state: 315.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET BAR row_field_list . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -1357,7 +1365,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BAR UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BAR WITH
 ##
-## Ends in an error in state: 310.
+## Ends in an error in state: 314.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET BAR . row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1369,7 +1377,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BAR WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 317.
+## Ends in an error in state: 321.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR row_field_list . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -1382,7 +1390,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 316.
+## Ends in an error in state: 320.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR . row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1394,7 +1402,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE BAR WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE WITH
 ##
-## Ends in an error in state: 315.
+## Ends in an error in state: 319.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field . BAR row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1406,7 +1414,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET WITH
 ##
-## Ends in an error in state: 309.
+## Ends in an error in state: 313.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET . tag_field RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> LBRACKET . BAR row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
@@ -1420,7 +1428,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER BAR ASSERT
 ##
-## Ends in an error in state: 306.
+## Ends in an error in state: 310.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar . row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1432,7 +1440,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER BAR ASSERT
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 307.
+## Ends in an error in state: 311.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar row_field_list . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -1445,7 +1453,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER WITH
 ##
-## Ends in an error in state: 304.
+## Ends in an error in state: 308.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER . opt_bar row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
@@ -1458,7 +1466,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS BAR ASSERT
 ##
-## Ends in an error in state: 295.
+## Ends in an error in state: 299.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar . row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar . row_field_list GREATER name_tag_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
@@ -1471,7 +1479,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS BAR ASSERT
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 ##
-## Ends in an error in state: 299.
+## Ends in an error in state: 303.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER name_tag_list . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## name_tag_list -> name_tag_list . name_tag [ RBRACKET BACKQUOTE ]
@@ -1484,7 +1492,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE GREATER BACKQUOTE
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE GREATER WITH
 ##
-## Ends in an error in state: 298.
+## Ends in an error in state: 302.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER . name_tag_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1496,7 +1504,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE GREATER WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE WITH
 ##
-## Ends in an error in state: 296.
+## Ends in an error in state: 300.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . GREATER name_tag_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
@@ -1510,7 +1518,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS WITH
 ##
-## Ends in an error in state: 294.
+## Ends in an error in state: 298.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS . opt_bar row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS . opt_bar row_field_list GREATER name_tag_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
@@ -1523,7 +1531,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LESS DOTDOT WITH
 ##
-## Ends in an error in state: 288.
+## Ends in an error in state: 292.
 ##
 ## _non_arrowed_simple_core_type -> LESS meth_list . GREATER [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1535,7 +1543,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LESS DOTDOT WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LESS WITH
 ##
-## Ends in an error in state: 287.
+## Ends in an error in state: 291.
 ##
 ## _non_arrowed_simple_core_type -> LESS . meth_list GREATER [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1547,7 +1555,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LESS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2403.
+## Ends in an error in state: 2410.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1559,7 +1567,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 ##
-## Ends in an error in state: 330.
+## Ends in an error in state: 334.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1571,7 +1579,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE QUESTION EQU
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 ##
-## Ends in an error in state: 329.
+## Ends in an error in state: 333.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION . EQUALGREATER core_type2 [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1583,7 +1591,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE QUESTION WIT
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 328.
+## Ends in an error in state: 332.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . QUESTION EQUALGREATER core_type2 [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER core_type2 [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
@@ -1597,7 +1605,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 327.
+## Ends in an error in state: 331.
 ##
 ## _core_type2 -> LIDENT COLONCOLON . non_arrowed_core_type QUESTION EQUALGREATER core_type2 [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ## _core_type2 -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER core_type2 [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
@@ -1610,7 +1618,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT SHARP WITH
 ##
-## Ends in an error in state: 254.
+## Ends in an error in state: 247.
 ##
 ## _non_arrowed_simple_core_type -> SHARP . class_longident [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1622,7 +1630,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT SHARP WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 332.
+## Ends in an error in state: 336.
 ##
 ## _non_arrowed_non_simple_core_type -> type_longident non_arrowed_simple_core_type_list . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
@@ -1635,7 +1643,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT UNDERSCORE WHILE
 
 parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE UIDENT COLONGREATER
 ##
-## Ends in an error in state: 261.
+## Ends in an error in state: 254.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN MODULE package_type . RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1646,16 +1654,16 @@ parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE UIDENT COLONGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 109, spurious reduction of production package_type -> mty_longident
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 120, spurious reduction of production package_type -> mty_longident
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE WITH
 ##
-## Ends in an error in state: 260.
+## Ends in an error in state: 253.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN MODULE . package_type RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1667,7 +1675,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 271.
+## Ends in an error in state: 275.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN core_type_comma_list . RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## core_type_comma_list -> core_type_comma_list . COMMA core_type [ RPAREN COMMA ]
@@ -1679,33 +1687,20 @@ parse_pattern: LPAREN UNDERSCORE COLON LPAREN UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 284, spurious reduction of production core_type_comma_list -> core_type
-##
-
-<SYNTAX ERROR>
-
-parse_pattern: LPAREN UNDERSCORE COLON LPAREN WITH
-##
-## Ends in an error in state: 259.
-##
-## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
-## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 288, spurious reduction of production core_type_comma_list -> core_type
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN UNDERSCORE COLON QUOTE WITH
 ##
-## Ends in an error in state: 256.
+## Ends in an error in state: 249.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1717,7 +1712,7 @@ parse_pattern: LPAREN UNDERSCORE COLON QUOTE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON SHARP LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 320.
+## Ends in an error in state: 324.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP class_longident non_arrowed_simple_core_type_list . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
@@ -1730,7 +1725,7 @@ parse_pattern: LPAREN UNDERSCORE COLON SHARP LIDENT UNDERSCORE WHILE
 
 parse_pattern: LPAREN UNDERSCORE COLON SHARP WITH
 ##
-## Ends in an error in state: 252.
+## Ends in an error in state: 245.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP . class_longident non_arrowed_simple_core_type_list [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> SHARP . class_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
@@ -1743,7 +1738,7 @@ parse_pattern: LPAREN UNDERSCORE COLON SHARP WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS QUOTE WITH
 ##
-## Ends in an error in state: 459.
+## Ends in an error in state: 451.
 ##
 ## _core_type -> core_type2 AS QUOTE . ident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AND ]
 ##
@@ -1755,7 +1750,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS QUOTE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS WITH
 ##
-## Ends in an error in state: 458.
+## Ends in an error in state: 450.
 ##
 ## _core_type -> core_type2 AS . QUOTE ident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AND ]
 ##
@@ -1767,7 +1762,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 454.
+## Ends in an error in state: 446.
 ##
 ## _core_type2 -> core_type2 EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1779,7 +1774,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 837.
+## Ends in an error in state: 838.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1794,7 +1789,7 @@ parse_pattern: LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 710.
+## Ends in an error in state: 711.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -1811,7 +1806,7 @@ parse_pattern: LPAREN UNDERSCORE COLONCOLON UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLONCOLON WITH
 ##
-## Ends in an error in state: 708.
+## Ends in an error in state: 709.
 ##
 ## _pattern_without_or -> pattern_without_or COLONCOLON . pattern_without_or [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> pattern_without_or COLONCOLON . error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -1824,7 +1819,7 @@ parse_pattern: LPAREN UNDERSCORE COLONCOLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 721.
+## Ends in an error in state: 722.
 ##
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1836,7 +1831,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 793.
+## Ends in an error in state: 794.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ RPAREN COMMA ]
 ##
@@ -1848,7 +1843,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ##
-## Ends in an error in state: 832.
+## Ends in an error in state: 833.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -1860,18 +1855,18 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 781, spurious reduction of production pattern -> pattern_without_or
-## In state 792, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 801, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 800, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 804, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 782, spurious reduction of production pattern -> pattern_without_or
+## In state 793, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 802, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 801, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 805, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 803.
+## Ends in an error in state: 804.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1883,7 +1878,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 802.
+## Ends in an error in state: 803.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint . COMMA pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1894,17 +1889,17 @@ parse_pattern: LPAREN UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 707, spurious reduction of production pattern -> pattern_without_or
-## In state 834, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 801, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 800, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 708, spurious reduction of production pattern -> pattern_without_or
+## In state 835, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 802, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 801, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN WITH
 ##
-## Ends in an error in state: 217.
+## Ends in an error in state: 210.
 ##
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -1928,7 +1923,7 @@ parse_pattern: LPAREN WITH
 
 parse_pattern: MINUS WITH
 ##
-## Ends in an error in state: 211.
+## Ends in an error in state: 204.
 ##
 ## signed_constant -> MINUS . INT [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOTDOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## signed_constant -> MINUS . FLOAT [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOTDOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1944,7 +1939,7 @@ parse_pattern: MINUS WITH
 
 parse_pattern: PLUS WITH
 ##
-## Ends in an error in state: 205.
+## Ends in an error in state: 198.
 ##
 ## signed_constant -> PLUS . INT [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOTDOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## signed_constant -> PLUS . FLOAT [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOTDOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1960,7 +1955,7 @@ parse_pattern: PLUS WITH
 
 parse_pattern: SHARP WITH
 ##
-## Ends in an error in state: 203.
+## Ends in an error in state: 193.
 ##
 ## _simple_pattern_not_ident -> SHARP . type_longident [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ##
@@ -1972,7 +1967,7 @@ parse_pattern: SHARP WITH
 
 parse_pattern: STRING DOTDOT WITH
 ##
-## Ends in an error in state: 758.
+## Ends in an error in state: 759.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ##
@@ -1984,7 +1979,7 @@ parse_pattern: STRING DOTDOT WITH
 
 parse_pattern: UIDENT DOT WITH
 ##
-## Ends in an error in state: 586.
+## Ends in an error in state: 587.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ WITH WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS AND ]
 ##
@@ -1996,7 +1991,7 @@ parse_pattern: UIDENT DOT WITH
 
 parse_pattern: UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 622.
+## Ends in an error in state: 623.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -2018,7 +2013,7 @@ parse_pattern: UIDENT LPAREN WITH
 
 parse_pattern: UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 777.
+## Ends in an error in state: 778.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -2031,7 +2026,7 @@ parse_pattern: UIDENT UNDERSCORE WITH
 
 parse_pattern: UNDERSCORE AS WITH
 ##
-## Ends in an error in state: 785.
+## Ends in an error in state: 786.
 ##
 ## _pattern_without_or -> pattern_without_or AS . val_ident [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> pattern_without_or AS . error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -2044,7 +2039,7 @@ parse_pattern: UNDERSCORE AS WITH
 
 parse_pattern: UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 795.
+## Ends in an error in state: 796.
 ##
 ## _or_pattern -> pattern BAR . pattern [ WHEN SEMI RPAREN RBRACKET IN EQUALGREATER EQUAL EOF COMMA COLON BAR ]
 ##
@@ -2056,7 +2051,7 @@ parse_pattern: UNDERSCORE BAR WITH
 
 parse_pattern: UNDERSCORE COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 784.
+## Ends in an error in state: 785.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -2073,7 +2068,7 @@ parse_pattern: UNDERSCORE COLONCOLON UNDERSCORE WITH
 
 parse_pattern: UNDERSCORE COLONCOLON WITH
 ##
-## Ends in an error in state: 782.
+## Ends in an error in state: 783.
 ##
 ## _pattern_without_or -> pattern_without_or COLONCOLON . pattern_without_or [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> pattern_without_or COLONCOLON . error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -2086,7 +2081,7 @@ parse_pattern: UNDERSCORE COLONCOLON WITH
 
 parse_pattern: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2614.
+## Ends in an error in state: 2622.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EOF BAR ]
 ## parse_pattern -> pattern . EOF [ # ]
@@ -2098,14 +2093,14 @@ parse_pattern: UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 781, spurious reduction of production pattern -> pattern_without_or
+## In state 782, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: WITH
 ##
-## Ends in an error in state: 2613.
+## Ends in an error in state: 2621.
 ##
 ## parse_pattern' -> . parse_pattern [ # ]
 ##
@@ -2117,7 +2112,7 @@ parse_pattern: WITH
 
 parse_expression: UIDENT SEMI
 ##
-## Ends in an error in state: 2611.
+## Ends in an error in state: 2619.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -2151,21 +2146,21 @@ parse_expression: UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 parse_expression: WITH
 ##
-## Ends in an error in state: 2609.
+## Ends in an error in state: 2617.
 ##
 ## parse_expression' -> . parse_expression [ # ]
 ##
@@ -2175,21 +2170,21 @@ parse_expression: WITH
 
 <SYNTAX ERROR>
 
-parse_core_type: LBRACKET BACKQUOTE UIDENT OF AMPERSAND WITH
+parse_core_type: LBRACKET BACKQUOTE UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 152.
+## Ends in an error in state: 2513.
 ##
-## tag_field -> name_tag OF opt_ampersand . amper_type_list attributes [ RBRACKET GREATER BAR ]
+## tag_field -> name_tag opt_ampersand . amper_type_list attributes [ RBRACKET GREATER BAR ]
 ##
 ## The known suffix of the stack is as follows:
-## name_tag OF opt_ampersand
+## name_tag opt_ampersand
 ##
 
 <SYNTAX ERROR>
 
-parse_core_type: LBRACKET BACKQUOTE UIDENT OF UNDERSCORE AMPERSAND WITH
+parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 ##
-## Ends in an error in state: 2507.
+## Ends in an error in state: 2516.
 ##
 ## amper_type_list -> amper_type_list AMPERSAND . core_type [ RBRACKET LBRACKETAT GREATER BAR AMPERSAND ]
 ##
@@ -2199,9 +2194,9 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT OF UNDERSCORE AMPERSAND WITH
 
 <SYNTAX ERROR>
 
-parse_core_type: LBRACKET BACKQUOTE UIDENT OF UNDERSCORE WITH
+parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ##
-## Ends in an error in state: 2511.
+## Ends in an error in state: 2520.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET tag_field . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field -> tag_field . [ BAR ]
@@ -2213,34 +2208,15 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT OF UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2505, spurious reduction of production amper_type_list -> core_type
-## In state 2506, spurious reduction of production attributes ->
-## In state 2509, spurious reduction of production tag_field -> name_tag OF opt_ampersand amper_type_list attributes
-##
-
-<SYNTAX ERROR>
-
-parse_core_type: LBRACKET BACKQUOTE UIDENT OF WITH
-##
-## Ends in an error in state: 150.
-##
-## tag_field -> name_tag OF . opt_ampersand amper_type_list attributes [ RBRACKET GREATER BAR ]
-##
-## The known suffix of the stack is as follows:
-## name_tag OF
+## In state 160, spurious reduction of production attributes ->
+## In state 2519, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: LBRACKET BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 144.
+## Ends in an error in state: 155.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET BAR row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2253,7 +2229,7 @@ parse_core_type: LBRACKET BAR UNDERSCORE WITH
 
 parse_core_type: LBRACKET BAR WITH
 ##
-## Ends in an error in state: 139.
+## Ends in an error in state: 150.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET BAR . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2265,7 +2241,7 @@ parse_core_type: LBRACKET BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 2515.
+## Ends in an error in state: 2524.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2278,7 +2254,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 2514.
+## Ends in an error in state: 2523.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2290,7 +2266,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE WITH
 ##
-## Ends in an error in state: 2513.
+## Ends in an error in state: 2522.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field . BAR row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2302,7 +2278,7 @@ parse_core_type: LBRACKET UNDERSCORE WITH
 
 parse_core_type: LBRACKET WITH
 ##
-## Ends in an error in state: 138.
+## Ends in an error in state: 149.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET . tag_field RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKET . BAR row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2316,7 +2292,7 @@ parse_core_type: LBRACKET WITH
 
 parse_core_type: LBRACKETGREATER BAR ASSERT
 ##
-## Ends in an error in state: 137.
+## Ends in an error in state: 148.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2328,7 +2304,7 @@ parse_core_type: LBRACKETGREATER BAR ASSERT
 
 parse_core_type: LBRACKETGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 2517.
+## Ends in an error in state: 2526.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2341,7 +2317,7 @@ parse_core_type: LBRACKETGREATER UNDERSCORE WITH
 
 parse_core_type: LBRACKETGREATER WITH
 ##
-## Ends in an error in state: 135.
+## Ends in an error in state: 146.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER . opt_bar row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2354,7 +2330,7 @@ parse_core_type: LBRACKETGREATER WITH
 
 parse_core_type: LBRACKETLESS BAR ASSERT
 ##
-## Ends in an error in state: 134.
+## Ends in an error in state: 145.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar . row_field_list GREATER name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2367,7 +2343,7 @@ parse_core_type: LBRACKETLESS BAR ASSERT
 
 parse_core_type: LBRACKETLESS UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 146.
+## Ends in an error in state: 157.
 ##
 ## row_field_list -> row_field_list BAR . row_field [ RBRACKET GREATER BAR ]
 ##
@@ -2379,7 +2355,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2522.
+## Ends in an error in state: 2531.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER name_tag_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## name_tag_list -> name_tag_list . name_tag [ RBRACKET BACKQUOTE ]
@@ -2392,7 +2368,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 ##
-## Ends in an error in state: 2521.
+## Ends in an error in state: 2530.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER . name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2404,7 +2380,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE WITH
 ##
-## Ends in an error in state: 2519.
+## Ends in an error in state: 2528.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . GREATER name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2418,7 +2394,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE WITH
 
 parse_core_type: LBRACKETLESS WITH
 ##
-## Ends in an error in state: 132.
+## Ends in an error in state: 143.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS . opt_bar row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS . opt_bar row_field_list GREATER name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2431,7 +2407,7 @@ parse_core_type: LBRACKETLESS WITH
 
 parse_core_type: LESS DOTDOT WITH
 ##
-## Ends in an error in state: 126.
+## Ends in an error in state: 137.
 ##
 ## _non_arrowed_simple_core_type -> LESS meth_list . GREATER [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2443,7 +2419,7 @@ parse_core_type: LESS DOTDOT WITH
 
 parse_core_type: LESS LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 ##
-## Ends in an error in state: 291.
+## Ends in an error in state: 295.
 ##
 ## meth_list -> field COMMA . meth_list [ GREATER ]
 ## opt_comma -> COMMA . [ GREATER ]
@@ -2456,7 +2432,7 @@ parse_core_type: LESS LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 ##
-## Ends in an error in state: 489.
+## Ends in an error in state: 490.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ##
@@ -2468,7 +2444,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 486.
+## Ends in an error in state: 487.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -2481,7 +2457,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE WITH
 ##
-## Ends in an error in state: 487.
+## Ends in an error in state: 488.
 ##
 ## typevar_list -> typevar_list QUOTE . ident [ QUOTE DOT ]
 ##
@@ -2493,7 +2469,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE WITH
 ##
-## Ends in an error in state: 130.
+## Ends in an error in state: 141.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ RBRACE LBRACKETAT GREATER EQUALGREATER EQUAL COMMA COLONGREATER AS ]
 ## typevar_list -> QUOTE . ident [ QUOTE DOT ]
@@ -2506,7 +2482,7 @@ parse_core_type: LESS LIDENT COLON QUOTE WITH
 
 parse_core_type: LESS LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 290.
+## Ends in an error in state: 294.
 ##
 ## meth_list -> field . COMMA meth_list [ GREATER ]
 ## meth_list -> field . opt_comma [ GREATER ]
@@ -2518,24 +2494,24 @@ parse_core_type: LESS LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 496, spurious reduction of production _poly_type -> core_type
-## In state 497, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 495, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 2524, spurious reduction of production attributes ->
-## In state 2525, spurious reduction of production field -> label COLON poly_type attributes
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 497, spurious reduction of production _poly_type -> core_type
+## In state 498, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 496, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 2533, spurious reduction of production attributes ->
+## In state 2534, spurious reduction of production field -> label COLON poly_type attributes
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: LESS LIDENT COLON WITH
 ##
-## Ends in an error in state: 129.
+## Ends in an error in state: 140.
 ##
 ## field -> label COLON . poly_type attributes [ GREATER COMMA ]
 ##
@@ -2547,7 +2523,7 @@ parse_core_type: LESS LIDENT COLON WITH
 
 parse_core_type: LESS LIDENT WITH
 ##
-## Ends in an error in state: 128.
+## Ends in an error in state: 139.
 ##
 ## field -> label . COLON poly_type attributes [ GREATER COMMA ]
 ##
@@ -2559,7 +2535,7 @@ parse_core_type: LESS LIDENT WITH
 
 parse_core_type: LESS WITH
 ##
-## Ends in an error in state: 123.
+## Ends in an error in state: 134.
 ##
 ## _non_arrowed_simple_core_type -> LESS . meth_list GREATER [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2571,7 +2547,7 @@ parse_core_type: LESS WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2530.
+## Ends in an error in state: 2539.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2583,7 +2559,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 ##
-## Ends in an error in state: 2528.
+## Ends in an error in state: 2537.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2595,7 +2571,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 ##
-## Ends in an error in state: 2527.
+## Ends in an error in state: 2536.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION . EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2607,7 +2583,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2526.
+## Ends in an error in state: 2535.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . QUESTION EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2621,7 +2597,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE WITH
 
 parse_core_type: LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 119.
+## Ends in an error in state: 130.
 ##
 ## _core_type2 -> LIDENT COLONCOLON . non_arrowed_core_type QUESTION EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## _core_type2 -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2634,7 +2610,7 @@ parse_core_type: LIDENT COLONCOLON WITH
 
 parse_core_type: LIDENT SHARP WITH
 ##
-## Ends in an error in state: 100.
+## Ends in an error in state: 108.
 ##
 ## _non_arrowed_simple_core_type -> SHARP . class_longident [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2646,7 +2622,7 @@ parse_core_type: LIDENT SHARP WITH
 
 parse_core_type: LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 154.
+## Ends in an error in state: 262.
 ##
 ## _non_arrowed_non_simple_core_type -> type_longident non_arrowed_simple_core_type_list . [ WITH SEMI RPAREN RBRACKET RBRACE QUESTION LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2659,7 +2635,7 @@ parse_core_type: LIDENT UNDERSCORE WHILE
 
 parse_core_type: LPAREN MODULE UIDENT COLONGREATER
 ##
-## Ends in an error in state: 107.
+## Ends in an error in state: 118.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN MODULE package_type . RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2670,16 +2646,16 @@ parse_core_type: LPAREN MODULE UIDENT COLONGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 109, spurious reduction of production package_type -> mty_longident
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 120, spurious reduction of production package_type -> mty_longident
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: LPAREN MODULE UIDENT SEMI
 ##
-## Ends in an error in state: 109.
+## Ends in an error in state: 120.
 ##
 ## package_type -> mty_longident . [ RPAREN COLONGREATER ]
 ## package_type -> mty_longident . WITH package_type_cstrs [ RPAREN COLONGREATER ]
@@ -2691,15 +2667,15 @@ parse_core_type: LPAREN MODULE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2535.
+## Ends in an error in state: 2544.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ RPAREN COLONGREATER ]
 ##
@@ -2711,7 +2687,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER A
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2534.
+## Ends in an error in state: 2543.
 ##
 ## package_type_cstrs -> package_type_cstr . [ RPAREN COLONGREATER ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ RPAREN COLONGREATER ]
@@ -2723,20 +2699,20 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER W
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2532, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 2541, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 117.
+## Ends in an error in state: 128.
 ##
 ## package_type_cstr -> TYPE label_longident EQUAL . core_type [ RPAREN COLONGREATER AND ]
 ##
@@ -2748,7 +2724,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL WITH
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT WITH
 ##
-## Ends in an error in state: 116.
+## Ends in an error in state: 127.
 ##
 ## package_type_cstr -> TYPE label_longident . EQUAL core_type [ RPAREN COLONGREATER AND ]
 ##
@@ -2760,7 +2736,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT WITH
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 111.
+## Ends in an error in state: 122.
 ##
 ## package_type_cstr -> TYPE . label_longident EQUAL core_type [ RPAREN COLONGREATER AND ]
 ##
@@ -2772,7 +2748,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE WITH
 
 parse_core_type: LPAREN MODULE UIDENT WITH WITH
 ##
-## Ends in an error in state: 110.
+## Ends in an error in state: 121.
 ##
 ## package_type -> mty_longident WITH . package_type_cstrs [ RPAREN COLONGREATER ]
 ##
@@ -2784,7 +2760,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH WITH
 
 parse_core_type: LPAREN MODULE WITH
 ##
-## Ends in an error in state: 105.
+## Ends in an error in state: 116.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN MODULE . package_type RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2796,7 +2772,7 @@ parse_core_type: LPAREN MODULE WITH
 
 parse_core_type: LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 273.
+## Ends in an error in state: 277.
 ##
 ## core_type_comma_list -> core_type_comma_list COMMA . core_type [ RPAREN COMMA ]
 ##
@@ -2808,7 +2784,7 @@ parse_core_type: LPAREN UNDERSCORE COMMA WITH
 
 parse_core_type: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2537.
+## Ends in an error in state: 2546.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN core_type_comma_list . RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## core_type_comma_list -> core_type_comma_list . COMMA core_type [ RPAREN COMMA ]
@@ -2820,35 +2796,22 @@ parse_core_type: LPAREN UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 284, spurious reduction of production core_type_comma_list -> core_type
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 288, spurious reduction of production core_type_comma_list -> core_type
 ##
 
 Expecting one of the following:
   - "," to start the type in the tuple
   - ")" to finish the tuple type definition
 
-parse_core_type: LPAREN WITH
-##
-## Ends in an error in state: 104.
-##
-## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
-## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN
-##
-
-<SYNTAX ERROR>
-
 parse_core_type: QUOTE WITH
 ##
-## Ends in an error in state: 102.
+## Ends in an error in state: 110.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2860,7 +2823,7 @@ parse_core_type: QUOTE WITH
 
 parse_core_type: SHARP LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 2539.
+## Ends in an error in state: 2548.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP class_longident non_arrowed_simple_core_type_list . [ WITH SEMI RPAREN RBRACKET RBRACE QUESTION LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2899,7 +2862,7 @@ parse_core_type: SHARP UIDENT WITH
 
 parse_core_type: SHARP WITH
 ##
-## Ends in an error in state: 98.
+## Ends in an error in state: 113.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP . class_longident non_arrowed_simple_core_type_list [ WITH SEMI RPAREN RBRACKET RBRACE QUESTION LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> SHARP . class_longident [ WITH SEMI RPAREN RBRACKET RBRACE QUESTION LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2912,9 +2875,10 @@ parse_core_type: SHARP WITH
 
 parse_core_type: UIDENT DOT WITH
 ##
-## Ends in an error in state: 162.
+## Ends in an error in state: 196.
 ##
-## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ LPAREN DOT ]
+## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ RPAREN LPAREN DOT ]
+## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ RPAREN DOT ]
 ## type_longident -> mod_ext_longident DOT . LIDENT [ WITH WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN GREATER FLOAT FALSE EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLONCOLON COLON CHAR BAR BACKQUOTE AS AND AMPERSAND ]
 ##
 ## The known suffix of the stack is as follows:
@@ -2925,9 +2889,10 @@ parse_core_type: UIDENT DOT WITH
 
 parse_core_type: UIDENT LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 160.
+## Ends in an error in state: 80.
 ##
-## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF DOT AND ]
+## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF DOT AND ]
+## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF DOT AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## mod_ext_longident DOT
@@ -2937,47 +2902,59 @@ parse_core_type: UIDENT LPAREN UIDENT DOT WITH
 
 parse_core_type: UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 158.
+## Ends in an error in state: 78.
 ##
-## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ RPAREN LPAREN DOT ]
-## mod_ext_longident -> mod_ext_longident . LPAREN mod_ext_longident RPAREN [ RPAREN LPAREN DOT ]
-## mod_ext_longident -> mod_ext_longident LPAREN mod_ext_longident . RPAREN [ WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF DOT AND ]
+## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ RPAREN LPAREN DOT ]
+## mod_ext2 -> UIDENT LPAREN mod_ext_longident . RPAREN [ WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF DOT AND ]
+## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ RPAREN DOT ]
 ##
 ## The known suffix of the stack is as follows:
-## mod_ext_longident LPAREN mod_ext_longident
+## UIDENT LPAREN mod_ext_longident
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 76, spurious reduction of production mod_ext_longident -> UIDENT
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 157.
+## Ends in an error in state: 77.
 ##
-## mod_ext_longident -> mod_ext_longident LPAREN . mod_ext_longident RPAREN [ WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF DOT AND ]
+## mod_ext2 -> UIDENT LPAREN . mod_ext_longident RPAREN [ WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF DOT AND ]
 ##
 ## The known suffix of the stack is as follows:
-## mod_ext_longident LPAREN
+## UIDENT LPAREN
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: UIDENT WITH
 ##
-## Ends in an error in state: 156.
+## Ends in an error in state: 195.
 ##
-## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ LPAREN DOT ]
-## mod_ext_longident -> mod_ext_longident . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
 ## type_longident -> mod_ext_longident . DOT LIDENT [ WITH WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN GREATER FLOAT FALSE EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLONCOLON COLON CHAR BAR BACKQUOTE AS AND AMPERSAND ]
 ##
 ## The known suffix of the stack is as follows:
 ## mod_ext_longident
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 76, spurious reduction of production mod_ext_longident -> UIDENT
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: UNDERSCORE AS QUOTE WITH
 ##
-## Ends in an error in state: 280.
+## Ends in an error in state: 284.
 ##
 ## _core_type -> core_type2 AS QUOTE . ident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AND AMPERSAND ]
 ##
@@ -2989,7 +2966,7 @@ parse_core_type: UNDERSCORE AS QUOTE WITH
 
 parse_core_type: UNDERSCORE AS WITH
 ##
-## Ends in an error in state: 279.
+## Ends in an error in state: 283.
 ##
 ## _core_type -> core_type2 AS . QUOTE ident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AND AMPERSAND ]
 ##
@@ -3001,7 +2978,7 @@ parse_core_type: UNDERSCORE AS WITH
 
 parse_core_type: UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 275.
+## Ends in an error in state: 279.
 ##
 ## _core_type2 -> core_type2 EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -3013,7 +2990,7 @@ parse_core_type: UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2607.
+## Ends in an error in state: 2615.
 ##
 ## parse_core_type -> core_type . EOF [ # ]
 ##
@@ -3024,19 +3001,19 @@ parse_core_type: UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: WITH
 ##
-## Ends in an error in state: 2605.
+## Ends in an error in state: 2613.
 ##
 ## parse_core_type' -> . parse_core_type [ # ]
 ##
@@ -3173,7 +3150,7 @@ interface: CLASS WITH
 
 interface: EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 937.
+## Ends in an error in state: 939.
 ##
 ## extension_constructor_declaration -> constr_ident . generalized_constructor_arguments attributes [ SEMI LBRACKETATAT BAR ]
 ##
@@ -3220,12 +3197,12 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
@@ -3279,8 +3256,8 @@ interface: INCLUDE LBRACE OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 399, spurious reduction of production post_item_attributes ->
-## In state 2398, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 402, spurious reduction of production post_item_attributes ->
+## In state 2405, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
 ## In state 1733, spurious reduction of production _signature_item -> open_statement
 ## In state 1750, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
 ## In state 1734, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
@@ -3302,7 +3279,7 @@ interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 
 interface: INCLUDE LBRACE WITH
 ##
-## Ends in an error in state: 917.
+## Ends in an error in state: 918.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LBRACE . signature error [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3328,7 +3305,7 @@ interface: INCLUDE LPAREN LBRACE WITH
 
 interface: INCLUDE LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 2304.
+## Ends in an error in state: 2311.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3360,7 +3337,7 @@ interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 1959.
+## Ends in an error in state: 1966.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3375,7 +3352,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LID
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1958.
+## Ends in an error in state: 1965.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3387,7 +3364,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WIT
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1957.
+## Ends in an error in state: 1964.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3399,7 +3376,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1956.
+## Ends in an error in state: 1963.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3413,24 +3390,24 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 957, spurious reduction of production _simple_module_type -> mty_longident
-## In state 993, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 989, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 955, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 994, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 990, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 956, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 995, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 991, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 958, spurious reduction of production _simple_module_type -> mty_longident
+## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1955.
+## Ends in an error in state: 1962.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3442,7 +3419,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1954.
+## Ends in an error in state: 1961.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3466,49 +3443,37 @@ interface: INCLUDE LPAREN LPAREN WITH
 
 <SYNTAX ERROR>
 
-interface: INCLUDE LPAREN MODULE TYPE OF UIDENT COLON
+interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2303.
+## Ends in an error in state: 2310.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER ]
 ## _module_expr -> module_expr . attribute [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER ]
-## _non_arrowed_module_type -> MODULE TYPE OF module_expr . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
+## _non_arrowed_module_type -> MODULE TYPE module_expr . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
 ## The known suffix of the stack is as follows:
-## MODULE TYPE OF module_expr
+## MODULE TYPE module_expr
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1997, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2001, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1998, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1970, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2003, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2002, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
-##
-
-<SYNTAX ERROR>
-
-interface: INCLUDE LPAREN MODULE TYPE OF WITH
-##
-## Ends in an error in state: 547.
-##
-## _non_arrowed_module_type -> MODULE TYPE OF . module_expr [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
-##
-## The known suffix of the stack is as follows:
-## MODULE TYPE OF
+## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN MODULE TYPE WITH
 ##
-## Ends in an error in state: 546.
+## Ends in an error in state: 548.
 ##
-## _non_arrowed_module_type -> MODULE TYPE . OF module_expr [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
+## _non_arrowed_module_type -> MODULE TYPE . module_expr [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
 ## The known suffix of the stack is as follows:
 ## MODULE TYPE
@@ -3518,9 +3483,9 @@ interface: INCLUDE LPAREN MODULE TYPE WITH
 
 interface: INCLUDE LPAREN MODULE WITH
 ##
-## Ends in an error in state: 545.
+## Ends in an error in state: 547.
 ##
-## _non_arrowed_module_type -> MODULE . TYPE OF module_expr [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
+## _non_arrowed_module_type -> MODULE . TYPE module_expr [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
 ## The known suffix of the stack is as follows:
 ## MODULE
@@ -3530,10 +3495,11 @@ interface: INCLUDE LPAREN MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 ##
-## Ends in an error in state: 640.
+## Ends in an error in state: 641.
 ##
 ## ident -> UIDENT . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
-## mod_ext_longident -> mod_ext_longident DOT UIDENT . [ LPAREN DOT ]
+## mod_ext2 -> mod_ext_longident DOT UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> mod_ext_longident DOT UIDENT . [ DOT ]
 ##
 ## The known suffix of the stack is as follows:
 ## mod_ext_longident DOT UIDENT
@@ -3543,9 +3509,10 @@ interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 639.
+## Ends in an error in state: 640.
 ##
-## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ LPAREN DOT ]
+## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
 ## mty_longident -> mod_ext_longident DOT . ident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
 ## The known suffix of the stack is as follows:
@@ -3556,7 +3523,7 @@ interface: INCLUDE LPAREN UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 1945.
+## Ends in an error in state: 1952.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -3571,7 +3538,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1944.
+## Ends in an error in state: 1951.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
@@ -3583,25 +3550,32 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 638.
+## Ends in an error in state: 639.
 ##
-## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ LPAREN DOT ]
-## mod_ext_longident -> mod_ext_longident . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
 ## mty_longident -> mod_ext_longident . DOT ident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ##
 ## The known suffix of the stack is as follows:
 ## mod_ext_longident
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 85, spurious reduction of production mod_ext_longident -> mod_ext2
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WHILE
 ##
-## Ends in an error in state: 544.
+## Ends in an error in state: 546.
 ##
 ## functor_arg_name -> UIDENT . [ COLON ]
 ## ident -> UIDENT . [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
-## mod_ext_longident -> UIDENT . [ LPAREN DOT ]
+## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> UIDENT . [ DOT ]
 ##
 ## The known suffix of the stack is as follows:
 ## UIDENT
@@ -3613,7 +3587,8 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 ##
 ## Ends in an error in state: 1934.
 ##
-## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
+## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
+## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## mod_ext_longident DOT
@@ -3623,43 +3598,48 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1932.
+## Ends in an error in state: 1931.
 ##
-## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ RPAREN LPAREN DOT ]
-## mod_ext_longident -> mod_ext_longident . LPAREN mod_ext_longident RPAREN [ RPAREN LPAREN DOT ]
-## mod_ext_longident -> mod_ext_longident LPAREN mod_ext_longident . RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
+## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ RPAREN LPAREN DOT ]
+## mod_ext2 -> UIDENT LPAREN mod_ext_longident . RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
+## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ RPAREN DOT ]
 ##
 ## The known suffix of the stack is as follows:
-## mod_ext_longident LPAREN mod_ext_longident
+## UIDENT LPAREN mod_ext_longident
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 76, spurious reduction of production mod_ext_longident -> UIDENT
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1931.
-##
-## mod_ext_longident -> mod_ext_longident LPAREN . mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
-##
-## The known suffix of the stack is as follows:
-## mod_ext_longident LPAREN
-##
-
-<SYNTAX ERROR>
-
-interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT WHILE
-##
 ## Ends in an error in state: 1930.
 ##
-## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
-## mod_ext_longident -> mod_ext_longident . LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
-## with_constraint -> MODULE UIDENT COLONEQUAL mod_ext_longident . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
+## mod_ext2 -> UIDENT LPAREN . mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
 ##
 ## The known suffix of the stack is as follows:
-## MODULE UIDENT COLONEQUAL mod_ext_longident
+## UIDENT LPAREN
 ##
 
 <SYNTAX ERROR>
+
+# interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT WHILE
+##
+## Ends in an error in state: 1929.
+##
+## mod_ext_longident -> UIDENT . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
+## mod_ext_longident -> UIDENT . LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
+##
+## The known suffix of the stack is as follows:
+## UIDENT
+##
+
+# <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
@@ -3675,7 +3655,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 1936.
+## Ends in an error in state: 1943.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3688,21 +3668,20 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 ##
-## Ends in an error in state: 1938.
+## Ends in an error in state: 1929.
 ##
-## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
-## mod_ext_longident -> mod_ext_longident . LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
-## with_constraint -> MODULE mod_longident EQUAL mod_ext_longident . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
+## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
+## mod_ext_longident -> UIDENT . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER DOT AND ]
 ##
 ## The known suffix of the stack is as follows:
-## MODULE mod_longident EQUAL mod_ext_longident
+## UIDENT
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1937.
+## Ends in an error in state: 1944.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ##
@@ -3740,7 +3719,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 1940.
+## Ends in an error in state: 1947.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ##
@@ -3752,7 +3731,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER A
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER EQUAL
 ##
-## Ends in an error in state: 1939.
+## Ends in an error in state: 1946.
 ##
 ## _module_type -> module_type WITH with_constraints . [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER ]
 ## with_constraints -> with_constraints . AND with_constraint [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -3764,14 +3743,14 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER E
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 457, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 451, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 453, spurious reduction of production _core_type -> core_type2
-## In state 462, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 452, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 339, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 449, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 443, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 445, spurious reduction of production _core_type -> core_type2
+## In state 454, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 444, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ## In state 1922, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1942, spurious reduction of production with_constraints -> with_constraint
+## In state 1949, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
@@ -3814,12 +3793,12 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 457, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 451, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 453, spurious reduction of production _core_type -> core_type2
-## In state 462, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 452, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 339, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 449, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 443, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 445, spurious reduction of production _core_type -> core_type2
+## In state 454, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 444, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ## In state 1924, spurious reduction of production constraints ->
 ##
 
@@ -3839,7 +3818,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 528, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 530, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
 ##
 
 <SYNTAX ERROR>
@@ -3871,7 +3850,7 @@ interface: INCLUDE LPAREN UIDENT WITH WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2312.
+## Ends in an error in state: 2319.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3885,24 +3864,24 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 957, spurious reduction of production _simple_module_type -> mty_longident
-## In state 993, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 989, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 955, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 994, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 990, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 956, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 995, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 991, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 958, spurious reduction of production _simple_module_type -> mty_longident
+## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2311.
+## Ends in an error in state: 2318.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3914,7 +3893,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2310.
+## Ends in an error in state: 2317.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3926,7 +3905,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2309.
+## Ends in an error in state: 2316.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3940,24 +3919,24 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 957, spurious reduction of production _simple_module_type -> mty_longident
-## In state 993, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 989, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 955, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 994, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 990, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 956, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 995, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 991, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 958, spurious reduction of production _simple_module_type -> mty_longident
+## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2308.
+## Ends in an error in state: 2315.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3969,7 +3948,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2307.
+## Ends in an error in state: 2314.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3981,7 +3960,7 @@ interface: INCLUDE LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN WITH
 ##
-## Ends in an error in state: 543.
+## Ends in an error in state: 545.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3993,49 +3972,37 @@ interface: INCLUDE LPAREN WITH
 
 <SYNTAX ERROR>
 
-interface: INCLUDE MODULE TYPE OF UIDENT COLON
+interface: INCLUDE MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2392.
+## Ends in an error in state: 2399.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
 ## _module_expr -> module_expr . attribute [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
-## _non_arrowed_module_type -> MODULE TYPE OF module_expr . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
+## _non_arrowed_module_type -> MODULE TYPE module_expr . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
 ## The known suffix of the stack is as follows:
-## MODULE TYPE OF module_expr
+## MODULE TYPE module_expr
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 909, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 913, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 910, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 851, spurious reduction of production _module_expr -> simple_module_expr
-## In state 915, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 914, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
-##
-
-<SYNTAX ERROR>
-
-interface: INCLUDE MODULE TYPE OF WITH
-##
-## Ends in an error in state: 408.
-##
-## _non_arrowed_module_type -> MODULE TYPE OF . module_expr [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
-##
-## The known suffix of the stack is as follows:
-## MODULE TYPE OF
+## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 852, spurious reduction of production _module_expr -> simple_module_expr
+## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE MODULE TYPE WITH
 ##
-## Ends in an error in state: 407.
+## Ends in an error in state: 410.
 ##
-## _non_arrowed_module_type -> MODULE TYPE . OF module_expr [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
+## _non_arrowed_module_type -> MODULE TYPE . module_expr [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## MODULE TYPE
@@ -4045,9 +4012,9 @@ interface: INCLUDE MODULE TYPE WITH
 
 interface: INCLUDE MODULE WITH
 ##
-## Ends in an error in state: 406.
+## Ends in an error in state: 409.
 ##
-## _non_arrowed_module_type -> MODULE . TYPE OF module_expr [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
+## _non_arrowed_module_type -> MODULE . TYPE module_expr [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## MODULE
@@ -4057,10 +4024,11 @@ interface: INCLUDE MODULE WITH
 
 interface: INCLUDE UIDENT DOT UIDENT WHILE
 ##
-## Ends in an error in state: 265.
+## Ends in an error in state: 258.
 ##
 ## ident -> UIDENT . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF COLONGREATER AND ]
-## mod_ext_longident -> mod_ext_longident DOT UIDENT . [ LPAREN DOT ]
+## mod_ext2 -> mod_ext_longident DOT UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> mod_ext_longident DOT UIDENT . [ DOT ]
 ##
 ## The known suffix of the stack is as follows:
 ## mod_ext_longident DOT UIDENT
@@ -4070,9 +4038,10 @@ interface: INCLUDE UIDENT DOT UIDENT WHILE
 
 interface: INCLUDE UIDENT DOT WITH
 ##
-## Ends in an error in state: 264.
+## Ends in an error in state: 257.
 ##
-## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ LPAREN DOT ]
+## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
 ## mty_longident -> mod_ext_longident DOT . ident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF COLONGREATER AND ]
 ##
 ## The known suffix of the stack is as follows:
@@ -4083,7 +4052,7 @@ interface: INCLUDE UIDENT DOT WITH
 
 interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 987.
+## Ends in an error in state: 988.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4097,24 +4066,24 @@ interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 957, spurious reduction of production _simple_module_type -> mty_longident
-## In state 993, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 989, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 955, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 994, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 990, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 956, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 995, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 991, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 958, spurious reduction of production _simple_module_type -> mty_longident
+## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 986.
+## Ends in an error in state: 987.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4126,24 +4095,31 @@ interface: INCLUDE UIDENT EQUALGREATER WITH
 
 interface: INCLUDE UIDENT LPAREN UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 263.
+## Ends in an error in state: 256.
 ##
-## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ LPAREN DOT ]
-## mod_ext_longident -> mod_ext_longident . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
 ## mty_longident -> mod_ext_longident . DOT ident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF COLONGREATER AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## mod_ext_longident
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 85, spurious reduction of production mod_ext_longident -> mod_ext2
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WHILE
 ##
-## Ends in an error in state: 106.
+## Ends in an error in state: 117.
 ##
 ## ident -> UIDENT . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF COLONGREATER AND ]
-## mod_ext_longident -> UIDENT . [ LPAREN DOT ]
+## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> UIDENT . [ DOT ]
 ##
 ## The known suffix of the stack is as follows:
 ## UIDENT
@@ -4151,23 +4127,23 @@ interface: INCLUDE UIDENT WHILE
 
 <SYNTAX ERROR>
 
-interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT WHILE
+# What's wrong here?
+# interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT WHILE
 ##
-## Ends in an error in state: 978.
+## Ends in an error in state: 77.
 ##
-## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF DOT AND ]
-## mod_ext_longident -> mod_ext_longident . LPAREN mod_ext_longident RPAREN [ WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF DOT AND ]
-## with_constraint -> MODULE UIDENT COLONEQUAL mod_ext_longident . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
+## mod_ext_longident -> UIDENT . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF DOT AND ]
+## mod_ext_longident -> UIDENT . LPAREN mod_ext_longident RPAREN [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF DOT AND ]
 ##
 ## The known suffix of the stack is as follows:
-## MODULE UIDENT COLONEQUAL mod_ext_longident
+## UIDENT
 ##
 
-<SYNTAX ERROR>
+# <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 977.
+## Ends in an error in state: 978.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4179,7 +4155,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 979.
+## Ends in an error in state: 980.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4192,21 +4168,20 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 ##
-## Ends in an error in state: 981.
+## Ends in an error in state: 76.
 ##
-## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF DOT AND ]
-## mod_ext_longident -> mod_ext_longident . LPAREN mod_ext_longident RPAREN [ WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF DOT AND ]
-## with_constraint -> MODULE mod_longident EQUAL mod_ext_longident . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
+## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF DOT AND ]
+## mod_ext_longident -> UIDENT . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF DOT AND ]
 ##
 ## The known suffix of the stack is as follows:
-## MODULE mod_longident EQUAL mod_ext_longident
+## UIDENT
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 980.
+## Ends in an error in state: 981.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4218,7 +4193,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 976.
+## Ends in an error in state: 977.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4231,7 +4206,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 975.
+## Ends in an error in state: 976.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4244,7 +4219,7 @@ interface: INCLUDE UIDENT WITH MODULE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 983.
+## Ends in an error in state: 984.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4256,7 +4231,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ##
-## Ends in an error in state: 982.
+## Ends in an error in state: 983.
 ##
 ## _module_type -> module_type WITH with_constraints . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraints -> with_constraints . AND with_constraint [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4268,21 +4243,21 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 966, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 985, spurious reduction of production with_constraints -> with_constraint
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 967, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 986, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 965.
+## Ends in an error in state: 966.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4294,7 +4269,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 967.
+## Ends in an error in state: 968.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4306,7 +4281,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ##
-## Ends in an error in state: 969.
+## Ends in an error in state: 970.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4318,20 +4293,20 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 968, spurious reduction of production constraints ->
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 969, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 963.
+## Ends in an error in state: 964.
 ##
 ## with_type_binder -> EQUAL . [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
 ## with_type_binder -> EQUAL . PRIVATE [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
@@ -4344,7 +4319,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ##
-## Ends in an error in state: 962.
+## Ends in an error in state: 963.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4356,14 +4331,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 961, spurious reduction of production optional_type_parameters ->
+## In state 962, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 960.
+## Ends in an error in state: 961.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4376,7 +4351,7 @@ interface: INCLUDE UIDENT WITH TYPE WITH
 
 interface: INCLUDE UIDENT WITH WITH
 ##
-## Ends in an error in state: 959.
+## Ends in an error in state: 960.
 ##
 ## _module_type -> module_type WITH . with_constraints [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4400,7 +4375,7 @@ interface: INCLUDE WITH
 
 interface: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 1025.
+## Ends in an error in state: 1026.
 ##
 ## _signature_item -> LET val_ident COLON . core_type post_item_attributes [ SEMI ]
 ##
@@ -4412,7 +4387,7 @@ interface: LET LIDENT COLON WITH
 
 interface: LET LIDENT WITH
 ##
-## Ends in an error in state: 1024.
+## Ends in an error in state: 1025.
 ##
 ## _signature_item -> LET val_ident . COLON core_type post_item_attributes [ SEMI ]
 ##
@@ -4424,7 +4399,7 @@ interface: LET LIDENT WITH
 
 interface: LET LPAREN WITH
 ##
-## Ends in an error in state: 787.
+## Ends in an error in state: 788.
 ##
 ## val_ident -> LPAREN . operator RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -4460,16 +4435,16 @@ interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 922, spurious reduction of production post_item_attributes ->
-## In state 923, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1023, spurious reduction of production many_module_rec_declarations -> LET MODULE REC module_rec_declaration_details post_item_attributes
+## In state 923, spurious reduction of production post_item_attributes ->
+## In state 924, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1024, spurious reduction of production many_module_rec_declarations -> LET MODULE REC module_rec_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 1021.
+## Ends in an error in state: 1022.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -4483,24 +4458,24 @@ interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 957, spurious reduction of production _simple_module_type -> mty_longident
-## In state 993, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 989, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 955, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 994, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 990, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 956, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 995, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 991, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 958, spurious reduction of production _simple_module_type -> mty_longident
+## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON WITH
 ##
-## Ends in an error in state: 1020.
+## Ends in an error in state: 1021.
 ##
 ## module_rec_declaration_details -> UIDENT COLON . module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4512,7 +4487,7 @@ interface: LET MODULE REC UIDENT COLON WITH
 
 interface: LET MODULE REC UIDENT WITH
 ##
-## Ends in an error in state: 1019.
+## Ends in an error in state: 1020.
 ##
 ## module_rec_declaration_details -> UIDENT . COLON module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4524,7 +4499,7 @@ interface: LET MODULE REC UIDENT WITH
 
 interface: LET MODULE REC WITH
 ##
-## Ends in an error in state: 1018.
+## Ends in an error in state: 1019.
 ##
 ## many_module_rec_declarations -> LET MODULE REC . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4536,7 +4511,7 @@ interface: LET MODULE REC WITH
 
 interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 1007.
+## Ends in an error in state: 1008.
 ##
 ## _module_declaration -> COLON module_type . [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -4550,24 +4525,24 @@ interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 957, spurious reduction of production _simple_module_type -> mty_longident
-## In state 993, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 989, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 955, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 994, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 990, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 956, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 995, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 991, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 958, spurious reduction of production _simple_module_type -> mty_longident
+## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 1006.
+## Ends in an error in state: 1007.
 ##
 ## _module_declaration -> COLON . module_type [ SEMI LBRACKETATAT ]
 ##
@@ -4579,7 +4554,7 @@ interface: LET MODULE UIDENT COLON WITH
 
 interface: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1013.
+## Ends in an error in state: 1014.
 ##
 ## _signature_item -> LET MODULE UIDENT EQUAL . mod_longident post_item_attributes [ SEMI ]
 ##
@@ -4591,7 +4566,7 @@ interface: LET MODULE UIDENT EQUAL WITH
 
 interface: LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1011.
+## Ends in an error in state: 1012.
 ##
 ## _module_declaration -> LPAREN RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4603,7 +4578,7 @@ interface: LET MODULE UIDENT LPAREN RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1005.
+## Ends in an error in state: 1006.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4615,7 +4590,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1004.
+## Ends in an error in state: 1005.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type . RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -4629,24 +4604,24 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 957, spurious reduction of production _simple_module_type -> mty_longident
-## In state 993, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 989, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 955, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 994, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 990, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 956, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 995, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 991, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 958, spurious reduction of production _simple_module_type -> mty_longident
+## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1003.
+## Ends in an error in state: 1004.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON . module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4658,7 +4633,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1002.
+## Ends in an error in state: 1003.
 ##
 ## _module_declaration -> LPAREN UIDENT . COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4670,7 +4645,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT WITH
 
 interface: LET MODULE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1001.
+## Ends in an error in state: 1002.
 ##
 ## _module_declaration -> LPAREN . UIDENT COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_declaration -> LPAREN . RPAREN module_declaration [ SEMI LBRACKETATAT ]
@@ -4683,7 +4658,7 @@ interface: LET MODULE UIDENT LPAREN WITH
 
 interface: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1000.
+## Ends in an error in state: 1001.
 ##
 ## _signature_item -> LET MODULE UIDENT . module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> LET MODULE UIDENT . EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4696,7 +4671,7 @@ interface: LET MODULE UIDENT WITH
 
 interface: LET MODULE WITH
 ##
-## Ends in an error in state: 999.
+## Ends in an error in state: 1000.
 ##
 ## _signature_item -> LET MODULE . UIDENT module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> LET MODULE . UIDENT EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4710,7 +4685,7 @@ interface: LET MODULE WITH
 
 interface: LET WITH
 ##
-## Ends in an error in state: 998.
+## Ends in an error in state: 999.
 ##
 ## _signature_item -> LET . val_ident COLON core_type post_item_attributes [ SEMI ]
 ## _signature_item -> LET . MODULE UIDENT module_declaration post_item_attributes [ SEMI ]
@@ -4725,7 +4700,7 @@ interface: LET WITH
 
 interface: MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 954.
+## Ends in an error in state: 955.
 ##
 ## _signature_item -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ SEMI ]
 ##
@@ -4737,7 +4712,7 @@ interface: MODULE TYPE UIDENT EQUAL WITH
 
 interface: MODULE TYPE WITH
 ##
-## Ends in an error in state: 952.
+## Ends in an error in state: 953.
 ##
 ## _signature_item -> MODULE TYPE . ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4750,7 +4725,7 @@ interface: MODULE TYPE WITH
 
 interface: MODULE WITH
 ##
-## Ends in an error in state: 951.
+## Ends in an error in state: 952.
 ##
 ## _signature_item -> MODULE . TYPE ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4763,7 +4738,7 @@ interface: MODULE WITH
 
 interface: OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2599.
+## Ends in an error in state: 2607.
 ##
 ## signature -> signature_item . SEMI signature [ EOF ]
 ##
@@ -4774,8 +4749,8 @@ interface: OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 399, spurious reduction of production post_item_attributes ->
-## In state 2398, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 402, spurious reduction of production post_item_attributes ->
+## In state 2405, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
 ## In state 1733, spurious reduction of production _signature_item -> open_statement
 ## In state 1750, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
 ## In state 1734, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
@@ -4785,7 +4760,7 @@ interface: OPEN UIDENT WITH
 
 interface: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 928.
+## Ends in an error in state: 929.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4797,7 +4772,7 @@ interface: TYPE LIDENT PLUSEQ BAR WITH
 
 interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 927.
+## Ends in an error in state: 928.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4809,7 +4784,7 @@ interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 
 interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 935.
+## Ends in an error in state: 937.
 ##
 ## sig_extension_constructors -> sig_extension_constructors BAR . extension_constructor_declaration [ SEMI LBRACKETATAT BAR ]
 ##
@@ -4821,7 +4796,7 @@ interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 interface: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 925.
+## Ends in an error in state: 926.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4845,19 +4820,19 @@ interface: TYPE LIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 78, spurious reduction of production optional_type_parameters ->
-## In state 93, spurious reduction of production type_kind ->
-## In state 1129, spurious reduction of production constraints ->
-## In state 1130, spurious reduction of production type_declaration_details -> LIDENT optional_type_parameters type_kind constraints
-## In state 920, spurious reduction of production post_item_attributes ->
-## In state 921, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 89, spurious reduction of production optional_type_parameters ->
+## In state 104, spurious reduction of production type_kind ->
+## In state 1130, spurious reduction of production constraints ->
+## In state 1131, spurious reduction of production type_declaration_details -> LIDENT optional_type_parameters type_kind constraints
+## In state 921, spurious reduction of production post_item_attributes ->
+## In state 922, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2600.
+## Ends in an error in state: 2608.
 ##
 ## signature -> signature_item SEMI . signature [ EOF ]
 ##
@@ -4869,7 +4844,7 @@ interface: TYPE LIDENT SEMI WITH
 
 interface: TYPE NONREC LET
 ##
-## Ends in an error in state: 919.
+## Ends in an error in state: 920.
 ##
 ## many_type_declarations -> TYPE nonrec_flag . type_declaration_details post_item_attributes [ SEMI AND ]
 ## sig_type_extension -> TYPE nonrec_flag . potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
@@ -4882,7 +4857,7 @@ interface: TYPE NONREC LET
 
 interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ##
-## Ends in an error in state: 924.
+## Ends in an error in state: 925.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters . PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4893,15 +4868,15 @@ interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 528, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
-## In state 527, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
+## In state 530, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 529, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
 ##
 
 <SYNTAX ERROR>
 
 interface: WITH
 ##
-## Ends in an error in state: 2598.
+## Ends in an error in state: 2606.
 ##
 ## interface' -> . interface [ # ]
 ##
@@ -4913,7 +4888,7 @@ interface: WITH
 
 implementation: ASSERT WITH
 ##
-## Ends in an error in state: 883.
+## Ends in an error in state: 884.
 ##
 ## _expr -> ASSERT . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -4925,9 +4900,9 @@ implementation: ASSERT WITH
 
 implementation: BACKQUOTE WITH
 ##
-## Ends in an error in state: 140.
+## Ends in an error in state: 151.
 ##
-## name_tag -> BACKQUOTE . ident [ WITH WHEN UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR OPTIONAL_NO_DEFAULT OF NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 IN GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
+## name_tag -> BACKQUOTE . ident [ WITH WHEN UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR OPTIONAL_NO_DEFAULT NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 IN GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
 ## The known suffix of the stack is as follows:
 ## BACKQUOTE
@@ -4937,7 +4912,7 @@ implementation: BACKQUOTE WITH
 
 implementation: BANG WITH
 ##
-## Ends in an error in state: 562.
+## Ends in an error in state: 563.
 ##
 ## _simple_expr -> BANG . simple_expr [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -5036,10 +5011,10 @@ implementation: CLASS LIDENT COLON LIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 1631, spurious reduction of production type_longident -> LIDENT
-## In state 153, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
-## In state 166, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
-## In state 164, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
-## In state 168, spurious reduction of production non_arrowed_core_type -> non_arrowed_simple_core_type
+## In state 261, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
+## In state 266, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
+## In state 264, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
+## In state 268, spurious reduction of production non_arrowed_core_type -> non_arrowed_simple_core_type
 ##
 
 <SYNTAX ERROR>
@@ -5266,7 +5241,7 @@ implementation: CLASS LIDENT EQUAL LBRACKETPERCENT AND RBRACKET WITH
 
 implementation: CLASS LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1145.
+## Ends in an error in state: 1146.
 ##
 ## and_class_declaration -> AND . class_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5278,7 +5253,7 @@ implementation: CLASS LIDENT EQUAL LIDENT AND WITH
 
 implementation: CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1144.
+## Ends in an error in state: 1145.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_declarations . [ SEMI RBRACKET RBRACE EOF ]
 ## many_class_declarations -> many_class_declarations . and_class_declaration [ SEMI RBRACKET RBRACE EOF AND ]
@@ -5290,8 +5265,8 @@ implementation: CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 922, spurious reduction of production post_item_attributes ->
-## In state 923, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 923, spurious reduction of production post_item_attributes ->
+## In state 924, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
 ## In state 1702, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
 ##
 
@@ -5311,13 +5286,13 @@ implementation: CLASS LIDENT EQUAL LIDENT UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 880, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 1170, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1175, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
-## In state 1178, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 881, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 1171, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1176, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
+## In state 1179, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
 ##
 
 <SYNTAX ERROR>
@@ -5374,7 +5349,7 @@ implementation: CLASS LIDENT EQUAL LPAREN LIDENT SEMI
 
 implementation: CLASS LIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 1152.
+## Ends in an error in state: 1153.
 ##
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type RPAREN [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type error [ UIDENT TRUE STRING SEMI RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF CHAR BANG BACKQUOTE AND ]
@@ -5389,7 +5364,7 @@ implementation: CLASS LIDENT EQUAL LPAREN WITH
 
 implementation: CLASS LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1151.
+## Ends in an error in state: 1152.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5401,7 +5376,7 @@ implementation: CLASS LIDENT EQUAL WITH
 
 implementation: CLASS LIDENT MINUS WITH
 ##
-## Ends in an error in state: 1150.
+## Ends in an error in state: 1151.
 ##
 ## signed_constant -> MINUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> MINUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -5418,7 +5393,7 @@ implementation: CLASS LIDENT MINUS WITH
 
 implementation: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1149.
+## Ends in an error in state: 1150.
 ##
 ## signed_constant -> PLUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> PLUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -5447,7 +5422,7 @@ implementation: CLASS LIDENT QUOTE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1074.
+## Ends in an error in state: 1075.
 ##
 ## class_sig_body -> class_self_type . class_sig_fields opt_semi [ error RBRACE ]
 ##
@@ -5459,7 +5434,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 ##
-## Ends in an error in state: 1069.
+## Ends in an error in state: 1070.
 ##
 ## class_self_type -> AS core_type . SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -5470,19 +5445,19 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 ##
-## Ends in an error in state: 1068.
+## Ends in an error in state: 1069.
 ##
 ## class_self_type -> AS . core_type SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -5541,7 +5516,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH RBRACKET WITH
 ##
-## Ends in an error in state: 1071.
+## Ends in an error in state: 1072.
 ##
 ## _class_instance_type -> LBRACE class_sig_body . RBRACE [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE class_sig_body . error [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5566,7 +5541,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 ##
-## Ends in an error in state: 1100.
+## Ends in an error in state: 1101.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label COLON . poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5578,7 +5553,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 ##
-## Ends in an error in state: 1099.
+## Ends in an error in state: 1100.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label . COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5590,7 +5565,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 ##
-## Ends in an error in state: 1096.
+## Ends in an error in state: 1097.
 ##
 ## private_virtual_flags -> PRIVATE . [ LIDENT ]
 ## private_virtual_flags -> PRIVATE . VIRTUAL [ LIDENT ]
@@ -5603,7 +5578,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1098.
+## Ends in an error in state: 1099.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags . label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5615,7 +5590,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 ##
-## Ends in an error in state: 1094.
+## Ends in an error in state: 1095.
 ##
 ## private_virtual_flags -> VIRTUAL . [ LIDENT ]
 ## private_virtual_flags -> VIRTUAL . PRIVATE [ LIDENT ]
@@ -5628,7 +5603,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 ##
-## Ends in an error in state: 1093.
+## Ends in an error in state: 1094.
 ##
 ## _class_sig_field -> METHOD . private_virtual_flags label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5640,7 +5615,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1091.
+## Ends in an error in state: 1092.
 ##
 ## value_type -> label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5652,7 +5627,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1090.
+## Ends in an error in state: 1091.
 ##
 ## value_type -> label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5664,7 +5639,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1084.
+## Ends in an error in state: 1085.
 ##
 ## value_type -> MUTABLE virtual_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5676,7 +5651,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 ##
-## Ends in an error in state: 1083.
+## Ends in an error in state: 1084.
 ##
 ## value_type -> MUTABLE virtual_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5688,7 +5663,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 ##
-## Ends in an error in state: 1082.
+## Ends in an error in state: 1083.
 ##
 ## value_type -> MUTABLE virtual_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5700,7 +5675,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1081.
+## Ends in an error in state: 1082.
 ##
 ## value_type -> MUTABLE . virtual_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5712,7 +5687,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1079.
+## Ends in an error in state: 1080.
 ##
 ## value_type -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5724,7 +5699,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1078.
+## Ends in an error in state: 1079.
 ##
 ## value_type -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5736,7 +5711,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1077.
+## Ends in an error in state: 1078.
 ##
 ## value_type -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5748,7 +5723,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1076.
+## Ends in an error in state: 1077.
 ##
 ## value_type -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5760,7 +5735,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 ##
-## Ends in an error in state: 1075.
+## Ends in an error in state: 1076.
 ##
 ## _class_sig_field -> VAL . value_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5772,7 +5747,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 ##
-## Ends in an error in state: 1067.
+## Ends in an error in state: 1068.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5907,7 +5882,8 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 ## Ends in an error in state: 1622.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
-## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ LPAREN DOT ]
+## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
 ##
 ## The known suffix of the stack is as follows:
 ## mod_ext_longident DOT
@@ -5920,11 +5896,17 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 ## Ends in an error in state: 1621.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
-## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ LPAREN DOT ]
-## mod_ext_longident -> mod_ext_longident . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
 ##
 ## The known suffix of the stack is as follows:
 ## mod_ext_longident
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 76, spurious reduction of production mod_ext_longident -> UIDENT
 ##
 
 <SYNTAX ERROR>
@@ -5981,7 +5963,7 @@ implementation: CLASS LIDENT UNDERSCORE WITH
 
 implementation: CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1148.
+## Ends in an error in state: 1149.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . class_fun_binding [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . constrained_class_declaration [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5996,7 +5978,7 @@ implementation: CLASS LIDENT WITH
 
 implementation: CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1140.
+## Ends in an error in state: 1141.
 ##
 ## and_class_type_declaration -> AND . class_type_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -6008,7 +5990,7 @@ implementation: CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 
 implementation: CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1139.
+## Ends in an error in state: 1140.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_type_declarations . [ SEMI RBRACKET RBRACE EOF ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ SEMI RBRACKET RBRACE EOF AND ]
@@ -6020,8 +6002,8 @@ implementation: CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 922, spurious reduction of production post_item_attributes ->
-## In state 923, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 923, spurious reduction of production post_item_attributes ->
+## In state 924, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
 ## In state 1700, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
@@ -6050,7 +6032,7 @@ implementation: CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 
 implementation: CLASS TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1065.
+## Ends in an error in state: 1066.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_instance_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -6062,7 +6044,7 @@ implementation: CLASS TYPE LIDENT EQUAL WITH
 
 implementation: CLASS TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1062.
+## Ends in an error in state: 1063.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters . EQUAL class_instance_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS EQUAL ]
@@ -6075,7 +6057,7 @@ implementation: CLASS TYPE LIDENT WITH
 
 implementation: CLASS TYPE VIRTUAL LET
 ##
-## Ends in an error in state: 1060.
+## Ends in an error in state: 1061.
 ##
 ## class_type_declaration_details -> virtual_flag . LIDENT class_type_parameters EQUAL class_instance_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -6087,7 +6069,7 @@ implementation: CLASS TYPE VIRTUAL LET
 
 implementation: CLASS TYPE WITH
 ##
-## Ends in an error in state: 1059.
+## Ends in an error in state: 1060.
 ##
 ## many_class_type_declarations -> CLASS TYPE . class_type_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -6099,7 +6081,7 @@ implementation: CLASS TYPE WITH
 
 implementation: CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 1146.
+## Ends in an error in state: 1147.
 ##
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters class_fun_binding [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters constrained_class_declaration [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -6113,7 +6095,7 @@ implementation: CLASS VIRTUAL LET
 
 implementation: CLASS WITH
 ##
-## Ends in an error in state: 1057.
+## Ends in an error in state: 1058.
 ##
 ## many_class_declarations -> CLASS . class_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
@@ -6126,9 +6108,9 @@ implementation: CLASS WITH
 
 implementation: EXCEPTION LPAREN WITH
 ##
-## Ends in an error in state: 930.
+## Ends in an error in state: 932.
 ##
-## constr_ident -> LPAREN . RPAREN [ SEMI RBRACKET RBRACE OF LBRACKETATAT LBRACKETAT EQUAL EOF CONSTRAINT COLON BAR AND ]
+## constr_ident -> LPAREN . RPAREN [ UNDERSCORE UIDENT SHARP SEMI RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUAL EOF CONSTRAINT COLON BAR AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -6138,7 +6120,7 @@ implementation: EXCEPTION LPAREN WITH
 
 implementation: EXCEPTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 942.
+## Ends in an error in state: 940.
 ##
 ## generalized_constructor_arguments -> COLON . core_type [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -6150,7 +6132,7 @@ implementation: EXCEPTION UIDENT COLON WITH
 
 implementation: EXCEPTION UIDENT EQUAL LBRACKET WITH
 ##
-## Ends in an error in state: 1052.
+## Ends in an error in state: 1053.
 ##
 ## constr_longident -> LBRACKET . RBRACKET [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -6162,7 +6144,7 @@ implementation: EXCEPTION UIDENT EQUAL LBRACKET WITH
 
 implementation: EXCEPTION UIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 1051.
+## Ends in an error in state: 1052.
 ##
 ## constr_longident -> LPAREN . RPAREN [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -6174,7 +6156,7 @@ implementation: EXCEPTION UIDENT EQUAL LPAREN WITH
 
 implementation: EXCEPTION UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1050.
+## Ends in an error in state: 1051.
 ##
 ## extension_constructor_rebind -> constr_ident EQUAL . constr_longident attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ##
@@ -6184,48 +6166,35 @@ implementation: EXCEPTION UIDENT EQUAL WITH
 
 <SYNTAX ERROR>
 
-implementation: EXCEPTION UIDENT OF UNDERSCORE COLON WITH
+implementation: EXCEPTION UIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 940.
+## Ends in an error in state: 943.
 ##
-## generalized_constructor_arguments -> OF non_arrowed_simple_core_type_list COLON . core_type [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
+## generalized_constructor_arguments -> non_arrowed_simple_core_type_list COLON . core_type [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
 ## The known suffix of the stack is as follows:
-## OF non_arrowed_simple_core_type_list COLON
+## non_arrowed_simple_core_type_list COLON
 ##
 
 <SYNTAX ERROR>
 
-implementation: EXCEPTION UIDENT OF UNDERSCORE WITH
+implementation: EXCEPTION UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 939.
+## Ends in an error in state: 942.
 ##
-## generalized_constructor_arguments -> OF non_arrowed_simple_core_type_list . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
-## generalized_constructor_arguments -> OF non_arrowed_simple_core_type_list . COLON core_type [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
+## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
+## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . COLON core_type [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ UNDERSCORE UIDENT SHARP SEMI RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF CONSTRAINT COLON BAR AND ]
 ##
 ## The known suffix of the stack is as follows:
-## OF non_arrowed_simple_core_type_list
-##
-
-<SYNTAX ERROR>
-
-implementation: EXCEPTION UIDENT OF WITH
-##
-## Ends in an error in state: 938.
-##
-## generalized_constructor_arguments -> OF . non_arrowed_simple_core_type_list [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
-## generalized_constructor_arguments -> OF . non_arrowed_simple_core_type_list COLON core_type [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
-##
-## The known suffix of the stack is as follows:
-## OF
+## non_arrowed_simple_core_type_list
 ##
 
 <SYNTAX ERROR>
 
 implementation: EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1049.
+## Ends in an error in state: 1050.
 ##
 ## extension_constructor_declaration -> constr_ident . generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## extension_constructor_rebind -> constr_ident . EQUAL constr_longident attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -6238,7 +6207,7 @@ implementation: EXCEPTION UIDENT WITH
 
 implementation: EXCEPTION WITH
 ##
-## Ends in an error in state: 1044.
+## Ends in an error in state: 1045.
 ##
 ## str_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ## str_exception_declaration -> EXCEPTION . extension_constructor_rebind post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
@@ -6251,7 +6220,7 @@ implementation: EXCEPTION WITH
 
 implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 ##
-## Ends in an error in state: 1040.
+## Ends in an error in state: 1041.
 ##
 ## primitive_declaration -> STRING . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ## primitive_declaration -> STRING . primitive_declaration [ SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
@@ -6264,7 +6233,7 @@ implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 
 implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1039.
+## Ends in an error in state: 1040.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6276,7 +6245,7 @@ implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1038.
+## Ends in an error in state: 1039.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6287,19 +6256,19 @@ implementation: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1037.
+## Ends in an error in state: 1038.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6311,7 +6280,7 @@ implementation: EXTERNAL LIDENT COLON WITH
 
 implementation: EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 1036.
+## Ends in an error in state: 1037.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6323,7 +6292,7 @@ implementation: EXTERNAL LIDENT WITH
 
 implementation: EXTERNAL WITH
 ##
-## Ends in an error in state: 1035.
+## Ends in an error in state: 1036.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6335,7 +6304,7 @@ implementation: EXTERNAL WITH
 
 implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ##
-## Ends in an error in state: 876.
+## Ends in an error in state: 877.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag simple_expr . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -6353,17 +6322,17 @@ implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 880, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 881, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FOR UNDERSCORE IN UIDENT TO WITH
 ##
-## Ends in an error in state: 875.
+## Ends in an error in state: 876.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag . simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6375,7 +6344,7 @@ implementation: FOR UNDERSCORE IN UIDENT TO WITH
 
 implementation: FOR UNDERSCORE IN UIDENT WITH
 ##
-## Ends in an error in state: 872.
+## Ends in an error in state: 873.
 ##
 ## _expr -> FOR pattern IN simple_expr . direction_flag simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ TO SHARP DOWNTO DOT ]
@@ -6393,17 +6362,17 @@ implementation: FOR UNDERSCORE IN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 880, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 881, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FOR UNDERSCORE IN WITH
 ##
-## Ends in an error in state: 871.
+## Ends in an error in state: 872.
 ##
 ## _expr -> FOR pattern IN . simple_expr direction_flag simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6415,7 +6384,7 @@ implementation: FOR UNDERSCORE IN WITH
 
 implementation: FOR UNDERSCORE WHEN
 ##
-## Ends in an error in state: 870.
+## Ends in an error in state: 871.
 ##
 ## _expr -> FOR pattern . IN simple_expr direction_flag simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _or_pattern -> pattern . BAR pattern [ IN BAR ]
@@ -6427,14 +6396,14 @@ implementation: FOR UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 781, spurious reduction of production pattern -> pattern_without_or
+## In state 782, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: FOR WITH
 ##
-## Ends in an error in state: 869.
+## Ends in an error in state: 870.
 ##
 ## _expr -> FOR . pattern IN simple_expr direction_flag simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6480,10 +6449,10 @@ implementation: FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -6536,10 +6505,10 @@ implementation: FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -6592,14 +6561,14 @@ implementation: FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -6618,7 +6587,7 @@ implementation: FUN BAR UNDERSCORE WHEN WITH
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 845.
+## Ends in an error in state: 846.
 ##
 ## _simple_expr -> simple_expr . DOT label_longident [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
 ## _simple_expr -> simple_expr . DOT LPAREN expr RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
@@ -6636,17 +6605,17 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 880, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 881, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 844.
+## Ends in an error in state: 845.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern EQUAL . simple_expr [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ##
@@ -6658,7 +6627,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 842.
+## Ends in an error in state: 843.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -6672,7 +6641,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 
 implementation: FUN LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 621.
+## Ends in an error in state: 622.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -6697,10 +6666,10 @@ implementation: FUN LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 620, spurious reduction of production val_ident -> LIDENT
-## In state 754, spurious reduction of production _simple_pattern -> val_ident
-## In state 768, spurious reduction of production mark_position_pat(_simple_pattern) -> _simple_pattern
-## In state 764, spurious reduction of production simple_pattern -> mark_position_pat(_simple_pattern)
+## In state 621, spurious reduction of production val_ident -> LIDENT
+## In state 755, spurious reduction of production _simple_pattern -> val_ident
+## In state 769, spurious reduction of production mark_position_pat(_simple_pattern) -> _simple_pattern
+## In state 765, spurious reduction of production simple_pattern -> mark_position_pat(_simple_pattern)
 ## In state 1245, spurious reduction of production labeled_simple_pattern -> simple_pattern
 ##
 
@@ -6708,7 +6677,7 @@ implementation: FUN LIDENT WITH
 
 implementation: FUN LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 863.
+## Ends in an error in state: 864.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT RPAREN . fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6720,7 +6689,7 @@ implementation: FUN LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: FUN LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 862.
+## Ends in an error in state: 863.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT . RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6732,7 +6701,7 @@ implementation: FUN LPAREN TYPE LIDENT WITH
 
 implementation: FUN LPAREN TYPE WITH
 ##
-## Ends in an error in state: 861.
+## Ends in an error in state: 862.
 ##
 ## _expr -> FUN LPAREN TYPE . LIDENT RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6744,7 +6713,7 @@ implementation: FUN LPAREN TYPE WITH
 
 implementation: FUN LPAREN WITH
 ##
-## Ends in an error in state: 860.
+## Ends in an error in state: 861.
 ##
 ## _expr -> FUN LPAREN . TYPE LIDENT RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
@@ -6801,17 +6770,17 @@ implementation: FUN UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 868.
+## Ends in an error in state: 869.
 ##
 ## fun_def -> EQUALGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6823,7 +6792,7 @@ implementation: FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 867.
+## Ends in an error in state: 868.
 ##
 ## fun_def -> LPAREN TYPE LIDENT RPAREN . fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6835,7 +6804,7 @@ implementation: FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 866.
+## Ends in an error in state: 867.
 ##
 ## fun_def -> LPAREN TYPE LIDENT . RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6847,7 +6816,7 @@ implementation: FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: FUN UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 865.
+## Ends in an error in state: 866.
 ##
 ## fun_def -> LPAREN TYPE . LIDENT RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6859,7 +6828,7 @@ implementation: FUN UNDERSCORE LPAREN TYPE WITH
 
 implementation: FUN UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 864.
+## Ends in an error in state: 865.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
@@ -6894,7 +6863,7 @@ implementation: FUN UNDERSCORE UNDERSCORE WITH
 
 implementation: FUN WITH
 ##
-## Ends in an error in state: 859.
+## Ends in an error in state: 860.
 ##
 ## _expr -> FUN . labeled_simple_pattern fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> FUN . LPAREN TYPE LIDENT RPAREN fun_def [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6908,7 +6877,7 @@ implementation: FUN WITH
 
 implementation: IF UIDENT UIDENT ELSE WITH
 ##
-## Ends in an error in state: 858.
+## Ends in an error in state: 859.
 ##
 ## _expr -> IF simple_expr simple_expr ELSE . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -6920,7 +6889,7 @@ implementation: IF UIDENT UIDENT ELSE WITH
 
 implementation: IF UIDENT WITH
 ##
-## Ends in an error in state: 856.
+## Ends in an error in state: 857.
 ##
 ## _expr -> IF simple_expr . simple_expr ELSE expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF simple_expr . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6939,17 +6908,17 @@ implementation: IF UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 880, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 881, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: IF WITH
 ##
-## Ends in an error in state: 855.
+## Ends in an error in state: 856.
 ##
 ## _expr -> IF . simple_expr simple_expr ELSE expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF . simple_expr simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -6962,7 +6931,7 @@ implementation: IF WITH
 
 implementation: INCLUDE FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 2317.
+## Ends in an error in state: 2324.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER module_expr . [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _module_expr -> module_expr . simple_module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -6977,7 +6946,7 @@ implementation: INCLUDE FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 
 implementation: INCLUDE FUN LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2316.
+## Ends in an error in state: 2323.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER . module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -6989,7 +6958,7 @@ implementation: INCLUDE FUN LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE FUN LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2315.
+## Ends in an error in state: 2322.
 ##
 ## _module_expr -> FUN functor_args . EQUALGREATER module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## functor_args -> functor_args . functor_arg [ LPAREN EQUALGREATER ]
@@ -7002,7 +6971,7 @@ implementation: INCLUDE FUN LPAREN RPAREN WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2313.
+## Ends in an error in state: 2320.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -7016,24 +6985,24 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 957, spurious reduction of production _simple_module_type -> mty_longident
-## In state 993, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 989, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 955, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 994, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 990, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 956, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 995, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 991, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 958, spurious reduction of production _simple_module_type -> mty_longident
+## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 542.
+## Ends in an error in state: 544.
 ##
 ## functor_arg -> LPAREN functor_arg_name COLON . module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -7045,7 +7014,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 541.
+## Ends in an error in state: 543.
 ##
 ## functor_arg -> LPAREN functor_arg_name . COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -7057,7 +7026,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 
 implementation: INCLUDE FUN LPAREN WITH
 ##
-## Ends in an error in state: 537.
+## Ends in an error in state: 539.
 ##
 ## functor_arg -> LPAREN . RPAREN [ LPAREN EQUALGREATER COLON ]
 ## functor_arg -> LPAREN . functor_arg_name COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
@@ -7070,7 +7039,7 @@ implementation: INCLUDE FUN LPAREN WITH
 
 implementation: INCLUDE FUN WITH
 ##
-## Ends in an error in state: 536.
+## Ends in an error in state: 538.
 ##
 ## _module_expr -> FUN . functor_args EQUALGREATER module_expr [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -7082,7 +7051,7 @@ implementation: INCLUDE FUN WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 2108.
+## Ends in an error in state: 2115.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL class_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7103,7 +7072,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2107.
+## Ends in an error in state: 2114.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL . class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7115,7 +7084,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 2106.
+## Ends in an error in state: 2113.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type . EQUAL class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7138,7 +7107,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 2105.
+## Ends in an error in state: 2112.
 ##
 ## _constrained_class_declaration -> COLON . class_constructor_type EQUAL class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7150,7 +7119,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 2153.
+## Ends in an error in state: 2160.
 ##
 ## and_class_declaration -> AND . class_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7162,7 +7131,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2152.
+## Ends in an error in state: 2159.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_declarations . [ error SEMI RBRACE ]
 ## many_class_declarations -> many_class_declarations . and_class_declaration [ error SEMI RBRACE AND ]
@@ -7174,16 +7143,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1088, spurious reduction of production post_item_attributes ->
-## In state 1089, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2125, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
+## In state 1089, spurious reduction of production post_item_attributes ->
+## In state 1090, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2132, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 2104.
+## Ends in an error in state: 2111.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7204,7 +7173,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2103.
+## Ends in an error in state: 2110.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7216,7 +7185,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 2117.
+## Ends in an error in state: 2124.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER class_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7237,7 +7206,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2116.
+## Ends in an error in state: 2123.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER . class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7249,7 +7218,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2115.
+## Ends in an error in state: 2122.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type . EQUALGREATER class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7261,7 +7230,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT R
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2114.
+## Ends in an error in state: 2121.
 ##
 ## class_fun_return -> COLON . non_arrowed_class_constructor_type EQUALGREATER class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7273,7 +7242,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 2113.
+## Ends in an error in state: 2120.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## class_fun_return -> EQUALGREATER class_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7294,7 +7263,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPARE
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2112.
+## Ends in an error in state: 2119.
 ##
 ## class_fun_return -> EQUALGREATER . class_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7306,7 +7275,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2111.
+## Ends in an error in state: 2118.
 ##
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_binding [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_return [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7319,7 +7288,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT WITH
 ##
-## Ends in an error in state: 2102.
+## Ends in an error in state: 2109.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . class_fun_binding [ error SEMI RBRACE LBRACKETATAT AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . constrained_class_declaration [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7334,7 +7303,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 2148.
+## Ends in an error in state: 2155.
 ##
 ## and_class_type_declaration -> AND . class_type_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7346,7 +7315,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2147.
+## Ends in an error in state: 2154.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_type_declarations . [ error SEMI RBRACE ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ error SEMI RBRACE AND ]
@@ -7358,16 +7327,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND R
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1088, spurious reduction of production post_item_attributes ->
-## In state 1089, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2099, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
+## In state 1089, spurious reduction of production post_item_attributes ->
+## In state 1090, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2106, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 2097.
+## Ends in an error in state: 2104.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AND ]
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7388,7 +7357,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2096.
+## Ends in an error in state: 2103.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_instance_type [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7400,7 +7369,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 ##
-## Ends in an error in state: 2095.
+## Ends in an error in state: 2102.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters . EQUAL class_instance_type [ error SEMI RBRACE LBRACKETATAT AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS EQUAL ]
@@ -7413,7 +7382,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 ##
-## Ends in an error in state: 2093.
+## Ends in an error in state: 2100.
 ##
 ## class_type_declaration_details -> virtual_flag . LIDENT class_type_parameters EQUAL class_instance_type [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7425,7 +7394,7 @@ implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE WITH
 ##
-## Ends in an error in state: 2092.
+## Ends in an error in state: 2099.
 ##
 ## many_class_type_declarations -> CLASS TYPE . class_type_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7437,7 +7406,7 @@ implementation: INCLUDE LBRACE CLASS TYPE WITH
 
 implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 2100.
+## Ends in an error in state: 2107.
 ##
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters class_fun_binding [ error SEMI RBRACE LBRACKETATAT AND ]
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters constrained_class_declaration [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7451,7 +7420,7 @@ implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 
 implementation: INCLUDE LBRACE CLASS WITH
 ##
-## Ends in an error in state: 2091.
+## Ends in an error in state: 2098.
 ##
 ## many_class_declarations -> CLASS . class_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
@@ -7464,9 +7433,9 @@ implementation: INCLUDE LBRACE CLASS WITH
 
 implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 ##
-## Ends in an error in state: 445.
+## Ends in an error in state: 466.
 ##
-## constr_ident -> LPAREN . RPAREN [ error SEMI RBRACE OF LBRACKETATAT LBRACKETAT EQUAL CONSTRAINT COLON BAR AND ]
+## constr_ident -> LPAREN . RPAREN [ error UNDERSCORE UIDENT SHARP SEMI RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUAL CONSTRAINT COLON BAR AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -7476,7 +7445,7 @@ implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 463.
+## Ends in an error in state: 441.
 ##
 ## generalized_constructor_arguments -> COLON . core_type [ error SEMI RBRACE LBRACKETATAT LBRACKETAT CONSTRAINT BAR AND ]
 ##
@@ -7488,7 +7457,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 ##
-## Ends in an error in state: 2086.
+## Ends in an error in state: 2093.
 ##
 ## constr_longident -> LBRACKET . RBRACKET [ error SEMI RBRACE LBRACKETATAT LBRACKETAT BAR ]
 ##
@@ -7500,7 +7469,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 2085.
+## Ends in an error in state: 2092.
 ##
 ## constr_longident -> LPAREN . RPAREN [ error SEMI RBRACE LBRACKETATAT LBRACKETAT BAR ]
 ##
@@ -7512,7 +7481,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2084.
+## Ends in an error in state: 2091.
 ##
 ## extension_constructor_rebind -> constr_ident EQUAL . constr_longident attributes [ error SEMI RBRACE LBRACKETATAT BAR ]
 ##
@@ -7522,48 +7491,35 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 
 <SYNTAX ERROR>
 
-implementation: INCLUDE LBRACE EXCEPTION UIDENT OF UNDERSCORE COLON WITH
+implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 449.
+## Ends in an error in state: 456.
 ##
-## generalized_constructor_arguments -> OF non_arrowed_simple_core_type_list COLON . core_type [ error SEMI RBRACE LBRACKETATAT LBRACKETAT CONSTRAINT BAR AND ]
+## generalized_constructor_arguments -> non_arrowed_simple_core_type_list COLON . core_type [ error SEMI RBRACE LBRACKETATAT LBRACKETAT CONSTRAINT BAR AND ]
 ##
 ## The known suffix of the stack is as follows:
-## OF non_arrowed_simple_core_type_list COLON
+## non_arrowed_simple_core_type_list COLON
 ##
 
 <SYNTAX ERROR>
 
-implementation: INCLUDE LBRACE EXCEPTION UIDENT OF UNDERSCORE WITH
+implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 448.
+## Ends in an error in state: 455.
 ##
-## generalized_constructor_arguments -> OF non_arrowed_simple_core_type_list . [ error SEMI RBRACE LBRACKETATAT LBRACKETAT CONSTRAINT BAR AND ]
-## generalized_constructor_arguments -> OF non_arrowed_simple_core_type_list . COLON core_type [ error SEMI RBRACE LBRACKETATAT LBRACKETAT CONSTRAINT BAR AND ]
+## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . [ error SEMI RBRACE LBRACKETATAT LBRACKETAT CONSTRAINT BAR AND ]
+## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . COLON core_type [ error SEMI RBRACE LBRACKETATAT LBRACKETAT CONSTRAINT BAR AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET CONSTRAINT COLON BAR AND ]
 ##
 ## The known suffix of the stack is as follows:
-## OF non_arrowed_simple_core_type_list
-##
-
-<SYNTAX ERROR>
-
-implementation: INCLUDE LBRACE EXCEPTION UIDENT OF WITH
-##
-## Ends in an error in state: 447.
-##
-## generalized_constructor_arguments -> OF . non_arrowed_simple_core_type_list [ error SEMI RBRACE LBRACKETATAT LBRACKETAT CONSTRAINT BAR AND ]
-## generalized_constructor_arguments -> OF . non_arrowed_simple_core_type_list COLON core_type [ error SEMI RBRACE LBRACKETATAT LBRACKETAT CONSTRAINT BAR AND ]
-##
-## The known suffix of the stack is as follows:
-## OF
+## non_arrowed_simple_core_type_list
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 2083.
+## Ends in an error in state: 2090.
 ##
 ## extension_constructor_declaration -> constr_ident . generalized_constructor_arguments attributes [ error SEMI RBRACE LBRACKETATAT BAR ]
 ## extension_constructor_rebind -> constr_ident . EQUAL constr_longident attributes [ error SEMI RBRACE LBRACKETATAT BAR ]
@@ -7576,7 +7532,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 
 implementation: INCLUDE LBRACE EXCEPTION WITH
 ##
-## Ends in an error in state: 2078.
+## Ends in an error in state: 2085.
 ##
 ## str_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ error SEMI RBRACE ]
 ## str_exception_declaration -> EXCEPTION . extension_constructor_rebind post_item_attributes [ error SEMI RBRACE ]
@@ -7589,7 +7545,7 @@ implementation: INCLUDE LBRACE EXCEPTION WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 ##
-## Ends in an error in state: 2074.
+## Ends in an error in state: 2081.
 ##
 ## primitive_declaration -> STRING . [ error SEMI RBRACE LBRACKETATAT ]
 ## primitive_declaration -> STRING . primitive_declaration [ error SEMI RBRACE LBRACKETATAT ]
@@ -7602,7 +7558,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WIT
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2073.
+## Ends in an error in state: 2080.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7614,7 +7570,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2072.
+## Ends in an error in state: 2079.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7625,19 +7581,19 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 2071.
+## Ends in an error in state: 2078.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7649,7 +7605,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 2070.
+## Ends in an error in state: 2077.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7661,7 +7617,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 
 implementation: INCLUDE LBRACE EXTERNAL WITH
 ##
-## Ends in an error in state: 2069.
+## Ends in an error in state: 2076.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7673,7 +7629,7 @@ implementation: INCLUDE LBRACE EXTERNAL WITH
 
 implementation: INCLUDE LBRACE INCLUDE WITH
 ##
-## Ends in an error in state: 2066.
+## Ends in an error in state: 2073.
 ##
 ## _structure_item_without_item_extension_sugar -> INCLUDE . module_expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7685,7 +7641,7 @@ implementation: INCLUDE LBRACE INCLUDE WITH
 
 implementation: INCLUDE LBRACE LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 ##
-## Ends in an error in state: 2143.
+## Ends in an error in state: 2150.
 ##
 ## and_nonlocal_module_bindings -> AND . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7697,7 +7653,7 @@ implementation: INCLUDE LBRACE LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 
 implementation: INCLUDE LBRACE LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2142.
+## Ends in an error in state: 2149.
 ##
 ## _structure_item_without_item_extension_sugar -> many_nonlocal_module_bindings . [ error SEMI RBRACE ]
 ## many_nonlocal_module_bindings -> many_nonlocal_module_bindings . and_nonlocal_module_bindings [ error SEMI RBRACE AND ]
@@ -7709,16 +7665,16 @@ implementation: INCLUDE LBRACE LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT A
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1088, spurious reduction of production post_item_attributes ->
-## In state 1089, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2023, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
+## In state 1089, spurious reduction of production post_item_attributes ->
+## In state 1090, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2030, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE REC WITH
 ##
-## Ends in an error in state: 2021.
+## Ends in an error in state: 2028.
 ##
 ## many_nonlocal_module_bindings -> LET MODULE REC . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -7730,7 +7686,7 @@ implementation: INCLUDE LBRACE LET MODULE REC WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2008.
+## Ends in an error in state: 2015.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
@@ -7744,19 +7700,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1997, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2001, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1998, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1970, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2003, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2002, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2007.
+## Ends in an error in state: 2014.
 ##
 ## module_binding_body_expr -> COLON module_type EQUAL . module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7768,7 +7724,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2006.
+## Ends in an error in state: 2013.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER EQUAL ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER EQUAL ]
@@ -7782,24 +7738,24 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 957, spurious reduction of production _simple_module_type -> mty_longident
-## In state 993, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 989, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 955, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 994, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 990, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 956, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 995, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 991, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 958, spurious reduction of production _simple_module_type -> mty_longident
+## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2005.
+## Ends in an error in state: 2012.
 ##
 ## module_binding_body_expr -> COLON . module_type EQUAL module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7811,7 +7767,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT COLON WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2004.
+## Ends in an error in state: 2011.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
@@ -7825,19 +7781,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1997, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2001, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1998, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1970, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2003, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2002, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1966.
+## Ends in an error in state: 1973.
 ##
 ## module_binding_body_expr -> EQUAL . module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7849,7 +7805,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2019.
+## Ends in an error in state: 2026.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER module_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
@@ -7863,19 +7819,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1997, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2001, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1998, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1970, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2003, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2002, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2018.
+## Ends in an error in state: 2025.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER . module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7887,7 +7843,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUA
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2017.
+## Ends in an error in state: 2024.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type . EQUALGREATER module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _module_type -> non_arrowed_module_type . [ WITH LBRACKETAT EQUALGREATER ]
@@ -7899,21 +7855,21 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 957, spurious reduction of production _simple_module_type -> mty_longident
-## In state 993, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 989, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 955, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 994, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 990, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 958, spurious reduction of production _simple_module_type -> mty_longident
+## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON WITH
 ##
-## Ends in an error in state: 2016.
+## Ends in an error in state: 2023.
 ##
 ## _module_binding_body_functor -> functor_args COLON . non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7925,7 +7881,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN COLON WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2015.
+## Ends in an error in state: 2022.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER module_expr . [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE AND ]
@@ -7939,19 +7895,19 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1997, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2001, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1998, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1970, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2003, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2002, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2014.
+## Ends in an error in state: 2021.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER . module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7963,7 +7919,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2013.
+## Ends in an error in state: 2020.
 ##
 ## _module_binding_body_functor -> functor_args . EQUALGREATER module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _module_binding_body_functor -> functor_args . COLON non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -7977,7 +7933,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT LPAREN RPAREN WITH
 
 implementation: INCLUDE LBRACE LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1965.
+## Ends in an error in state: 1972.
 ##
 ## nonlocal_module_binding_details -> UIDENT . module_binding_body [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -7989,7 +7945,7 @@ implementation: INCLUDE LBRACE LET MODULE UIDENT WITH
 
 implementation: INCLUDE LBRACE LET MODULE WITH
 ##
-## Ends in an error in state: 1964.
+## Ends in an error in state: 1971.
 ##
 ## _structure_item_without_item_extension_sugar -> LET MODULE . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE ]
 ## many_nonlocal_module_bindings -> LET MODULE . REC nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE AND ]
@@ -8002,7 +7958,7 @@ implementation: INCLUDE LBRACE LET MODULE WITH
 
 implementation: INCLUDE LBRACE LET WITH
 ##
-## Ends in an error in state: 1963.
+## Ends in an error in state: 1970.
 ##
 ## _structure_item_without_item_extension_sugar -> LET . MODULE nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACE ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ error SEMI RBRACE AND ]
@@ -8078,7 +8034,7 @@ implementation: INCLUDE LBRACE OPEN WITH
 
 implementation: INCLUDE LBRACE STRING WITH
 ##
-## Ends in an error in state: 2127.
+## Ends in an error in state: 2134.
 ##
 ## structure -> structure_item . [ error RBRACE ]
 ## structure -> structure_item . SEMI structure [ error RBRACE ]
@@ -8094,20 +8050,20 @@ implementation: INCLUDE LBRACE STRING WITH
 ## In state 1368, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2170, spurious reduction of production post_item_attributes ->
-## In state 2171, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 2172, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 2133, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 2126, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 2173, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 2134, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 2177, spurious reduction of production post_item_attributes ->
+## In state 2178, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 2179, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 2140, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 2133, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 2180, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 2141, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT AND LIDENT WITH
 ##
-## Ends in an error in state: 2138.
+## Ends in an error in state: 2145.
 ##
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -8118,14 +8074,14 @@ implementation: INCLUDE LBRACE TYPE LIDENT AND LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2137, spurious reduction of production optional_type_parameters ->
+## In state 2144, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT AND WITH
 ##
-## Ends in an error in state: 2136.
+## Ends in an error in state: 2143.
 ##
 ## and_type_declaration -> AND . type_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -8137,7 +8093,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT AND WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 520.
+## Ends in an error in state: 522.
 ##
 ## constrain -> core_type EQUAL . core_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER CONSTRAINT AND ]
 ##
@@ -8149,7 +8105,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 519.
+## Ends in an error in state: 521.
 ##
 ## constrain -> core_type . EQUAL core_type [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER CONSTRAINT AND ]
 ##
@@ -8160,19 +8116,19 @@ implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT WITH
 ##
-## Ends in an error in state: 518.
+## Ends in an error in state: 520.
 ##
 ## constraints -> constraints CONSTRAINT . constrain [ error WITH SEMI RPAREN RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER CONSTRAINT AND ]
 ##
@@ -8184,7 +8140,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT CONSTRAINT WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL DOTDOT WITH
 ##
-## Ends in an error in state: 517.
+## Ends in an error in state: 519.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ## type_declaration_details -> LIDENT optional_type_parameters type_kind constraints . [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -8197,7 +8153,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL DOTDOT WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 498.
+## Ends in an error in state: 499.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8209,17 +8165,17 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LBRACE LIDENT COLON LESSDOTDOTG
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 493, spurious reduction of production attributes ->
-## In state 494, spurious reduction of production attributes -> attribute attributes
-## In state 492, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 503, spurious reduction of production label_declarations -> label_declaration
+## In state 494, spurious reduction of production attributes ->
+## In state 495, spurious reduction of production attributes -> attribute attributes
+## In state 493, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 504, spurious reduction of production label_declarations -> label_declaration
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 481.
+## Ends in an error in state: 482.
 ##
 ## type_kind -> EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ##
@@ -8231,11 +8187,10 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LBRACE WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 439.
+## Ends in an error in state: 252.
 ##
-## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ error SEMI RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT AS AND ]
-## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ error SEMI RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL CONSTRAINT AS AND ]
-## constr_ident -> LPAREN . RPAREN [ error SEMI RBRACE OF LBRACKETATAT LBRACKETAT CONSTRAINT COLON BAR AND ]
+## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
+## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -8245,7 +8200,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL LPAREN WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 438.
+## Ends in an error in state: 462.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL PRIVATE . core_type [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8257,21 +8212,9 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL PRIVATE WITH
 
 <SYNTAX ERROR>
 
-implementation: INCLUDE LBRACE TYPE LIDENT EQUAL TRUE WITH
-##
-## Ends in an error in state: 476.
-##
-## constructor_declaration_no_leading_bar -> constr_ident . generalized_constructor_arguments attributes [ error SEMI RBRACE LBRACKETATAT CONSTRAINT BAR AND ]
-##
-## The known suffix of the stack is as follows:
-## constr_ident
-##
-
-<SYNTAX ERROR>
-
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UIDENT BAR WITH
 ##
-## Ends in an error in state: 443.
+## Ends in an error in state: 463.
 ##
 ## constructor_declaration_leading_bar -> BAR . constr_ident generalized_constructor_arguments attributes [ error SEMI RBRACE LBRACKETATAT CONSTRAINT BAR AND ]
 ##
@@ -8283,7 +8226,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UIDENT BAR WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 473.
+## Ends in an error in state: 477.
 ##
 ## constructor_declarations -> constructor_declaration_no_leading_bar . [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ## constructor_declarations -> constructor_declaration_no_leading_bar . constructor_declarations_leading_bar [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8295,25 +8238,26 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 457, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 451, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 453, spurious reduction of production _core_type -> core_type2
-## In state 462, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 452, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 464, spurious reduction of production generalized_constructor_arguments -> COLON core_type
-## In state 477, spurious reduction of production attributes ->
-## In state 478, spurious reduction of production constructor_declaration_no_leading_bar -> constr_ident generalized_constructor_arguments attributes
+## In state 339, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 449, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 443, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 445, spurious reduction of production _core_type -> core_type2
+## In state 454, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 444, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 453, spurious reduction of production generalized_constructor_arguments -> COLON core_type
+## In state 458, spurious reduction of production attributes ->
+## In state 459, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 436.
+## Ends in an error in state: 438.
 ##
-## constr_ident -> UIDENT . [ error SEMI RBRACE OF LBRACKETATAT LBRACKETAT CONSTRAINT COLON BAR AND ]
-## mod_ext_longident -> UIDENT . [ LPAREN DOT ]
+## constructor_declaration_no_leading_bar -> UIDENT . generalized_constructor_arguments attributes [ error SEMI RBRACE LBRACKETATAT CONSTRAINT BAR AND ]
+## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> UIDENT . [ DOT ]
 ##
 ## The known suffix of the stack is as follows:
 ## UIDENT
@@ -8323,7 +8267,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UIDENT WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 511.
+## Ends in an error in state: 513.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8335,17 +8279,17 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 493, spurious reduction of production attributes ->
-## In state 494, spurious reduction of production attributes -> attribute attributes
-## In state 492, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 503, spurious reduction of production label_declarations -> label_declaration
+## In state 494, spurious reduction of production attributes ->
+## In state 495, spurious reduction of production attributes -> attribute attributes
+## In state 493, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 504, spurious reduction of production label_declarations -> label_declaration
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 510.
+## Ends in an error in state: 512.
 ##
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ##
@@ -8357,7 +8301,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 ##
-## Ends in an error in state: 506.
+## Ends in an error in state: 508.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL core_type EQUAL PRIVATE . constructor_declarations [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8370,7 +8314,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 505.
+## Ends in an error in state: 506.
 ##
 ## type_kind -> EQUAL core_type EQUAL . constructor_declarations [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type EQUAL . PRIVATE constructor_declarations [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8385,7 +8329,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 504.
+## Ends in an error in state: 505.
 ##
 ## type_kind -> EQUAL core_type . [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type . EQUAL constructor_declarations [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8400,19 +8344,19 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 457, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 451, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 453, spurious reduction of production _core_type -> core_type2
-## In state 462, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 452, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 339, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 449, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 443, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 445, spurious reduction of production _core_type -> core_type2
+## In state 454, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 444, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 435.
+## Ends in an error in state: 437.
 ##
 ## type_kind -> EQUAL . core_type [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
 ## type_kind -> EQUAL . PRIVATE core_type [ error SEMI RBRACE LBRACKETATAT CONSTRAINT AND ]
@@ -8433,7 +8377,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT LBRACKETATAT WITH RBRACKET WITH
 ##
-## Ends in an error in state: 2135.
+## Ends in an error in state: 2142.
 ##
 ## _structure_item_without_item_extension_sugar -> many_type_declarations . [ error SEMI RBRACE ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ error SEMI RBRACE AND ]
@@ -8445,16 +8389,16 @@ implementation: INCLUDE LBRACE TYPE LIDENT LBRACKETATAT WITH RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1088, spurious reduction of production post_item_attributes ->
-## In state 1089, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2346, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 1089, spurious reduction of production post_item_attributes ->
+## In state 1090, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2353, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE LIDENT MINUS QUOTE WITH
 ##
-## Ends in an error in state: 431.
+## Ends in an error in state: 433.
 ##
 ## _optional_type_variable_with_variance -> MINUS QUOTE . ident [ error UNDERSCORE SEMI RBRACE QUOTE PLUSEQ PLUS MINUS LBRACKETATAT EQUAL CONSTRAINT AND ]
 ##
@@ -8466,7 +8410,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT MINUS QUOTE WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT MINUS WITH
 ##
-## Ends in an error in state: 429.
+## Ends in an error in state: 431.
 ##
 ## _optional_type_variable_with_variance -> MINUS . QUOTE ident [ error UNDERSCORE SEMI RBRACE QUOTE PLUSEQ PLUS MINUS LBRACKETATAT EQUAL CONSTRAINT AND ]
 ## _optional_type_variable_with_variance -> MINUS . UNDERSCORE [ error UNDERSCORE SEMI RBRACE QUOTE PLUSEQ PLUS MINUS LBRACKETATAT EQUAL CONSTRAINT AND ]
@@ -8479,7 +8423,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT MINUS WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUS QUOTE WITH
 ##
-## Ends in an error in state: 427.
+## Ends in an error in state: 429.
 ##
 ## _optional_type_variable_with_variance -> PLUS QUOTE . ident [ error UNDERSCORE SEMI RBRACE QUOTE PLUSEQ PLUS MINUS LBRACKETATAT EQUAL CONSTRAINT AND ]
 ##
@@ -8491,7 +8435,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUS QUOTE WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUS WITH
 ##
-## Ends in an error in state: 425.
+## Ends in an error in state: 427.
 ##
 ## _optional_type_variable_with_variance -> PLUS . QUOTE ident [ error UNDERSCORE SEMI RBRACE QUOTE PLUSEQ PLUS MINUS LBRACKETATAT EQUAL CONSTRAINT AND ]
 ## _optional_type_variable_with_variance -> PLUS . UNDERSCORE [ error UNDERSCORE SEMI RBRACE QUOTE PLUSEQ PLUS MINUS LBRACKETATAT EQUAL CONSTRAINT AND ]
@@ -8504,7 +8448,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUS WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 2350.
+## Ends in an error in state: 2357.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . str_extension_constructors post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8516,7 +8460,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ BAR WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 2349.
+## Ends in an error in state: 2356.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8528,7 +8472,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ PRIVATE BANG
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 2352.
+## Ends in an error in state: 2359.
 ##
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_declaration [ error SEMI RBRACE LBRACKETATAT BAR ]
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_rebind [ error SEMI RBRACE LBRACKETATAT BAR ]
@@ -8541,7 +8485,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 2348.
+## Ends in an error in state: 2355.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8553,7 +8497,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT PLUSEQ WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT QUOTE WITH
 ##
-## Ends in an error in state: 423.
+## Ends in an error in state: 425.
 ##
 ## _optional_type_variable_with_variance -> QUOTE . ident [ error UNDERSCORE SEMI RBRACE QUOTE PLUSEQ PLUS MINUS LBRACKETATAT EQUAL CONSTRAINT AND ]
 ##
@@ -8565,7 +8509,7 @@ implementation: INCLUDE LBRACE TYPE LIDENT QUOTE WITH
 
 implementation: INCLUDE LBRACE TYPE LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 436.
 ##
 ## potentially_long_ident_and_optional_type_parameters -> LIDENT optional_type_parameters . [ PLUSEQ ]
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -8577,14 +8521,14 @@ implementation: INCLUDE LBRACE TYPE LIDENT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 523, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 525, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE TYPE WITH
 ##
-## Ends in an error in state: 420.
+## Ends in an error in state: 422.
 ##
 ## many_type_declarations -> TYPE nonrec_flag . type_declaration_details post_item_attributes [ error SEMI RBRACE AND ]
 ## str_type_extension -> TYPE nonrec_flag . potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACE ]
@@ -8596,14 +8540,14 @@ implementation: INCLUDE LBRACE TYPE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 419, spurious reduction of production nonrec_flag ->
+## In state 421, spurious reduction of production nonrec_flag ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2128.
+## Ends in an error in state: 2135.
 ##
 ## structure -> structure_item SEMI . structure [ error RBRACE ]
 ##
@@ -8615,7 +8559,7 @@ implementation: INCLUDE LBRACE UIDENT SEMI WITH
 
 implementation: INCLUDE LBRACE WITH
 ##
-## Ends in an error in state: 417.
+## Ends in an error in state: 419.
 ##
 ## _module_expr -> LBRACE . structure error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LBRACE . structure RBRACE [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -8628,7 +8572,7 @@ implementation: INCLUDE LBRACE WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1971.
+## Ends in an error in state: 1978.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER module_expr . [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8643,7 +8587,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHIL
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1969.
+## Ends in an error in state: 1976.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER . module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8655,7 +8599,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1968.
+## Ends in an error in state: 1975.
 ##
 ## _module_expr -> FUN functor_args . EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## functor_args -> functor_args . functor_arg [ LPAREN EQUALGREATER ]
@@ -8668,7 +8612,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 
 implementation: INCLUDE LPAREN FUN WITH
 ##
-## Ends in an error in state: 1967.
+## Ends in an error in state: 1974.
 ##
 ## _module_expr -> FUN . functor_args EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8693,7 +8637,7 @@ implementation: INCLUDE LPAREN LBRACE WITH
 
 implementation: INCLUDE LPAREN LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1993.
+## Ends in an error in state: 2000.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -8708,24 +8652,24 @@ implementation: INCLUDE LPAREN LPAREN UIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 241, spurious reduction of production ident -> UIDENT
-## In state 642, spurious reduction of production mty_longident -> ident
+## In state 234, spurious reduction of production ident -> UIDENT
+## In state 643, spurious reduction of production mty_longident -> ident
 ## In state 1914, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1951, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1947, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1958, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1954, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
 ## In state 1912, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1952, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1948, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1959, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1955, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
 ## In state 1913, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1953, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1949, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1960, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1956, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1992.
+## Ends in an error in state: 1999.
 ##
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8738,7 +8682,7 @@ implementation: INCLUDE LPAREN LPAREN UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2301.
+## Ends in an error in state: 2308.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -8755,19 +8699,19 @@ implementation: INCLUDE LPAREN LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1997, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2001, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1998, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1970, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2003, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2002, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1983.
+## Ends in an error in state: 1990.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8778,16 +8722,16 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 109, spurious reduction of production package_type -> mty_longident
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 120, spurious reduction of production package_type -> mty_longident
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1982.
+## Ends in an error in state: 1989.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8799,7 +8743,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 2299.
+## Ends in an error in state: 2306.
 ##
 ## _module_expr -> LPAREN VAL expr COLON . error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8813,7 +8757,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1977.
+## Ends in an error in state: 1984.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8824,16 +8768,16 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 109, spurious reduction of production package_type -> mty_longident
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 120, spurious reduction of production package_type -> mty_longident
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 2297.
+## Ends in an error in state: 2304.
 ##
 ## _module_expr -> LPAREN VAL expr COLONGREATER . error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8846,7 +8790,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 2295.
+## Ends in an error in state: 2302.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -8886,7 +8830,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -8900,7 +8844,7 @@ implementation: INCLUDE LPAREN LPAREN VAL UIDENT SEMI
 
 implementation: INCLUDE LPAREN LPAREN VAL WITH
 ##
-## Ends in an error in state: 549.
+## Ends in an error in state: 550.
 ##
 ## _module_expr -> LPAREN VAL . expr COLON error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _module_expr -> LPAREN VAL . expr COLONGREATER error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8918,7 +8862,7 @@ implementation: INCLUDE LPAREN LPAREN VAL WITH
 
 implementation: INCLUDE LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 548.
+## Ends in an error in state: 549.
 ##
 ## _module_expr -> LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _module_expr -> LPAREN . VAL expr COLON error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -8941,7 +8885,7 @@ implementation: INCLUDE LPAREN LPAREN WITH
 
 implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2180.
+## Ends in an error in state: 2187.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -8956,24 +8900,24 @@ implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 241, spurious reduction of production ident -> UIDENT
-## In state 642, spurious reduction of production mty_longident -> ident
+## In state 234, spurious reduction of production ident -> UIDENT
+## In state 643, spurious reduction of production mty_longident -> ident
 ## In state 1914, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1951, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1947, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1958, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1954, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
 ## In state 1912, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1952, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1948, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1959, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1955, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
 ## In state 1913, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1953, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1949, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1960, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1956, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 2179.
+## Ends in an error in state: 2186.
 ##
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -8986,7 +8930,7 @@ implementation: INCLUDE LPAREN UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN UIDENT LBRACE UIDENT EOF
 ##
-## Ends in an error in state: 1990.
+## Ends in an error in state: 1997.
 ##
 ## _simple_module_expr -> LBRACE structure . RBRACE [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -8997,29 +8941,29 @@ implementation: INCLUDE LPAREN UIDENT LBRACE UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1513, spurious reduction of production post_item_attributes ->
 ## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1122, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1113, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
 ## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1123, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1114, spurious reduction of production structure -> structure_item
+## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1115, spurious reduction of production structure -> structure_item
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 1989.
+## Ends in an error in state: 1996.
 ##
 ## _simple_module_expr -> LBRACE . structure RBRACE [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -9031,7 +8975,7 @@ implementation: INCLUDE LPAREN UIDENT LBRACE WITH
 
 implementation: INCLUDE LPAREN UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1986.
+## Ends in an error in state: 1993.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -9048,19 +8992,19 @@ implementation: INCLUDE LPAREN UIDENT LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1997, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2001, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1998, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1970, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2003, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2002, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 1979.
+## Ends in an error in state: 1986.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type COLONGREATER package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -9073,7 +9017,7 @@ implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1976.
+## Ends in an error in state: 1983.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ##
@@ -9085,7 +9029,7 @@ implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 1974.
+## Ends in an error in state: 1981.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -9122,21 +9066,21 @@ implementation: INCLUDE LPAREN UIDENT LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT LPAREN VAL WITH
 ##
-## Ends in an error in state: 1973.
+## Ends in an error in state: 1980.
 ##
 ## _simple_module_expr -> LPAREN VAL . expr RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN VAL . expr COLON package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -9151,7 +9095,7 @@ implementation: INCLUDE LPAREN UIDENT LPAREN VAL WITH
 
 implementation: INCLUDE LPAREN UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1972.
+## Ends in an error in state: 1979.
 ##
 ## _module_expr -> module_expr LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## _simple_module_expr -> LPAREN . module_expr COLON module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
@@ -9171,7 +9115,7 @@ implementation: INCLUDE LPAREN UIDENT LPAREN WITH
 
 implementation: INCLUDE LPAREN UIDENT WHILE
 ##
-## Ends in an error in state: 1997.
+## Ends in an error in state: 2004.
 ##
 ## _simple_module_expr -> mod_longident . [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ error WITH UIDENT SEMI RPAREN RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER DOT COLON AND ]
@@ -9184,7 +9128,7 @@ implementation: INCLUDE LPAREN UIDENT WHILE
 
 implementation: INCLUDE LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2390.
+## Ends in an error in state: 2397.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -9201,12 +9145,12 @@ implementation: INCLUDE LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1997, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2001, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1998, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1970, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2003, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2002, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
@@ -9224,9 +9168,9 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 109, spurious reduction of production package_type -> mty_longident
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 120, spurious reduction of production package_type -> mty_longident
 ##
 
 <SYNTAX ERROR>
@@ -9245,7 +9189,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 2388.
+## Ends in an error in state: 2395.
 ##
 ## _module_expr -> LPAREN VAL expr COLON . error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9270,16 +9214,16 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 109, spurious reduction of production package_type -> mty_longident
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 120, spurious reduction of production package_type -> mty_longident
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 2386.
+## Ends in an error in state: 2393.
 ##
 ## _module_expr -> LPAREN VAL expr COLONGREATER . error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9292,7 +9236,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 2384.
+## Ends in an error in state: 2391.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -9332,7 +9276,7 @@ implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -9346,7 +9290,7 @@ implementation: INCLUDE LPAREN VAL UIDENT SEMI
 
 implementation: INCLUDE LPAREN VAL WITH
 ##
-## Ends in an error in state: 410.
+## Ends in an error in state: 412.
 ##
 ## _module_expr -> LPAREN VAL . expr COLON error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _module_expr -> LPAREN VAL . expr COLONGREATER error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9364,7 +9308,7 @@ implementation: INCLUDE LPAREN VAL WITH
 
 implementation: INCLUDE LPAREN WITH
 ##
-## Ends in an error in state: 409.
+## Ends in an error in state: 411.
 ##
 ## _module_expr -> LPAREN . module_expr error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _module_expr -> LPAREN . VAL expr COLON error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9398,29 +9342,29 @@ implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1513, spurious reduction of production post_item_attributes ->
 ## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1122, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1113, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
 ## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1123, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1114, spurious reduction of production structure -> structure_item
+## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1115, spurious reduction of production structure -> structure_item
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 902.
+## Ends in an error in state: 903.
 ##
 ## _simple_module_expr -> LBRACE . structure RBRACE [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ##
@@ -9432,7 +9376,7 @@ implementation: INCLUDE UIDENT LBRACE WITH
 
 implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2176.
+## Ends in an error in state: 2183.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -9449,12 +9393,12 @@ implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1997, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2001, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1998, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1970, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2003, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2002, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2004, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2008, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2005, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1977, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2010, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2009, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
@@ -9523,21 +9467,21 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL WITH
 ##
-## Ends in an error in state: 854.
+## Ends in an error in state: 855.
 ##
 ## _simple_module_expr -> LPAREN VAL . expr RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL . expr COLON package_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9552,7 +9496,7 @@ implementation: INCLUDE UIDENT LPAREN VAL WITH
 
 implementation: INCLUDE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 853.
+## Ends in an error in state: 854.
 ##
 ## _module_expr -> module_expr LPAREN . module_expr error [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## _simple_module_expr -> LPAREN . module_expr COLON module_type RPAREN [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
@@ -9572,7 +9516,7 @@ implementation: INCLUDE UIDENT LPAREN WITH
 
 implementation: INCLUDE UIDENT WHILE
 ##
-## Ends in an error in state: 909.
+## Ends in an error in state: 910.
 ##
 ## _simple_module_expr -> mod_longident . [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF DOT COLON AND ]
@@ -9585,7 +9529,7 @@ implementation: INCLUDE UIDENT WHILE
 
 implementation: INCLUDE WITH
 ##
-## Ends in an error in state: 1032.
+## Ends in an error in state: 1033.
 ##
 ## _structure_item_without_item_extension_sugar -> INCLUDE . module_expr post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -9597,7 +9541,7 @@ implementation: INCLUDE WITH
 
 implementation: LAZY WITH
 ##
-## Ends in an error in state: 555.
+## Ends in an error in state: 556.
 ##
 ## _expr -> LAZY . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -9633,7 +9577,7 @@ implementation: LBRACE AS UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 781, spurious reduction of production pattern -> pattern_without_or
+## In state 782, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
@@ -9675,12 +9619,12 @@ implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
@@ -9722,14 +9666,14 @@ implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1810, spurious reduction of production expr_optional_constraint -> expr
 ##
 
@@ -9874,10 +9818,10 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1289, spurious reduction of production let_binding_body -> pattern EQUAL expr
 ## In state 1290, spurious reduction of production post_item_attributes ->
 ## In state 1291, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
@@ -9889,7 +9833,7 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 
 implementation: LBRACE INHERIT LBRACE LET WITH
 ##
-## Ends in an error in state: 1155.
+## Ends in an error in state: 1156.
 ##
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI AND ]
 ##
@@ -9933,15 +9877,15 @@ implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 392, spurious reduction of production attr_id -> single_attr_id
-## In state 395, spurious reduction of production item_extension_sugar -> PERCENT attr_id
+## In state 395, spurious reduction of production attr_id -> single_attr_id
+## In state 398, spurious reduction of production item_extension_sugar -> PERCENT attr_id
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE WITH
 ##
-## Ends in an error in state: 1154.
+## Ends in an error in state: 1155.
 ##
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest RBRACE [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest error [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
@@ -10011,7 +9955,7 @@ implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1309, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -10124,10 +10068,10 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 1570, spurious reduction of production type_longident -> LIDENT
-## In state 153, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
-## In state 166, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
-## In state 164, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
-## In state 168, spurious reduction of production non_arrowed_core_type -> non_arrowed_simple_core_type
+## In state 261, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
+## In state 266, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
+## In state 264, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
+## In state 268, spurious reduction of production non_arrowed_core_type -> non_arrowed_simple_core_type
 ##
 
 <SYNTAX ERROR>
@@ -10197,7 +10141,8 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 ## Ends in an error in state: 1561.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET AND ]
-## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ LPAREN DOT ]
+## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
 ##
 ## The known suffix of the stack is as follows:
 ## mod_ext_longident DOT
@@ -10210,11 +10155,17 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 ## Ends in an error in state: 1560.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET AND ]
-## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ LPAREN DOT ]
-## mod_ext_longident -> mod_ext_longident . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
 ##
 ## The known suffix of the stack is as follows:
 ## mod_ext_longident
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 76, spurious reduction of production mod_ext_longident -> UIDENT
 ##
 
 <SYNTAX ERROR>
@@ -10282,7 +10233,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 
 implementation: LBRACE INHERIT LPAREN WITH
 ##
-## Ends in an error in state: 1153.
+## Ends in an error in state: 1154.
 ##
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE COLON CHAR BANG BACKQUOTE AS AND ]
@@ -10356,22 +10307,22 @@ implementation: LBRACE LBRACKETATATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1513, spurious reduction of production post_item_attributes ->
 ## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1122, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1113, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
 ## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1123, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1114, spurious reduction of production structure -> structure_item
+## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1115, spurious reduction of production structure -> structure_item
 ## In state 1500, spurious reduction of production payload -> structure
 ##
 
@@ -10379,7 +10330,7 @@ implementation: LBRACE LBRACKETATATAT WITH UIDENT RBRACE
 
 implementation: LBRACE LBRACKETPERCENTPERCENT UNDERSCORE
 ##
-## Ends in an error in state: 1111.
+## Ends in an error in state: 1112.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT . attr_id payload RBRACKET [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -10402,22 +10353,22 @@ implementation: LBRACE LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1513, spurious reduction of production post_item_attributes ->
 ## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1122, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1113, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
 ## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1123, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1114, spurious reduction of production structure -> structure_item
+## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1115, spurious reduction of production structure -> structure_item
 ## In state 1500, spurious reduction of production payload -> structure
 ##
 
@@ -10425,7 +10376,7 @@ implementation: LBRACE LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 
 implementation: LBRACE LET CHAR EQUAL CHAR AND WITH
 ##
-## Ends in an error in state: 2158.
+## Ends in an error in state: 2165.
 ##
 ## and_let_binding -> AND . let_binding_body post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -10437,7 +10388,7 @@ implementation: LBRACE LET CHAR EQUAL CHAR AND WITH
 
 implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 2424.
+## Ends in an error in state: 2431.
 ##
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . RBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -10449,17 +10400,17 @@ implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2249, spurious reduction of production opt_semi -> SEMI
-## In state 2260, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
-## In state 2258, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2247, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2256, spurious reduction of production opt_semi -> SEMI
+## In state 2267, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
+## In state 2265, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2254, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
 ##
 
 Expecting "}" to finish the block
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 2042.
+## Ends in an error in state: 2049.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -10493,7 +10444,7 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -10507,7 +10458,7 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2046.
+## Ends in an error in state: 2053.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10519,7 +10470,7 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2045.
+## Ends in an error in state: 2052.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10530,19 +10481,19 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 2044.
+## Ends in an error in state: 2051.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10554,7 +10505,7 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LBRACE LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2043.
+## Ends in an error in state: 2050.
 ##
 ## let_binding_body -> val_ident COLON typevar_list . DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -10567,7 +10518,7 @@ implementation: LBRACE LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 
 implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2040.
+## Ends in an error in state: 2047.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10579,7 +10530,7 @@ implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2039.
+## Ends in an error in state: 2046.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10590,19 +10541,19 @@ implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 2038.
+## Ends in an error in state: 2045.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10614,7 +10565,7 @@ implementation: LBRACE LET LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LBRACE LET LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 2036.
+## Ends in an error in state: 2043.
 ##
 ## let_binding_body -> val_ident COLON TYPE . lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10626,7 +10577,7 @@ implementation: LBRACE LET LIDENT COLON TYPE WITH
 
 implementation: LBRACE LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 2035.
+## Ends in an error in state: 2042.
 ##
 ## let_binding_body -> val_ident COLON . typevar_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
 ## let_binding_body -> val_ident COLON . TYPE lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -10640,7 +10591,7 @@ implementation: LBRACE LET LIDENT COLON WITH
 
 implementation: LBRACE LET LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 ##
-## Ends in an error in state: 2049.
+## Ends in an error in state: 2056.
 ##
 ## let_binding_body -> val_ident type_constraint EQUAL . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10652,7 +10603,7 @@ implementation: LBRACE LET LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 
 implementation: LBRACE LET LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2048.
+## Ends in an error in state: 2055.
 ##
 ## let_binding_body -> val_ident type_constraint . EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10663,12 +10614,12 @@ implementation: LBRACE LET LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ## In state 1254, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
@@ -10676,7 +10627,7 @@ implementation: LBRACE LET LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 
 implementation: LBRACE LET LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2033.
+## Ends in an error in state: 2040.
 ##
 ## _curried_binding_return_typed -> EQUALGREATER . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10688,7 +10639,7 @@ implementation: LBRACE LET LIDENT EQUALGREATER WITH
 
 implementation: LBRACE LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2031.
+## Ends in an error in state: 2038.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10700,7 +10651,7 @@ implementation: LBRACE LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LBRACE LET LIDENT LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 2030.
+## Ends in an error in state: 2037.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10712,7 +10663,7 @@ implementation: LBRACE LET LIDENT LPAREN TYPE LIDENT WITH
 
 implementation: LBRACE LET LIDENT LPAREN TYPE WITH
 ##
-## Ends in an error in state: 2029.
+## Ends in an error in state: 2036.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10724,7 +10675,7 @@ implementation: LBRACE LET LIDENT LPAREN TYPE WITH
 
 implementation: LBRACE LET LIDENT LPAREN WITH
 ##
-## Ends in an error in state: 2028.
+## Ends in an error in state: 2035.
 ##
 ## _curried_binding_return_typed -> LPAREN . TYPE LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -10781,7 +10732,7 @@ implementation: LBRACE LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -10832,7 +10783,7 @@ implementation: LBRACE LET LIDENT UNDERSCORE COLON WITH
 
 implementation: LBRACE LET LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2052.
+## Ends in an error in state: 2059.
 ##
 ## _curried_binding_return_typed -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -10844,7 +10795,7 @@ implementation: LBRACE LET LIDENT UNDERSCORE WITH
 
 implementation: LBRACE LET LIDENT WITH
 ##
-## Ends in an error in state: 2027.
+## Ends in an error in state: 2034.
 ##
 ## _simple_pattern -> val_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> val_ident . type_constraint EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -10860,7 +10811,7 @@ implementation: LBRACE LET LIDENT WITH
 
 implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT RBRACKET
 ##
-## Ends in an error in state: 2264.
+## Ends in an error in state: 2271.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes . SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10871,22 +10822,22 @@ implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 909, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 913, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 910, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 851, spurious reduction of production _module_expr -> simple_module_expr
-## In state 915, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 914, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
-## In state 907, spurious reduction of production module_binding_body_expr -> EQUAL module_expr
+## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 852, spurious reduction of production _module_expr -> simple_module_expr
+## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 908, spurious reduction of production module_binding_body_expr -> EQUAL module_expr
 ## In state 1758, spurious reduction of production module_binding_body -> module_binding_body_expr
-## In state 2263, spurious reduction of production post_item_attributes ->
+## In state 2270, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2265.
+## Ends in an error in state: 2272.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10898,7 +10849,7 @@ implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 
 implementation: LBRACE LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2262.
+## Ends in an error in state: 2269.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10910,7 +10861,7 @@ implementation: LBRACE LET MODULE UIDENT WITH
 
 implementation: LBRACE LET MODULE WITH
 ##
-## Ends in an error in state: 2261.
+## Ends in an error in state: 2268.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10922,7 +10873,7 @@ implementation: LBRACE LET MODULE WITH
 
 implementation: LBRACE LET OPEN BANG WITH
 ##
-## Ends in an error in state: 584.
+## Ends in an error in state: 585.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10934,7 +10885,7 @@ implementation: LBRACE LET OPEN BANG WITH
 
 implementation: LBRACE LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 588.
+## Ends in an error in state: 589.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10946,7 +10897,7 @@ implementation: LBRACE LET OPEN UIDENT SEMI WITH
 
 implementation: LBRACE LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 587.
+## Ends in an error in state: 588.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10957,14 +10908,14 @@ implementation: LBRACE LET OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 585, spurious reduction of production post_item_attributes ->
+## In state 586, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET OPEN WITH
 ##
-## Ends in an error in state: 583.
+## Ends in an error in state: 584.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -10976,7 +10927,7 @@ implementation: LBRACE LET OPEN WITH
 
 implementation: LBRACE LET REC ASSERT
 ##
-## Ends in an error in state: 2026.
+## Ends in an error in state: 2033.
 ##
 ## let_binding_impl -> LET rec_flag . let_binding_body post_item_attributes [ error SEMI RBRACE AND ]
 ##
@@ -10988,7 +10939,7 @@ implementation: LBRACE LET REC ASSERT
 
 implementation: LBRACE LET UIDENT UNDERSCORE WHEN
 ##
-## Ends in an error in state: 2061.
+## Ends in an error in state: 2068.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EQUAL BAR ]
 ## let_binding_body -> pattern . EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -11000,17 +10951,17 @@ implementation: LBRACE LET UIDENT UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 777, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
-## In state 780, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
-## In state 775, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
-## In state 781, spurious reduction of production pattern -> pattern_without_or
+## In state 778, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
+## In state 781, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
+## In state 776, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
+## In state 782, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2059.
+## Ends in an error in state: 2066.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11022,7 +10973,7 @@ implementation: LBRACE LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 
 implementation: LBRACE LET UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2058.
+## Ends in an error in state: 2065.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11033,19 +10984,19 @@ implementation: LBRACE LET UNDERSCORE COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2057.
+## Ends in an error in state: 2064.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON . core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11057,7 +11008,7 @@ implementation: LBRACE LET UNDERSCORE COLON WITH
 
 implementation: LBRACE LET UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2062.
+## Ends in an error in state: 2069.
 ##
 ## let_binding_body -> pattern EQUAL . expr [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11069,7 +11020,7 @@ implementation: LBRACE LET UNDERSCORE EQUAL WITH
 
 implementation: LBRACE LET UNDERSCORE WITH
 ##
-## Ends in an error in state: 2056.
+## Ends in an error in state: 2063.
 ##
 ## _simple_pattern -> simple_pattern_not_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> simple_pattern_not_ident . COLON core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT AND ]
@@ -11082,7 +11033,7 @@ implementation: LBRACE LET UNDERSCORE WITH
 
 implementation: LBRACE LET WITH
 ##
-## Ends in an error in state: 581.
+## Ends in an error in state: 582.
 ##
 ## _semi_terminated_seq_expr_row -> LET . MODULE UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ## _semi_terminated_seq_expr_row -> LET . OPEN override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
@@ -11131,7 +11082,7 @@ implementation: LBRACE LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -11192,7 +11143,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -11307,7 +11258,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -11344,12 +11295,12 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
@@ -11414,7 +11365,7 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -11451,15 +11402,15 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 496, spurious reduction of production _poly_type -> core_type
-## In state 497, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 495, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 497, spurious reduction of production _poly_type -> core_type
+## In state 498, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 496, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
 ##
 
 <SYNTAX ERROR>
@@ -11513,7 +11464,7 @@ implementation: LBRACE METHOD LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -11551,7 +11502,7 @@ implementation: LBRACE METHOD LIDENT EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -11718,7 +11669,7 @@ implementation: LBRACE METHOD PRIVATE WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1104.
+## Ends in an error in state: 1105.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -11730,7 +11681,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1103.
+## Ends in an error in state: 1104.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -11743,7 +11694,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WIT
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE WITH
 ##
-## Ends in an error in state: 1101.
+## Ends in an error in state: 1102.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ error SEMI RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AS ]
 ## typevar_list -> QUOTE . ident [ QUOTE DOT ]
@@ -11816,7 +11767,7 @@ implementation: LBRACE METHOD WITH
 
 implementation: LBRACE PERCENT WITH TYPE
 ##
-## Ends in an error in state: 2251.
+## Ends in an error in state: 2258.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ error RBRACE ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ error SEMI RBRACE AND ]
@@ -11828,15 +11779,15 @@ implementation: LBRACE PERCENT WITH TYPE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 392, spurious reduction of production attr_id -> single_attr_id
-## In state 395, spurious reduction of production item_extension_sugar -> PERCENT attr_id
+## In state 395, spurious reduction of production attr_id -> single_attr_id
+## In state 398, spurious reduction of production item_extension_sugar -> PERCENT attr_id
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE UIDENT DOT WITH
 ##
-## Ends in an error in state: 2274.
+## Ends in an error in state: 2281.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
@@ -11861,7 +11812,7 @@ implementation: LBRACE UIDENT DOT WITH
 
 implementation: LBRACE UIDENT LBRACKETATAT UNDERSCORE
 ##
-## Ends in an error in state: 532.
+## Ends in an error in state: 534.
 ##
 ## item_attribute -> LBRACKETATAT . attr_id payload RBRACKET [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11873,7 +11824,7 @@ implementation: LBRACE UIDENT LBRACKETATAT UNDERSCORE
 
 implementation: LBRACE UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2344.
+## Ends in an error in state: 2351.
 ##
 ## item_attribute -> LBRACKETATAT attr_id payload . RBRACKET [ error SEMI RBRACE LBRACKETATAT AND ]
 ##
@@ -11884,22 +11835,22 @@ implementation: LBRACE UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1513, spurious reduction of production post_item_attributes ->
 ## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1122, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1113, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
 ## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1123, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1114, spurious reduction of production structure -> structure_item
+## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1115, spurious reduction of production structure -> structure_item
 ## In state 1500, spurious reduction of production payload -> structure
 ##
 
@@ -11956,7 +11907,7 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL UIDENT RP
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -11993,12 +11944,12 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ## In state 1254, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
@@ -12040,7 +11991,7 @@ implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -12091,12 +12042,12 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 457, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 451, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 453, spurious reduction of production _core_type -> core_type2
-## In state 462, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 452, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 339, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 449, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 443, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 445, spurious reduction of production _core_type -> core_type2
+## In state 454, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 444, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
@@ -12168,12 +12119,12 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 457, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 451, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 453, spurious reduction of production _core_type -> core_type2
-## In state 462, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 452, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 339, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 449, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 443, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 445, spurious reduction of production _core_type -> core_type2
+## In state 454, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 444, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
@@ -12244,7 +12195,7 @@ implementation: LBRACE VAL WITH
 
 implementation: LBRACE WITH
 ##
-## Ends in an error in state: 184.
+## Ends in an error in state: 174.
 ##
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr RBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -12261,7 +12212,7 @@ implementation: LBRACE WITH
 
 implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2475.
+## Ends in an error in state: 2482.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -12295,7 +12246,7 @@ implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -12309,7 +12260,7 @@ implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 
 implementation: LBRACELESS LIDENT COLON WITH
 ##
-## Ends in an error in state: 181.
+## Ends in an error in state: 171.
 ##
 ## field_expr -> LIDENT COLON . expr [ error GREATERRBRACE COMMA ]
 ##
@@ -12321,7 +12272,7 @@ implementation: LBRACELESS LIDENT COLON WITH
 
 implementation: LBRACELESS LIDENT COMMA WITH
 ##
-## Ends in an error in state: 573.
+## Ends in an error in state: 574.
 ##
 ## field_expr_list -> field_expr_list COMMA . field_expr [ error GREATERRBRACE COMMA ]
 ## opt_comma -> COMMA . [ error GREATERRBRACE ]
@@ -12334,7 +12285,7 @@ implementation: LBRACELESS LIDENT COMMA WITH
 
 implementation: LBRACELESS LIDENT WITH
 ##
-## Ends in an error in state: 180.
+## Ends in an error in state: 170.
 ##
 ## field_expr -> LIDENT . COLON expr [ error GREATERRBRACE COMMA ]
 ## field_expr -> LIDENT . [ error GREATERRBRACE COMMA ]
@@ -12347,7 +12298,7 @@ implementation: LBRACELESS LIDENT WITH
 
 implementation: LBRACELESS WITH
 ##
-## Ends in an error in state: 179.
+## Ends in an error in state: 169.
 ##
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -12361,7 +12312,7 @@ implementation: LBRACELESS WITH
 
 implementation: LBRACKET DOTDOTDOT UIDENT COMMA
 ##
-## Ends in an error in state: 2197.
+## Ends in an error in state: 2204.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT expr_optional_constraint . RBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -12372,14 +12323,14 @@ implementation: LBRACKET DOTDOTDOT UIDENT COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1810, spurious reduction of production expr_optional_constraint -> expr
 ##
 
@@ -12387,7 +12338,7 @@ implementation: LBRACKET DOTDOTDOT UIDENT COMMA
 
 implementation: LBRACKET DOTDOTDOT WITH
 ##
-## Ends in an error in state: 2196.
+## Ends in an error in state: 2203.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT . expr_optional_constraint RBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -12399,7 +12350,7 @@ implementation: LBRACKET DOTDOTDOT WITH
 
 implementation: LBRACKET UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2200.
+## Ends in an error in state: 2207.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint COMMA . expr_comma_seq_extension [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## opt_comma -> COMMA . [ RBRACKET ]
@@ -12412,7 +12363,7 @@ implementation: LBRACKET UIDENT COMMA WITH
 
 implementation: LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2199.
+## Ends in an error in state: 2206.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint . opt_comma RBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## expr_comma_seq_extension -> expr_optional_constraint . COMMA expr_comma_seq_extension [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -12424,14 +12375,14 @@ implementation: LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1810, spurious reduction of production expr_optional_constraint -> expr
 ##
 
@@ -12441,7 +12392,7 @@ Expecting one of the following:
 
 implementation: LBRACKET WITH
 ##
-## Ends in an error in state: 177.
+## Ends in an error in state: 167.
 ##
 ## _simple_expr -> LBRACKET . expr_comma_seq_extension [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## constr_longident -> LBRACKET . RBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -12457,7 +12408,7 @@ Expecting one of the following:
 
 implementation: LBRACKETATATAT UNDERSCORE
 ##
-## Ends in an error in state: 1030.
+## Ends in an error in state: 1031.
 ##
 ## floating_attribute -> LBRACKETATATAT . attr_id payload RBRACKET [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12480,22 +12431,22 @@ implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1513, spurious reduction of production post_item_attributes ->
 ## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1122, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1113, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
 ## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1123, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1114, spurious reduction of production structure -> structure_item
+## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1115, spurious reduction of production structure -> structure_item
 ## In state 1500, spurious reduction of production payload -> structure
 ##
 
@@ -12503,7 +12454,7 @@ Expecting "]" to finish current floating attribute
 
 implementation: LBRACKETBAR BANG WITH
 ##
-## Ends in an error in state: 596.
+## Ends in an error in state: 597.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12539,7 +12490,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR PREFIXOP WITH
 ##
-## Ends in an error in state: 186.
+## Ends in an error in state: 176.
 ##
 ## _simple_expr -> PREFIXOP . simple_expr [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12600,7 +12551,7 @@ implementation: LBRACKETBAR UIDENT COMMA WITH
 
 implementation: LBRACKETBAR UIDENT SEMI
 ##
-## Ends in an error in state: 2493.
+## Ends in an error in state: 2500.
 ##
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -12613,7 +12564,7 @@ implementation: LBRACKETBAR UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -12629,7 +12580,7 @@ implementation: LBRACKETBAR UIDENT SEMI
 
 implementation: LBRACKETBAR WITH
 ##
-## Ends in an error in state: 174.
+## Ends in an error in state: 164.
 ##
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -12655,7 +12606,7 @@ implementation: LBRACKETPERCENT UNDERSCORE
 
 implementation: LBRACKETPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2585.
+## Ends in an error in state: 2593.
 ##
 ## extension -> LBRACKETPERCENT attr_id payload . RBRACKET [ WITH WHEN UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR OPTIONAL_NO_DEFAULT NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 IN GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOWNTO DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12666,22 +12617,22 @@ implementation: LBRACKETPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1513, spurious reduction of production post_item_attributes ->
 ## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1122, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1113, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
 ## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1123, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1114, spurious reduction of production structure -> structure_item
+## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1115, spurious reduction of production structure -> structure_item
 ## In state 1500, spurious reduction of production payload -> structure
 ##
 
@@ -12689,7 +12640,7 @@ implementation: LBRACKETPERCENT WITH UIDENT RBRACE
 
 implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 ##
-## Ends in an error in state: 1028.
+## Ends in an error in state: 1029.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT . attr_id payload RBRACKET [ SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -12701,7 +12652,7 @@ implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH COLON WITH
 ##
-## Ends in an error in state: 1055.
+## Ends in an error in state: 1056.
 ##
 ## payload -> COLON . core_type [ RBRACKET ]
 ##
@@ -12713,7 +12664,7 @@ implementation: LBRACKETPERCENTPERCENT WITH COLON WITH
 
 implementation: LBRACKETPERCENTPERCENT WITH DOT UNDERSCORE
 ##
-## Ends in an error in state: 71.
+## Ends in an error in state: 70.
 ##
 ## attr_id -> single_attr_id DOT . attr_id [ error WHILE UIDENT TYPE TRY TRUE SWITCH STRING RBRACKET QUESTION PREFIXOP PLUSDOT PLUS PERCENT OPEN NEW NATIVEINT MODULE MINUSDOT MINUS LPAREN LIDENT LET LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION COLON CLASS CHAR BANG BACKQUOTE ASSERT ]
 ##
@@ -12725,7 +12676,7 @@ implementation: LBRACKETPERCENTPERCENT WITH DOT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ##
-## Ends in an error in state: 2418.
+## Ends in an error in state: 2425.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN RBRACKET BAR ]
 ## payload -> QUESTION pattern . [ RBRACKET ]
@@ -12738,14 +12689,14 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 781, spurious reduction of production pattern -> pattern_without_or
+## In state 782, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2420.
+## Ends in an error in state: 2427.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -12779,21 +12730,21 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2419.
+## Ends in an error in state: 2426.
 ##
 ## payload -> QUESTION pattern WHEN . expr [ RBRACKET ]
 ##
@@ -12805,7 +12756,7 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN WITH
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION WITH
 ##
-## Ends in an error in state: 201.
+## Ends in an error in state: 191.
 ##
 ## payload -> QUESTION . pattern [ RBRACKET ]
 ## payload -> QUESTION . pattern WHEN expr [ RBRACKET ]
@@ -12829,22 +12780,22 @@ implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1513, spurious reduction of production post_item_attributes ->
 ## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1122, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1113, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
 ## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1123, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1114, spurious reduction of production structure -> structure_item
+## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1115, spurious reduction of production structure -> structure_item
 ## In state 1500, spurious reduction of production payload -> structure
 ##
 
@@ -12852,7 +12803,7 @@ implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 
 implementation: LBRACKETPERCENTPERCENT WITH WITH
 ##
-## Ends in an error in state: 70.
+## Ends in an error in state: 69.
 ##
 ## attr_id -> single_attr_id . [ error WHILE UIDENT TYPE TRY TRUE SWITCH STRING RBRACKET QUESTION PREFIXOP PLUSDOT PLUS PERCENT OPEN NEW NATIVEINT MODULE MINUSDOT MINUS LPAREN LIDENT LET LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION COLON CLASS CHAR BANG BACKQUOTE ASSERT ]
 ## attr_id -> single_attr_id . DOT attr_id [ error WHILE UIDENT TYPE TRY TRUE SWITCH STRING RBRACKET QUESTION PREFIXOP PLUSDOT PLUS PERCENT OPEN NEW NATIVEINT MODULE MINUSDOT MINUS LPAREN LIDENT LET LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION COLON CLASS CHAR BANG BACKQUOTE ASSERT ]
@@ -12911,14 +12862,14 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -12948,12 +12899,12 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
@@ -13008,12 +12959,12 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
@@ -13094,12 +13045,12 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ## In state 1254, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
@@ -13119,7 +13070,7 @@ implementation: LET LIDENT EQUALGREATER WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1161.
+## Ends in an error in state: 1162.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13131,7 +13082,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1160.
+## Ends in an error in state: 1161.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13143,7 +13094,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1159.
+## Ends in an error in state: 1160.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13155,7 +13106,7 @@ implementation: LET LIDENT LPAREN TYPE WITH
 
 implementation: LET LIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1158.
+## Ends in an error in state: 1159.
 ##
 ## _curried_binding_return_typed -> LPAREN . TYPE LIDENT RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -13178,7 +13129,7 @@ implementation: LET LIDENT LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1243.
+## Ends in an error in state: 1244.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -13212,21 +13163,21 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1242.
+## Ends in an error in state: 1243.
 ##
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type EQUALGREATER . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13238,7 +13189,7 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1241.
+## Ends in an error in state: 1242.
 ##
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type . EQUALGREATER expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
@@ -13252,7 +13203,7 @@ Expecting "=>" to start the function body
 
 implementation: LET LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1240.
+## Ends in an error in state: 1241.
 ##
 ## curried_binding_return_typed_ -> COLON . non_arrowed_core_type EQUALGREATER expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13264,7 +13215,7 @@ implementation: LET LIDENT UNDERSCORE COLON WITH
 
 implementation: LET LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1166.
+## Ends in an error in state: 1167.
 ##
 ## curried_binding -> EQUALGREATER . expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13276,7 +13227,7 @@ Expecting an expression as function body
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1165.
+## Ends in an error in state: 1166.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13288,7 +13239,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1164.
+## Ends in an error in state: 1165.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13300,7 +13251,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1163.
+## Ends in an error in state: 1164.
 ##
 ## curried_binding -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -13312,7 +13263,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 1162.
+## Ends in an error in state: 1163.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -13363,7 +13314,7 @@ Expecting one of the following:
 
 implementation: LET LIDENT WITH
 ##
-## Ends in an error in state: 1157.
+## Ends in an error in state: 1158.
 ##
 ## _simple_pattern -> val_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> val_ident . type_constraint EQUAL expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
@@ -13379,7 +13330,7 @@ implementation: LET LIDENT WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 ##
-## Ends in an error in state: 1135.
+## Ends in an error in state: 1136.
 ##
 ## and_nonlocal_module_bindings -> AND . nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -13391,7 +13342,7 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1134.
+## Ends in an error in state: 1135.
 ##
 ## _structure_item_without_item_extension_sugar -> many_nonlocal_module_bindings . [ SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> many_nonlocal_module_bindings . and_nonlocal_module_bindings [ SEMI RBRACKET RBRACE EOF AND ]
@@ -13403,8 +13354,8 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WIT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 922, spurious reduction of production post_item_attributes ->
-## In state 923, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 923, spurious reduction of production post_item_attributes ->
+## In state 924, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
 ## In state 1774, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
 ##
 
@@ -13438,12 +13389,12 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 909, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 913, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 910, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 851, spurious reduction of production _module_expr -> simple_module_expr
-## In state 915, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 914, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 852, spurious reduction of production _module_expr -> simple_module_expr
+## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
@@ -13476,24 +13427,24 @@ implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 957, spurious reduction of production _simple_module_type -> mty_longident
-## In state 993, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 989, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 955, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 994, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 990, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 956, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 995, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 991, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 958, spurious reduction of production _simple_module_type -> mty_longident
+## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 957, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 916.
+## Ends in an error in state: 917.
 ##
 ## module_binding_body_expr -> COLON . module_type EQUAL module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13505,7 +13456,7 @@ implementation: LET MODULE UIDENT COLON WITH
 
 implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 907.
+## Ends in an error in state: 908.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -13519,19 +13470,19 @@ implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 909, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 913, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 910, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 851, spurious reduction of production _module_expr -> simple_module_expr
-## In state 915, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 914, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 852, spurious reduction of production _module_expr -> simple_module_expr
+## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 906.
+## Ends in an error in state: 907.
 ##
 ## module_binding_body_expr -> EQUAL . module_expr [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13557,12 +13508,12 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 909, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 913, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 910, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 851, spurious reduction of production _module_expr -> simple_module_expr
-## In state 915, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 914, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 852, spurious reduction of production _module_expr -> simple_module_expr
+## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
@@ -13593,14 +13544,14 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 957, spurious reduction of production _simple_module_type -> mty_longident
-## In state 993, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 989, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 955, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 994, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 990, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 958, spurious reduction of production _simple_module_type -> mty_longident
+## In state 994, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 990, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 956, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 995, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 991, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
 ##
 
 <SYNTAX ERROR>
@@ -13620,17 +13571,17 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT CO
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 966, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 985, spurious reduction of production with_constraints -> with_constraint
-## In state 982, spurious reduction of production _module_type -> module_type WITH with_constraints
-## In state 995, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 991, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 967, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 986, spurious reduction of production with_constraints -> with_constraint
+## In state 983, spurious reduction of production _module_type -> module_type WITH with_constraints
+## In state 996, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 992, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
@@ -13663,12 +13614,12 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 909, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 913, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 910, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 851, spurious reduction of production _module_expr -> simple_module_expr
-## In state 915, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 914, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 852, spurious reduction of production _module_expr -> simple_module_expr
+## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
@@ -13701,7 +13652,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 
 implementation: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 905.
+## Ends in an error in state: 906.
 ##
 ## nonlocal_module_binding_details -> UIDENT . module_binding_body [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13713,7 +13664,7 @@ implementation: LET MODULE UIDENT WITH
 
 implementation: LET MODULE WITH
 ##
-## Ends in an error in state: 904.
+## Ends in an error in state: 905.
 ##
 ## _structure_item_without_item_extension_sugar -> LET MODULE . nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> LET MODULE . REC nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
@@ -13726,7 +13677,7 @@ implementation: LET MODULE WITH
 
 implementation: LET REC ASSERT
 ##
-## Ends in an error in state: 1156.
+## Ends in an error in state: 1157.
 ##
 ## let_binding_impl -> LET rec_flag . let_binding_body post_item_attributes [ SEMI RBRACKET RBRACE EOF BAR AND ]
 ##
@@ -13750,10 +13701,10 @@ implementation: LET UIDENT UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 777, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
-## In state 780, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
-## In state 775, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
-## In state 781, spurious reduction of production pattern -> pattern_without_or
+## In state 778, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
+## In state 781, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
+## In state 776, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
+## In state 782, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
@@ -13783,12 +13734,12 @@ implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
@@ -13832,7 +13783,7 @@ implementation: LET UNDERSCORE WITH
 
 implementation: LET WITH
 ##
-## Ends in an error in state: 903.
+## Ends in an error in state: 904.
 ##
 ## _structure_item_without_item_extension_sugar -> LET . MODULE nonlocal_module_binding_details post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
@@ -13846,7 +13797,7 @@ Incomplete let binding
 
 implementation: LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1180.
+## Ends in an error in state: 1181.
 ##
 ## _expr -> label EQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13870,7 +13821,7 @@ implementation: LPAREN ASSERT WITH
 
 implementation: LPAREN BACKQUOTE WITH
 ##
-## Ends in an error in state: 597.
+## Ends in an error in state: 598.
 ##
 ## name_tag -> BACKQUOTE . ident [ error UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -13895,7 +13846,7 @@ implementation: LPAREN BANG WITH
 
 implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ##
-## Ends in an error in state: 2329.
+## Ends in an error in state: 2336.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr . RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13929,21 +13880,21 @@ implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2328.
+## Ends in an error in state: 2335.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA . expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13955,7 +13906,7 @@ implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2327.
+## Ends in an error in state: 2334.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr . COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13989,21 +13940,21 @@ implementation: LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2326.
+## Ends in an error in state: 2333.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN . expr COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14015,7 +13966,7 @@ implementation: LPAREN COLONCOLON RPAREN LPAREN WITH
 
 implementation: LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2325.
+## Ends in an error in state: 2332.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN . LPAREN expr COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14027,7 +13978,7 @@ implementation: LPAREN COLONCOLON RPAREN WITH
 
 implementation: LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2324.
+## Ends in an error in state: 2331.
 ##
 ## _expr -> LPAREN COLONCOLON . RPAREN LPAREN expr COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14039,7 +13990,7 @@ implementation: LPAREN COLONCOLON WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ##
-## Ends in an error in state: 894.
+## Ends in an error in state: 895.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag simple_expr . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -14057,17 +14008,17 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 880, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 881, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 ##
-## Ends in an error in state: 893.
+## Ends in an error in state: 894.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag . simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14079,7 +14030,7 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ##
-## Ends in an error in state: 892.
+## Ends in an error in state: 893.
 ##
 ## _expr -> FOR pattern IN simple_expr . direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ TO SHARP DOWNTO DOT ]
@@ -14097,17 +14048,17 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 880, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 881, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FOR UNDERSCORE IN WITH
 ##
-## Ends in an error in state: 891.
+## Ends in an error in state: 892.
 ##
 ## _expr -> FOR pattern IN . simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14119,7 +14070,7 @@ implementation: LPAREN FOR UNDERSCORE IN WITH
 
 implementation: LPAREN FOR UNDERSCORE WHEN
 ##
-## Ends in an error in state: 890.
+## Ends in an error in state: 891.
 ##
 ## _expr -> FOR pattern . IN simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _or_pattern -> pattern . BAR pattern [ IN BAR ]
@@ -14131,14 +14082,14 @@ implementation: LPAREN FOR UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 781, spurious reduction of production pattern -> pattern_without_or
+## In state 782, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FOR WITH
 ##
-## Ends in an error in state: 889.
+## Ends in an error in state: 890.
 ##
 ## _expr -> FOR . pattern IN simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14150,7 +14101,7 @@ implementation: LPAREN FOR WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2229.
+## Ends in an error in state: 2236.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14194,7 +14145,7 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2228.
+## Ends in an error in state: 2235.
 ##
 ## leading_bar_match_case -> bar_located_pattern EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14206,7 +14157,7 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2227.
+## Ends in an error in state: 2234.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14250,7 +14201,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2226.
+## Ends in an error in state: 2233.
 ##
 ## leading_bar_match_case -> bar_located_pattern WHEN expr EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14262,7 +14213,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2225.
+## Ends in an error in state: 2232.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -14296,21 +14247,21 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2224.
+## Ends in an error in state: 2231.
 ##
 ## leading_bar_match_case -> bar_located_pattern WHEN . expr EQUALGREATER expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14322,7 +14273,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 615.
+## Ends in an error in state: 616.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14334,7 +14285,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 614.
+## Ends in an error in state: 615.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14346,7 +14297,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN LPAREN TYPE WITH
 ##
-## Ends in an error in state: 613.
+## Ends in an error in state: 614.
 ##
 ## _expr -> FUN LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14358,7 +14309,7 @@ implementation: LPAREN FUN LPAREN TYPE WITH
 
 implementation: LPAREN FUN LPAREN WITH
 ##
-## Ends in an error in state: 612.
+## Ends in an error in state: 613.
 ##
 ## _expr -> FUN LPAREN . TYPE LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
@@ -14381,7 +14332,7 @@ implementation: LPAREN FUN LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2216.
+## Ends in an error in state: 2223.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14425,7 +14376,7 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2215.
+## Ends in an error in state: 2222.
 ##
 ## fun_def -> EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14437,7 +14388,7 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 619.
+## Ends in an error in state: 620.
 ##
 ## fun_def -> LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14449,7 +14400,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 618.
+## Ends in an error in state: 619.
 ##
 ## fun_def -> LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14461,7 +14412,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 617.
+## Ends in an error in state: 618.
 ##
 ## fun_def -> LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14473,7 +14424,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 616.
+## Ends in an error in state: 617.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER CHAR BACKQUOTE ]
@@ -14496,7 +14447,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 2217.
+## Ends in an error in state: 2224.
 ##
 ## fun_def -> labeled_simple_pattern . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14508,7 +14459,7 @@ implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 
 implementation: LPAREN FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2231.
+## Ends in an error in state: 2238.
 ##
 ## _expr -> FUN labeled_simple_pattern . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14520,7 +14471,7 @@ implementation: LPAREN FUN UNDERSCORE WITH
 
 implementation: LPAREN FUN WITH
 ##
-## Ends in an error in state: 611.
+## Ends in an error in state: 612.
 ##
 ## _expr -> FUN . labeled_simple_pattern fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> FUN . LPAREN TYPE LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14534,7 +14485,7 @@ implementation: LPAREN FUN WITH
 
 implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 ##
-## Ends in an error in state: 610.
+## Ends in an error in state: 611.
 ##
 ## _expr -> IF simple_expr simple_expr ELSE . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14546,7 +14497,7 @@ implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 
 implementation: LPAREN IF UIDENT WITH
 ##
-## Ends in an error in state: 608.
+## Ends in an error in state: 609.
 ##
 ## _expr -> IF simple_expr . simple_expr ELSE expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF simple_expr . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14565,17 +14516,17 @@ implementation: LPAREN IF UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 880, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 881, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN IF WITH
 ##
-## Ends in an error in state: 607.
+## Ends in an error in state: 608.
 ##
 ## _expr -> IF . simple_expr simple_expr ELSE expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF . simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -14588,7 +14539,7 @@ implementation: LPAREN IF WITH
 
 implementation: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 589.
+## Ends in an error in state: 590.
 ##
 ## _expr -> LAZY . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14600,7 +14551,7 @@ implementation: LPAREN LAZY WITH
 
 implementation: LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 579.
+## Ends in an error in state: 580.
 ##
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14617,7 +14568,7 @@ implementation: LPAREN LBRACE WITH
 
 implementation: LPAREN LBRACELESS WITH
 ##
-## Ends in an error in state: 570.
+## Ends in an error in state: 571.
 ##
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14642,14 +14593,14 @@ implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1810, spurious reduction of production expr_optional_constraint -> expr
 ##
 
@@ -14681,12 +14632,12 @@ implementation: LPAREN LBRACKET UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ## In state 1254, spurious reduction of production type_constraint -> COLONGREATER core_type
 ## In state 1811, spurious reduction of production expr_optional_constraint -> expr type_constraint
 ##
@@ -14708,7 +14659,7 @@ implementation: LPAREN LBRACKET UIDENT COMMA WITH
 
 implementation: LPAREN LBRACKET WITH
 ##
-## Ends in an error in state: 552.
+## Ends in an error in state: 553.
 ##
 ## _simple_expr -> LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## constr_longident -> LBRACKET . RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14721,7 +14672,7 @@ implementation: LPAREN LBRACKET WITH
 
 implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2291.
+## Ends in an error in state: 2298.
 ##
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14734,7 +14685,7 @@ implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -14750,7 +14701,7 @@ implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 
 implementation: LPAREN LBRACKETBAR WITH
 ##
-## Ends in an error in state: 551.
+## Ends in an error in state: 552.
 ##
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14764,7 +14715,7 @@ implementation: LPAREN LBRACKETBAR WITH
 
 implementation: LPAREN LBRACKETPERCENT UNDERSCORE
 ##
-## Ends in an error in state: 199.
+## Ends in an error in state: 189.
 ##
 ## extension -> LBRACKETPERCENT . attr_id payload RBRACKET [ error WITH UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUALGREATER EQUAL ELSE DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -14776,7 +14727,7 @@ implementation: LPAREN LBRACKETPERCENT UNDERSCORE
 
 implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2421.
+## Ends in an error in state: 2428.
 ##
 ## extension -> LBRACKETPERCENT attr_id payload . RBRACKET [ error WITH UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUALGREATER EQUAL ELSE DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -14787,22 +14738,22 @@ implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1513, spurious reduction of production post_item_attributes ->
 ## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1122, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1113, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
 ## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1123, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1114, spurious reduction of production structure -> structure_item
+## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1115, spurious reduction of production structure -> structure_item
 ## In state 1500, spurious reduction of production payload -> structure
 ##
 
@@ -14822,7 +14773,7 @@ implementation: LPAREN LIDENT EQUAL WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ##
-## Ends in an error in state: 2374.
+## Ends in an error in state: 2381.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr . RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -14856,21 +14807,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2373.
+## Ends in an error in state: 2380.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA . expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14882,7 +14833,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2372.
+## Ends in an error in state: 2379.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr . COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -14916,21 +14867,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2371.
+## Ends in an error in state: 2378.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN . expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14942,7 +14893,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2370.
+## Ends in an error in state: 2377.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN . LPAREN expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14954,7 +14905,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2369.
+## Ends in an error in state: 2376.
 ##
 ## _expr -> LPAREN COLONCOLON . RPAREN LPAREN expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -14966,7 +14917,7 @@ implementation: LPAREN LPAREN COLONCOLON WITH
 
 implementation: LPAREN LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2367.
+## Ends in an error in state: 2374.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -14977,16 +14928,16 @@ implementation: LPAREN LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 109, spurious reduction of production package_type -> mty_longident
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 120, spurious reduction of production package_type -> mty_longident
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2365.
+## Ends in an error in state: 2372.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -14999,7 +14950,7 @@ implementation: LPAREN LPAREN MODULE UIDENT COLON WITH
 
 implementation: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2363.
+## Ends in an error in state: 2370.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -15015,19 +14966,19 @@ implementation: LPAREN LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 909, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 913, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 910, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 851, spurious reduction of production _module_expr -> simple_module_expr
-## In state 915, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 914, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 852, spurious reduction of production _module_expr -> simple_module_expr
+## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN MODULE WITH
 ##
-## Ends in an error in state: 416.
+## Ends in an error in state: 418.
 ##
 ## _simple_expr -> LPAREN MODULE . module_expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE . module_expr COLON package_type RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15041,7 +14992,7 @@ Expecting a module expression
 
 implementation: LPAREN LPAREN STAR WITH
 ##
-## Ends in an error in state: 716.
+## Ends in an error in state: 717.
 ##
 ## val_ident -> LPAREN operator . RPAREN [ error UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15053,7 +15004,7 @@ implementation: LPAREN LPAREN STAR WITH
 
 implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ##
-## Ends in an error in state: 2376.
+## Ends in an error in state: 2383.
 ##
 ## _simple_expr -> LPAREN expr_comma_list . RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN expr_comma_list . error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -15071,14 +15022,14 @@ implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1794, spurious reduction of production expr_optional_constraint -> expr
-## In state 2333, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
+## In state 2340, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 413.
+## Ends in an error in state: 415.
 ##
 ## _expr -> LPAREN . COLONCOLON RPAREN LPAREN expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15131,7 +15082,7 @@ implementation: LPAREN MINUSDOT WITH
 
 implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2322.
+## Ends in an error in state: 2329.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON package_type . RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -15142,16 +15093,16 @@ implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 109, spurious reduction of production package_type -> mty_longident
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 120, spurious reduction of production package_type -> mty_longident
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2320.
+## Ends in an error in state: 2327.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON . package_type RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE module_expr COLON . error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15164,7 +15115,7 @@ implementation: LPAREN MODULE UIDENT COLON WITH
 
 implementation: LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2318.
+## Ends in an error in state: 2325.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -15180,19 +15131,19 @@ implementation: LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 909, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 913, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 910, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 851, spurious reduction of production _module_expr -> simple_module_expr
-## In state 915, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 914, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 852, spurious reduction of production _module_expr -> simple_module_expr
+## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN MODULE WITH
 ##
-## Ends in an error in state: 535.
+## Ends in an error in state: 537.
 ##
 ## _simple_expr -> LPAREN MODULE . module_expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE . module_expr COLON package_type RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15206,7 +15157,7 @@ implementation: LPAREN MODULE WITH
 
 implementation: LPAREN NEW UIDENT DOT WITH
 ##
-## Ends in an error in state: 190.
+## Ends in an error in state: 180.
 ##
 ## class_longident -> mod_longident DOT . LIDENT [ error WITH UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUALGREATER EQUAL ELSE DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident DOT . UIDENT [ DOT ]
@@ -15219,7 +15170,7 @@ implementation: LPAREN NEW UIDENT DOT WITH
 
 implementation: LPAREN NEW UIDENT WITH
 ##
-## Ends in an error in state: 189.
+## Ends in an error in state: 179.
 ##
 ## class_longident -> mod_longident . DOT LIDENT [ error WITH UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUALGREATER EQUAL ELSE DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident . DOT UIDENT [ DOT ]
@@ -15232,7 +15183,7 @@ implementation: LPAREN NEW UIDENT WITH
 
 implementation: LPAREN NEW WITH
 ##
-## Ends in an error in state: 187.
+## Ends in an error in state: 177.
 ##
 ## _simple_expr -> NEW . class_longident [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15244,7 +15195,7 @@ implementation: LPAREN NEW WITH
 
 implementation: LPAREN PLUS WITH
 ##
-## Ends in an error in state: 415.
+## Ends in an error in state: 417.
 ##
 ## additive -> PLUS . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
 ## operator -> PLUS . [ RPAREN ]
@@ -15257,7 +15208,7 @@ implementation: LPAREN PLUS WITH
 
 implementation: LPAREN PLUSDOT WITH
 ##
-## Ends in an error in state: 414.
+## Ends in an error in state: 416.
 ##
 ## additive -> PLUSDOT . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
 ## operator -> PLUSDOT . [ RPAREN ]
@@ -15270,7 +15221,7 @@ implementation: LPAREN PLUSDOT WITH
 
 implementation: LPAREN PREFIXOP WITH
 ##
-## Ends in an error in state: 197.
+## Ends in an error in state: 187.
 ##
 ## _simple_expr -> PREFIXOP . simple_expr [ error UIDENT TRUE STRING STAR SHARP RPAREN QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## operator -> PREFIXOP . [ RPAREN ]
@@ -15283,7 +15234,7 @@ implementation: LPAREN PREFIXOP WITH
 
 implementation: LPAREN STAR WITH
 ##
-## Ends in an error in state: 788.
+## Ends in an error in state: 789.
 ##
 ## val_ident -> LPAREN operator . RPAREN [ WITH WHEN UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR OPTIONAL_NO_DEFAULT NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 IN GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -15319,7 +15270,7 @@ implementation: LPAREN STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: LPAREN SWITCH UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2434.
+## Ends in an error in state: 2441.
 ##
 ## _expr -> SWITCH simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15331,7 +15282,7 @@ implementation: LPAREN SWITCH UIDENT LBRACE WITH
 
 implementation: LPAREN SWITCH UIDENT WITH
 ##
-## Ends in an error in state: 2433.
+## Ends in an error in state: 2440.
 ##
 ## _expr -> SWITCH simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ SHARP LBRACE DOT ]
@@ -15349,17 +15300,17 @@ implementation: LPAREN SWITCH UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 880, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 881, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN SWITCH WITH
 ##
-## Ends in an error in state: 183.
+## Ends in an error in state: 173.
 ##
 ## _expr -> SWITCH . simple_expr LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15418,14 +15369,14 @@ implementation: LPAREN TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -15493,7 +15444,7 @@ implementation: LPAREN TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -15581,7 +15532,7 @@ implementation: LPAREN TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -15630,7 +15581,7 @@ implementation: LPAREN TRUE DOT WITH
 
 implementation: LPAREN TRY UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2489.
+## Ends in an error in state: 2496.
 ##
 ## _expr -> TRY simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15642,7 +15593,7 @@ implementation: LPAREN TRY UIDENT LBRACE WITH
 
 implementation: LPAREN TRY UIDENT UNDERSCORE
 ##
-## Ends in an error in state: 2486.
+## Ends in an error in state: 2493.
 ##
 ## _expr -> TRY simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> TRY simple_expr . WITH error [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -15661,17 +15612,17 @@ implementation: LPAREN TRY UIDENT UNDERSCORE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 880, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 881, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN TRY UIDENT WITH WITH
 ##
-## Ends in an error in state: 2487.
+## Ends in an error in state: 2494.
 ##
 ## _expr -> TRY simple_expr WITH . error [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -15683,7 +15634,7 @@ implementation: LPAREN TRY UIDENT WITH WITH
 
 implementation: LPAREN TRY WITH
 ##
-## Ends in an error in state: 176.
+## Ends in an error in state: 166.
 ##
 ## _expr -> TRY . simple_expr LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> TRY . simple_expr WITH error [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -15768,7 +15719,7 @@ implementation: LPAREN UIDENT COLONEQUAL WITH
 
 implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2331.
+## Ends in an error in state: 2338.
 ##
 ## expr_comma_list -> expr_optional_constraint . COMMA expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -15779,14 +15730,14 @@ implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ## In state 1254, spurious reduction of production type_constraint -> COLONGREATER core_type
-## In state 2342, spurious reduction of production expr_optional_constraint -> expr type_constraint
+## In state 2349, spurious reduction of production expr_optional_constraint -> expr type_constraint
 ##
 
 <SYNTAX ERROR>
@@ -15805,7 +15756,7 @@ implementation: LPAREN UIDENT COLONGREATER WITH
 
 implementation: LPAREN UIDENT COMMA CHAR BARRBRACKET
 ##
-## Ends in an error in state: 2334.
+## Ends in an error in state: 2341.
 ##
 ## _simple_expr -> LPAREN expr_comma_list . RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN expr_comma_list . error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -15823,14 +15774,14 @@ implementation: LPAREN UIDENT COMMA CHAR BARRBRACKET
 ## In state 1387, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 1367, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1794, spurious reduction of production expr_optional_constraint -> expr
-## In state 2333, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
+## In state 2340, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 2337.
+## Ends in an error in state: 2344.
 ##
 ## expr_comma_list -> expr_comma_list COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -15842,7 +15793,7 @@ implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 
 implementation: LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2332.
+## Ends in an error in state: 2339.
 ##
 ## expr_comma_list -> expr_optional_constraint COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -15905,7 +15856,7 @@ implementation: LPAREN UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -15945,9 +15896,9 @@ implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 109, spurious reduction of production package_type -> mty_longident
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 120, spurious reduction of production package_type -> mty_longident
 ##
 
 <SYNTAX ERROR>
@@ -15967,7 +15918,7 @@ implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 
 implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 901.
+## Ends in an error in state: 902.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -15982,19 +15933,19 @@ implementation: LPAREN UIDENT DOT LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 909, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 913, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 910, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 851, spurious reduction of production _module_expr -> simple_module_expr
-## In state 915, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 914, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 852, spurious reduction of production _module_expr -> simple_module_expr
+## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT DOT LPAREN MODULE WITH
 ##
-## Ends in an error in state: 900.
+## Ends in an error in state: 901.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON package_type RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16042,7 +15993,7 @@ implementation: LPAREN UIDENT DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -16056,7 +16007,7 @@ implementation: LPAREN UIDENT DOT LPAREN UIDENT SEMI
 
 implementation: LPAREN UIDENT DOT LPAREN WITH
 ##
-## Ends in an error in state: 899.
+## Ends in an error in state: 900.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN . expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16072,7 +16023,7 @@ implementation: LPAREN UIDENT DOT LPAREN WITH
 
 implementation: LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 898.
+## Ends in an error in state: 899.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16168,7 +16119,7 @@ implementation: LPAREN UIDENT INFIXOP4 WITH
 
 implementation: LPAREN UIDENT LBRACKETAT UNDERSCORE
 ##
-## Ends in an error in state: 336.
+## Ends in an error in state: 340.
 ##
 ## attribute -> LBRACKETAT . attr_id payload RBRACKET [ error WITH UIDENT STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARRBRACKET BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -16180,7 +16131,7 @@ implementation: LPAREN UIDENT LBRACKETAT UNDERSCORE
 
 implementation: LPAREN UIDENT LBRACKETAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2399.
+## Ends in an error in state: 2406.
 ##
 ## attribute -> LBRACKETAT attr_id payload . RBRACKET [ error WITH UIDENT STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EQUALGREATER EQUAL CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARRBRACKET BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -16191,22 +16142,22 @@ implementation: LPAREN UIDENT LBRACKETAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1513, spurious reduction of production post_item_attributes ->
 ## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1122, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1113, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
 ## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1123, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1114, spurious reduction of production structure -> structure_item
+## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1115, spurious reduction of production structure -> structure_item
 ## In state 1500, spurious reduction of production payload -> structure
 ##
 
@@ -16250,7 +16201,7 @@ implementation: LPAREN UIDENT LESSGREATER WITH
 
 implementation: LPAREN UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 194.
+## Ends in an error in state: 184.
 ##
 ## _simple_expr -> LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16401,14 +16352,14 @@ implementation: LPAREN UIDENT QUESTION UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -16427,7 +16378,7 @@ implementation: LPAREN UIDENT QUESTION WITH
 
 implementation: LPAREN UIDENT SHARP WITH
 ##
-## Ends in an error in state: 602.
+## Ends in an error in state: 603.
 ##
 ## _simple_expr -> simple_expr SHARP . label [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -16451,7 +16402,7 @@ implementation: LPAREN UIDENT STAR WITH
 
 implementation: LPAREN UIDENT TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 2240.
+## Ends in an error in state: 2247.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -16485,21 +16436,21 @@ implementation: LPAREN UIDENT TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 2239.
+## Ends in an error in state: 2246.
 ##
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -16511,7 +16462,7 @@ implementation: LPAREN UIDENT TRUE DOT LBRACE WITH
 
 implementation: LPAREN UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2237.
+## Ends in an error in state: 2244.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -16546,7 +16497,7 @@ implementation: LPAREN UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -16560,7 +16511,7 @@ implementation: LPAREN UIDENT TRUE DOT LBRACKET UIDENT SEMI
 
 implementation: LPAREN UIDENT TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2236.
+## Ends in an error in state: 2243.
 ##
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16573,7 +16524,7 @@ implementation: LPAREN UIDENT TRUE DOT LBRACKET WITH
 
 implementation: LPAREN UIDENT TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2234.
+## Ends in an error in state: 2241.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -16608,7 +16559,7 @@ implementation: LPAREN UIDENT TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -16622,7 +16573,7 @@ implementation: LPAREN UIDENT TRUE DOT LPAREN UIDENT SEMI
 
 implementation: LPAREN UIDENT TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 606.
+## Ends in an error in state: 607.
 ##
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16635,7 +16586,7 @@ implementation: LPAREN UIDENT TRUE DOT LPAREN WITH
 
 implementation: LPAREN UIDENT TRUE DOT WITH
 ##
-## Ends in an error in state: 605.
+## Ends in an error in state: 606.
 ##
 ## _simple_expr -> simple_expr DOT . label_longident [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -16652,7 +16603,7 @@ implementation: LPAREN UIDENT TRUE DOT WITH
 
 implementation: LPAREN WHILE UIDENT WITH
 ##
-## Ends in an error in state: 2587.
+## Ends in an error in state: 2595.
 ##
 ## _expr -> WHILE simple_expr . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -16670,10 +16621,10 @@ implementation: LPAREN WHILE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 880, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 881, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -16692,7 +16643,7 @@ implementation: LPAREN WHILE WITH
 
 implementation: LPAREN WITH
 ##
-## Ends in an error in state: 534.
+## Ends in an error in state: 536.
 ##
 ## _expr -> LPAREN . COLONCOLON RPAREN LPAREN expr COMMA expr RPAREN [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . expr RPAREN [ UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -16714,7 +16665,7 @@ implementation: LPAREN WITH
 
 implementation: MINUSDOT WITH
 ##
-## Ends in an error in state: 885.
+## Ends in an error in state: 886.
 ##
 ## _expr -> subtractive . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16726,7 +16677,7 @@ implementation: MINUSDOT WITH
 
 implementation: MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 405.
+## Ends in an error in state: 408.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -16738,7 +16689,7 @@ implementation: MODULE TYPE UIDENT EQUAL WITH
 
 implementation: MODULE TYPE WITH
 ##
-## Ends in an error in state: 403.
+## Ends in an error in state: 406.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE . ident post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
@@ -16751,7 +16702,7 @@ implementation: MODULE TYPE WITH
 
 implementation: MODULE WITH
 ##
-## Ends in an error in state: 402.
+## Ends in an error in state: 405.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
@@ -16776,7 +16727,7 @@ implementation: NEW WITH
 
 implementation: OPEN BANG WITH
 ##
-## Ends in an error in state: 398.
+## Ends in an error in state: 401.
 ##
 ## open_statement -> OPEN override_flag . mod_longident post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -16788,7 +16739,7 @@ implementation: OPEN BANG WITH
 
 implementation: OPEN WITH
 ##
-## Ends in an error in state: 396.
+## Ends in an error in state: 399.
 ##
 ## open_statement -> OPEN . override_flag mod_longident post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -16800,7 +16751,7 @@ implementation: OPEN WITH
 
 implementation: PERCENT UNDERSCORE
 ##
-## Ends in an error in state: 340.
+## Ends in an error in state: 344.
 ##
 ## item_extension_sugar -> PERCENT . attr_id [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW NATIVEINT MODULE MINUSDOT MINUS LPAREN LIDENT LET LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION CLASS CHAR BANG BACKQUOTE ASSERT ]
 ##
@@ -16812,7 +16763,7 @@ implementation: PERCENT UNDERSCORE
 
 implementation: PERCENT WITH DOT UNDERSCORE
 ##
-## Ends in an error in state: 393.
+## Ends in an error in state: 396.
 ##
 ## attr_id -> single_attr_id DOT . attr_id [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW NATIVEINT MODULE MINUSDOT MINUS LPAREN LIDENT LET LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION CLASS CHAR BANG BACKQUOTE ASSERT ]
 ##
@@ -16824,7 +16775,7 @@ implementation: PERCENT WITH DOT UNDERSCORE
 
 implementation: PERCENT WITH WITH
 ##
-## Ends in an error in state: 392.
+## Ends in an error in state: 395.
 ##
 ## attr_id -> single_attr_id . [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW NATIVEINT MODULE MINUSDOT MINUS LPAREN LIDENT LET LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION CLASS CHAR BANG BACKQUOTE ASSERT ]
 ## attr_id -> single_attr_id . DOT attr_id [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW NATIVEINT MODULE MINUSDOT MINUS LPAREN LIDENT LET LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION CLASS CHAR BANG BACKQUOTE ASSERT ]
@@ -16837,7 +16788,7 @@ implementation: PERCENT WITH WITH
 
 implementation: PLUSDOT WITH
 ##
-## Ends in an error in state: 1194.
+## Ends in an error in state: 1195.
 ##
 ## _expr -> additive . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16861,7 +16812,7 @@ implementation: PREFIXOP WITH
 
 implementation: STRING LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1172.
+## Ends in an error in state: 1173.
 ##
 ## label_expr -> LIDENT COLONCOLON . less_aggressive_simple_expression [ UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -16873,7 +16824,7 @@ implementation: STRING LIDENT COLONCOLON WITH
 
 implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1169.
+## Ends in an error in state: 1170.
 ##
 ## label_expr -> LIDENT EXPLICITLY_PASSED_OPTIONAL . less_aggressive_simple_expression [ UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -16885,7 +16836,7 @@ implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: STRING WITH
 ##
-## Ends in an error in state: 1114.
+## Ends in an error in state: 1115.
 ##
 ## structure -> structure_item . [ RBRACKET RBRACE EOF ]
 ## structure -> structure_item . SEMI structure [ RBRACKET RBRACE EOF ]
@@ -16897,24 +16848,24 @@ implementation: STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1513, spurious reduction of production post_item_attributes ->
 ## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1122, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1113, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
 ## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1123, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 Incomplete module item, forgetting a ";"?
 
 implementation: SWITCH UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2482.
+## Ends in an error in state: 2489.
 ##
 ## _expr -> SWITCH simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -16926,7 +16877,7 @@ implementation: SWITCH UIDENT LBRACE WITH
 
 implementation: SWITCH UIDENT WITH
 ##
-## Ends in an error in state: 2481.
+## Ends in an error in state: 2488.
 ##
 ## _expr -> SWITCH simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ SHARP LBRACE DOT ]
@@ -16944,17 +16895,17 @@ implementation: SWITCH UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 880, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 881, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: SWITCH WITH
 ##
-## Ends in an error in state: 178.
+## Ends in an error in state: 168.
 ##
 ## _expr -> SWITCH . simple_expr LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17013,14 +16964,14 @@ implementation: TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -17088,7 +17039,7 @@ implementation: TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -17176,7 +17127,7 @@ implementation: TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -17190,7 +17141,7 @@ implementation: TRUE DOT LPAREN UIDENT SEMI
 
 implementation: TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 888.
+## Ends in an error in state: 889.
 ##
 ## _expr -> simple_expr DOT LPAREN . expr RPAREN EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -17204,7 +17155,7 @@ implementation: TRUE DOT LPAREN WITH
 
 implementation: TRUE DOT UIDENT DOT WITH
 ##
-## Ends in an error in state: 114.
+## Ends in an error in state: 125.
 ##
 ## label_longident -> mod_longident DOT . LIDENT [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident DOT . UIDENT [ DOT ]
@@ -17217,7 +17168,7 @@ implementation: TRUE DOT UIDENT DOT WITH
 
 implementation: TRUE DOT UIDENT WITH
 ##
-## Ends in an error in state: 113.
+## Ends in an error in state: 124.
 ##
 ## label_longident -> mod_longident . DOT LIDENT [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident . DOT UIDENT [ DOT ]
@@ -17230,7 +17181,7 @@ implementation: TRUE DOT UIDENT WITH
 
 implementation: TRUE DOT WITH
 ##
-## Ends in an error in state: 887.
+## Ends in an error in state: 888.
 ##
 ## _expr -> simple_expr DOT . label_longident EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> simple_expr DOT . LPAREN expr RPAREN EQUAL expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -17263,7 +17214,7 @@ Expecting a match case
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT RBRACKET
 ##
-## Ends in an error in state: 2468.
+## Ends in an error in state: 2475.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes . SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17274,22 +17225,22 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 909, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 913, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 910, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 851, spurious reduction of production _module_expr -> simple_module_expr
-## In state 915, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 914, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
-## In state 907, spurious reduction of production module_binding_body_expr -> EQUAL module_expr
+## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 852, spurious reduction of production _module_expr -> simple_module_expr
+## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 908, spurious reduction of production module_binding_body_expr -> EQUAL module_expr
 ## In state 1758, spurious reduction of production module_binding_body -> module_binding_body_expr
-## In state 2467, spurious reduction of production post_item_attributes ->
+## In state 2474, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2469.
+## Ends in an error in state: 2476.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17301,7 +17252,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2466.
+## Ends in an error in state: 2473.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17313,7 +17264,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 ##
-## Ends in an error in state: 2465.
+## Ends in an error in state: 2472.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17325,7 +17276,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 ##
-## Ends in an error in state: 2444.
+## Ends in an error in state: 2451.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17337,7 +17288,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2447.
+## Ends in an error in state: 2454.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17349,7 +17300,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2446.
+## Ends in an error in state: 2453.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17360,14 +17311,14 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2445, spurious reduction of production post_item_attributes ->
+## In state 2452, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 ##
-## Ends in an error in state: 2443.
+## Ends in an error in state: 2450.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17379,7 +17330,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 ##
-## Ends in an error in state: 2442.
+## Ends in an error in state: 2449.
 ##
 ## _semi_terminated_seq_expr_row -> LET . MODULE UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ## _semi_terminated_seq_expr_row -> LET . OPEN override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
@@ -17393,7 +17344,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 ##
-## Ends in an error in state: 2455.
+## Ends in an error in state: 2462.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ RBRACE BAR ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI RBRACE BAR AND ]
@@ -17405,15 +17356,15 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 392, spurious reduction of production attr_id -> single_attr_id
-## In state 395, spurious reduction of production item_extension_sugar -> PERCENT attr_id
+## In state 395, spurious reduction of production attr_id -> single_attr_id
+## In state 398, spurious reduction of production item_extension_sugar -> PERCENT attr_id
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 2501.
+## Ends in an error in state: 2508.
 ##
 ## _expr -> TRY simple_expr LBRACE leading_bar_match_cases_to_sequence_body . RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## leading_bar_match_cases_to_sequence_body -> leading_bar_match_cases_to_sequence_body . leading_bar_match_case_to_sequence_body [ RBRACE BAR ]
@@ -17425,24 +17376,24 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2457, spurious reduction of production post_item_attributes ->
-## In state 2458, spurious reduction of production opt_semi ->
-## In state 2463, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
-## In state 2461, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
-## In state 2450, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
-## In state 2448, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
-## In state 2462, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2451, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
-## In state 2473, spurious reduction of production leading_bar_match_case_to_sequence_body -> bar_located_pattern EQUALGREATER semi_terminated_seq_expr
-## In state 2474, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2464, spurious reduction of production post_item_attributes ->
+## In state 2465, spurious reduction of production opt_semi ->
+## In state 2470, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
+## In state 2468, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
+## In state 2457, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
+## In state 2455, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
+## In state 2469, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2458, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2480, spurious reduction of production leading_bar_match_case_to_sequence_body -> bar_located_pattern EQUALGREATER semi_terminated_seq_expr
+## In state 2481, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
 ##
 
 Expecting one of the following:
@@ -17451,7 +17402,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2472.
+## Ends in an error in state: 2479.
 ##
 ## leading_bar_match_case_to_sequence_body -> bar_located_pattern EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17475,7 +17426,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 781, spurious reduction of production pattern -> pattern_without_or
+## In state 782, spurious reduction of production pattern -> pattern_without_or
 ##
 
 Expecting one of the following:
@@ -17485,7 +17436,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2441.
+## Ends in an error in state: 2448.
 ##
 ## leading_bar_match_case_to_sequence_body -> bar_located_pattern WHEN expr EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17497,7 +17448,7 @@ Expecting a sequence item
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2440.
+## Ends in an error in state: 2447.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -17531,21 +17482,21 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2439.
+## Ends in an error in state: 2446.
 ##
 ## leading_bar_match_case_to_sequence_body -> bar_located_pattern WHEN . expr EQUALGREATER semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -17557,7 +17508,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 
 implementation: TRY UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2500.
+## Ends in an error in state: 2507.
 ##
 ## _expr -> TRY simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17569,7 +17520,7 @@ implementation: TRY UIDENT LBRACE WITH
 
 implementation: TRY UIDENT UNDERSCORE
 ##
-## Ends in an error in state: 2497.
+## Ends in an error in state: 2504.
 ##
 ## _expr -> TRY simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> TRY simple_expr . WITH error [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -17588,17 +17539,17 @@ implementation: TRY UIDENT UNDERSCORE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 880, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 881, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT WITH WITH
 ##
-## Ends in an error in state: 2498.
+## Ends in an error in state: 2505.
 ##
 ## _expr -> TRY simple_expr WITH . error [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -17610,7 +17561,7 @@ implementation: TRY UIDENT WITH WITH
 
 implementation: TRY WITH
 ##
-## Ends in an error in state: 173.
+## Ends in an error in state: 163.
 ##
 ## _expr -> TRY . simple_expr LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> TRY . simple_expr WITH error [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -17623,7 +17574,7 @@ implementation: TRY WITH
 
 implementation: TYPE LIDENT AND LIDENT WITH
 ##
-## Ends in an error in state: 1128.
+## Ends in an error in state: 1129.
 ##
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -17634,14 +17585,14 @@ implementation: TYPE LIDENT AND LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1127, spurious reduction of production optional_type_parameters ->
+## In state 1128, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT AND WITH
 ##
-## Ends in an error in state: 1126.
+## Ends in an error in state: 1127.
 ##
 ## and_type_declaration -> AND . type_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -17653,7 +17604,7 @@ implementation: TYPE LIDENT AND WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 972.
+## Ends in an error in state: 973.
 ##
 ## constrain -> core_type EQUAL . core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ##
@@ -17665,7 +17616,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 971.
+## Ends in an error in state: 972.
 ##
 ## constrain -> core_type . EQUAL core_type [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ##
@@ -17676,19 +17627,19 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT CONSTRAINT WITH
 ##
-## Ends in an error in state: 970.
+## Ends in an error in state: 971.
 ##
 ## constraints -> constraints CONSTRAINT . constrain [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ##
@@ -17700,7 +17651,7 @@ implementation: TYPE LIDENT CONSTRAINT WITH
 
 implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2547.
+## Ends in an error in state: 2557.
 ##
 ## constructor_declarations -> constructor_declarations_leading_bar . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations_leading_bar -> constructor_declarations_leading_bar . constructor_declaration_leading_bar [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
@@ -17712,17 +17663,17 @@ implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 493, spurious reduction of production attributes ->
-## In state 494, spurious reduction of production attributes -> attribute attributes
-## In state 2545, spurious reduction of production constructor_declaration_leading_bar -> BAR constr_ident generalized_constructor_arguments attributes
-## In state 2552, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
+## In state 494, spurious reduction of production attributes ->
+## In state 495, spurious reduction of production attributes -> attribute attributes
+## In state 2555, spurious reduction of production constructor_declaration_leading_bar -> BAR constr_ident generalized_constructor_arguments attributes
+## In state 2562, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 ##
-## Ends in an error in state: 1130.
+## Ends in an error in state: 1131.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_declaration_details -> LIDENT optional_type_parameters type_kind constraints . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -17735,7 +17686,7 @@ implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 ##
-## Ends in an error in state: 499.
+## Ends in an error in state: 500.
 ##
 ## label_declarations -> label_declarations COMMA . label_declaration [ RBRACE COMMA ]
 ## opt_comma -> COMMA . [ RBRACE ]
@@ -17750,7 +17701,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2559.
+## Ends in an error in state: 2566.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17762,18 +17713,18 @@ implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 496, spurious reduction of production _poly_type -> core_type
-## In state 497, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 495, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 491, spurious reduction of production attributes ->
-## In state 492, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 503, spurious reduction of production label_declarations -> label_declaration
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 497, spurious reduction of production _poly_type -> core_type
+## In state 498, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 496, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 492, spurious reduction of production attributes ->
+## In state 493, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 504, spurious reduction of production label_declarations -> label_declaration
 ##
 
 Expecting one of the following:
@@ -17782,7 +17733,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 485.
+## Ends in an error in state: 486.
 ##
 ## label_declaration -> mutable_flag LIDENT COLON . poly_type attributes [ RBRACE COMMA ]
 ##
@@ -17794,7 +17745,7 @@ Expecting a type name describing this field
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 484.
+## Ends in an error in state: 485.
 ##
 ## label_declaration -> mutable_flag LIDENT . COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -17807,7 +17758,7 @@ Expecting ":"
 
 implementation: TYPE LIDENT EQUAL LBRACE MUTABLE LET
 ##
-## Ends in an error in state: 483.
+## Ends in an error in state: 484.
 ##
 ## label_declaration -> mutable_flag . LIDENT COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -17820,7 +17771,7 @@ Expecting a type field definition in the form of:
 
 implementation: TYPE LIDENT EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2558.
+## Ends in an error in state: 2565.
 ##
 ## type_kind -> EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -17831,13 +17782,12 @@ implementation: TYPE LIDENT EQUAL LBRACE WITH
 Expecting at least one type field definition in the form of:
   <field name> : <type>
 
-implementation: TYPE LIDENT EQUAL LPAREN WITH
+    implementation: TYPE LIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 2541.
+## Ends in an error in state: 115.
 ##
-## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
-## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
-## constr_ident -> LPAREN . RPAREN [ SEMI RBRACKET RBRACE OF LBRACKETATAT LBRACKETAT EOF CONSTRAINT COLON BAR AND ]
+## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
+## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -17847,7 +17797,7 @@ implementation: TYPE LIDENT EQUAL LPAREN WITH
 
 implementation: TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 2540.
+## Ends in an error in state: 2551.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL PRIVATE . core_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17859,24 +17809,13 @@ implementation: TYPE LIDENT EQUAL PRIVATE WITH
 
 <SYNTAX ERROR>
 
-implementation: TYPE LIDENT EQUAL TRUE WITH
-##
-## Ends in an error in state: 2553.
-##
-## constructor_declaration_no_leading_bar -> constr_ident . generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
-##
-## The known suffix of the stack is as follows:
-## constr_ident
-##
-
-<SYNTAX ERROR>
-
 implementation: TYPE LIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 96.
+## Ends in an error in state: 107.
 ##
-## constr_ident -> UIDENT . [ SEMI RBRACKET RBRACE OF LBRACKETATAT LBRACKETAT EOF CONSTRAINT COLON BAR AND ]
-## mod_ext_longident -> UIDENT . [ LPAREN DOT ]
+## constructor_declaration_no_leading_bar -> UIDENT . generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
+## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> UIDENT . [ DOT ]
 ##
 ## The known suffix of the stack is as follows:
 ## UIDENT
@@ -17886,7 +17825,7 @@ implementation: TYPE LIDENT EQUAL UIDENT WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 ##
-## Ends in an error in state: 2542.
+## Ends in an error in state: 2552.
 ##
 ## constructor_declaration_leading_bar -> BAR . constr_ident generalized_constructor_arguments attributes [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
 ##
@@ -17898,7 +17837,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 2569.
+## Ends in an error in state: 2577.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17910,17 +17849,17 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDO
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 493, spurious reduction of production attributes ->
-## In state 494, spurious reduction of production attributes -> attribute attributes
-## In state 492, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 503, spurious reduction of production label_declarations -> label_declaration
+## In state 494, spurious reduction of production attributes ->
+## In state 495, spurious reduction of production attributes -> attribute attributes
+## In state 493, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 504, spurious reduction of production label_declarations -> label_declaration
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2568.
+## Ends in an error in state: 2576.
 ##
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -17932,7 +17871,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 ##
-## Ends in an error in state: 2564.
+## Ends in an error in state: 2572.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL core_type EQUAL PRIVATE . constructor_declarations [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17945,7 +17884,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2550.
+## Ends in an error in state: 2560.
 ##
 ## constructor_declarations -> constructor_declaration_no_leading_bar . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations -> constructor_declaration_no_leading_bar . constructor_declarations_leading_bar [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17957,16 +17896,16 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 493, spurious reduction of production attributes ->
-## In state 494, spurious reduction of production attributes -> attribute attributes
-## In state 2555, spurious reduction of production constructor_declaration_no_leading_bar -> constr_ident generalized_constructor_arguments attributes
+## In state 494, spurious reduction of production attributes ->
+## In state 495, spurious reduction of production attributes -> attribute attributes
+## In state 2550, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2563.
+## Ends in an error in state: 2570.
 ##
 ## type_kind -> EQUAL core_type EQUAL . constructor_declarations [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type EQUAL . PRIVATE constructor_declarations [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17981,7 +17920,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 2562.
+## Ends in an error in state: 2569.
 ##
 ## type_kind -> EQUAL core_type . [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type . EQUAL constructor_declarations [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -17996,19 +17935,19 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 170, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 278, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 269, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 274, spurious reduction of production _core_type -> core_type2
-## In state 283, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 270, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 270, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 282, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 273, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 278, spurious reduction of production _core_type -> core_type2
+## In state 287, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 274, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 94.
+## Ends in an error in state: 105.
 ##
 ## type_kind -> EQUAL . core_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL . PRIVATE core_type [ SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -18029,7 +17968,7 @@ implementation: TYPE LIDENT EQUAL WITH
 
 implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1125.
+## Ends in an error in state: 1126.
 ##
 ## _structure_item_without_item_extension_sugar -> many_type_declarations . [ SEMI RBRACKET RBRACE EOF ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ SEMI RBRACKET RBRACE EOF AND ]
@@ -18041,16 +17980,16 @@ implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 922, spurious reduction of production post_item_attributes ->
-## In state 923, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 921, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 923, spurious reduction of production post_item_attributes ->
+## In state 924, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 922, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT MINUS QUOTE WITH
 ##
-## Ends in an error in state: 90.
+## Ends in an error in state: 101.
 ##
 ## _optional_type_variable_with_variance -> MINUS QUOTE . ident [ UNDERSCORE SEMI RBRACKET RBRACE QUOTE PLUSEQ PLUS MINUS LBRACKETATAT EQUAL EOF CONSTRAINT COLONEQUAL AND ]
 ##
@@ -18062,7 +18001,7 @@ implementation: TYPE LIDENT MINUS QUOTE WITH
 
 implementation: TYPE LIDENT MINUS WITH
 ##
-## Ends in an error in state: 88.
+## Ends in an error in state: 99.
 ##
 ## _optional_type_variable_with_variance -> MINUS . QUOTE ident [ UNDERSCORE SEMI RBRACKET RBRACE QUOTE PLUSEQ PLUS MINUS LBRACKETATAT EQUAL EOF CONSTRAINT COLONEQUAL AND ]
 ## _optional_type_variable_with_variance -> MINUS . UNDERSCORE [ UNDERSCORE SEMI RBRACKET RBRACE QUOTE PLUSEQ PLUS MINUS LBRACKETATAT EQUAL EOF CONSTRAINT COLONEQUAL AND ]
@@ -18075,7 +18014,7 @@ implementation: TYPE LIDENT MINUS WITH
 
 implementation: TYPE LIDENT PLUS QUOTE WITH
 ##
-## Ends in an error in state: 86.
+## Ends in an error in state: 97.
 ##
 ## _optional_type_variable_with_variance -> PLUS QUOTE . ident [ UNDERSCORE SEMI RBRACKET RBRACE QUOTE PLUSEQ PLUS MINUS LBRACKETATAT EQUAL EOF CONSTRAINT COLONEQUAL AND ]
 ##
@@ -18087,7 +18026,7 @@ implementation: TYPE LIDENT PLUS QUOTE WITH
 
 implementation: TYPE LIDENT PLUS WITH
 ##
-## Ends in an error in state: 84.
+## Ends in an error in state: 95.
 ##
 ## _optional_type_variable_with_variance -> PLUS . QUOTE ident [ UNDERSCORE SEMI RBRACKET RBRACE QUOTE PLUSEQ PLUS MINUS LBRACKETATAT EQUAL EOF CONSTRAINT COLONEQUAL AND ]
 ## _optional_type_variable_with_variance -> PLUS . UNDERSCORE [ UNDERSCORE SEMI RBRACKET RBRACE QUOTE PLUSEQ PLUS MINUS LBRACKETATAT EQUAL EOF CONSTRAINT COLONEQUAL AND ]
@@ -18100,7 +18039,7 @@ implementation: TYPE LIDENT PLUS WITH
 
 implementation: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 2577.
+## Ends in an error in state: 2585.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . str_extension_constructors post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -18112,7 +18051,7 @@ implementation: TYPE LIDENT PLUSEQ BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 2576.
+## Ends in an error in state: 2584.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar str_extension_constructors post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -18124,7 +18063,7 @@ implementation: TYPE LIDENT PLUSEQ PRIVATE BANG
 
 implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 2579.
+## Ends in an error in state: 2587.
 ##
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_declaration [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_rebind [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -18137,7 +18076,7 @@ implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 2575.
+## Ends in an error in state: 2583.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar str_extension_constructors post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
 ##
@@ -18149,7 +18088,7 @@ implementation: TYPE LIDENT PLUSEQ WITH
 
 implementation: TYPE LIDENT QUOTE WITH
 ##
-## Ends in an error in state: 80.
+## Ends in an error in state: 91.
 ##
 ## _optional_type_variable_with_variance -> QUOTE . ident [ UNDERSCORE SEMI RBRACKET RBRACE QUOTE PLUSEQ PLUS MINUS LBRACKETATAT EQUAL EOF CONSTRAINT COLONEQUAL AND ]
 ##
@@ -18161,7 +18100,7 @@ implementation: TYPE LIDENT QUOTE WITH
 
 implementation: TYPE LIDENT WITH
 ##
-## Ends in an error in state: 93.
+## Ends in an error in state: 104.
 ##
 ## potentially_long_ident_and_optional_type_parameters -> LIDENT optional_type_parameters . [ PLUSEQ ]
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -18173,7 +18112,7 @@ implementation: TYPE LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 78, spurious reduction of production optional_type_parameters ->
+## In state 89, spurious reduction of production optional_type_parameters ->
 ##
 
 Expecting one of the following:
@@ -18185,9 +18124,10 @@ Expecting one of the following:
 
 implementation: TYPE UIDENT DOT WITH
 ##
-## Ends in an error in state: 949.
+## Ends in an error in state: 950.
 ##
-## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ LPAREN DOT ]
+## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
 ## type_strictly_longident -> mod_ext_longident DOT . LIDENT [ UNDERSCORE QUOTE PLUSEQ PLUS MINUS ]
 ##
 ## The known suffix of the stack is as follows:
@@ -18198,21 +18138,27 @@ implementation: TYPE UIDENT DOT WITH
 
 implementation: TYPE UIDENT WITH
 ##
-## Ends in an error in state: 948.
+## Ends in an error in state: 949.
 ##
-## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ LPAREN DOT ]
-## mod_ext_longident -> mod_ext_longident . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
+## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
 ## type_strictly_longident -> mod_ext_longident . DOT LIDENT [ UNDERSCORE QUOTE PLUSEQ PLUS MINUS ]
 ##
 ## The known suffix of the stack is as follows:
 ## mod_ext_longident
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 76, spurious reduction of production mod_ext_longident -> UIDENT
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE WITH
 ##
-## Ends in an error in state: 76.
+## Ends in an error in state: 75.
 ##
 ## many_type_declarations -> TYPE nonrec_flag . type_declaration_details post_item_attributes [ SEMI RBRACKET RBRACE EOF AND ]
 ## str_type_extension -> TYPE nonrec_flag . potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar str_extension_constructors post_item_attributes [ SEMI RBRACKET RBRACE EOF ]
@@ -18224,14 +18170,14 @@ implementation: TYPE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 74, spurious reduction of production nonrec_flag ->
+## In state 73, spurious reduction of production nonrec_flag ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT AMPERAMPER WITH
 ##
-## Ends in an error in state: 1231.
+## Ends in an error in state: 1232.
 ##
 ## _expr -> expr AMPERAMPER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18243,7 +18189,7 @@ implementation: UIDENT AMPERAMPER WITH
 
 implementation: UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 1229.
+## Ends in an error in state: 1230.
 ##
 ## _expr -> expr AMPERSAND . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18255,7 +18201,7 @@ implementation: UIDENT AMPERSAND WITH
 
 implementation: UIDENT BARBAR WITH
 ##
-## Ends in an error in state: 1227.
+## Ends in an error in state: 1228.
 ##
 ## _expr -> expr BARBAR . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18267,7 +18213,7 @@ implementation: UIDENT BARBAR WITH
 
 implementation: UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1233.
+## Ends in an error in state: 1234.
 ##
 ## _expr -> expr COLONEQUAL . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18293,7 +18239,7 @@ implementation: UIDENT DOT LBRACE LIDENT WITH
 
 implementation: UIDENT DOT LBRACE WITH
 ##
-## Ends in an error in state: 2210.
+## Ends in an error in state: 2217.
 ##
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr RBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18306,7 +18252,7 @@ implementation: UIDENT DOT LBRACE WITH
 
 implementation: UIDENT DOT LBRACELESS WITH
 ##
-## Ends in an error in state: 2205.
+## Ends in an error in state: 2212.
 ##
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18319,7 +18265,7 @@ implementation: UIDENT DOT LBRACELESS WITH
 
 implementation: UIDENT DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2195.
+## Ends in an error in state: 2202.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKET . expr_comma_seq_extension [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -18331,7 +18277,7 @@ implementation: UIDENT DOT LBRACKET WITH
 
 implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2191.
+## Ends in an error in state: 2198.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18344,7 +18290,7 @@ implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -18360,7 +18306,7 @@ implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 
 implementation: UIDENT DOT LBRACKETBAR WITH
 ##
-## Ends in an error in state: 2190.
+## Ends in an error in state: 2197.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18373,7 +18319,7 @@ implementation: UIDENT DOT LBRACKETBAR WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2185.
+## Ends in an error in state: 2192.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON package_type . RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -18384,16 +18330,16 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 106, spurious reduction of production ident -> UIDENT
-## In state 267, spurious reduction of production mty_longident -> ident
-## In state 109, spurious reduction of production package_type -> mty_longident
+## In state 117, spurious reduction of production ident -> UIDENT
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 120, spurious reduction of production package_type -> mty_longident
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2183.
+## Ends in an error in state: 2190.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . package_type RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18406,7 +18352,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 852.
+## Ends in an error in state: 853.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -18421,19 +18367,19 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 909, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 913, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 910, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 851, spurious reduction of production _module_expr -> simple_module_expr
-## In state 915, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 914, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 910, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 914, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 911, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 852, spurious reduction of production _module_expr -> simple_module_expr
+## In state 916, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 915, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN MODULE WITH
 ##
-## Ends in an error in state: 850.
+## Ends in an error in state: 851.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON package_type RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18446,7 +18392,7 @@ implementation: UIDENT DOT LPAREN MODULE WITH
 
 implementation: UIDENT DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2187.
+## Ends in an error in state: 2194.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -18481,7 +18427,7 @@ implementation: UIDENT DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -18495,7 +18441,7 @@ implementation: UIDENT DOT LPAREN UIDENT SEMI
 
 implementation: UIDENT DOT LPAREN WITH
 ##
-## Ends in an error in state: 849.
+## Ends in an error in state: 850.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN . expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN . expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18511,7 +18457,7 @@ implementation: UIDENT DOT LPAREN WITH
 
 implementation: UIDENT DOT WITH
 ##
-## Ends in an error in state: 848.
+## Ends in an error in state: 849.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -18535,7 +18481,7 @@ implementation: UIDENT DOT WITH
 
 implementation: UIDENT GREATER WITH
 ##
-## Ends in an error in state: 1225.
+## Ends in an error in state: 1226.
 ##
 ## _expr -> expr GREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18547,7 +18493,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP0 WITH
 ##
-## Ends in an error in state: 1223.
+## Ends in an error in state: 1224.
 ##
 ## _expr -> expr INFIXOP0 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18559,7 +18505,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP1 WITH
 ##
-## Ends in an error in state: 1217.
+## Ends in an error in state: 1218.
 ##
 ## _expr -> expr INFIXOP1 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18571,7 +18517,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP2 WITH
 ##
-## Ends in an error in state: 1215.
+## Ends in an error in state: 1216.
 ##
 ## _expr -> expr INFIXOP2 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18583,7 +18529,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP3 WITH
 ##
-## Ends in an error in state: 1201.
+## Ends in an error in state: 1202.
 ##
 ## _expr -> expr INFIXOP3 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18595,7 +18541,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP4 WITH
 ##
-## Ends in an error in state: 1184.
+## Ends in an error in state: 1185.
 ##
 ## _expr -> expr INFIXOP4 . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18607,7 +18553,7 @@ Expecting an expression
 
 implementation: UIDENT LBRACKETAT UNDERSCORE
 ##
-## Ends in an error in state: 171.
+## Ends in an error in state: 161.
 ##
 ## attribute -> LBRACKETAT . attr_id payload RBRACKET [ WITH WHEN UIDENT STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 IN GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -18619,7 +18565,7 @@ Expecting an attribute id
 
 implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2503.
+## Ends in an error in state: 2510.
 ##
 ## attribute -> LBRACKETAT attr_id payload . RBRACKET [ WITH WHEN UIDENT STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 IN GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -18630,22 +18576,22 @@ implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1513, spurious reduction of production post_item_attributes ->
 ## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1122, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1113, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
 ## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1123, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1114, spurious reduction of production structure -> structure_item
+## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1115, spurious reduction of production structure -> structure_item
 ## In state 1500, spurious reduction of production payload -> structure
 ##
 
@@ -18653,7 +18599,7 @@ Expecting "]"
 
 implementation: UIDENT LBRACKETATAT UNDERSCORE
 ##
-## Ends in an error in state: 400.
+## Ends in an error in state: 403.
 ##
 ## item_attribute -> LBRACKETATAT . attr_id payload RBRACKET [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -18665,7 +18611,7 @@ Expecting an attributed id
 
 implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2396.
+## Ends in an error in state: 2403.
 ##
 ## item_attribute -> LBRACKETATAT attr_id payload . RBRACKET [ SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR AND ]
 ##
@@ -18676,22 +18622,22 @@ implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1513, spurious reduction of production post_item_attributes ->
 ## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1122, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1113, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
 ## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1123, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1114, spurious reduction of production structure -> structure_item
+## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1115, spurious reduction of production structure -> structure_item
 ## In state 1500, spurious reduction of production payload -> structure
 ##
 
@@ -18699,7 +18645,7 @@ Expecting "]"
 
 implementation: UIDENT LESS WITH
 ##
-## Ends in an error in state: 1221.
+## Ends in an error in state: 1222.
 ##
 ## _expr -> expr LESS . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18711,7 +18657,7 @@ Expecting an expression
 
 implementation: UIDENT LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1219.
+## Ends in an error in state: 1220.
 ##
 ## _expr -> expr LESSDOTDOTGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18723,7 +18669,7 @@ Expecting an expression
 
 implementation: UIDENT LESSGREATER WITH
 ##
-## Ends in an error in state: 1213.
+## Ends in an error in state: 1214.
 ##
 ## _expr -> expr LESSGREATER . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18760,7 +18706,7 @@ Expecting one of the following:
 
 implementation: UIDENT MINUS WITH
 ##
-## Ends in an error in state: 1211.
+## Ends in an error in state: 1212.
 ##
 ## _expr -> expr MINUS . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18772,7 +18718,7 @@ Expecting an expression
 
 implementation: UIDENT MINUSDOT WITH
 ##
-## Ends in an error in state: 1209.
+## Ends in an error in state: 1210.
 ##
 ## _expr -> expr MINUSDOT . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18784,7 +18730,7 @@ Expecting an expression
 
 implementation: UIDENT OR WITH
 ##
-## Ends in an error in state: 1207.
+## Ends in an error in state: 1208.
 ##
 ## _expr -> expr OR . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18796,7 +18742,7 @@ Expecting an expression
 
 implementation: UIDENT PERCENT WITH
 ##
-## Ends in an error in state: 1199.
+## Ends in an error in state: 1200.
 ##
 ## _expr -> expr PERCENT . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18808,7 +18754,7 @@ Expecting an expression
 
 implementation: UIDENT PLUS WITH
 ##
-## Ends in an error in state: 1205.
+## Ends in an error in state: 1206.
 ##
 ## _expr -> expr PLUS . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18820,7 +18766,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSDOT WITH
 ##
-## Ends in an error in state: 1203.
+## Ends in an error in state: 1204.
 ##
 ## _expr -> expr PLUSDOT . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18832,7 +18778,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 1197.
+## Ends in an error in state: 1198.
 ##
 ## _expr -> expr PLUSEQ . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18844,7 +18790,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1238.
+## Ends in an error in state: 1239.
 ##
 ## _expr -> expr QUESTION expr COLON . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18856,7 +18802,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT SEMI
 ##
-## Ends in an error in state: 1237.
+## Ends in an error in state: 1238.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -18890,14 +18836,14 @@ implementation: UIDENT QUESTION UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -18906,7 +18852,7 @@ Expecting one of the following:
 
 implementation: UIDENT QUESTION WITH
 ##
-## Ends in an error in state: 1236.
+## Ends in an error in state: 1237.
 ##
 ## _expr -> expr QUESTION . expr COLON expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18918,7 +18864,7 @@ Expecting an expression
 
 implementation: UIDENT RBRACKET
 ##
-## Ends in an error in state: 2595.
+## Ends in an error in state: 2603.
 ##
 ## implementation -> structure . EOF [ # ]
 ##
@@ -18929,29 +18875,29 @@ implementation: UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1513, spurious reduction of production post_item_attributes ->
 ## In state 1514, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 1515, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1122, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1113, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1123, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1114, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
 ## In state 1516, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1123, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1114, spurious reduction of production structure -> structure_item
+## In state 1124, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1115, spurious reduction of production structure -> structure_item
 ##
 
 Invalid token
 
 implementation: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 1115.
+## Ends in an error in state: 1116.
 ##
 ## structure -> structure_item SEMI . structure [ RBRACKET RBRACE EOF ]
 ##
@@ -18963,7 +18909,7 @@ Expecting a structure item
 
 implementation: UIDENT SHARP WITH
 ##
-## Ends in an error in state: 566.
+## Ends in an error in state: 567.
 ##
 ## _simple_expr -> simple_expr SHARP . label [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -18975,7 +18921,7 @@ Expecting an identifier
 
 implementation: UIDENT STAR WITH
 ##
-## Ends in an error in state: 1182.
+## Ends in an error in state: 1183.
 ##
 ## _expr -> expr STAR . expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -18987,7 +18933,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 2285.
+## Ends in an error in state: 2292.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -19021,14 +18967,14 @@ implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 1187, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 886, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 1167, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 1196, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 1124, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 1188, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 1168, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 1197, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 1125, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -19037,7 +18983,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 2284.
+## Ends in an error in state: 2291.
 ##
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ##
@@ -19049,7 +18995,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2282.
+## Ends in an error in state: 2289.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -19084,7 +19030,7 @@ implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -19100,7 +19046,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2281.
+## Ends in an error in state: 2288.
 ##
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -19113,7 +19059,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2279.
+## Ends in an error in state: 2286.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -19148,7 +19094,7 @@ implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 897, spurious reduction of production constr_longident -> mod_longident
+## In state 898, spurious reduction of production constr_longident -> mod_longident
 ## In state 1378, spurious reduction of production _simple_expr -> constr_longident
 ## In state 1311, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
 ## In state 1306, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
@@ -19164,7 +19110,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 569.
+## Ends in an error in state: 570.
 ##
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr error [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -19177,7 +19123,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT WITH
 ##
-## Ends in an error in state: 568.
+## Ends in an error in state: 569.
 ##
 ## _simple_expr -> simple_expr DOT . label_longident [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT . LPAREN expr RPAREN [ WITH UNDERSCORE UIDENT TRUE TO STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF ELSE DOWNTO DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -19198,7 +19144,7 @@ Expecting one of the following:
 
 implementation: WHILE UIDENT WITH
 ##
-## Ends in an error in state: 2590.
+## Ends in an error in state: 2598.
 ##
 ## _expr -> WHILE simple_expr . simple_expr [ STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -19216,10 +19162,10 @@ implementation: WHILE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 847, spurious reduction of production constr_longident -> mod_longident
-## In state 880, spurious reduction of production _simple_expr -> constr_longident
-## In state 882, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 878, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 848, spurious reduction of production constr_longident -> mod_longident
+## In state 881, spurious reduction of production _simple_expr -> constr_longident
+## In state 883, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 879, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -3552,13 +3552,7 @@ constructor_declarations:
 ;
 
 constructor_declaration_no_leading_bar:
-  | as_loc(UIDENT) generalized_constructor_arguments attributes
-      {
-       let args,res = $2 in
-       let loc = mklocation $symbolstartpos $endpos in
-       Type.constructor $1 ~args ?res ~loc ~attrs:$3
-      }
-  | as_loc(constr_ident2) generalized_constructor_arguments attributes
+  | as_loc(constr_ident) generalized_constructor_arguments attributes
      {
         let args,res = $2 in
         let loc = mklocation $symbolstartpos $endpos in
@@ -4090,11 +4084,8 @@ operator:
   | BANG                                        { "!" }
   | infix_operator                              { $1 }
 ;
-constr_ident:
+%inline constr_ident:
     UIDENT                                      { $1 }
-    | constr_ident2                               { $1 }
-;
-constr_ident2:
 /*  | LBRACKET RBRACKET                           { "[]" } */
   | LPAREN RPAREN                               { "()" }
   | COLONCOLON                                  { "::" }

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -3558,7 +3558,14 @@ constructor_declaration_no_leading_bar:
        let loc = mklocation $symbolstartpos $endpos in
        Type.constructor $1 ~args ?res ~loc ~attrs:$3
       }
+  | as_loc(constr_ident2) generalized_constructor_arguments attributes
+     {
+        let args,res = $2 in
+        let loc = mklocation $symbolstartpos $endpos in
+        Type.constructor $1 ~args ?res ~loc ~attrs:$3
+     }
 ;
+
 constructor_declaration_leading_bar:
   | BAR as_loc(constr_ident) generalized_constructor_arguments attributes
       {
@@ -4092,6 +4099,15 @@ constr_ident:
   | FALSE                                       { "false" }
   | TRUE                                        { "true" }
 ;
+constr_ident2:
+/*  | LBRACKET RBRACKET                           { "[]" } */
+  | LPAREN RPAREN                               { "()" }
+  | COLONCOLON                                  { "::" }
+/*  | LPAREN COLONCOLON RPAREN                    { "::" } */
+  | FALSE                                       { "false" }
+  | TRUE                                        { "true" }
+;
+
 
 val_longident:
     val_ident                                   { Lident $1 }

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -4092,12 +4092,7 @@ operator:
 ;
 constr_ident:
     UIDENT                                      { $1 }
-/*  | LBRACKET RBRACKET                           { "[]" } */
-  | LPAREN RPAREN                               { "()" }
-  | COLONCOLON                                  { "::" }
-/*  | LPAREN COLONCOLON RPAREN                    { "::" } */
-  | FALSE                                       { "false" }
-  | TRUE                                        { "true" }
+    | constr_ident2                               { $1 }
 ;
 constr_ident2:
 /*  | LBRACKET RBRACKET                           { "[]" } */

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -877,7 +877,6 @@ let built_in_explicit_arity_constructors = ["Some"; "Assert_failure"; "Match_fai
 %token NEW
 %token NONREC
 %token OBJECT
-%token OF
 %token OPEN
 %token OR
 /* %token PARSER */
@@ -1537,8 +1536,8 @@ nonlocal_module_binding_details:
 non_arrowed_module_type: mark_position_mty(_non_arrowed_module_type) {$1}
 _non_arrowed_module_type:
   | simple_module_type {$1}
-  | MODULE TYPE OF module_expr %prec below_LBRACKETAT
-      { mkmty(Pmty_typeof $4) }
+  | MODULE TYPE module_expr %prec below_LBRACKETAT
+      { mkmty(Pmty_typeof $3) }
   | module_type attribute
       { Mty.attr $1 $2 }
 
@@ -3553,7 +3552,7 @@ constructor_declarations:
 ;
 
 constructor_declaration_no_leading_bar:
-  | as_loc(constr_ident) generalized_constructor_arguments attributes
+  | as_loc(UIDENT) generalized_constructor_arguments attributes
       {
        let args,res = $2 in
        let loc = mklocation $symbolstartpos $endpos in
@@ -3590,9 +3589,9 @@ sig_exception_declaration:
 ;
 generalized_constructor_arguments:
     /*empty*/                                   { ([],None) }
-  | OF non_arrowed_simple_core_type_list                    { (List.rev $2, None) }
-  | OF non_arrowed_simple_core_type_list COLON core_type
-                                                { (List.rev $2,Some $4) }
+  | non_arrowed_simple_core_type_list                    { (List.rev $1, None) }
+  | non_arrowed_simple_core_type_list COLON core_type
+                                                { (List.rev $1,Some $3) }
   | COLON core_type
                                                 { ([],Some $2) }
 ;
@@ -3978,8 +3977,8 @@ row_field:
   | non_arrowed_simple_core_type                            { Rinherit $1 }
 ;
 tag_field:
-    name_tag OF opt_ampersand amper_type_list attributes
-      { Rtag ($1, $5, $3, List.rev $4) }
+    name_tag opt_ampersand amper_type_list attributes
+      { Rtag ($1, $4, $2, List.rev $3) }
   | name_tag attributes
       { Rtag ($1, $2, true, []) }
 ;
@@ -4130,8 +4129,15 @@ mod_longident:
 mod_ext_longident:
     UIDENT                                      { Lident $1 }
   | mod_ext_longident DOT UIDENT                { Ldot($1, $3) }
-  | mod_ext_longident LPAREN mod_ext_longident RPAREN { lapply $1 $3 }
+  | mod_ext2 { $1 }
 ;
+
+mod_ext2:
+   | mod_ext_longident DOT UIDENT LPAREN mod_ext_longident RPAREN { lapply ( Ldot($1, $3)) $5 }
+   | mod_ext2 LPAREN mod_ext_longident RPAREN { lapply $1 $3 }
+   | UIDENT LPAREN mod_ext_longident RPAREN { lapply (Lident($1)) $3 }
+;
+
 mty_longident:
     ident                                       { Lident $1 }
   | mod_ext_longident DOT ident                 { Ldot($1, $3) }
@@ -4255,7 +4261,6 @@ single_attr_id:
   | NEW { "new" }
   | NONREC { "nonrec" }
   | OBJECT { "object" }
-  | OF { "of" }
   | OPEN { "open" }
   | OR { "or" }
   | PRIVATE { "private" }

--- a/src/reason_parser_message.ml
+++ b/src/reason_parser_message.ml
@@ -10,129 +10,129 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2 ->
         "<SYNTAX ERROR>\n"
-    | 2616 ->
+    | 2608 ->
         "<SYNTAX ERROR>\n"
-    | 578 ->
+    | 574 ->
         "Expecting one of the following:\n  - an identifier to access a member of an object\n  - \"[\" + expression + \"]\" to access an element of a list\n  - \"(\" + expression + \")\"\n  - \"{\" + expression + \"}\"\n"
-    | 579 ->
+    | 575 ->
+        "Expecting an expression\n"
+    | 2292 ->
+        "Expecting one of the following:\n  - an infix operation to connect two expressions\n  - \")\" to close the block\n"
+    | 2294 ->
         "Expecting an expression\n"
     | 2295 ->
-        "Expecting one of the following:\n  - an infix operation to connect two expressions\n  - \")\" to close the block\n"
+        "Expecting one of the following:\n  - an infix operation to connect two expressions\n  - \"}\" to close the block\n"
     | 2297 ->
         "Expecting an expression\n"
     | 2298 ->
         "Expecting one of the following:\n  - an infix operation to connect two expressions\n  - \"}\" to close the block\n"
-    | 2300 ->
+    | 1189 ->
         "Expecting an expression\n"
-    | 2301 ->
-        "Expecting one of the following:\n  - an infix operation to connect two expressions\n  - \"}\" to close the block\n"
-    | 1192 ->
-        "Expecting an expression\n"
-    | 576 ->
+    | 572 ->
         "Expecting an identifier\n"
-    | 1125 ->
+    | 1122 ->
         "Expecting a structure item\n"
-    | 2621 ->
+    | 2613 ->
         "Invalid token\n"
-    | 1246 ->
+    | 1243 ->
         "Expecting an expression\n"
-    | 1247 ->
+    | 1244 ->
         "Expecting one of the following:\n  - The continuation of the previous expression\n  - \":\" to start the next expression\n"
-    | 1248 ->
+    | 1245 ->
         "Expecting an expression\n"
-    | 1207 ->
+    | 1204 ->
         "Expecting an expression\n"
-    | 1213 ->
+    | 1210 ->
         "Expecting an expression\n"
-    | 1215 ->
+    | 1212 ->
         "Expecting an expression\n"
-    | 1209 ->
+    | 1206 ->
         "Expecting an expression\n"
-    | 1217 ->
+    | 1214 ->
         "Expecting an expression\n"
-    | 1219 ->
+    | 1216 ->
         "Expecting an expression\n"
-    | 1221 ->
+    | 1218 ->
         "Expecting an expression\n"
     | 15 ->
         "Expecting one of the following:\n  - \")\" to form a unit value \"()\"\n  - \"module\" to start a module expression\n  - an expression\n  - an operator to denote the prefix form of an operator\n"
-    | 1223 ->
+    | 1220 ->
         "Expecting an expression\n"
-    | 1229 ->
+    | 1226 ->
         "Expecting an expression\n"
-    | 1231 ->
+    | 1228 ->
         "Expecting an expression\n"
-    | 2412 ->
+    | 2409 ->
         "Expecting \"]\"\n"
     | 403 ->
         "Expecting an attributed id\n"
-    | 2519 ->
+    | 2516 ->
         "Expecting \"]\"\n"
     | 161 ->
         "Expecting an attribute id\n"
-    | 1194 ->
+    | 1191 ->
         "Expecting an expression\n"
-    | 1211 ->
+    | 1208 ->
         "Expecting an expression\n"
-    | 1225 ->
+    | 1222 ->
         "Expecting an expression\n"
-    | 1227 ->
+    | 1224 ->
         "Expecting an expression\n"
-    | 1233 ->
+    | 1230 ->
         "Expecting an expression\n"
-    | 1235 ->
+    | 1232 ->
         "Expecting an expression\n"
+    | 854 ->
+        "<SYNTAX ERROR>\n"
+    | 855 ->
+        "<SYNTAX ERROR>\n"
+    | 2200 ->
+        "<SYNTAX ERROR>\n"
+    | 856 ->
+        "<SYNTAX ERROR>\n"
     | 858 ->
         "<SYNTAX ERROR>\n"
-    | 859 ->
+    | 2196 ->
+        "<SYNTAX ERROR>\n"
+    | 2198 ->
         "<SYNTAX ERROR>\n"
     | 2203 ->
         "<SYNTAX ERROR>\n"
-    | 860 ->
+    | 2204 ->
         "<SYNTAX ERROR>\n"
-    | 862 ->
+    | 2208 ->
         "<SYNTAX ERROR>\n"
-    | 2199 ->
+    | 2218 ->
         "<SYNTAX ERROR>\n"
-    | 2201 ->
+    | 2223 ->
         "<SYNTAX ERROR>\n"
-    | 2206 ->
+    | 1848 ->
         "<SYNTAX ERROR>\n"
-    | 2207 ->
+    | 1240 ->
         "<SYNTAX ERROR>\n"
-    | 2211 ->
+    | 1234 ->
         "<SYNTAX ERROR>\n"
-    | 2221 ->
+    | 1236 ->
         "<SYNTAX ERROR>\n"
-    | 2226 ->
-        "<SYNTAX ERROR>\n"
-    | 1851 ->
-        "<SYNTAX ERROR>\n"
-    | 1243 ->
-        "<SYNTAX ERROR>\n"
-    | 1237 ->
-        "<SYNTAX ERROR>\n"
-    | 1239 ->
-        "<SYNTAX ERROR>\n"
-    | 1241 ->
+    | 1238 ->
         "<SYNTAX ERROR>\n"
     | 75 ->
         "<SYNTAX ERROR>\n"
-    | 958 ->
+    | 955 ->
         "<SYNTAX ERROR>\n"
-    | 959 ->
+    | 956 ->
         "<SYNTAX ERROR>\n"
     | 104 ->
         "Expecting one of the following:\n  - \"=\" to start the body of the type declaration\n  - \"constraint\" to add constraints to the type declaration\n  - \";\" to finish type declaratoin\n  - \"+=\" to form a string type extension\n  - \"and\" to declare another type\n"
     | 91 ->
         "<SYNTAX ERROR>\n"
-    | 2601 ->
+    | 2593 ->
         "<SYNTAX ERROR>\n"
-    | 2605 ->
+    | 2597 ->
         "<SYNTAX ERROR>\n"
-    | 2602 ->
+    | 2594 ->
         "<SYNTAX ERROR>\n"
-    | 2603 ->
+    | 2595 ->
         "<SYNTAX ERROR>\n"
     | 95 ->
         "<SYNTAX ERROR>\n"
@@ -142,139 +142,139 @@ let message =
         "<SYNTAX ERROR>\n"
     | 101 ->
         "<SYNTAX ERROR>\n"
-    | 1135 ->
+    | 1132 ->
         "<SYNTAX ERROR>\n"
     | 105 ->
+        "<SYNTAX ERROR>\n"
+    | 2579 ->
+        "<SYNTAX ERROR>\n"
+    | 2580 ->
+        "<SYNTAX ERROR>\n"
+    | 2567 ->
+        "<SYNTAX ERROR>\n"
+    | 2582 ->
         "<SYNTAX ERROR>\n"
     | 2586 ->
         "<SYNTAX ERROR>\n"
     | 2587 ->
         "<SYNTAX ERROR>\n"
-    | 2574 ->
-        "<SYNTAX ERROR>\n"
-    | 2589 ->
-        "<SYNTAX ERROR>\n"
-    | 2594 ->
-        "<SYNTAX ERROR>\n"
-    | 2595 ->
-        "<SYNTAX ERROR>\n"
-    | 2566 ->
+    | 2559 ->
         "<SYNTAX ERROR>\n"
     | 107 ->
         "<SYNTAX ERROR>\n"
-    | 2561 ->
+    | 2557 ->
         "<SYNTAX ERROR>\n"
-    | 2562 ->
+    | 2558 ->
         "<SYNTAX ERROR>\n"
-    | 2582 ->
+    | 2575 ->
         "Expecting at least one type field definition in the form of:\n  <field name> : <type>\n"
-    | 492 ->
+    | 489 ->
         "Expecting a type field definition in the form of:\n  <field name> : <type>\n"
-    | 493 ->
+    | 490 ->
         "Expecting \":\"\n"
-    | 494 ->
+    | 491 ->
         "Expecting a type name describing this field\n"
-    | 2583 ->
+    | 2576 ->
         "Expecting one of the following:\n  - \",\" to finish current type field\n  - \"}\" to finish type definition\n"
-    | 508 ->
+    | 505 ->
         "Expecting one of the following:\n  - another type field definition\n  - \"}\" to finish entire type definition\n"
-    | 1140 ->
+    | 1137 ->
         "<SYNTAX ERROR>\n"
-    | 2571 ->
+    | 2564 ->
         "<SYNTAX ERROR>\n"
-    | 980 ->
+    | 977 ->
         "<SYNTAX ERROR>\n"
-    | 981 ->
+    | 978 ->
         "<SYNTAX ERROR>\n"
-    | 982 ->
+    | 979 ->
         "<SYNTAX ERROR>\n"
-    | 1136 ->
+    | 1133 ->
         "<SYNTAX ERROR>\n"
-    | 1138 ->
+    | 1135 ->
         "<SYNTAX ERROR>\n"
     | 163 ->
         "<SYNTAX ERROR>\n"
-    | 2514 ->
+    | 2511 ->
+        "<SYNTAX ERROR>\n"
+    | 2510 ->
         "<SYNTAX ERROR>\n"
     | 2513 ->
         "<SYNTAX ERROR>\n"
-    | 2516 ->
+    | 2452 ->
+        "<SYNTAX ERROR>\n"
+    | 2453 ->
+        "<SYNTAX ERROR>\n"
+    | 2454 ->
+        "Expecting a sequence item\n"
+    | 1878 ->
+        "Expecting one of the following:\n  - \"|\" to open the next pattern\n  - \"=>\" to start the body of the matched pattern\n  - \"when\" to start a contitional guard for the previous pattern\n"
+    | 2485 ->
+        "Expecting the body of the matched pattern\n"
+    | 2514 ->
+        "Expecting one of the following:\n  - \"}\" to finish the block\n  - \"|\" to start another pattern matching case\n"
+    | 2468 ->
         "<SYNTAX ERROR>\n"
     | 2455 ->
         "<SYNTAX ERROR>\n"
     | 2456 ->
         "<SYNTAX ERROR>\n"
-    | 2457 ->
-        "Expecting a sequence item\n"
-    | 1881 ->
-        "Expecting one of the following:\n  - \"|\" to open the next pattern\n  - \"=>\" to start the body of the matched pattern\n  - \"when\" to start a contitional guard for the previous pattern\n"
-    | 2488 ->
-        "Expecting the body of the matched pattern\n"
-    | 2517 ->
-        "Expecting one of the following:\n  - \"}\" to finish the block\n  - \"|\" to start another pattern matching case\n"
-    | 2471 ->
-        "<SYNTAX ERROR>\n"
-    | 2458 ->
-        "<SYNTAX ERROR>\n"
     | 2459 ->
-        "<SYNTAX ERROR>\n"
-    | 2462 ->
-        "<SYNTAX ERROR>\n"
-    | 2463 ->
         "<SYNTAX ERROR>\n"
     | 2460 ->
         "<SYNTAX ERROR>\n"
-    | 2481 ->
+    | 2457 ->
+        "<SYNTAX ERROR>\n"
+    | 2478 ->
+        "<SYNTAX ERROR>\n"
+    | 2479 ->
         "<SYNTAX ERROR>\n"
     | 2482 ->
         "<SYNTAX ERROR>\n"
-    | 2485 ->
+    | 2481 ->
         "<SYNTAX ERROR>\n"
-    | 2484 ->
-        "<SYNTAX ERROR>\n"
-    | 1880 ->
+    | 1877 ->
         "Expecting a match case\n"
-    | 897 ->
+    | 893 ->
         "<SYNTAX ERROR>\n"
     | 124 ->
         "<SYNTAX ERROR>\n"
     | 125 ->
         "<SYNTAX ERROR>\n"
-    | 898 ->
+    | 894 ->
+        "<SYNTAX ERROR>\n"
+    | 1852 ->
         "<SYNTAX ERROR>\n"
     | 1855 ->
         "<SYNTAX ERROR>\n"
+    | 1869 ->
+        "<SYNTAX ERROR>\n"
+    | 1857 ->
+        "<SYNTAX ERROR>\n"
     | 1858 ->
         "<SYNTAX ERROR>\n"
-    | 1872 ->
-        "<SYNTAX ERROR>\n"
-    | 1860 ->
-        "<SYNTAX ERROR>\n"
     | 1861 ->
+        "<SYNTAX ERROR>\n"
+    | 1863 ->
         "<SYNTAX ERROR>\n"
     | 1864 ->
         "<SYNTAX ERROR>\n"
     | 1866 ->
         "<SYNTAX ERROR>\n"
-    | 1867 ->
-        "<SYNTAX ERROR>\n"
-    | 1869 ->
-        "<SYNTAX ERROR>\n"
     | 168 ->
         "<SYNTAX ERROR>\n"
-    | 2497 ->
+    | 2494 ->
         "<SYNTAX ERROR>\n"
-    | 2498 ->
+    | 2495 ->
         "<SYNTAX ERROR>\n"
-    | 1124 ->
+    | 1121 ->
         "Incomplete module item, forgetting a \";\"?\n"
-    | 1179 ->
+    | 1176 ->
         "<SYNTAX ERROR>\n"
-    | 1182 ->
+    | 1179 ->
         "<SYNTAX ERROR>\n"
     | 6 ->
         "<SYNTAX ERROR>\n"
-    | 1204 ->
+    | 1201 ->
         "<SYNTAX ERROR>\n"
     | 395 ->
         "<SYNTAX ERROR>\n"
@@ -294,17 +294,21 @@ let message =
         "<SYNTAX ERROR>\n"
     | 408 ->
         "<SYNTAX ERROR>\n"
-    | 895 ->
+    | 891 ->
         "<SYNTAX ERROR>\n"
-    | 545 ->
+    | 541 ->
         "<SYNTAX ERROR>\n"
     | 16 ->
         "<SYNTAX ERROR>\n"
-    | 2613 ->
+    | 2605 ->
         "<SYNTAX ERROR>\n"
-    | 615 ->
+    | 611 ->
         "<SYNTAX ERROR>\n"
-    | 616 ->
+    | 612 ->
+        "<SYNTAX ERROR>\n"
+    | 2247 ->
+        "<SYNTAX ERROR>\n"
+    | 2249 ->
         "<SYNTAX ERROR>\n"
     | 2250 ->
         "<SYNTAX ERROR>\n"
@@ -312,145 +316,141 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2253 ->
         "<SYNTAX ERROR>\n"
-    | 2255 ->
+    | 1379 ->
         "<SYNTAX ERROR>\n"
-    | 2256 ->
+    | 608 ->
         "<SYNTAX ERROR>\n"
-    | 1382 ->
+    | 1437 ->
         "<SYNTAX ERROR>\n"
-    | 612 ->
+    | 1438 ->
         "<SYNTAX ERROR>\n"
-    | 1440 ->
+    | 1439 ->
+        "<SYNTAX ERROR>\n"
+    | 1394 ->
+        "<SYNTAX ERROR>\n"
+    | 1400 ->
+        "<SYNTAX ERROR>\n"
+    | 1402 ->
+        "<SYNTAX ERROR>\n"
+    | 1396 ->
+        "<SYNTAX ERROR>\n"
+    | 1404 ->
+        "<SYNTAX ERROR>\n"
+    | 1406 ->
+        "<SYNTAX ERROR>\n"
+    | 1408 ->
+        "<SYNTAX ERROR>\n"
+    | 184 ->
+        "<SYNTAX ERROR>\n"
+    | 1410 ->
+        "<SYNTAX ERROR>\n"
+    | 1416 ->
+        "<SYNTAX ERROR>\n"
+    | 1418 ->
+        "<SYNTAX ERROR>\n"
+    | 2412 ->
+        "<SYNTAX ERROR>\n"
+    | 340 ->
+        "<SYNTAX ERROR>\n"
+    | 1381 ->
+        "<SYNTAX ERROR>\n"
+    | 1398 ->
+        "<SYNTAX ERROR>\n"
+    | 1412 ->
+        "<SYNTAX ERROR>\n"
+    | 1414 ->
+        "<SYNTAX ERROR>\n"
+    | 1420 ->
+        "<SYNTAX ERROR>\n"
+    | 1422 ->
+        "<SYNTAX ERROR>\n"
+    | 904 ->
+        "<SYNTAX ERROR>\n"
+    | 905 ->
+        "<SYNTAX ERROR>\n"
+    | 1792 ->
+        "<SYNTAX ERROR>\n"
+    | 906 ->
+        "<SYNTAX ERROR>\n"
+    | 907 ->
+        "<SYNTAX ERROR>\n"
+    | 1785 ->
+        "<SYNTAX ERROR>\n"
+    | 1787 ->
+        "<SYNTAX ERROR>\n"
+    | 1795 ->
+        "<SYNTAX ERROR>\n"
+    | 1797 ->
+        "<SYNTAX ERROR>\n"
+    | 1812 ->
+        "<SYNTAX ERROR>\n"
+    | 1824 ->
+        "<SYNTAX ERROR>\n"
+    | 1829 ->
+        "<SYNTAX ERROR>\n"
+    | 2345 ->
+        "<SYNTAX ERROR>\n"
+    | 2350 ->
+        "<SYNTAX ERROR>\n"
+    | 2347 ->
+        "<SYNTAX ERROR>\n"
+    | 1259 ->
+        "<SYNTAX ERROR>\n"
+    | 2344 ->
+        "<SYNTAX ERROR>\n"
+    | 1430 ->
+        "<SYNTAX ERROR>\n"
+    | 1457 ->
+        "<SYNTAX ERROR>\n"
+    | 1278 ->
+        "<SYNTAX ERROR>\n"
+    | 1424 ->
+        "<SYNTAX ERROR>\n"
+    | 1426 ->
+        "<SYNTAX ERROR>\n"
+    | 1428 ->
+        "<SYNTAX ERROR>\n"
+    | 166 ->
+        "<SYNTAX ERROR>\n"
+    | 2500 ->
+        "<SYNTAX ERROR>\n"
+    | 2499 ->
+        "<SYNTAX ERROR>\n"
+    | 2502 ->
+        "<SYNTAX ERROR>\n"
+    | 1369 ->
+        "<SYNTAX ERROR>\n"
+    | 1370 ->
+        "<SYNTAX ERROR>\n"
+    | 1432 ->
+        "<SYNTAX ERROR>\n"
+    | 1435 ->
+        "<SYNTAX ERROR>\n"
+    | 1453 ->
         "<SYNTAX ERROR>\n"
     | 1441 ->
         "<SYNTAX ERROR>\n"
     | 1442 ->
         "<SYNTAX ERROR>\n"
-    | 1397 ->
-        "<SYNTAX ERROR>\n"
-    | 1403 ->
-        "<SYNTAX ERROR>\n"
-    | 1405 ->
-        "<SYNTAX ERROR>\n"
-    | 1399 ->
-        "<SYNTAX ERROR>\n"
-    | 1407 ->
-        "<SYNTAX ERROR>\n"
-    | 1409 ->
-        "<SYNTAX ERROR>\n"
-    | 1411 ->
-        "<SYNTAX ERROR>\n"
-    | 184 ->
-        "<SYNTAX ERROR>\n"
-    | 1413 ->
-        "<SYNTAX ERROR>\n"
-    | 1419 ->
-        "<SYNTAX ERROR>\n"
-    | 1421 ->
-        "<SYNTAX ERROR>\n"
-    | 2415 ->
-        "<SYNTAX ERROR>\n"
-    | 340 ->
-        "<SYNTAX ERROR>\n"
-    | 1384 ->
-        "<SYNTAX ERROR>\n"
-    | 1401 ->
-        "<SYNTAX ERROR>\n"
-    | 1415 ->
-        "<SYNTAX ERROR>\n"
-    | 1417 ->
-        "<SYNTAX ERROR>\n"
-    | 1423 ->
-        "<SYNTAX ERROR>\n"
-    | 1425 ->
-        "<SYNTAX ERROR>\n"
-    | 908 ->
-        "<SYNTAX ERROR>\n"
-    | 909 ->
-        "<SYNTAX ERROR>\n"
-    | 1795 ->
-        "<SYNTAX ERROR>\n"
-    | 910 ->
-        "<SYNTAX ERROR>\n"
-    | 911 ->
-        "<SYNTAX ERROR>\n"
-    | 1788 ->
-        "<SYNTAX ERROR>\n"
-    | 1790 ->
-        "<SYNTAX ERROR>\n"
-    | 1798 ->
-        "<SYNTAX ERROR>\n"
-    | 1800 ->
-        "<SYNTAX ERROR>\n"
-    | 1815 ->
-        "<SYNTAX ERROR>\n"
-    | 1827 ->
-        "<SYNTAX ERROR>\n"
-    | 1832 ->
-        "<SYNTAX ERROR>\n"
-    | 2348 ->
-        "<SYNTAX ERROR>\n"
-    | 2353 ->
-        "<SYNTAX ERROR>\n"
-    | 2350 ->
-        "<SYNTAX ERROR>\n"
-    | 1262 ->
-        "<SYNTAX ERROR>\n"
-    | 2347 ->
-        "<SYNTAX ERROR>\n"
-    | 1433 ->
-        "<SYNTAX ERROR>\n"
-    | 1460 ->
-        "<SYNTAX ERROR>\n"
-    | 1281 ->
-        "<SYNTAX ERROR>\n"
-    | 1427 ->
-        "<SYNTAX ERROR>\n"
-    | 1429 ->
-        "<SYNTAX ERROR>\n"
-    | 1431 ->
-        "<SYNTAX ERROR>\n"
-    | 166 ->
-        "<SYNTAX ERROR>\n"
-    | 2503 ->
-        "<SYNTAX ERROR>\n"
-    | 2502 ->
-        "<SYNTAX ERROR>\n"
-    | 2505 ->
-        "<SYNTAX ERROR>\n"
-    | 1372 ->
-        "<SYNTAX ERROR>\n"
-    | 1373 ->
-        "<SYNTAX ERROR>\n"
-    | 1435 ->
-        "<SYNTAX ERROR>\n"
-    | 1438 ->
-        "<SYNTAX ERROR>\n"
-    | 1456 ->
-        "<SYNTAX ERROR>\n"
-    | 1444 ->
-        "<SYNTAX ERROR>\n"
     | 1445 ->
+        "<SYNTAX ERROR>\n"
+    | 1447 ->
         "<SYNTAX ERROR>\n"
     | 1448 ->
         "<SYNTAX ERROR>\n"
     | 1450 ->
         "<SYNTAX ERROR>\n"
-    | 1451 ->
-        "<SYNTAX ERROR>\n"
-    | 1453 ->
-        "<SYNTAX ERROR>\n"
     | 173 ->
         "<SYNTAX ERROR>\n"
-    | 2449 ->
+    | 2446 ->
         "<SYNTAX ERROR>\n"
-    | 2450 ->
+    | 2447 ->
         "<SYNTAX ERROR>\n"
-    | 1313 ->
+    | 1310 ->
         "<SYNTAX ERROR>\n"
-    | 1321 ->
+    | 1318 ->
         "<SYNTAX ERROR>\n"
-    | 798 ->
+    | 794 ->
         "<SYNTAX ERROR>\n"
     | 187 ->
         "<SYNTAX ERROR>\n"
@@ -464,31 +464,37 @@ let message =
         "<SYNTAX ERROR>\n"
     | 180 ->
         "<SYNTAX ERROR>\n"
-    | 546 ->
+    | 542 ->
         "<SYNTAX ERROR>\n"
-    | 2334 ->
+    | 2331 ->
         "<SYNTAX ERROR>\n"
-    | 2336 ->
+    | 2333 ->
         "<SYNTAX ERROR>\n"
-    | 2338 ->
+    | 2335 ->
         "<SYNTAX ERROR>\n"
-    | 1792 ->
+    | 1789 ->
         "<SYNTAX ERROR>\n"
-    | 1793 ->
+    | 1790 ->
         "<SYNTAX ERROR>\n"
     | 415 ->
         "Expecting one of the following:\n  - \")\" to form a unit value \"()\"\n  - \"module\" to start a module expression\n  - an expression\n  - an operator to denote the prefix form of an operator\n"
-    | 2392 ->
+    | 2389 ->
         "<SYNTAX ERROR>\n"
-    | 726 ->
+    | 722 ->
         "<SYNTAX ERROR>\n"
     | 418 ->
         "Expecting a module expression\n"
-    | 2379 ->
+    | 2376 ->
         "<SYNTAX ERROR>\n"
-    | 2381 ->
+    | 2378 ->
+        "<SYNTAX ERROR>\n"
+    | 2380 ->
+        "<SYNTAX ERROR>\n"
+    | 2382 ->
         "<SYNTAX ERROR>\n"
     | 2383 ->
+        "<SYNTAX ERROR>\n"
+    | 2384 ->
         "<SYNTAX ERROR>\n"
     | 2385 ->
         "<SYNTAX ERROR>\n"
@@ -496,61 +502,43 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2387 ->
         "<SYNTAX ERROR>\n"
-    | 2388 ->
+    | 1377 ->
         "<SYNTAX ERROR>\n"
-    | 2389 ->
-        "<SYNTAX ERROR>\n"
-    | 2390 ->
-        "<SYNTAX ERROR>\n"
-    | 1380 ->
-        "<SYNTAX ERROR>\n"
-    | 2437 ->
+    | 2434 ->
         "<SYNTAX ERROR>\n"
     | 189 ->
         "<SYNTAX ERROR>\n"
-    | 561 ->
+    | 557 ->
         "<SYNTAX ERROR>\n"
-    | 2307 ->
+    | 2304 ->
         "<SYNTAX ERROR>\n"
-    | 562 ->
+    | 558 ->
         "<SYNTAX ERROR>\n"
-    | 1822 ->
+    | 1819 ->
         "<SYNTAX ERROR>\n"
-    | 1821 ->
+    | 1818 ->
         "<SYNTAX ERROR>\n"
-    | 1816 ->
+    | 1813 ->
         "<SYNTAX ERROR>\n"
-    | 1817 ->
+    | 1814 ->
         "<SYNTAX ERROR>\n"
-    | 580 ->
+    | 576 ->
         "<SYNTAX ERROR>\n"
-    | 589 ->
+    | 585 ->
         "<SYNTAX ERROR>\n"
-    | 599 ->
+    | 595 ->
+        "<SYNTAX ERROR>\n"
+    | 613 ->
+        "<SYNTAX ERROR>\n"
+    | 614 ->
+        "<SYNTAX ERROR>\n"
+    | 616 ->
         "<SYNTAX ERROR>\n"
     | 617 ->
         "<SYNTAX ERROR>\n"
-    | 618 ->
+    | 2244 ->
         "<SYNTAX ERROR>\n"
-    | 620 ->
-        "<SYNTAX ERROR>\n"
-    | 621 ->
-        "<SYNTAX ERROR>\n"
-    | 2247 ->
-        "<SYNTAX ERROR>\n"
-    | 2233 ->
-        "<SYNTAX ERROR>\n"
-    | 626 ->
-        "<SYNTAX ERROR>\n"
-    | 627 ->
-        "<SYNTAX ERROR>\n"
-    | 628 ->
-        "<SYNTAX ERROR>\n"
-    | 629 ->
-        "<SYNTAX ERROR>\n"
-    | 2231 ->
-        "<SYNTAX ERROR>\n"
-    | 2232 ->
+    | 2230 ->
         "<SYNTAX ERROR>\n"
     | 622 ->
         "<SYNTAX ERROR>\n"
@@ -560,29 +548,47 @@ let message =
         "<SYNTAX ERROR>\n"
     | 625 ->
         "<SYNTAX ERROR>\n"
+    | 2228 ->
+        "<SYNTAX ERROR>\n"
+    | 2229 ->
+        "<SYNTAX ERROR>\n"
+    | 618 ->
+        "<SYNTAX ERROR>\n"
+    | 619 ->
+        "<SYNTAX ERROR>\n"
+    | 620 ->
+        "<SYNTAX ERROR>\n"
+    | 621 ->
+        "<SYNTAX ERROR>\n"
+    | 2237 ->
+        "<SYNTAX ERROR>\n"
+    | 2238 ->
+        "<SYNTAX ERROR>\n"
+    | 2239 ->
+        "<SYNTAX ERROR>\n"
     | 2240 ->
         "<SYNTAX ERROR>\n"
     | 2241 ->
         "<SYNTAX ERROR>\n"
     | 2242 ->
         "<SYNTAX ERROR>\n"
-    | 2243 ->
+    | 895 ->
         "<SYNTAX ERROR>\n"
-    | 2244 ->
+    | 896 ->
         "<SYNTAX ERROR>\n"
-    | 2245 ->
+    | 897 ->
+        "<SYNTAX ERROR>\n"
+    | 898 ->
         "<SYNTAX ERROR>\n"
     | 899 ->
         "<SYNTAX ERROR>\n"
     | 900 ->
         "<SYNTAX ERROR>\n"
-    | 901 ->
+    | 2337 ->
         "<SYNTAX ERROR>\n"
-    | 902 ->
+    | 2338 ->
         "<SYNTAX ERROR>\n"
-    | 903 ->
-        "<SYNTAX ERROR>\n"
-    | 904 ->
+    | 2339 ->
         "<SYNTAX ERROR>\n"
     | 2340 ->
         "<SYNTAX ERROR>\n"
@@ -590,41 +596,43 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2342 ->
         "<SYNTAX ERROR>\n"
-    | 2343 ->
+    | 1791 ->
         "<SYNTAX ERROR>\n"
-    | 2344 ->
+    | 603 ->
         "<SYNTAX ERROR>\n"
-    | 2345 ->
+    | 1365 ->
         "<SYNTAX ERROR>\n"
-    | 1794 ->
+    | 1187 ->
         "<SYNTAX ERROR>\n"
-    | 607 ->
-        "<SYNTAX ERROR>\n"
-    | 1368 ->
-        "<SYNTAX ERROR>\n"
-    | 1190 ->
-        "<SYNTAX ERROR>\n"
-    | 913 ->
+    | 909 ->
         "Incomplete let binding\n"
-    | 1291 ->
-        "<SYNTAX ERROR>\n"
-    | 1297 ->
-        "<SYNTAX ERROR>\n"
-    | 1292 ->
-        "<SYNTAX ERROR>\n"
-    | 1293 ->
+    | 1288 ->
         "<SYNTAX ERROR>\n"
     | 1294 ->
         "<SYNTAX ERROR>\n"
-    | 1296 ->
+    | 1289 ->
         "<SYNTAX ERROR>\n"
-    | 1166 ->
+    | 1290 ->
         "<SYNTAX ERROR>\n"
-    | 914 ->
+    | 1291 ->
         "<SYNTAX ERROR>\n"
-    | 915 ->
+    | 1293 ->
+        "<SYNTAX ERROR>\n"
+    | 1163 ->
+        "<SYNTAX ERROR>\n"
+    | 910 ->
+        "<SYNTAX ERROR>\n"
+    | 911 ->
+        "<SYNTAX ERROR>\n"
+    | 1767 ->
+        "<SYNTAX ERROR>\n"
+    | 1768 ->
+        "<SYNTAX ERROR>\n"
+    | 1769 ->
         "<SYNTAX ERROR>\n"
     | 1770 ->
+        "<SYNTAX ERROR>\n"
+    | 1774 ->
         "<SYNTAX ERROR>\n"
     | 1771 ->
         "<SYNTAX ERROR>\n"
@@ -632,57 +640,29 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1773 ->
         "<SYNTAX ERROR>\n"
-    | 1777 ->
+    | 912 ->
         "<SYNTAX ERROR>\n"
-    | 1774 ->
+    | 913 ->
         "<SYNTAX ERROR>\n"
-    | 1775 ->
+    | 922 ->
         "<SYNTAX ERROR>\n"
-    | 1776 ->
+    | 1760 ->
         "<SYNTAX ERROR>\n"
-    | 916 ->
+    | 1761 ->
         "<SYNTAX ERROR>\n"
-    | 917 ->
+    | 1762 ->
         "<SYNTAX ERROR>\n"
-    | 926 ->
+    | 1778 ->
         "<SYNTAX ERROR>\n"
-    | 1763 ->
+    | 1141 ->
         "<SYNTAX ERROR>\n"
-    | 1764 ->
+    | 1142 ->
         "<SYNTAX ERROR>\n"
-    | 1765 ->
+    | 1164 ->
         "<SYNTAX ERROR>\n"
-    | 1781 ->
-        "<SYNTAX ERROR>\n"
-    | 1144 ->
-        "<SYNTAX ERROR>\n"
-    | 1145 ->
-        "<SYNTAX ERROR>\n"
-    | 1167 ->
-        "<SYNTAX ERROR>\n"
-    | 1287 ->
+    | 1284 ->
         "Defining a function?\nExpecting one of the following:\n  - \"=>\" to start the function body\n  - an identifier to add a function parameter\n  - \":\" to specify the return type\n"
-    | 1255 ->
-        "<SYNTAX ERROR>\n"
-    | 1172 ->
-        "<SYNTAX ERROR>\n"
-    | 1173 ->
-        "<SYNTAX ERROR>\n"
-    | 1174 ->
-        "<SYNTAX ERROR>\n"
-    | 1175 ->
-        "<SYNTAX ERROR>\n"
-    | 1176 ->
-        "Expecting an expression as function body\n"
-    | 1250 ->
-        "<SYNTAX ERROR>\n"
-    | 1251 ->
-        "Defining a function?\nExpecting \"=>\" to start the function body\n"
     | 1252 ->
-        "<SYNTAX ERROR>\n"
-    | 1253 ->
-        "<SYNTAX ERROR>\n"
-    | 1168 ->
         "<SYNTAX ERROR>\n"
     | 1169 ->
         "<SYNTAX ERROR>\n"
@@ -690,103 +670,129 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1171 ->
         "<SYNTAX ERROR>\n"
-    | 1260 ->
+    | 1172 ->
         "<SYNTAX ERROR>\n"
-    | 1283 ->
+    | 1173 ->
+        "Expecting an expression as function body\n"
+    | 1247 ->
         "<SYNTAX ERROR>\n"
-    | 1284 ->
+    | 1248 ->
+        "Defining a function?\nExpecting \"=>\" to start the function body\n"
+    | 1249 ->
         "<SYNTAX ERROR>\n"
-    | 1264 ->
+    | 1250 ->
         "<SYNTAX ERROR>\n"
-    | 1265 ->
+    | 1165 ->
+        "<SYNTAX ERROR>\n"
+    | 1166 ->
+        "<SYNTAX ERROR>\n"
+    | 1167 ->
+        "<SYNTAX ERROR>\n"
+    | 1168 ->
+        "<SYNTAX ERROR>\n"
+    | 1257 ->
+        "<SYNTAX ERROR>\n"
+    | 1280 ->
+        "<SYNTAX ERROR>\n"
+    | 1281 ->
+        "<SYNTAX ERROR>\n"
+    | 1261 ->
+        "<SYNTAX ERROR>\n"
+    | 1262 ->
+        "<SYNTAX ERROR>\n"
+    | 1263 ->
         "<SYNTAX ERROR>\n"
     | 1266 ->
         "<SYNTAX ERROR>\n"
-    | 1269 ->
+    | 1267 ->
         "<SYNTAX ERROR>\n"
-    | 1270 ->
+    | 1268 ->
         "<SYNTAX ERROR>\n"
     | 1271 ->
         "<SYNTAX ERROR>\n"
-    | 1274 ->
-        "<SYNTAX ERROR>\n"
-    | 1275 ->
-        "<SYNTAX ERROR>\n"
-    | 1276 ->
-        "<SYNTAX ERROR>\n"
-    | 1277 ->
+    | 1272 ->
         "<SYNTAX ERROR>\n"
     | 1273 ->
         "<SYNTAX ERROR>\n"
-    | 1513 ->
+    | 1274 ->
+        "<SYNTAX ERROR>\n"
+    | 1270 ->
+        "<SYNTAX ERROR>\n"
+    | 1510 ->
         "<SYNTAX ERROR>\n"
     | 69 ->
         "<SYNTAX ERROR>\n"
-    | 1714 ->
+    | 1711 ->
         "<SYNTAX ERROR>\n"
     | 191 ->
         "<SYNTAX ERROR>\n"
-    | 2435 ->
+    | 2432 ->
         "<SYNTAX ERROR>\n"
-    | 2436 ->
+    | 2433 ->
         "<SYNTAX ERROR>\n"
-    | 2434 ->
+    | 2431 ->
         "<SYNTAX ERROR>\n"
     | 70 ->
         "<SYNTAX ERROR>\n"
-    | 1065 ->
+    | 1062 ->
         "<SYNTAX ERROR>\n"
-    | 1038 ->
+    | 1035 ->
         "<SYNTAX ERROR>\n"
-    | 2611 ->
+    | 2603 ->
         "<SYNTAX ERROR>\n"
     | 18 ->
         "<SYNTAX ERROR>\n"
     | 164 ->
         "<SYNTAX ERROR>\n"
-    | 2509 ->
+    | 2506 ->
+        "<SYNTAX ERROR>\n"
+    | 1798 ->
         "<SYNTAX ERROR>\n"
     | 1801 ->
         "<SYNTAX ERROR>\n"
-    | 1804 ->
+    | 1803 ->
         "<SYNTAX ERROR>\n"
     | 1806 ->
-        "<SYNTAX ERROR>\n"
-    | 1809 ->
         "Expecting a type name\n"
     | 176 ->
         "Expecting an expression\n"
-    | 1394 ->
+    | 1391 ->
         "Expecting an expression\n"
-    | 1370 ->
+    | 1367 ->
         "Expecting an expression\n"
-    | 606 ->
+    | 602 ->
         "<SYNTAX ERROR>\n"
-    | 1712 ->
+    | 1709 ->
         "Expecting \"]\" to finish current floating attribute\n"
-    | 1040 ->
+    | 1037 ->
         "<SYNTAX ERROR>\n"
     | 167 ->
         "Expecting one of the following:\n  - an list item\n  - \"]\" to finish this list\n"
-    | 2215 ->
-        "Expecting one of the following:\n  - \",\" to separate two items in a list\n  - \"]\" to finish this list\n"
-    | 2216 ->
-        "<SYNTAX ERROR>\n"
     | 2212 ->
-        "<SYNTAX ERROR>\n"
+        "Expecting one of the following:\n  - \",\" to separate two items in a list\n  - \"]\" to finish this list\n"
     | 2213 ->
+        "<SYNTAX ERROR>\n"
+    | 2209 ->
+        "<SYNTAX ERROR>\n"
+    | 2210 ->
         "<SYNTAX ERROR>\n"
     | 169 ->
         "<SYNTAX ERROR>\n"
     | 170 ->
         "<SYNTAX ERROR>\n"
-    | 583 ->
+    | 579 ->
         "<SYNTAX ERROR>\n"
     | 171 ->
         "<SYNTAX ERROR>\n"
-    | 2491 ->
+    | 2488 ->
         "<SYNTAX ERROR>\n"
     | 174 ->
+        "<SYNTAX ERROR>\n"
+    | 1346 ->
+        "<SYNTAX ERROR>\n"
+    | 1347 ->
+        "<SYNTAX ERROR>\n"
+    | 1348 ->
         "<SYNTAX ERROR>\n"
     | 1349 ->
         "<SYNTAX ERROR>\n"
@@ -794,99 +800,83 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1351 ->
         "<SYNTAX ERROR>\n"
-    | 1352 ->
+    | 1356 ->
         "<SYNTAX ERROR>\n"
-    | 1353 ->
+    | 1357 ->
         "<SYNTAX ERROR>\n"
-    | 1354 ->
+    | 1358 ->
         "<SYNTAX ERROR>\n"
     | 1359 ->
         "<SYNTAX ERROR>\n"
     | 1360 ->
         "<SYNTAX ERROR>\n"
-    | 1361 ->
-        "<SYNTAX ERROR>\n"
-    | 1362 ->
-        "<SYNTAX ERROR>\n"
     | 1363 ->
         "<SYNTAX ERROR>\n"
-    | 1366 ->
+    | 1364 ->
         "<SYNTAX ERROR>\n"
-    | 1367 ->
+    | 1456 ->
+        "<SYNTAX ERROR>\n"
+    | 1458 ->
         "<SYNTAX ERROR>\n"
     | 1459 ->
         "<SYNTAX ERROR>\n"
-    | 1461 ->
+    | 1460 ->
         "<SYNTAX ERROR>\n"
-    | 1462 ->
+    | 1355 ->
+        "<SYNTAX ERROR>\n"
+    | 2357 ->
+        "<SYNTAX ERROR>\n"
+    | 539 ->
+        "<SYNTAX ERROR>\n"
+    | 2287 ->
+        "<SYNTAX ERROR>\n"
+    | 2264 ->
+        "<SYNTAX ERROR>\n"
+    | 1461 ->
         "<SYNTAX ERROR>\n"
     | 1463 ->
         "<SYNTAX ERROR>\n"
-    | 1358 ->
-        "<SYNTAX ERROR>\n"
-    | 2360 ->
-        "<SYNTAX ERROR>\n"
-    | 543 ->
-        "<SYNTAX ERROR>\n"
-    | 2290 ->
-        "<SYNTAX ERROR>\n"
-    | 2267 ->
-        "<SYNTAX ERROR>\n"
     | 1464 ->
+        "<SYNTAX ERROR>\n"
+    | 1465 ->
         "<SYNTAX ERROR>\n"
     | 1466 ->
         "<SYNTAX ERROR>\n"
-    | 1467 ->
+    | 1108 ->
+        "<SYNTAX ERROR>\n"
+    | 1110 ->
+        "<SYNTAX ERROR>\n"
+    | 1111 ->
         "<SYNTAX ERROR>\n"
     | 1468 ->
         "<SYNTAX ERROR>\n"
     | 1469 ->
         "<SYNTAX ERROR>\n"
-    | 1111 ->
-        "<SYNTAX ERROR>\n"
-    | 1113 ->
-        "<SYNTAX ERROR>\n"
-    | 1114 ->
+    | 1470 ->
         "<SYNTAX ERROR>\n"
     | 1471 ->
         "<SYNTAX ERROR>\n"
-    | 1472 ->
-        "<SYNTAX ERROR>\n"
-    | 1473 ->
-        "<SYNTAX ERROR>\n"
     | 1474 ->
         "<SYNTAX ERROR>\n"
-    | 1477 ->
+    | 1485 ->
         "<SYNTAX ERROR>\n"
-    | 1488 ->
+    | 1475 ->
+        "<SYNTAX ERROR>\n"
+    | 1476 ->
+        "<SYNTAX ERROR>\n"
+    | 1477 ->
         "<SYNTAX ERROR>\n"
     | 1478 ->
         "<SYNTAX ERROR>\n"
     | 1479 ->
         "<SYNTAX ERROR>\n"
-    | 1480 ->
+    | 1545 ->
         "<SYNTAX ERROR>\n"
-    | 1481 ->
+    | 1489 ->
         "<SYNTAX ERROR>\n"
-    | 1482 ->
+    | 1490 ->
         "<SYNTAX ERROR>\n"
-    | 1548 ->
-        "<SYNTAX ERROR>\n"
-    | 1492 ->
-        "<SYNTAX ERROR>\n"
-    | 1493 ->
-        "<SYNTAX ERROR>\n"
-    | 1494 ->
-        "<SYNTAX ERROR>\n"
-    | 1501 ->
-        "<SYNTAX ERROR>\n"
-    | 1502 ->
-        "<SYNTAX ERROR>\n"
-    | 1503 ->
-        "<SYNTAX ERROR>\n"
-    | 1495 ->
-        "<SYNTAX ERROR>\n"
-    | 1497 ->
+    | 1491 ->
         "<SYNTAX ERROR>\n"
     | 1498 ->
         "<SYNTAX ERROR>\n"
@@ -894,307 +884,317 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1500 ->
         "<SYNTAX ERROR>\n"
-    | 1465 ->
+    | 1492 ->
         "<SYNTAX ERROR>\n"
-    | 1849 ->
+    | 1494 ->
         "<SYNTAX ERROR>\n"
-    | 1840 ->
+    | 1495 ->
+        "<SYNTAX ERROR>\n"
+    | 1496 ->
+        "<SYNTAX ERROR>\n"
+    | 1497 ->
+        "<SYNTAX ERROR>\n"
+    | 1462 ->
+        "<SYNTAX ERROR>\n"
+    | 1846 ->
+        "<SYNTAX ERROR>\n"
+    | 1837 ->
+        "<SYNTAX ERROR>\n"
+    | 1835 ->
         "<SYNTAX ERROR>\n"
     | 1838 ->
         "<SYNTAX ERROR>\n"
-    | 1841 ->
+    | 1839 ->
         "<SYNTAX ERROR>\n"
-    | 1842 ->
+    | 1849 ->
         "<SYNTAX ERROR>\n"
-    | 1852 ->
+    | 1850 ->
         "<SYNTAX ERROR>\n"
-    | 1853 ->
+    | 587 ->
         "<SYNTAX ERROR>\n"
-    | 591 ->
-        "<SYNTAX ERROR>\n"
-    | 2072 ->
-        "<SYNTAX ERROR>\n"
-    | 2078 ->
-        "<SYNTAX ERROR>\n"
-    | 2073 ->
-        "<SYNTAX ERROR>\n"
-    | 2074 ->
+    | 2069 ->
         "<SYNTAX ERROR>\n"
     | 2075 ->
         "<SYNTAX ERROR>\n"
-    | 2077 ->
+    | 2070 ->
         "<SYNTAX ERROR>\n"
-    | 2042 ->
+    | 2071 ->
+        "<SYNTAX ERROR>\n"
+    | 2072 ->
+        "<SYNTAX ERROR>\n"
+    | 2074 ->
+        "<SYNTAX ERROR>\n"
+    | 2039 ->
+        "<SYNTAX ERROR>\n"
+    | 589 ->
         "<SYNTAX ERROR>\n"
     | 593 ->
         "<SYNTAX ERROR>\n"
-    | 597 ->
-        "<SYNTAX ERROR>\n"
-    | 598 ->
-        "<SYNTAX ERROR>\n"
     | 594 ->
         "<SYNTAX ERROR>\n"
-    | 2277 ->
+    | 590 ->
+        "<SYNTAX ERROR>\n"
+    | 2274 ->
+        "<SYNTAX ERROR>\n"
+    | 2275 ->
         "<SYNTAX ERROR>\n"
     | 2278 ->
         "<SYNTAX ERROR>\n"
-    | 2281 ->
+    | 2277 ->
         "<SYNTAX ERROR>\n"
-    | 2280 ->
-        "<SYNTAX ERROR>\n"
-    | 2043 ->
-        "<SYNTAX ERROR>\n"
-    | 2068 ->
-        "<SYNTAX ERROR>\n"
-    | 1484 ->
-        "<SYNTAX ERROR>\n"
-    | 1485 ->
-        "<SYNTAX ERROR>\n"
-    | 1486 ->
-        "<SYNTAX ERROR>\n"
-    | 1487 ->
-        "<SYNTAX ERROR>\n"
-    | 2044 ->
-        "<SYNTAX ERROR>\n"
-    | 2045 ->
-        "<SYNTAX ERROR>\n"
-    | 2046 ->
-        "<SYNTAX ERROR>\n"
-    | 2047 ->
-        "<SYNTAX ERROR>\n"
-    | 2049 ->
-        "<SYNTAX ERROR>\n"
-    | 2064 ->
+    | 2040 ->
         "<SYNTAX ERROR>\n"
     | 2065 ->
         "<SYNTAX ERROR>\n"
-    | 2051 ->
+    | 1481 ->
         "<SYNTAX ERROR>\n"
-    | 2052 ->
+    | 1482 ->
         "<SYNTAX ERROR>\n"
-    | 2054 ->
+    | 1483 ->
         "<SYNTAX ERROR>\n"
-    | 2055 ->
+    | 1484 ->
         "<SYNTAX ERROR>\n"
-    | 2056 ->
+    | 2041 ->
         "<SYNTAX ERROR>\n"
-    | 2059 ->
+    | 2042 ->
         "<SYNTAX ERROR>\n"
-    | 2060 ->
+    | 2043 ->
+        "<SYNTAX ERROR>\n"
+    | 2044 ->
+        "<SYNTAX ERROR>\n"
+    | 2046 ->
         "<SYNTAX ERROR>\n"
     | 2061 ->
         "<SYNTAX ERROR>\n"
     | 2062 ->
         "<SYNTAX ERROR>\n"
+    | 2048 ->
+        "<SYNTAX ERROR>\n"
+    | 2049 ->
+        "<SYNTAX ERROR>\n"
+    | 2051 ->
+        "<SYNTAX ERROR>\n"
+    | 2052 ->
+        "<SYNTAX ERROR>\n"
+    | 2053 ->
+        "<SYNTAX ERROR>\n"
+    | 2056 ->
+        "<SYNTAX ERROR>\n"
+    | 2057 ->
+        "<SYNTAX ERROR>\n"
     | 2058 ->
         "<SYNTAX ERROR>\n"
-    | 2440 ->
+    | 2059 ->
+        "<SYNTAX ERROR>\n"
+    | 2055 ->
+        "<SYNTAX ERROR>\n"
+    | 2437 ->
         "Expecting \"}\" to finish the block\n"
-    | 2174 ->
+    | 2171 ->
         "<SYNTAX ERROR>\n"
-    | 1688 ->
+    | 1685 ->
         "<SYNTAX ERROR>\n"
-    | 1121 ->
-        "<SYNTAX ERROR>\n"
-    | 1510 ->
+    | 1118 ->
         "<SYNTAX ERROR>\n"
     | 1507 ->
         "<SYNTAX ERROR>\n"
-    | 1526 ->
+    | 1504 ->
+        "<SYNTAX ERROR>\n"
+    | 1523 ->
+        "<SYNTAX ERROR>\n"
+    | 1524 ->
         "<SYNTAX ERROR>\n"
     | 1527 ->
         "<SYNTAX ERROR>\n"
-    | 1530 ->
+    | 1160 ->
         "<SYNTAX ERROR>\n"
-    | 1163 ->
+    | 1556 ->
         "<SYNTAX ERROR>\n"
     | 1559 ->
         "<SYNTAX ERROR>\n"
+    | 1581 ->
+        "<SYNTAX ERROR>\n"
+    | 1560 ->
+        "<SYNTAX ERROR>\n"
+    | 1566 ->
+        "<SYNTAX ERROR>\n"
+    | 1567 ->
+        "<SYNTAX ERROR>\n"
+    | 1571 ->
+        "<SYNTAX ERROR>\n"
+    | 1572 ->
+        "<SYNTAX ERROR>\n"
+    | 1573 ->
+        "<SYNTAX ERROR>\n"
     | 1562 ->
-        "<SYNTAX ERROR>\n"
-    | 1584 ->
-        "<SYNTAX ERROR>\n"
-    | 1563 ->
-        "<SYNTAX ERROR>\n"
-    | 1569 ->
-        "<SYNTAX ERROR>\n"
-    | 1570 ->
-        "<SYNTAX ERROR>\n"
-    | 1574 ->
-        "<SYNTAX ERROR>\n"
-    | 1575 ->
-        "<SYNTAX ERROR>\n"
-    | 1576 ->
-        "<SYNTAX ERROR>\n"
-    | 1565 ->
-        "<SYNTAX ERROR>\n"
-    | 1583 ->
         "<SYNTAX ERROR>\n"
     | 1580 ->
         "<SYNTAX ERROR>\n"
-    | 1581 ->
+    | 1577 ->
         "<SYNTAX ERROR>\n"
-    | 1582 ->
+    | 1578 ->
         "<SYNTAX ERROR>\n"
-    | 1589 ->
+    | 1579 ->
         "<SYNTAX ERROR>\n"
-    | 1590 ->
+    | 1586 ->
         "<SYNTAX ERROR>\n"
-    | 1591 ->
+    | 1587 ->
         "<SYNTAX ERROR>\n"
-    | 1311 ->
+    | 1588 ->
         "<SYNTAX ERROR>\n"
-    | 1323 ->
+    | 1308 ->
         "<SYNTAX ERROR>\n"
-    | 1549 ->
+    | 1320 ->
         "<SYNTAX ERROR>\n"
-    | 1532 ->
+    | 1546 ->
         "<SYNTAX ERROR>\n"
-    | 1533 ->
+    | 1529 ->
         "<SYNTAX ERROR>\n"
-    | 1164 ->
+    | 1530 ->
         "<SYNTAX ERROR>\n"
-    | 1345 ->
-        "<SYNTAX ERROR>\n"
-    | 1553 ->
-        "<SYNTAX ERROR>\n"
-    | 1165 ->
-        "<SYNTAX ERROR>\n"
-    | 1341 ->
+    | 1161 ->
         "<SYNTAX ERROR>\n"
     | 1342 ->
         "<SYNTAX ERROR>\n"
+    | 1550 ->
+        "<SYNTAX ERROR>\n"
+    | 1162 ->
+        "<SYNTAX ERROR>\n"
+    | 1338 ->
+        "<SYNTAX ERROR>\n"
+    | 1339 ->
+        "<SYNTAX ERROR>\n"
+    | 1298 ->
+        "<SYNTAX ERROR>\n"
+    | 1300 ->
+        "<SYNTAX ERROR>\n"
     | 1301 ->
+        "<SYNTAX ERROR>\n"
+    | 1326 ->
+        "<SYNTAX ERROR>\n"
+    | 1302 ->
         "<SYNTAX ERROR>\n"
     | 1303 ->
         "<SYNTAX ERROR>\n"
     | 1304 ->
         "<SYNTAX ERROR>\n"
-    | 1329 ->
+    | 1528 ->
         "<SYNTAX ERROR>\n"
-    | 1305 ->
+    | 1830 ->
         "<SYNTAX ERROR>\n"
-    | 1306 ->
+    | 1831 ->
         "<SYNTAX ERROR>\n"
-    | 1307 ->
+    | 1832 ->
         "<SYNTAX ERROR>\n"
-    | 1531 ->
+    | 1534 ->
         "<SYNTAX ERROR>\n"
-    | 1833 ->
+    | 1535 ->
         "<SYNTAX ERROR>\n"
-    | 1834 ->
+    | 1536 ->
         "<SYNTAX ERROR>\n"
-    | 1835 ->
+    | 1333 ->
         "<SYNTAX ERROR>\n"
-    | 1537 ->
+    | 1334 ->
         "<SYNTAX ERROR>\n"
-    | 1538 ->
+    | 1345 ->
         "<SYNTAX ERROR>\n"
-    | 1539 ->
+    | 561 ->
         "<SYNTAX ERROR>\n"
-    | 1336 ->
+    | 1039 ->
         "<SYNTAX ERROR>\n"
-    | 1337 ->
+    | 915 ->
         "<SYNTAX ERROR>\n"
-    | 1348 ->
+    | 859 ->
         "<SYNTAX ERROR>\n"
-    | 565 ->
+    | 860 ->
         "<SYNTAX ERROR>\n"
-    | 1042 ->
+    | 1892 ->
         "<SYNTAX ERROR>\n"
-    | 919 ->
-        "<SYNTAX ERROR>\n"
-    | 863 ->
-        "<SYNTAX ERROR>\n"
-    | 864 ->
-        "<SYNTAX ERROR>\n"
-    | 1895 ->
+    | 1894 ->
         "<SYNTAX ERROR>\n"
     | 1897 ->
         "<SYNTAX ERROR>\n"
-    | 1900 ->
+    | 2189 ->
         "<SYNTAX ERROR>\n"
-    | 2192 ->
+    | 908 ->
         "<SYNTAX ERROR>\n"
-    | 912 ->
-        "<SYNTAX ERROR>\n"
-    | 1786 ->
+    | 1783 ->
         "<SYNTAX ERROR>\n"
     | 411 ->
         "<SYNTAX ERROR>\n"
     | 412 ->
         "<SYNTAX ERROR>\n"
-    | 2400 ->
+    | 2397 ->
         "<SYNTAX ERROR>\n"
-    | 2402 ->
+    | 2399 ->
         "<SYNTAX ERROR>\n"
-    | 1898 ->
+    | 1895 ->
         "<SYNTAX ERROR>\n"
-    | 2404 ->
+    | 2401 ->
         "<SYNTAX ERROR>\n"
-    | 1903 ->
+    | 1900 ->
         "<SYNTAX ERROR>\n"
-    | 1904 ->
+    | 1901 ->
         "<SYNTAX ERROR>\n"
-    | 2406 ->
+    | 2403 ->
         "<SYNTAX ERROR>\n"
-    | 2013 ->
+    | 2010 ->
         "<SYNTAX ERROR>\n"
-    | 1988 ->
+    | 1985 ->
+        "<SYNTAX ERROR>\n"
+    | 1986 ->
+        "<SYNTAX ERROR>\n"
+    | 1987 ->
         "<SYNTAX ERROR>\n"
     | 1989 ->
         "<SYNTAX ERROR>\n"
+    | 1992 ->
+        "<SYNTAX ERROR>\n"
+    | 1999 ->
+        "<SYNTAX ERROR>\n"
+    | 2002 ->
+        "<SYNTAX ERROR>\n"
+    | 2003 ->
+        "<SYNTAX ERROR>\n"
+    | 2192 ->
+        "<SYNTAX ERROR>\n"
+    | 2193 ->
+        "<SYNTAX ERROR>\n"
+    | 554 ->
+        "<SYNTAX ERROR>\n"
+    | 555 ->
+        "<SYNTAX ERROR>\n"
+    | 2308 ->
+        "<SYNTAX ERROR>\n"
+    | 2310 ->
+        "<SYNTAX ERROR>\n"
     | 1990 ->
         "<SYNTAX ERROR>\n"
-    | 1992 ->
+    | 2312 ->
         "<SYNTAX ERROR>\n"
     | 1995 ->
         "<SYNTAX ERROR>\n"
-    | 2002 ->
+    | 1996 ->
+        "<SYNTAX ERROR>\n"
+    | 2314 ->
         "<SYNTAX ERROR>\n"
     | 2005 ->
         "<SYNTAX ERROR>\n"
     | 2006 ->
         "<SYNTAX ERROR>\n"
-    | 2195 ->
+    | 1904 ->
         "<SYNTAX ERROR>\n"
-    | 2196 ->
+    | 1980 ->
         "<SYNTAX ERROR>\n"
-    | 558 ->
+    | 1981 ->
         "<SYNTAX ERROR>\n"
-    | 559 ->
-        "<SYNTAX ERROR>\n"
-    | 2311 ->
-        "<SYNTAX ERROR>\n"
-    | 2313 ->
-        "<SYNTAX ERROR>\n"
-    | 1993 ->
-        "<SYNTAX ERROR>\n"
-    | 2315 ->
-        "<SYNTAX ERROR>\n"
-    | 1998 ->
-        "<SYNTAX ERROR>\n"
-    | 1999 ->
-        "<SYNTAX ERROR>\n"
-    | 2317 ->
-        "<SYNTAX ERROR>\n"
-    | 2008 ->
-        "<SYNTAX ERROR>\n"
-    | 2009 ->
-        "<SYNTAX ERROR>\n"
-    | 1907 ->
-        "<SYNTAX ERROR>\n"
-    | 1983 ->
+    | 1982 ->
         "<SYNTAX ERROR>\n"
     | 1984 ->
         "<SYNTAX ERROR>\n"
-    | 1985 ->
-        "<SYNTAX ERROR>\n"
-    | 1987 ->
-        "<SYNTAX ERROR>\n"
     | 419 ->
         "<SYNTAX ERROR>\n"
-    | 2144 ->
+    | 2141 ->
         "<SYNTAX ERROR>\n"
     | 422 ->
         "<SYNTAX ERROR>\n"
@@ -1202,13 +1202,13 @@ let message =
         "<SYNTAX ERROR>\n"
     | 425 ->
         "<SYNTAX ERROR>\n"
-    | 2364 ->
-        "<SYNTAX ERROR>\n"
-    | 2368 ->
+    | 2361 ->
         "<SYNTAX ERROR>\n"
     | 2365 ->
         "<SYNTAX ERROR>\n"
-    | 2366 ->
+    | 2362 ->
+        "<SYNTAX ERROR>\n"
+    | 2363 ->
         "<SYNTAX ERROR>\n"
     | 427 ->
         "<SYNTAX ERROR>\n"
@@ -1218,23 +1218,23 @@ let message =
         "<SYNTAX ERROR>\n"
     | 433 ->
         "<SYNTAX ERROR>\n"
-    | 2151 ->
+    | 2148 ->
         "<SYNTAX ERROR>\n"
     | 437 ->
         "<SYNTAX ERROR>\n"
+    | 510 ->
+        "<SYNTAX ERROR>\n"
+    | 511 ->
+        "<SYNTAX ERROR>\n"
     | 513 ->
         "<SYNTAX ERROR>\n"
-    | 514 ->
+    | 517 ->
         "<SYNTAX ERROR>\n"
-    | 516 ->
-        "<SYNTAX ERROR>\n"
-    | 521 ->
-        "<SYNTAX ERROR>\n"
-    | 522 ->
+    | 518 ->
         "<SYNTAX ERROR>\n"
     | 438 ->
         "<SYNTAX ERROR>\n"
-    | 482 ->
+    | 479 ->
         "<SYNTAX ERROR>\n"
     | 468 ->
         "<SYNTAX ERROR>\n"
@@ -1242,39 +1242,45 @@ let message =
         "<SYNTAX ERROR>\n"
     | 464 ->
         "<SYNTAX ERROR>\n"
-    | 490 ->
+    | 487 ->
         "<SYNTAX ERROR>\n"
-    | 507 ->
+    | 504 ->
         "<SYNTAX ERROR>\n"
-    | 528 ->
+    | 524 ->
         "<SYNTAX ERROR>\n"
-    | 529 ->
+    | 525 ->
         "<SYNTAX ERROR>\n"
-    | 530 ->
+    | 526 ->
         "<SYNTAX ERROR>\n"
-    | 531 ->
+    | 527 ->
         "<SYNTAX ERROR>\n"
-    | 2152 ->
+    | 2149 ->
         "<SYNTAX ERROR>\n"
-    | 2154 ->
+    | 2151 ->
         "<SYNTAX ERROR>\n"
-    | 2143 ->
+    | 2140 ->
         "<SYNTAX ERROR>\n"
-    | 1908 ->
+    | 1905 ->
+        "<SYNTAX ERROR>\n"
+    | 1906 ->
         "<SYNTAX ERROR>\n"
     | 1909 ->
         "<SYNTAX ERROR>\n"
+    | 1910 ->
+        "<SYNTAX ERROR>\n"
     | 1912 ->
         "<SYNTAX ERROR>\n"
-    | 1913 ->
+    | 1976 ->
         "<SYNTAX ERROR>\n"
-    | 1915 ->
+    | 1977 ->
         "<SYNTAX ERROR>\n"
-    | 1979 ->
+    | 1978 ->
         "<SYNTAX ERROR>\n"
-    | 1980 ->
+    | 2026 ->
         "<SYNTAX ERROR>\n"
-    | 1981 ->
+    | 2027 ->
+        "<SYNTAX ERROR>\n"
+    | 2028 ->
         "<SYNTAX ERROR>\n"
     | 2029 ->
         "<SYNTAX ERROR>\n"
@@ -1284,31 +1290,31 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2032 ->
         "<SYNTAX ERROR>\n"
-    | 2033 ->
+    | 1979 ->
         "<SYNTAX ERROR>\n"
-    | 2034 ->
+    | 2017 ->
         "<SYNTAX ERROR>\n"
-    | 2035 ->
+    | 2018 ->
         "<SYNTAX ERROR>\n"
-    | 1982 ->
+    | 2019 ->
         "<SYNTAX ERROR>\n"
     | 2020 ->
         "<SYNTAX ERROR>\n"
     | 2021 ->
         "<SYNTAX ERROR>\n"
-    | 2022 ->
+    | 2034 ->
         "<SYNTAX ERROR>\n"
-    | 2023 ->
+    | 2155 ->
         "<SYNTAX ERROR>\n"
-    | 2024 ->
+    | 2156 ->
         "<SYNTAX ERROR>\n"
-    | 2037 ->
-        "<SYNTAX ERROR>\n"
-    | 2158 ->
-        "<SYNTAX ERROR>\n"
-    | 2159 ->
+    | 2079 ->
         "<SYNTAX ERROR>\n"
     | 2082 ->
+        "<SYNTAX ERROR>\n"
+    | 2083 ->
+        "<SYNTAX ERROR>\n"
+    | 2084 ->
         "<SYNTAX ERROR>\n"
     | 2085 ->
         "<SYNTAX ERROR>\n"
@@ -1316,49 +1322,49 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2087 ->
         "<SYNTAX ERROR>\n"
-    | 2088 ->
+    | 2091 ->
         "<SYNTAX ERROR>\n"
-    | 2089 ->
-        "<SYNTAX ERROR>\n"
-    | 2090 ->
-        "<SYNTAX ERROR>\n"
-    | 2094 ->
-        "<SYNTAX ERROR>\n"
-    | 2099 ->
+    | 2096 ->
         "<SYNTAX ERROR>\n"
     | 455 ->
         "<SYNTAX ERROR>\n"
     | 456 ->
         "<SYNTAX ERROR>\n"
-    | 2100 ->
+    | 2097 ->
         "<SYNTAX ERROR>\n"
-    | 2101 ->
+    | 2098 ->
         "<SYNTAX ERROR>\n"
-    | 2102 ->
+    | 2099 ->
         "<SYNTAX ERROR>\n"
     | 441 ->
         "<SYNTAX ERROR>\n"
-    | 471 ->
+    | 470 ->
         "<SYNTAX ERROR>\n"
-    | 2107 ->
+    | 2104 ->
         "<SYNTAX ERROR>\n"
-    | 2116 ->
+    | 2113 ->
+        "<SYNTAX ERROR>\n"
+    | 2105 ->
+        "<SYNTAX ERROR>\n"
+    | 2106 ->
         "<SYNTAX ERROR>\n"
     | 2108 ->
         "<SYNTAX ERROR>\n"
     | 2109 ->
         "<SYNTAX ERROR>\n"
-    | 2111 ->
+    | 2110 ->
         "<SYNTAX ERROR>\n"
-    | 2112 ->
+    | 2160 ->
         "<SYNTAX ERROR>\n"
-    | 2113 ->
+    | 2161 ->
         "<SYNTAX ERROR>\n"
-    | 2163 ->
+    | 2115 ->
         "<SYNTAX ERROR>\n"
-    | 2164 ->
+    | 2124 ->
         "<SYNTAX ERROR>\n"
-    | 2118 ->
+    | 2125 ->
+        "<SYNTAX ERROR>\n"
+    | 2126 ->
         "<SYNTAX ERROR>\n"
     | 2127 ->
         "<SYNTAX ERROR>\n"
@@ -1368,65 +1374,47 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2130 ->
         "<SYNTAX ERROR>\n"
-    | 2131 ->
+    | 2116 ->
         "<SYNTAX ERROR>\n"
-    | 2132 ->
+    | 2117 ->
         "<SYNTAX ERROR>\n"
-    | 2133 ->
+    | 2165 ->
+        "<SYNTAX ERROR>\n"
+    | 2166 ->
+        "<SYNTAX ERROR>\n"
+    | 2118 ->
         "<SYNTAX ERROR>\n"
     | 2119 ->
         "<SYNTAX ERROR>\n"
     | 2120 ->
         "<SYNTAX ERROR>\n"
-    | 2168 ->
-        "<SYNTAX ERROR>\n"
-    | 2169 ->
-        "<SYNTAX ERROR>\n"
     | 2121 ->
         "<SYNTAX ERROR>\n"
-    | 2122 ->
+    | 543 ->
         "<SYNTAX ERROR>\n"
-    | 2123 ->
-        "<SYNTAX ERROR>\n"
-    | 2124 ->
-        "<SYNTAX ERROR>\n"
-    | 547 ->
+    | 544 ->
         "<SYNTAX ERROR>\n"
     | 548 ->
         "<SYNTAX ERROR>\n"
-    | 552 ->
+    | 549 ->
         "<SYNTAX ERROR>\n"
-    | 553 ->
+    | 2326 ->
+        "<SYNTAX ERROR>\n"
+    | 2328 ->
         "<SYNTAX ERROR>\n"
     | 2329 ->
         "<SYNTAX ERROR>\n"
-    | 2331 ->
+    | 2330 ->
         "<SYNTAX ERROR>\n"
-    | 2332 ->
+    | 861 ->
         "<SYNTAX ERROR>\n"
-    | 2333 ->
+    | 862 ->
+        "<SYNTAX ERROR>\n"
+    | 864 ->
         "<SYNTAX ERROR>\n"
     | 865 ->
         "<SYNTAX ERROR>\n"
-    | 866 ->
-        "<SYNTAX ERROR>\n"
-    | 868 ->
-        "<SYNTAX ERROR>\n"
-    | 869 ->
-        "<SYNTAX ERROR>\n"
-    | 1876 ->
-        "<SYNTAX ERROR>\n"
-    | 874 ->
-        "<SYNTAX ERROR>\n"
-    | 875 ->
-        "<SYNTAX ERROR>\n"
-    | 876 ->
-        "<SYNTAX ERROR>\n"
-    | 877 ->
-        "<SYNTAX ERROR>\n"
-    | 878 ->
-        "<SYNTAX ERROR>\n"
-    | 1875 ->
+    | 1873 ->
         "<SYNTAX ERROR>\n"
     | 870 ->
         "<SYNTAX ERROR>\n"
@@ -1436,15 +1424,33 @@ let message =
         "<SYNTAX ERROR>\n"
     | 873 ->
         "<SYNTAX ERROR>\n"
-    | 1892 ->
+    | 874 ->
         "<SYNTAX ERROR>\n"
-    | 631 ->
+    | 1872 ->
         "<SYNTAX ERROR>\n"
-    | 852 ->
+    | 866 ->
         "<SYNTAX ERROR>\n"
-    | 854 ->
+    | 867 ->
         "<SYNTAX ERROR>\n"
-    | 855 ->
+    | 868 ->
+        "<SYNTAX ERROR>\n"
+    | 869 ->
+        "<SYNTAX ERROR>\n"
+    | 1889 ->
+        "<SYNTAX ERROR>\n"
+    | 627 ->
+        "<SYNTAX ERROR>\n"
+    | 848 ->
+        "<SYNTAX ERROR>\n"
+    | 850 ->
+        "<SYNTAX ERROR>\n"
+    | 851 ->
+        "<SYNTAX ERROR>\n"
+    | 1882 ->
+        "<SYNTAX ERROR>\n"
+    | 1883 ->
+        "<SYNTAX ERROR>\n"
+    | 1884 ->
         "<SYNTAX ERROR>\n"
     | 1885 ->
         "<SYNTAX ERROR>\n"
@@ -1452,23 +1458,23 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1887 ->
         "<SYNTAX ERROR>\n"
-    | 1888 ->
+    | 875 ->
         "<SYNTAX ERROR>\n"
-    | 1889 ->
+    | 876 ->
         "<SYNTAX ERROR>\n"
-    | 1890 ->
+    | 877 ->
         "<SYNTAX ERROR>\n"
-    | 879 ->
-        "<SYNTAX ERROR>\n"
-    | 880 ->
+    | 878 ->
         "<SYNTAX ERROR>\n"
     | 881 ->
         "<SYNTAX ERROR>\n"
     | 882 ->
         "<SYNTAX ERROR>\n"
-    | 885 ->
+    | 1042 ->
         "<SYNTAX ERROR>\n"
-    | 886 ->
+    | 1043 ->
+        "<SYNTAX ERROR>\n"
+    | 1044 ->
         "<SYNTAX ERROR>\n"
     | 1045 ->
         "<SYNTAX ERROR>\n"
@@ -1476,227 +1482,227 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1047 ->
         "<SYNTAX ERROR>\n"
-    | 1048 ->
+    | 1051 ->
         "<SYNTAX ERROR>\n"
-    | 1049 ->
+    | 1056 ->
         "<SYNTAX ERROR>\n"
-    | 1050 ->
-        "<SYNTAX ERROR>\n"
-    | 1054 ->
-        "<SYNTAX ERROR>\n"
-    | 1059 ->
-        "<SYNTAX ERROR>\n"
-    | 951 ->
-        "<SYNTAX ERROR>\n"
-    | 952 ->
-        "<SYNTAX ERROR>\n"
-    | 1060 ->
-        "<SYNTAX ERROR>\n"
-    | 1061 ->
-        "<SYNTAX ERROR>\n"
-    | 1062 ->
+    | 948 ->
         "<SYNTAX ERROR>\n"
     | 949 ->
         "<SYNTAX ERROR>\n"
-    | 941 ->
+    | 1057 ->
         "<SYNTAX ERROR>\n"
-    | 1067 ->
+    | 1058 ->
         "<SYNTAX ERROR>\n"
-    | 1156 ->
-        "<SYNTAX ERROR>\n"
-    | 1069 ->
-        "<SYNTAX ERROR>\n"
-    | 1070 ->
-        "<SYNTAX ERROR>\n"
-    | 1072 ->
-        "<SYNTAX ERROR>\n"
-    | 1075 ->
-        "<SYNTAX ERROR>\n"
-    | 1707 ->
-        "<SYNTAX ERROR>\n"
-    | 1149 ->
-        "<SYNTAX ERROR>\n"
-    | 1150 ->
-        "<SYNTAX ERROR>\n"
-    | 1158 ->
-        "<SYNTAX ERROR>\n"
-    | 1666 ->
-        "<SYNTAX ERROR>\n"
-    | 1667 ->
-        "<SYNTAX ERROR>\n"
-    | 1668 ->
-        "<SYNTAX ERROR>\n"
-    | 1669 ->
-        "<SYNTAX ERROR>\n"
-    | 1630 ->
-        "<SYNTAX ERROR>\n"
-    | 1631 ->
-        "<SYNTAX ERROR>\n"
-    | 1670 ->
-        "<SYNTAX ERROR>\n"
-    | 1671 ->
-        "<SYNTAX ERROR>\n"
-    | 1673 ->
-        "<SYNTAX ERROR>\n"
-    | 1635 ->
-        "<SYNTAX ERROR>\n"
-    | 1636 ->
-        "<SYNTAX ERROR>\n"
-    | 1677 ->
-        "<SYNTAX ERROR>\n"
-    | 1674 ->
-        "<SYNTAX ERROR>\n"
-    | 1675 ->
-        "<SYNTAX ERROR>\n"
-    | 1077 ->
-        "<SYNTAX ERROR>\n"
-    | 1085 ->
-        "<SYNTAX ERROR>\n"
-    | 1086 ->
-        "<SYNTAX ERROR>\n"
-    | 1087 ->
-        "<SYNTAX ERROR>\n"
-    | 1088 ->
-        "<SYNTAX ERROR>\n"
-    | 1089 ->
-        "<SYNTAX ERROR>\n"
-    | 1091 ->
-        "<SYNTAX ERROR>\n"
-    | 1092 ->
-        "<SYNTAX ERROR>\n"
-    | 1093 ->
-        "<SYNTAX ERROR>\n"
-    | 1094 ->
-        "<SYNTAX ERROR>\n"
-    | 1100 ->
-        "<SYNTAX ERROR>\n"
-    | 1101 ->
-        "<SYNTAX ERROR>\n"
-    | 1103 ->
-        "<SYNTAX ERROR>\n"
-    | 1104 ->
-        "<SYNTAX ERROR>\n"
-    | 1108 ->
-        "<SYNTAX ERROR>\n"
-    | 1106 ->
-        "<SYNTAX ERROR>\n"
-    | 1109 ->
-        "<SYNTAX ERROR>\n"
-    | 1110 ->
-        "<SYNTAX ERROR>\n"
-    | 1081 ->
-        "<SYNTAX ERROR>\n"
-    | 1690 ->
-        "<SYNTAX ERROR>\n"
-    | 1691 ->
-        "<SYNTAX ERROR>\n"
-    | 1694 ->
-        "<SYNTAX ERROR>\n"
-    | 1078 ->
-        "<SYNTAX ERROR>\n"
-    | 1079 ->
-        "<SYNTAX ERROR>\n"
-    | 1084 ->
-        "<SYNTAX ERROR>\n"
-    | 1658 ->
-        "<SYNTAX ERROR>\n"
-    | 1159 ->
-        "<SYNTAX ERROR>\n"
-    | 1160 ->
-        "<SYNTAX ERROR>\n"
-    | 1161 ->
-        "<SYNTAX ERROR>\n"
-    | 1162 ->
-        "<SYNTAX ERROR>\n"
-    | 1596 ->
-        "<SYNTAX ERROR>\n"
-    | 1599 ->
-        "<SYNTAX ERROR>\n"
-    | 1617 ->
-        "<SYNTAX ERROR>\n"
-    | 1618 ->
-        "<SYNTAX ERROR>\n"
-    | 1154 ->
-        "<SYNTAX ERROR>\n"
-    | 1155 ->
-        "<SYNTAX ERROR>\n"
-    | 1627 ->
-        "<SYNTAX ERROR>\n"
-    | 1603 ->
-        "<SYNTAX ERROR>\n"
-    | 1607 ->
-        "<SYNTAX ERROR>\n"
-    | 1609 ->
-        "<SYNTAX ERROR>\n"
-    | 1610 ->
-        "<SYNTAX ERROR>\n"
-    | 1620 ->
-        "<SYNTAX ERROR>\n"
-    | 1611 ->
-        "<SYNTAX ERROR>\n"
-    | 1612 ->
-        "<SYNTAX ERROR>\n"
-    | 1613 ->
-        "<SYNTAX ERROR>\n"
-    | 1628 ->
-        "<SYNTAX ERROR>\n"
-    | 1645 ->
-        "<SYNTAX ERROR>\n"
-    | 1629 ->
-        "<SYNTAX ERROR>\n"
-    | 1654 ->
-        "<SYNTAX ERROR>\n"
-    | 1637 ->
-        "<SYNTAX ERROR>\n"
-    | 1655 ->
-        "<SYNTAX ERROR>\n"
-    | 1656 ->
-        "<SYNTAX ERROR>\n"
-    | 1644 ->
-        "<SYNTAX ERROR>\n"
-    | 1641 ->
-        "<SYNTAX ERROR>\n"
-    | 1642 ->
-        "<SYNTAX ERROR>\n"
-    | 1643 ->
-        "<SYNTAX ERROR>\n"
-    | 1650 ->
-        "<SYNTAX ERROR>\n"
-    | 1651 ->
-        "<SYNTAX ERROR>\n"
-    | 1652 ->
-        "<SYNTAX ERROR>\n"
-    | 572 ->
-        "<SYNTAX ERROR>\n"
-    | 151 ->
-        "<SYNTAX ERROR>\n"
-    | 893 ->
-        "<SYNTAX ERROR>\n"
-    | 2624 ->
-        "<SYNTAX ERROR>\n"
-    | 934 ->
-        "<SYNTAX ERROR>\n"
-    | 929 ->
-        "<SYNTAX ERROR>\n"
-    | 2626 ->
-        "<SYNTAX ERROR>\n"
-    | 1744 ->
-        "<SYNTAX ERROR>\n"
-    | 935 ->
+    | 1059 ->
         "<SYNTAX ERROR>\n"
     | 946 ->
         "<SYNTAX ERROR>\n"
     | 937 ->
         "<SYNTAX ERROR>\n"
-    | 938 ->
+    | 1064 ->
         "<SYNTAX ERROR>\n"
-    | 2625 ->
+    | 1153 ->
+        "<SYNTAX ERROR>\n"
+    | 1066 ->
+        "<SYNTAX ERROR>\n"
+    | 1067 ->
+        "<SYNTAX ERROR>\n"
+    | 1069 ->
+        "<SYNTAX ERROR>\n"
+    | 1072 ->
+        "<SYNTAX ERROR>\n"
+    | 1704 ->
+        "<SYNTAX ERROR>\n"
+    | 1146 ->
+        "<SYNTAX ERROR>\n"
+    | 1147 ->
+        "<SYNTAX ERROR>\n"
+    | 1155 ->
+        "<SYNTAX ERROR>\n"
+    | 1663 ->
+        "<SYNTAX ERROR>\n"
+    | 1664 ->
+        "<SYNTAX ERROR>\n"
+    | 1665 ->
+        "<SYNTAX ERROR>\n"
+    | 1666 ->
+        "<SYNTAX ERROR>\n"
+    | 1627 ->
+        "<SYNTAX ERROR>\n"
+    | 1628 ->
+        "<SYNTAX ERROR>\n"
+    | 1667 ->
+        "<SYNTAX ERROR>\n"
+    | 1668 ->
+        "<SYNTAX ERROR>\n"
+    | 1670 ->
+        "<SYNTAX ERROR>\n"
+    | 1632 ->
+        "<SYNTAX ERROR>\n"
+    | 1633 ->
+        "<SYNTAX ERROR>\n"
+    | 1674 ->
+        "<SYNTAX ERROR>\n"
+    | 1671 ->
+        "<SYNTAX ERROR>\n"
+    | 1672 ->
+        "<SYNTAX ERROR>\n"
+    | 1074 ->
+        "<SYNTAX ERROR>\n"
+    | 1082 ->
+        "<SYNTAX ERROR>\n"
+    | 1083 ->
+        "<SYNTAX ERROR>\n"
+    | 1084 ->
+        "<SYNTAX ERROR>\n"
+    | 1085 ->
+        "<SYNTAX ERROR>\n"
+    | 1086 ->
+        "<SYNTAX ERROR>\n"
+    | 1088 ->
+        "<SYNTAX ERROR>\n"
+    | 1089 ->
+        "<SYNTAX ERROR>\n"
+    | 1090 ->
+        "<SYNTAX ERROR>\n"
+    | 1091 ->
+        "<SYNTAX ERROR>\n"
+    | 1097 ->
+        "<SYNTAX ERROR>\n"
+    | 1098 ->
+        "<SYNTAX ERROR>\n"
+    | 1100 ->
+        "<SYNTAX ERROR>\n"
+    | 1101 ->
+        "<SYNTAX ERROR>\n"
+    | 1105 ->
+        "<SYNTAX ERROR>\n"
+    | 1103 ->
+        "<SYNTAX ERROR>\n"
+    | 1106 ->
+        "<SYNTAX ERROR>\n"
+    | 1107 ->
+        "<SYNTAX ERROR>\n"
+    | 1078 ->
+        "<SYNTAX ERROR>\n"
+    | 1687 ->
+        "<SYNTAX ERROR>\n"
+    | 1688 ->
+        "<SYNTAX ERROR>\n"
+    | 1691 ->
+        "<SYNTAX ERROR>\n"
+    | 1075 ->
+        "<SYNTAX ERROR>\n"
+    | 1076 ->
+        "<SYNTAX ERROR>\n"
+    | 1081 ->
+        "<SYNTAX ERROR>\n"
+    | 1655 ->
+        "<SYNTAX ERROR>\n"
+    | 1156 ->
+        "<SYNTAX ERROR>\n"
+    | 1157 ->
+        "<SYNTAX ERROR>\n"
+    | 1158 ->
+        "<SYNTAX ERROR>\n"
+    | 1159 ->
+        "<SYNTAX ERROR>\n"
+    | 1593 ->
+        "<SYNTAX ERROR>\n"
+    | 1596 ->
+        "<SYNTAX ERROR>\n"
+    | 1614 ->
+        "<SYNTAX ERROR>\n"
+    | 1615 ->
+        "<SYNTAX ERROR>\n"
+    | 1151 ->
+        "<SYNTAX ERROR>\n"
+    | 1152 ->
+        "<SYNTAX ERROR>\n"
+    | 1624 ->
+        "<SYNTAX ERROR>\n"
+    | 1600 ->
+        "<SYNTAX ERROR>\n"
+    | 1604 ->
+        "<SYNTAX ERROR>\n"
+    | 1606 ->
+        "<SYNTAX ERROR>\n"
+    | 1607 ->
+        "<SYNTAX ERROR>\n"
+    | 1617 ->
+        "<SYNTAX ERROR>\n"
+    | 1608 ->
+        "<SYNTAX ERROR>\n"
+    | 1609 ->
+        "<SYNTAX ERROR>\n"
+    | 1610 ->
+        "<SYNTAX ERROR>\n"
+    | 1625 ->
+        "<SYNTAX ERROR>\n"
+    | 1642 ->
+        "<SYNTAX ERROR>\n"
+    | 1626 ->
+        "<SYNTAX ERROR>\n"
+    | 1651 ->
+        "<SYNTAX ERROR>\n"
+    | 1634 ->
+        "<SYNTAX ERROR>\n"
+    | 1652 ->
+        "<SYNTAX ERROR>\n"
+    | 1653 ->
+        "<SYNTAX ERROR>\n"
+    | 1641 ->
+        "<SYNTAX ERROR>\n"
+    | 1638 ->
+        "<SYNTAX ERROR>\n"
+    | 1639 ->
+        "<SYNTAX ERROR>\n"
+    | 1640 ->
+        "<SYNTAX ERROR>\n"
+    | 1647 ->
+        "<SYNTAX ERROR>\n"
+    | 1648 ->
+        "<SYNTAX ERROR>\n"
+    | 1649 ->
+        "<SYNTAX ERROR>\n"
+    | 568 ->
+        "<SYNTAX ERROR>\n"
+    | 151 ->
+        "<SYNTAX ERROR>\n"
+    | 889 ->
+        "<SYNTAX ERROR>\n"
+    | 2616 ->
+        "<SYNTAX ERROR>\n"
+    | 930 ->
+        "<SYNTAX ERROR>\n"
+    | 925 ->
+        "<SYNTAX ERROR>\n"
+    | 2618 ->
+        "<SYNTAX ERROR>\n"
+    | 1741 ->
+        "<SYNTAX ERROR>\n"
+    | 931 ->
+        "<SYNTAX ERROR>\n"
+    | 942 ->
+        "<SYNTAX ERROR>\n"
+    | 933 ->
+        "<SYNTAX ERROR>\n"
+    | 934 ->
+        "<SYNTAX ERROR>\n"
+    | 2617 ->
+        "<SYNTAX ERROR>\n"
+    | 958 ->
+        "<SYNTAX ERROR>\n"
+    | 959 ->
         "<SYNTAX ERROR>\n"
     | 961 ->
         "<SYNTAX ERROR>\n"
-    | 962 ->
+    | 1005 ->
         "<SYNTAX ERROR>\n"
-    | 964 ->
+    | 1006 ->
+        "<SYNTAX ERROR>\n"
+    | 1007 ->
         "<SYNTAX ERROR>\n"
     | 1008 ->
         "<SYNTAX ERROR>\n"
@@ -1708,77 +1714,71 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1012 ->
         "<SYNTAX ERROR>\n"
+    | 1018 ->
+        "<SYNTAX ERROR>\n"
+    | 1020 ->
+        "<SYNTAX ERROR>\n"
     | 1013 ->
         "<SYNTAX ERROR>\n"
     | 1014 ->
         "<SYNTAX ERROR>\n"
-    | 1015 ->
+    | 1025 ->
         "<SYNTAX ERROR>\n"
-    | 1021 ->
+    | 1026 ->
         "<SYNTAX ERROR>\n"
-    | 1023 ->
-        "<SYNTAX ERROR>\n"
-    | 1016 ->
-        "<SYNTAX ERROR>\n"
-    | 1017 ->
+    | 1027 ->
         "<SYNTAX ERROR>\n"
     | 1028 ->
         "<SYNTAX ERROR>\n"
-    | 1029 ->
+    | 1742 ->
         "<SYNTAX ERROR>\n"
-    | 1030 ->
+    | 1743 ->
+        "<SYNTAX ERROR>\n"
+    | 793 ->
         "<SYNTAX ERROR>\n"
     | 1031 ->
         "<SYNTAX ERROR>\n"
-    | 1745 ->
+    | 1032 ->
         "<SYNTAX ERROR>\n"
-    | 1746 ->
+    | 1713 ->
         "<SYNTAX ERROR>\n"
-    | 797 ->
+    | 966 ->
         "<SYNTAX ERROR>\n"
-    | 1034 ->
-        "<SYNTAX ERROR>\n"
-    | 1035 ->
-        "<SYNTAX ERROR>\n"
-    | 1716 ->
+    | 967 ->
         "<SYNTAX ERROR>\n"
     | 969 ->
         "<SYNTAX ERROR>\n"
     | 970 ->
         "<SYNTAX ERROR>\n"
+    | 976 ->
+        "<SYNTAX ERROR>\n"
+    | 974 ->
+        "<SYNTAX ERROR>\n"
     | 972 ->
-        "<SYNTAX ERROR>\n"
-    | 973 ->
-        "<SYNTAX ERROR>\n"
-    | 979 ->
-        "<SYNTAX ERROR>\n"
-    | 977 ->
-        "<SYNTAX ERROR>\n"
-    | 975 ->
-        "<SYNTAX ERROR>\n"
-    | 992 ->
-        "<SYNTAX ERROR>\n"
-    | 993 ->
-        "<SYNTAX ERROR>\n"
-    | 985 ->
-        "<SYNTAX ERROR>\n"
-    | 986 ->
-        "<SYNTAX ERROR>\n"
-    | 990 ->
-        "<SYNTAX ERROR>\n"
-    | 76 ->
         "<SYNTAX ERROR>\n"
     | 989 ->
         "<SYNTAX ERROR>\n"
+    | 990 ->
+        "<SYNTAX ERROR>\n"
+    | 982 ->
+        "<SYNTAX ERROR>\n"
+    | 983 ->
+        "<SYNTAX ERROR>\n"
     | 987 ->
+        "<SYNTAX ERROR>\n"
+    | 76 ->
+        "<SYNTAX ERROR>\n"
+    | 986 ->
+        "<SYNTAX ERROR>\n"
+    | 984 ->
         "<SYNTAX ERROR>\n"
     | 117 ->
         "<SYNTAX ERROR>\n"
     | 256 ->
         "<SYNTAX ERROR>\n"
-    | 996 ->
+    | 993 ->
         "<SYNTAX ERROR>\n"
-    | 997 ->
+    | 994 ->
         "<SYNTAX ERROR>\n"
     | 257 ->
         "<SYNTAX ERROR>\n"
@@ -1788,9 +1788,15 @@ let message =
         "<SYNTAX ERROR>\n"
     | 410 ->
         "<SYNTAX ERROR>\n"
-    | 2408 ->
+    | 2405 ->
         "<SYNTAX ERROR>\n"
-    | 554 ->
+    | 550 ->
+        "<SYNTAX ERROR>\n"
+    | 2320 ->
+        "<SYNTAX ERROR>\n"
+    | 2321 ->
+        "<SYNTAX ERROR>\n"
+    | 2322 ->
         "<SYNTAX ERROR>\n"
     | 2323 ->
         "<SYNTAX ERROR>\n"
@@ -1798,65 +1804,65 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2325 ->
         "<SYNTAX ERROR>\n"
-    | 2326 ->
+    | 1923 ->
         "<SYNTAX ERROR>\n"
-    | 2327 ->
-        "<SYNTAX ERROR>\n"
-    | 2328 ->
+    | 1924 ->
         "<SYNTAX ERROR>\n"
     | 1926 ->
         "<SYNTAX ERROR>\n"
-    | 1927 ->
+    | 1931 ->
         "<SYNTAX ERROR>\n"
     | 1929 ->
         "<SYNTAX ERROR>\n"
-    | 1934 ->
-        "<SYNTAX ERROR>\n"
-    | 1932 ->
-        "<SYNTAX ERROR>\n"
-    | 1930 ->
-        "<SYNTAX ERROR>\n"
-    | 1955 ->
-        "<SYNTAX ERROR>\n"
-    | 1956 ->
-        "<SYNTAX ERROR>\n"
-    | 1935 ->
-        "<SYNTAX ERROR>\n"
-    | 1936 ->
-        "<SYNTAX ERROR>\n"
-    | 1953 ->
-        "<SYNTAX ERROR>\n"
-    | 1938 ->
+    | 1927 ->
         "<SYNTAX ERROR>\n"
     | 1952 ->
         "<SYNTAX ERROR>\n"
-    | 1937 ->
+    | 1953 ->
         "<SYNTAX ERROR>\n"
-    | 1939 ->
+    | 1932 ->
+        "<SYNTAX ERROR>\n"
+    | 1933 ->
+        "<SYNTAX ERROR>\n"
+    | 1950 ->
+        "<SYNTAX ERROR>\n"
+    | 1935 ->
+        "<SYNTAX ERROR>\n"
+    | 1949 ->
+        "<SYNTAX ERROR>\n"
+    | 1934 ->
+        "<SYNTAX ERROR>\n"
+    | 1936 ->
+        "<SYNTAX ERROR>\n"
+    | 1937 ->
         "<SYNTAX ERROR>\n"
     | 1940 ->
         "<SYNTAX ERROR>\n"
-    | 1943 ->
+    | 551 ->
         "<SYNTAX ERROR>\n"
-    | 555 ->
+    | 644 ->
         "<SYNTAX ERROR>\n"
-    | 648 ->
+    | 1957 ->
         "<SYNTAX ERROR>\n"
-    | 1960 ->
+    | 1958 ->
         "<SYNTAX ERROR>\n"
-    | 1961 ->
+    | 645 ->
         "<SYNTAX ERROR>\n"
-    | 649 ->
+    | 646 ->
         "<SYNTAX ERROR>\n"
-    | 650 ->
+    | 552 ->
         "<SYNTAX ERROR>\n"
-    | 556 ->
+    | 553 ->
         "<SYNTAX ERROR>\n"
-    | 557 ->
+    | 2316 ->
         "<SYNTAX ERROR>\n"
-    | 2319 ->
+    | 1913 ->
         "<SYNTAX ERROR>\n"
-    | 1916 ->
+    | 1967 ->
+        "<SYNTAX ERROR>\n"
+    | 1968 ->
+        "<SYNTAX ERROR>\n"
+    | 1969 ->
         "<SYNTAX ERROR>\n"
     | 1970 ->
         "<SYNTAX ERROR>\n"
@@ -1864,57 +1870,51 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1972 ->
         "<SYNTAX ERROR>\n"
-    | 1973 ->
+    | 1921 ->
         "<SYNTAX ERROR>\n"
-    | 1974 ->
+    | 2317 ->
         "<SYNTAX ERROR>\n"
-    | 1975 ->
+    | 1914 ->
         "<SYNTAX ERROR>\n"
-    | 1924 ->
+    | 923 ->
         "<SYNTAX ERROR>\n"
-    | 2320 ->
+    | 1735 ->
         "<SYNTAX ERROR>\n"
-    | 1917 ->
+    | 1734 ->
         "<SYNTAX ERROR>\n"
-    | 927 ->
+    | 1716 ->
         "<SYNTAX ERROR>\n"
-    | 1738 ->
+    | 1717 ->
         "<SYNTAX ERROR>\n"
-    | 1737 ->
+    | 1718 ->
         "<SYNTAX ERROR>\n"
     | 1719 ->
         "<SYNTAX ERROR>\n"
     | 1720 ->
         "<SYNTAX ERROR>\n"
-    | 1721 ->
-        "<SYNTAX ERROR>\n"
-    | 1722 ->
-        "<SYNTAX ERROR>\n"
     | 1723 ->
+        "<SYNTAX ERROR>\n"
+    | 945 ->
         "<SYNTAX ERROR>\n"
     | 1726 ->
         "<SYNTAX ERROR>\n"
-    | 948 ->
+    | 1727 ->
+        "<SYNTAX ERROR>\n"
+    | 1747 ->
         "<SYNTAX ERROR>\n"
     | 1729 ->
         "<SYNTAX ERROR>\n"
+    | 1654 ->
+        "<SYNTAX ERROR>\n"
     | 1730 ->
         "<SYNTAX ERROR>\n"
-    | 1750 ->
+    | 1748 ->
         "<SYNTAX ERROR>\n"
-    | 1732 ->
+    | 1749 ->
         "<SYNTAX ERROR>\n"
-    | 1657 ->
+    | 2623 ->
         "<SYNTAX ERROR>\n"
-    | 1733 ->
-        "<SYNTAX ERROR>\n"
-    | 1751 ->
-        "<SYNTAX ERROR>\n"
-    | 1752 ->
-        "<SYNTAX ERROR>\n"
-    | 2631 ->
-        "<SYNTAX ERROR>\n"
-    | 2633 ->
+    | 2625 ->
         "<SYNTAX ERROR>\n"
     | 279 ->
         "<SYNTAX ERROR>\n"
@@ -1938,11 +1938,11 @@ let message =
         "<SYNTAX ERROR>\n"
     | 10 ->
         "<SYNTAX ERROR>\n"
-    | 2557 ->
+    | 2554 ->
         "<SYNTAX ERROR>\n"
     | 110 ->
         "<SYNTAX ERROR>\n"
-    | 2555 ->
+    | 2552 ->
         "Expecting one of the following:\n  - \",\" to start the type in the tuple\n  - \")\" to finish the tuple type definition\n"
     | 277 ->
         "<SYNTAX ERROR>\n"
@@ -1956,9 +1956,9 @@ let message =
         "<SYNTAX ERROR>\n"
     | 128 ->
         "<SYNTAX ERROR>\n"
-    | 2552 ->
+    | 2549 ->
         "<SYNTAX ERROR>\n"
-    | 2553 ->
+    | 2550 ->
         "<SYNTAX ERROR>\n"
     | 120 ->
         "<SYNTAX ERROR>\n"
@@ -1970,13 +1970,13 @@ let message =
         "<SYNTAX ERROR>\n"
     | 130 ->
         "<SYNTAX ERROR>\n"
-    | 2544 ->
+    | 2541 ->
+        "<SYNTAX ERROR>\n"
+    | 2542 ->
+        "<SYNTAX ERROR>\n"
+    | 2543 ->
         "<SYNTAX ERROR>\n"
     | 2545 ->
-        "<SYNTAX ERROR>\n"
-    | 2546 ->
-        "<SYNTAX ERROR>\n"
-    | 2548 ->
         "<SYNTAX ERROR>\n"
     | 134 ->
         "<SYNTAX ERROR>\n"
@@ -1988,11 +1988,11 @@ let message =
         "<SYNTAX ERROR>\n"
     | 141 ->
         "<SYNTAX ERROR>\n"
-    | 496 ->
+    | 493 ->
+        "<SYNTAX ERROR>\n"
+    | 492 ->
         "<SYNTAX ERROR>\n"
     | 495 ->
-        "<SYNTAX ERROR>\n"
-    | 498 ->
         "<SYNTAX ERROR>\n"
     | 295 ->
         "<SYNTAX ERROR>\n"
@@ -2000,11 +2000,11 @@ let message =
         "<SYNTAX ERROR>\n"
     | 143 ->
         "<SYNTAX ERROR>\n"
+    | 2534 ->
+        "<SYNTAX ERROR>\n"
+    | 2536 ->
+        "<SYNTAX ERROR>\n"
     | 2537 ->
-        "<SYNTAX ERROR>\n"
-    | 2539 ->
-        "<SYNTAX ERROR>\n"
-    | 2540 ->
         "<SYNTAX ERROR>\n"
     | 157 ->
         "<SYNTAX ERROR>\n"
@@ -2012,51 +2012,51 @@ let message =
         "<SYNTAX ERROR>\n"
     | 146 ->
         "<SYNTAX ERROR>\n"
-    | 2535 ->
+    | 2532 ->
         "<SYNTAX ERROR>\n"
     | 148 ->
         "<SYNTAX ERROR>\n"
     | 149 ->
         "<SYNTAX ERROR>\n"
-    | 2531 ->
+    | 2528 ->
         "<SYNTAX ERROR>\n"
-    | 2532 ->
+    | 2529 ->
         "<SYNTAX ERROR>\n"
-    | 2533 ->
+    | 2530 ->
         "<SYNTAX ERROR>\n"
     | 150 ->
         "<SYNTAX ERROR>\n"
     | 155 ->
         "<SYNTAX ERROR>\n"
-    | 2529 ->
-        "<SYNTAX ERROR>\n"
-    | 2525 ->
+    | 2526 ->
         "<SYNTAX ERROR>\n"
     | 2522 ->
         "<SYNTAX ERROR>\n"
-    | 2635 ->
+    | 2519 ->
         "<SYNTAX ERROR>\n"
-    | 2637 ->
+    | 2627 ->
         "<SYNTAX ERROR>\n"
-    | 2639 ->
+    | 2629 ->
         "<SYNTAX ERROR>\n"
-    | 2640 ->
+    | 2631 ->
         "<SYNTAX ERROR>\n"
-    | 792 ->
+    | 2632 ->
         "<SYNTAX ERROR>\n"
-    | 794 ->
+    | 788 ->
         "<SYNTAX ERROR>\n"
-    | 805 ->
+    | 790 ->
         "<SYNTAX ERROR>\n"
-    | 795 ->
+    | 801 ->
         "<SYNTAX ERROR>\n"
-    | 787 ->
+    | 791 ->
         "<SYNTAX ERROR>\n"
-    | 632 ->
+    | 783 ->
         "<SYNTAX ERROR>\n"
-    | 596 ->
+    | 628 ->
         "<SYNTAX ERROR>\n"
-    | 768 ->
+    | 592 ->
+        "<SYNTAX ERROR>\n"
+    | 764 ->
         "<SYNTAX ERROR>\n"
     | 193 ->
         "<SYNTAX ERROR>\n"
@@ -2066,21 +2066,21 @@ let message =
         "<SYNTAX ERROR>\n"
     | 210 ->
         "<SYNTAX ERROR>\n"
-    | 812 ->
+    | 808 ->
         "<SYNTAX ERROR>\n"
-    | 813 ->
+    | 809 ->
         "<SYNTAX ERROR>\n"
-    | 842 ->
+    | 838 ->
         "<SYNTAX ERROR>\n"
-    | 803 ->
+    | 799 ->
         "<SYNTAX ERROR>\n"
-    | 731 ->
+    | 727 ->
         "<SYNTAX ERROR>\n"
-    | 718 ->
+    | 714 ->
         "<SYNTAX ERROR>\n"
-    | 720 ->
+    | 716 ->
         "<SYNTAX ERROR>\n"
-    | 847 ->
+    | 843 ->
         "<SYNTAX ERROR>\n"
     | 446 ->
         "<SYNTAX ERROR>\n"
@@ -2112,7 +2112,7 @@ let message =
         "<SYNTAX ERROR>\n"
     | 334 ->
         "<SYNTAX ERROR>\n"
-    | 2419 ->
+    | 2416 ->
         "<SYNTAX ERROR>\n"
     | 291 ->
         "<SYNTAX ERROR>\n"
@@ -2148,19 +2148,19 @@ let message =
         "<SYNTAX ERROR>\n"
     | 317 ->
         "<SYNTAX ERROR>\n"
-    | 738 ->
+    | 734 ->
         "<SYNTAX ERROR>\n"
-    | 721 ->
+    | 717 ->
         "<SYNTAX ERROR>\n"
-    | 723 ->
+    | 719 ->
         "<SYNTAX ERROR>\n"
-    | 708 ->
+    | 704 ->
         "<SYNTAX ERROR>\n"
-    | 677 ->
+    | 673 ->
         "<SYNTAX ERROR>\n"
-    | 698 ->
+    | 694 ->
         "<SYNTAX ERROR>\n"
-    | 689 ->
+    | 685 ->
         "<SYNTAX ERROR>\n"
     | 212 ->
         "<SYNTAX ERROR>\n"
@@ -2184,57 +2184,63 @@ let message =
         "<SYNTAX ERROR>\n"
     | 243 ->
         "<SYNTAX ERROR>\n"
-    | 2423 ->
+    | 2420 ->
         "<SYNTAX ERROR>\n"
-    | 2424 ->
+    | 2421 ->
         "<SYNTAX ERROR>\n"
     | 234 ->
         "<SYNTAX ERROR>\n"
     | 239 ->
         "<SYNTAX ERROR>\n"
-    | 634 ->
+    | 630 ->
+        "<SYNTAX ERROR>\n"
+    | 636 ->
+        "<SYNTAX ERROR>\n"
+    | 725 ->
+        "<SYNTAX ERROR>\n"
+    | 814 ->
+        "<SYNTAX ERROR>\n"
+    | 637 ->
+        "<SYNTAX ERROR>\n"
+    | 638 ->
         "<SYNTAX ERROR>\n"
     | 640 ->
         "<SYNTAX ERROR>\n"
-    | 729 ->
+    | 830 ->
         "<SYNTAX ERROR>\n"
-    | 818 ->
+    | 831 ->
         "<SYNTAX ERROR>\n"
-    | 641 ->
+    | 832 ->
         "<SYNTAX ERROR>\n"
-    | 642 ->
-        "<SYNTAX ERROR>\n"
-    | 644 ->
+    | 833 ->
         "<SYNTAX ERROR>\n"
     | 834 ->
         "<SYNTAX ERROR>\n"
     | 835 ->
         "<SYNTAX ERROR>\n"
-    | 836 ->
+    | 652 ->
         "<SYNTAX ERROR>\n"
-    | 837 ->
+    | 827 ->
         "<SYNTAX ERROR>\n"
-    | 838 ->
+    | 655 ->
         "<SYNTAX ERROR>\n"
-    | 839 ->
+    | 822 ->
         "<SYNTAX ERROR>\n"
     | 656 ->
         "<SYNTAX ERROR>\n"
-    | 831 ->
+    | 661 ->
         "<SYNTAX ERROR>\n"
-    | 659 ->
+    | 672 ->
         "<SYNTAX ERROR>\n"
-    | 826 ->
+    | 680 ->
         "<SYNTAX ERROR>\n"
-    | 660 ->
+    | 688 ->
         "<SYNTAX ERROR>\n"
-    | 665 ->
+    | 2423 ->
         "<SYNTAX ERROR>\n"
-    | 676 ->
+    | 2424 ->
         "<SYNTAX ERROR>\n"
-    | 684 ->
-        "<SYNTAX ERROR>\n"
-    | 692 ->
+    | 2425 ->
         "<SYNTAX ERROR>\n"
     | 2426 ->
         "<SYNTAX ERROR>\n"
@@ -2242,87 +2248,81 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2428 ->
         "<SYNTAX ERROR>\n"
-    | 2429 ->
+    | 728 ->
         "<SYNTAX ERROR>\n"
-    | 2430 ->
+    | 739 ->
         "<SYNTAX ERROR>\n"
-    | 2431 ->
+    | 742 ->
         "<SYNTAX ERROR>\n"
     | 732 ->
+        "<SYNTAX ERROR>\n"
+    | 733 ->
+        "<SYNTAX ERROR>\n"
+    | 653 ->
+        "<SYNTAX ERROR>\n"
+    | 654 ->
         "<SYNTAX ERROR>\n"
     | 743 ->
         "<SYNTAX ERROR>\n"
     | 746 ->
         "<SYNTAX ERROR>\n"
-    | 736 ->
-        "<SYNTAX ERROR>\n"
-    | 737 ->
-        "<SYNTAX ERROR>\n"
-    | 657 ->
-        "<SYNTAX ERROR>\n"
-    | 658 ->
-        "<SYNTAX ERROR>\n"
-    | 747 ->
+    | 754 ->
         "<SYNTAX ERROR>\n"
     | 750 ->
         "<SYNTAX ERROR>\n"
-    | 758 ->
+    | 753 ->
         "<SYNTAX ERROR>\n"
-    | 754 ->
-        "<SYNTAX ERROR>\n"
-    | 757 ->
+    | 751 ->
+        "Expecting a valid list identifier\n"
+    | 752 ->
         "<SYNTAX ERROR>\n"
     | 755 ->
-        "Expecting a valid list identifier\n"
-    | 756 ->
         "<SYNTAX ERROR>\n"
-    | 759 ->
+    | 658 ->
         "<SYNTAX ERROR>\n"
-    | 662 ->
-        "<SYNTAX ERROR>\n"
-    | 663 ->
-        "<SYNTAX ERROR>\n"
-    | 674 ->
-        "<SYNTAX ERROR>\n"
-    | 669 ->
+    | 659 ->
         "<SYNTAX ERROR>\n"
     | 670 ->
         "<SYNTAX ERROR>\n"
-    | 760 ->
+    | 665 ->
         "<SYNTAX ERROR>\n"
-    | 675 ->
+    | 666 ->
         "<SYNTAX ERROR>\n"
-    | 824 ->
+    | 756 ->
         "<SYNTAX ERROR>\n"
-    | 763 ->
+    | 671 ->
         "<SYNTAX ERROR>\n"
-    | 779 ->
+    | 820 ->
         "<SYNTAX ERROR>\n"
-    | 781 ->
+    | 759 ->
+        "<SYNTAX ERROR>\n"
+    | 775 ->
+        "<SYNTAX ERROR>\n"
+    | 777 ->
+        "<SYNTAX ERROR>\n"
+    | 2635 ->
+        "<SYNTAX ERROR>\n"
+    | 2649 ->
+        "<SYNTAX ERROR>\n"
+    | 2636 ->
+        "<SYNTAX ERROR>\n"
+    | 2637 ->
         "<SYNTAX ERROR>\n"
     | 2643 ->
         "<SYNTAX ERROR>\n"
-    | 2657 ->
-        "<SYNTAX ERROR>\n"
     | 2644 ->
         "<SYNTAX ERROR>\n"
-    | 2645 ->
-        "<SYNTAX ERROR>\n"
-    | 2651 ->
+    | 2647 ->
         "<SYNTAX ERROR>\n"
     | 2652 ->
         "<SYNTAX ERROR>\n"
+    | 2659 ->
+        "<SYNTAX ERROR>\n"
+    | 2658 ->
+        "<SYNTAX ERROR>\n"
     | 2655 ->
         "<SYNTAX ERROR>\n"
-    | 2660 ->
-        "<SYNTAX ERROR>\n"
-    | 2667 ->
-        "<SYNTAX ERROR>\n"
-    | 2666 ->
-        "<SYNTAX ERROR>\n"
-    | 2663 ->
-        "<SYNTAX ERROR>\n"
-    | 2664 ->
+    | 2656 ->
         "<SYNTAX ERROR>\n"
     | _ ->
         raise Not_found

--- a/src/reason_parser_message.ml
+++ b/src/reason_parser_message.ml
@@ -10,239 +10,237 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2 ->
         "<SYNTAX ERROR>\n"
-    | 2590 ->
+    | 2598 ->
         "<SYNTAX ERROR>\n"
-    | 568 ->
-        "Expecting one of the following:\n  - an identifier to access a member of an object\n  - \"[\" + expression + \"]\" to access an element of a list\n  - \"(\" + expression + \")\"\n  - \"{\" + expression + \"}\"\n"
     | 569 ->
+        "Expecting one of the following:\n  - an identifier to access a member of an object\n  - \"[\" + expression + \"]\" to access an element of a list\n  - \"(\" + expression + \")\"\n  - \"{\" + expression + \"}\"\n"
+    | 570 ->
         "Expecting an expression\n"
-    | 2279 ->
+    | 2286 ->
         "Expecting one of the following:\n  - an infix operation to connect two expressions\n  - \")\" to close the block\n"
-    | 2281 ->
+    | 2288 ->
         "Expecting an expression\n"
-    | 2282 ->
+    | 2289 ->
         "Expecting one of the following:\n  - an infix operation to connect two expressions\n  - \"}\" to close the block\n"
-    | 2284 ->
+    | 2291 ->
         "Expecting an expression\n"
-    | 2285 ->
+    | 2292 ->
         "Expecting one of the following:\n  - an infix operation to connect two expressions\n  - \"}\" to close the block\n"
-    | 1182 ->
+    | 1183 ->
         "Expecting an expression\n"
-    | 566 ->
+    | 567 ->
         "Expecting an identifier\n"
-    | 1115 ->
+    | 1116 ->
         "Expecting a structure item\n"
-    | 2595 ->
+    | 2603 ->
         "Invalid token\n"
-    | 1236 ->
-        "Expecting an expression\n"
     | 1237 ->
-        "Expecting one of the following:\n  - The continuation of the previous expression\n  - \":\" to start the next expression\n"
+        "Expecting an expression\n"
     | 1238 ->
+        "Expecting one of the following:\n  - The continuation of the previous expression\n  - \":\" to start the next expression\n"
+    | 1239 ->
         "Expecting an expression\n"
-    | 1197 ->
+    | 1198 ->
         "Expecting an expression\n"
-    | 1203 ->
+    | 1204 ->
         "Expecting an expression\n"
-    | 1205 ->
+    | 1206 ->
         "Expecting an expression\n"
-    | 1199 ->
+    | 1200 ->
         "Expecting an expression\n"
-    | 1207 ->
+    | 1208 ->
         "Expecting an expression\n"
-    | 1209 ->
+    | 1210 ->
         "Expecting an expression\n"
-    | 1211 ->
+    | 1212 ->
         "Expecting an expression\n"
     | 15 ->
         "Expecting one of the following:\n  - \")\" to form a unit value \"()\"\n  - \"module\" to start a module expression\n  - an expression\n  - an operator to denote the prefix form of an operator\n"
-    | 1213 ->
+    | 1214 ->
         "Expecting an expression\n"
-    | 1219 ->
+    | 1220 ->
         "Expecting an expression\n"
-    | 1221 ->
+    | 1222 ->
         "Expecting an expression\n"
-    | 2396 ->
+    | 2403 ->
         "Expecting \"]\"\n"
-    | 400 ->
+    | 403 ->
         "Expecting an attributed id\n"
-    | 2503 ->
+    | 2510 ->
         "Expecting \"]\"\n"
-    | 171 ->
+    | 161 ->
         "Expecting an attribute id\n"
-    | 1184 ->
+    | 1185 ->
         "Expecting an expression\n"
-    | 1201 ->
+    | 1202 ->
         "Expecting an expression\n"
-    | 1215 ->
+    | 1216 ->
         "Expecting an expression\n"
-    | 1217 ->
+    | 1218 ->
         "Expecting an expression\n"
-    | 1223 ->
+    | 1224 ->
         "Expecting an expression\n"
-    | 1225 ->
+    | 1226 ->
         "Expecting an expression\n"
-    | 848 ->
-        "<SYNTAX ERROR>\n"
     | 849 ->
-        "<SYNTAX ERROR>\n"
-    | 2187 ->
         "<SYNTAX ERROR>\n"
     | 850 ->
         "<SYNTAX ERROR>\n"
-    | 852 ->
+    | 2194 ->
         "<SYNTAX ERROR>\n"
-    | 2183 ->
+    | 851 ->
         "<SYNTAX ERROR>\n"
-    | 2185 ->
+    | 853 ->
         "<SYNTAX ERROR>\n"
     | 2190 ->
         "<SYNTAX ERROR>\n"
-    | 2191 ->
+    | 2192 ->
         "<SYNTAX ERROR>\n"
-    | 2195 ->
+    | 2197 ->
         "<SYNTAX ERROR>\n"
-    | 2205 ->
+    | 2198 ->
         "<SYNTAX ERROR>\n"
-    | 2210 ->
+    | 2202 ->
+        "<SYNTAX ERROR>\n"
+    | 2212 ->
+        "<SYNTAX ERROR>\n"
+    | 2217 ->
         "<SYNTAX ERROR>\n"
     | 1842 ->
         "<SYNTAX ERROR>\n"
-    | 1233 ->
+    | 1234 ->
         "<SYNTAX ERROR>\n"
-    | 1227 ->
+    | 1228 ->
         "<SYNTAX ERROR>\n"
-    | 1229 ->
+    | 1230 ->
         "<SYNTAX ERROR>\n"
-    | 1231 ->
+    | 1232 ->
         "<SYNTAX ERROR>\n"
-    | 76 ->
-        "<SYNTAX ERROR>\n"
-    | 948 ->
+    | 75 ->
         "<SYNTAX ERROR>\n"
     | 949 ->
         "<SYNTAX ERROR>\n"
-    | 93 ->
+    | 950 ->
+        "<SYNTAX ERROR>\n"
+    | 104 ->
         "Expecting one of the following:\n  - \"=\" to start the body of the type declaration\n  - \"constraint\" to add constraints to the type declaration\n  - \";\" to finish type declaratoin\n  - \"+=\" to form a string type extension\n  - \"and\" to declare another type\n"
-    | 80 ->
+    | 91 ->
         "<SYNTAX ERROR>\n"
-    | 2575 ->
+    | 2583 ->
         "<SYNTAX ERROR>\n"
-    | 2579 ->
+    | 2587 ->
+        "<SYNTAX ERROR>\n"
+    | 2584 ->
+        "<SYNTAX ERROR>\n"
+    | 2585 ->
+        "<SYNTAX ERROR>\n"
+    | 95 ->
+        "<SYNTAX ERROR>\n"
+    | 97 ->
+        "<SYNTAX ERROR>\n"
+    | 99 ->
+        "<SYNTAX ERROR>\n"
+    | 101 ->
+        "<SYNTAX ERROR>\n"
+    | 1126 ->
+        "<SYNTAX ERROR>\n"
+    | 105 ->
+        "<SYNTAX ERROR>\n"
+    | 2569 ->
+        "<SYNTAX ERROR>\n"
+    | 2570 ->
+        "<SYNTAX ERROR>\n"
+    | 2560 ->
+        "<SYNTAX ERROR>\n"
+    | 2572 ->
         "<SYNTAX ERROR>\n"
     | 2576 ->
         "<SYNTAX ERROR>\n"
     | 2577 ->
         "<SYNTAX ERROR>\n"
-    | 84 ->
+    | 2552 ->
         "<SYNTAX ERROR>\n"
-    | 86 ->
+    | 107 ->
         "<SYNTAX ERROR>\n"
-    | 88 ->
+    | 2551 ->
         "<SYNTAX ERROR>\n"
-    | 90 ->
+    | 115 ->
         "<SYNTAX ERROR>\n"
-    | 1125 ->
-        "<SYNTAX ERROR>\n"
-    | 94 ->
-        "<SYNTAX ERROR>\n"
-    | 2562 ->
-        "<SYNTAX ERROR>\n"
-    | 2563 ->
-        "<SYNTAX ERROR>\n"
-    | 2550 ->
-        "<SYNTAX ERROR>\n"
-    | 2564 ->
-        "<SYNTAX ERROR>\n"
-    | 2568 ->
-        "<SYNTAX ERROR>\n"
-    | 2569 ->
-        "<SYNTAX ERROR>\n"
-    | 2542 ->
-        "<SYNTAX ERROR>\n"
-    | 96 ->
-        "<SYNTAX ERROR>\n"
-    | 2553 ->
-        "<SYNTAX ERROR>\n"
-    | 2540 ->
-        "<SYNTAX ERROR>\n"
-    | 2541 ->
-        "<SYNTAX ERROR>\n"
-    | 2558 ->
+    | 2565 ->
         "Expecting at least one type field definition in the form of:\n  <field name> : <type>\n"
-    | 483 ->
-        "Expecting a type field definition in the form of:\n  <field name> : <type>\n"
     | 484 ->
-        "Expecting \":\"\n"
+        "Expecting a type field definition in the form of:\n  <field name> : <type>\n"
     | 485 ->
+        "Expecting \":\"\n"
+    | 486 ->
         "Expecting a type name describing this field\n"
-    | 2559 ->
+    | 2566 ->
         "Expecting one of the following:\n  - \",\" to finish current type field\n  - \"}\" to finish type definition\n"
-    | 499 ->
+    | 500 ->
         "Expecting one of the following:\n  - another type field definition\n  - \"}\" to finish entire type definition\n"
-    | 1130 ->
+    | 1131 ->
         "<SYNTAX ERROR>\n"
-    | 2547 ->
-        "<SYNTAX ERROR>\n"
-    | 970 ->
+    | 2557 ->
         "<SYNTAX ERROR>\n"
     | 971 ->
         "<SYNTAX ERROR>\n"
     | 972 ->
         "<SYNTAX ERROR>\n"
-    | 1126 ->
+    | 973 ->
         "<SYNTAX ERROR>\n"
-    | 1128 ->
+    | 1127 ->
         "<SYNTAX ERROR>\n"
-    | 173 ->
+    | 1129 ->
         "<SYNTAX ERROR>\n"
-    | 2498 ->
+    | 163 ->
         "<SYNTAX ERROR>\n"
-    | 2497 ->
+    | 2505 ->
         "<SYNTAX ERROR>\n"
-    | 2500 ->
+    | 2504 ->
         "<SYNTAX ERROR>\n"
-    | 2439 ->
-        "<SYNTAX ERROR>\n"
-    | 2440 ->
-        "<SYNTAX ERROR>\n"
-    | 2441 ->
-        "Expecting a sequence item\n"
-    | 1872 ->
-        "Expecting one of the following:\n  - \"|\" to open the next pattern\n  - \"=>\" to start the body of the matched pattern\n  - \"when\" to start a contitional guard for the previous pattern\n"
-    | 2472 ->
-        "Expecting the body of the matched pattern\n"
-    | 2501 ->
-        "Expecting one of the following:\n  - \"}\" to finish the block\n  - \"|\" to start another pattern matching case\n"
-    | 2455 ->
-        "<SYNTAX ERROR>\n"
-    | 2442 ->
-        "<SYNTAX ERROR>\n"
-    | 2443 ->
+    | 2507 ->
         "<SYNTAX ERROR>\n"
     | 2446 ->
         "<SYNTAX ERROR>\n"
     | 2447 ->
         "<SYNTAX ERROR>\n"
-    | 2444 ->
+    | 2448 ->
+        "Expecting a sequence item\n"
+    | 1872 ->
+        "Expecting one of the following:\n  - \"|\" to open the next pattern\n  - \"=>\" to start the body of the matched pattern\n  - \"when\" to start a contitional guard for the previous pattern\n"
+    | 2479 ->
+        "Expecting the body of the matched pattern\n"
+    | 2508 ->
+        "Expecting one of the following:\n  - \"}\" to finish the block\n  - \"|\" to start another pattern matching case\n"
+    | 2462 ->
         "<SYNTAX ERROR>\n"
-    | 2465 ->
+    | 2449 ->
         "<SYNTAX ERROR>\n"
-    | 2466 ->
+    | 2450 ->
         "<SYNTAX ERROR>\n"
-    | 2469 ->
+    | 2453 ->
         "<SYNTAX ERROR>\n"
-    | 2468 ->
+    | 2454 ->
+        "<SYNTAX ERROR>\n"
+    | 2451 ->
+        "<SYNTAX ERROR>\n"
+    | 2472 ->
+        "<SYNTAX ERROR>\n"
+    | 2473 ->
+        "<SYNTAX ERROR>\n"
+    | 2476 ->
+        "<SYNTAX ERROR>\n"
+    | 2475 ->
         "<SYNTAX ERROR>\n"
     | 1871 ->
         "Expecting a match case\n"
-    | 887 ->
-        "<SYNTAX ERROR>\n"
-    | 113 ->
-        "<SYNTAX ERROR>\n"
-    | 114 ->
-        "<SYNTAX ERROR>\n"
     | 888 ->
+        "<SYNTAX ERROR>\n"
+    | 124 ->
+        "<SYNTAX ERROR>\n"
+    | 125 ->
+        "<SYNTAX ERROR>\n"
+    | 889 ->
         "<SYNTAX ERROR>\n"
     | 1846 ->
         "<SYNTAX ERROR>\n"
@@ -262,65 +260,65 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1860 ->
         "<SYNTAX ERROR>\n"
-    | 178 ->
+    | 168 ->
         "<SYNTAX ERROR>\n"
-    | 2481 ->
+    | 2488 ->
         "<SYNTAX ERROR>\n"
-    | 2482 ->
+    | 2489 ->
         "<SYNTAX ERROR>\n"
-    | 1114 ->
+    | 1115 ->
         "Incomplete module item, forgetting a \";\"?\n"
-    | 1169 ->
+    | 1170 ->
         "<SYNTAX ERROR>\n"
-    | 1172 ->
+    | 1173 ->
         "<SYNTAX ERROR>\n"
     | 6 ->
         "<SYNTAX ERROR>\n"
-    | 1194 ->
+    | 1195 ->
         "<SYNTAX ERROR>\n"
-    | 392 ->
-        "<SYNTAX ERROR>\n"
-    | 393 ->
-        "<SYNTAX ERROR>\n"
-    | 340 ->
+    | 395 ->
         "<SYNTAX ERROR>\n"
     | 396 ->
         "<SYNTAX ERROR>\n"
-    | 398 ->
+    | 344 ->
+        "<SYNTAX ERROR>\n"
+    | 399 ->
+        "<SYNTAX ERROR>\n"
+    | 401 ->
         "<SYNTAX ERROR>\n"
     | 7 ->
         "<SYNTAX ERROR>\n"
-    | 402 ->
-        "<SYNTAX ERROR>\n"
-    | 403 ->
-        "<SYNTAX ERROR>\n"
     | 405 ->
         "<SYNTAX ERROR>\n"
-    | 885 ->
+    | 406 ->
         "<SYNTAX ERROR>\n"
-    | 534 ->
+    | 408 ->
+        "<SYNTAX ERROR>\n"
+    | 886 ->
+        "<SYNTAX ERROR>\n"
+    | 536 ->
         "<SYNTAX ERROR>\n"
     | 16 ->
         "<SYNTAX ERROR>\n"
-    | 2587 ->
-        "<SYNTAX ERROR>\n"
-    | 605 ->
+    | 2595 ->
         "<SYNTAX ERROR>\n"
     | 606 ->
         "<SYNTAX ERROR>\n"
-    | 2234 ->
+    | 607 ->
         "<SYNTAX ERROR>\n"
-    | 2236 ->
+    | 2241 ->
         "<SYNTAX ERROR>\n"
-    | 2237 ->
+    | 2243 ->
         "<SYNTAX ERROR>\n"
-    | 2239 ->
+    | 2244 ->
         "<SYNTAX ERROR>\n"
-    | 2240 ->
+    | 2246 ->
+        "<SYNTAX ERROR>\n"
+    | 2247 ->
         "<SYNTAX ERROR>\n"
     | 1373 ->
         "<SYNTAX ERROR>\n"
-    | 602 ->
+    | 603 ->
         "<SYNTAX ERROR>\n"
     | 1431 ->
         "<SYNTAX ERROR>\n"
@@ -342,7 +340,7 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1402 ->
         "<SYNTAX ERROR>\n"
-    | 194 ->
+    | 184 ->
         "<SYNTAX ERROR>\n"
     | 1404 ->
         "<SYNTAX ERROR>\n"
@@ -350,9 +348,9 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1412 ->
         "<SYNTAX ERROR>\n"
-    | 2399 ->
+    | 2406 ->
         "<SYNTAX ERROR>\n"
-    | 336 ->
+    | 340 ->
         "<SYNTAX ERROR>\n"
     | 1375 ->
         "<SYNTAX ERROR>\n"
@@ -366,15 +364,15 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1416 ->
         "<SYNTAX ERROR>\n"
-    | 898 ->
-        "<SYNTAX ERROR>\n"
     | 899 ->
-        "<SYNTAX ERROR>\n"
-    | 1786 ->
         "<SYNTAX ERROR>\n"
     | 900 ->
         "<SYNTAX ERROR>\n"
+    | 1786 ->
+        "<SYNTAX ERROR>\n"
     | 901 ->
+        "<SYNTAX ERROR>\n"
+    | 902 ->
         "<SYNTAX ERROR>\n"
     | 1779 ->
         "<SYNTAX ERROR>\n"
@@ -390,15 +388,15 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1823 ->
         "<SYNTAX ERROR>\n"
-    | 2332 ->
+    | 2339 ->
         "<SYNTAX ERROR>\n"
-    | 2337 ->
+    | 2344 ->
         "<SYNTAX ERROR>\n"
-    | 2334 ->
+    | 2341 ->
         "<SYNTAX ERROR>\n"
     | 1253 ->
         "<SYNTAX ERROR>\n"
-    | 2331 ->
+    | 2338 ->
         "<SYNTAX ERROR>\n"
     | 1424 ->
         "<SYNTAX ERROR>\n"
@@ -412,13 +410,13 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1422 ->
         "<SYNTAX ERROR>\n"
-    | 176 ->
+    | 166 ->
         "<SYNTAX ERROR>\n"
-    | 2487 ->
+    | 2494 ->
         "<SYNTAX ERROR>\n"
-    | 2486 ->
+    | 2493 ->
         "<SYNTAX ERROR>\n"
-    | 2489 ->
+    | 2496 ->
         "<SYNTAX ERROR>\n"
     | 1363 ->
         "<SYNTAX ERROR>\n"
@@ -442,79 +440,79 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1444 ->
         "<SYNTAX ERROR>\n"
-    | 183 ->
+    | 173 ->
         "<SYNTAX ERROR>\n"
-    | 2433 ->
+    | 2440 ->
         "<SYNTAX ERROR>\n"
-    | 2434 ->
+    | 2441 ->
         "<SYNTAX ERROR>\n"
     | 1304 ->
         "<SYNTAX ERROR>\n"
     | 1312 ->
         "<SYNTAX ERROR>\n"
-    | 788 ->
-        "<SYNTAX ERROR>\n"
-    | 197 ->
-        "<SYNTAX ERROR>\n"
-    | 414 ->
-        "<SYNTAX ERROR>\n"
-    | 415 ->
+    | 789 ->
         "<SYNTAX ERROR>\n"
     | 187 ->
         "<SYNTAX ERROR>\n"
-    | 189 ->
+    | 416 ->
         "<SYNTAX ERROR>\n"
-    | 190 ->
+    | 417 ->
         "<SYNTAX ERROR>\n"
-    | 535 ->
+    | 177 ->
         "<SYNTAX ERROR>\n"
-    | 2318 ->
+    | 179 ->
         "<SYNTAX ERROR>\n"
-    | 2320 ->
+    | 180 ->
         "<SYNTAX ERROR>\n"
-    | 2322 ->
+    | 537 ->
+        "<SYNTAX ERROR>\n"
+    | 2325 ->
+        "<SYNTAX ERROR>\n"
+    | 2327 ->
+        "<SYNTAX ERROR>\n"
+    | 2329 ->
         "<SYNTAX ERROR>\n"
     | 1783 ->
         "<SYNTAX ERROR>\n"
     | 1784 ->
         "<SYNTAX ERROR>\n"
-    | 413 ->
+    | 415 ->
         "Expecting one of the following:\n  - \")\" to form a unit value \"()\"\n  - \"module\" to start a module expression\n  - an expression\n  - an operator to denote the prefix form of an operator\n"
-    | 2376 ->
+    | 2383 ->
         "<SYNTAX ERROR>\n"
-    | 716 ->
+    | 717 ->
         "<SYNTAX ERROR>\n"
-    | 416 ->
+    | 418 ->
         "Expecting a module expression\n"
-    | 2363 ->
-        "<SYNTAX ERROR>\n"
-    | 2365 ->
-        "<SYNTAX ERROR>\n"
-    | 2367 ->
-        "<SYNTAX ERROR>\n"
-    | 2369 ->
-        "<SYNTAX ERROR>\n"
     | 2370 ->
-        "<SYNTAX ERROR>\n"
-    | 2371 ->
         "<SYNTAX ERROR>\n"
     | 2372 ->
         "<SYNTAX ERROR>\n"
-    | 2373 ->
-        "<SYNTAX ERROR>\n"
     | 2374 ->
+        "<SYNTAX ERROR>\n"
+    | 2376 ->
+        "<SYNTAX ERROR>\n"
+    | 2377 ->
+        "<SYNTAX ERROR>\n"
+    | 2378 ->
+        "<SYNTAX ERROR>\n"
+    | 2379 ->
+        "<SYNTAX ERROR>\n"
+    | 2380 ->
+        "<SYNTAX ERROR>\n"
+    | 2381 ->
         "<SYNTAX ERROR>\n"
     | 1371 ->
         "<SYNTAX ERROR>\n"
-    | 2421 ->
+    | 2428 ->
         "<SYNTAX ERROR>\n"
-    | 199 ->
-        "<SYNTAX ERROR>\n"
-    | 551 ->
-        "<SYNTAX ERROR>\n"
-    | 2291 ->
+    | 189 ->
         "<SYNTAX ERROR>\n"
     | 552 ->
+        "<SYNTAX ERROR>\n"
+    | 2298 ->
+        "<SYNTAX ERROR>\n"
+    | 553 ->
         "<SYNTAX ERROR>\n"
     | 1813 ->
         "<SYNTAX ERROR>\n"
@@ -524,25 +522,23 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1808 ->
         "<SYNTAX ERROR>\n"
-    | 570 ->
+    | 571 ->
         "<SYNTAX ERROR>\n"
-    | 579 ->
+    | 580 ->
         "<SYNTAX ERROR>\n"
-    | 589 ->
-        "<SYNTAX ERROR>\n"
-    | 607 ->
+    | 590 ->
         "<SYNTAX ERROR>\n"
     | 608 ->
         "<SYNTAX ERROR>\n"
-    | 610 ->
+    | 609 ->
         "<SYNTAX ERROR>\n"
     | 611 ->
         "<SYNTAX ERROR>\n"
-    | 2231 ->
+    | 612 ->
         "<SYNTAX ERROR>\n"
-    | 2217 ->
+    | 2238 ->
         "<SYNTAX ERROR>\n"
-    | 616 ->
+    | 2224 ->
         "<SYNTAX ERROR>\n"
     | 617 ->
         "<SYNTAX ERROR>\n"
@@ -550,11 +546,11 @@ let message =
         "<SYNTAX ERROR>\n"
     | 619 ->
         "<SYNTAX ERROR>\n"
-    | 2215 ->
+    | 620 ->
         "<SYNTAX ERROR>\n"
-    | 2216 ->
+    | 2222 ->
         "<SYNTAX ERROR>\n"
-    | 612 ->
+    | 2223 ->
         "<SYNTAX ERROR>\n"
     | 613 ->
         "<SYNTAX ERROR>\n"
@@ -562,19 +558,19 @@ let message =
         "<SYNTAX ERROR>\n"
     | 615 ->
         "<SYNTAX ERROR>\n"
-    | 2224 ->
+    | 616 ->
         "<SYNTAX ERROR>\n"
-    | 2225 ->
+    | 2231 ->
         "<SYNTAX ERROR>\n"
-    | 2226 ->
+    | 2232 ->
         "<SYNTAX ERROR>\n"
-    | 2227 ->
+    | 2233 ->
         "<SYNTAX ERROR>\n"
-    | 2228 ->
+    | 2234 ->
         "<SYNTAX ERROR>\n"
-    | 2229 ->
+    | 2235 ->
         "<SYNTAX ERROR>\n"
-    | 889 ->
+    | 2236 ->
         "<SYNTAX ERROR>\n"
     | 890 ->
         "<SYNTAX ERROR>\n"
@@ -586,27 +582,29 @@ let message =
         "<SYNTAX ERROR>\n"
     | 894 ->
         "<SYNTAX ERROR>\n"
-    | 2324 ->
+    | 895 ->
         "<SYNTAX ERROR>\n"
-    | 2325 ->
+    | 2331 ->
         "<SYNTAX ERROR>\n"
-    | 2326 ->
+    | 2332 ->
         "<SYNTAX ERROR>\n"
-    | 2327 ->
+    | 2333 ->
         "<SYNTAX ERROR>\n"
-    | 2328 ->
+    | 2334 ->
         "<SYNTAX ERROR>\n"
-    | 2329 ->
+    | 2335 ->
+        "<SYNTAX ERROR>\n"
+    | 2336 ->
         "<SYNTAX ERROR>\n"
     | 1785 ->
         "<SYNTAX ERROR>\n"
-    | 597 ->
+    | 598 ->
         "<SYNTAX ERROR>\n"
     | 1359 ->
         "<SYNTAX ERROR>\n"
-    | 1180 ->
+    | 1181 ->
         "<SYNTAX ERROR>\n"
-    | 903 ->
+    | 904 ->
         "Incomplete let binding\n"
     | 1282 ->
         "<SYNTAX ERROR>\n"
@@ -620,11 +618,11 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1287 ->
         "<SYNTAX ERROR>\n"
-    | 1156 ->
-        "<SYNTAX ERROR>\n"
-    | 904 ->
+    | 1157 ->
         "<SYNTAX ERROR>\n"
     | 905 ->
+        "<SYNTAX ERROR>\n"
+    | 906 ->
         "<SYNTAX ERROR>\n"
     | 1761 ->
         "<SYNTAX ERROR>\n"
@@ -642,11 +640,11 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1767 ->
         "<SYNTAX ERROR>\n"
-    | 906 ->
-        "<SYNTAX ERROR>\n"
     | 907 ->
         "<SYNTAX ERROR>\n"
-    | 916 ->
+    | 908 ->
+        "<SYNTAX ERROR>\n"
+    | 917 ->
         "<SYNTAX ERROR>\n"
     | 1754 ->
         "<SYNTAX ERROR>\n"
@@ -656,17 +654,15 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1772 ->
         "<SYNTAX ERROR>\n"
-    | 1134 ->
-        "<SYNTAX ERROR>\n"
     | 1135 ->
         "<SYNTAX ERROR>\n"
-    | 1157 ->
+    | 1136 ->
+        "<SYNTAX ERROR>\n"
+    | 1158 ->
         "<SYNTAX ERROR>\n"
     | 1278 ->
         "Defining a function?\nExpecting one of the following:\n  - \"=>\" to start the function body\n  - an identifier to add a function parameter\n  - \":\" to specify the return type\n"
     | 1246 ->
-        "<SYNTAX ERROR>\n"
-    | 1162 ->
         "<SYNTAX ERROR>\n"
     | 1163 ->
         "<SYNTAX ERROR>\n"
@@ -675,22 +671,24 @@ let message =
     | 1165 ->
         "<SYNTAX ERROR>\n"
     | 1166 ->
+        "<SYNTAX ERROR>\n"
+    | 1167 ->
         "Expecting an expression as function body\n"
-    | 1240 ->
-        "<SYNTAX ERROR>\n"
     | 1241 ->
-        "Defining a function?\nExpecting \"=>\" to start the function body\n"
-    | 1242 ->
         "<SYNTAX ERROR>\n"
+    | 1242 ->
+        "Defining a function?\nExpecting \"=>\" to start the function body\n"
     | 1243 ->
         "<SYNTAX ERROR>\n"
-    | 1158 ->
+    | 1244 ->
         "<SYNTAX ERROR>\n"
     | 1159 ->
         "<SYNTAX ERROR>\n"
     | 1160 ->
         "<SYNTAX ERROR>\n"
     | 1161 ->
+        "<SYNTAX ERROR>\n"
+    | 1162 ->
         "<SYNTAX ERROR>\n"
     | 1251 ->
         "<SYNTAX ERROR>\n"
@@ -722,31 +720,31 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1504 ->
         "<SYNTAX ERROR>\n"
-    | 70 ->
+    | 69 ->
         "<SYNTAX ERROR>\n"
     | 1705 ->
         "<SYNTAX ERROR>\n"
-    | 201 ->
+    | 191 ->
         "<SYNTAX ERROR>\n"
-    | 2419 ->
+    | 2426 ->
         "<SYNTAX ERROR>\n"
-    | 2420 ->
+    | 2427 ->
         "<SYNTAX ERROR>\n"
-    | 2418 ->
+    | 2425 ->
         "<SYNTAX ERROR>\n"
-    | 71 ->
+    | 70 ->
         "<SYNTAX ERROR>\n"
-    | 1055 ->
+    | 1056 ->
         "<SYNTAX ERROR>\n"
-    | 1028 ->
+    | 1029 ->
         "<SYNTAX ERROR>\n"
-    | 2585 ->
+    | 2593 ->
         "<SYNTAX ERROR>\n"
     | 18 ->
         "<SYNTAX ERROR>\n"
-    | 174 ->
+    | 164 ->
         "<SYNTAX ERROR>\n"
-    | 2493 ->
+    | 2500 ->
         "<SYNTAX ERROR>\n"
     | 1792 ->
         "<SYNTAX ERROR>\n"
@@ -756,39 +754,39 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1800 ->
         "Expecting a type name\n"
-    | 186 ->
+    | 176 ->
         "Expecting an expression\n"
     | 1385 ->
         "Expecting an expression\n"
     | 1361 ->
         "Expecting an expression\n"
-    | 596 ->
+    | 597 ->
         "<SYNTAX ERROR>\n"
     | 1703 ->
         "Expecting \"]\" to finish current floating attribute\n"
-    | 1030 ->
+    | 1031 ->
         "<SYNTAX ERROR>\n"
-    | 177 ->
+    | 167 ->
         "Expecting one of the following:\n  - an list item\n  - \"]\" to finish this list\n"
-    | 2199 ->
+    | 2206 ->
         "Expecting one of the following:\n  - \",\" to separate two items in a list\n  - \"]\" to finish this list\n"
-    | 2200 ->
+    | 2207 ->
         "<SYNTAX ERROR>\n"
-    | 2196 ->
+    | 2203 ->
         "<SYNTAX ERROR>\n"
-    | 2197 ->
+    | 2204 ->
         "<SYNTAX ERROR>\n"
-    | 179 ->
+    | 169 ->
         "<SYNTAX ERROR>\n"
-    | 180 ->
+    | 170 ->
         "<SYNTAX ERROR>\n"
-    | 573 ->
+    | 574 ->
         "<SYNTAX ERROR>\n"
-    | 181 ->
+    | 171 ->
         "<SYNTAX ERROR>\n"
-    | 2475 ->
+    | 2482 ->
         "<SYNTAX ERROR>\n"
-    | 184 ->
+    | 174 ->
         "<SYNTAX ERROR>\n"
     | 1340 ->
         "<SYNTAX ERROR>\n"
@@ -826,13 +824,13 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1349 ->
         "<SYNTAX ERROR>\n"
-    | 2344 ->
+    | 2351 ->
         "<SYNTAX ERROR>\n"
-    | 532 ->
+    | 534 ->
         "<SYNTAX ERROR>\n"
-    | 2274 ->
+    | 2281 ->
         "<SYNTAX ERROR>\n"
-    | 2251 ->
+    | 2258 ->
         "<SYNTAX ERROR>\n"
     | 1455 ->
         "<SYNTAX ERROR>\n"
@@ -844,11 +842,11 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1460 ->
         "<SYNTAX ERROR>\n"
-    | 1101 ->
-        "<SYNTAX ERROR>\n"
-    | 1103 ->
+    | 1102 ->
         "<SYNTAX ERROR>\n"
     | 1104 ->
+        "<SYNTAX ERROR>\n"
+    | 1105 ->
         "<SYNTAX ERROR>\n"
     | 1462 ->
         "<SYNTAX ERROR>\n"
@@ -912,41 +910,41 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1844 ->
         "<SYNTAX ERROR>\n"
-    | 581 ->
+    | 582 ->
         "<SYNTAX ERROR>\n"
-    | 2056 ->
+    | 2063 ->
         "<SYNTAX ERROR>\n"
-    | 2062 ->
+    | 2069 ->
         "<SYNTAX ERROR>\n"
-    | 2057 ->
+    | 2064 ->
         "<SYNTAX ERROR>\n"
-    | 2058 ->
+    | 2065 ->
         "<SYNTAX ERROR>\n"
-    | 2059 ->
+    | 2066 ->
         "<SYNTAX ERROR>\n"
-    | 2061 ->
+    | 2068 ->
         "<SYNTAX ERROR>\n"
-    | 2026 ->
-        "<SYNTAX ERROR>\n"
-    | 583 ->
-        "<SYNTAX ERROR>\n"
-    | 587 ->
-        "<SYNTAX ERROR>\n"
-    | 588 ->
+    | 2033 ->
         "<SYNTAX ERROR>\n"
     | 584 ->
         "<SYNTAX ERROR>\n"
-    | 2261 ->
+    | 588 ->
         "<SYNTAX ERROR>\n"
-    | 2262 ->
+    | 589 ->
         "<SYNTAX ERROR>\n"
-    | 2265 ->
+    | 585 ->
         "<SYNTAX ERROR>\n"
-    | 2264 ->
+    | 2268 ->
         "<SYNTAX ERROR>\n"
-    | 2027 ->
+    | 2269 ->
         "<SYNTAX ERROR>\n"
-    | 2052 ->
+    | 2272 ->
+        "<SYNTAX ERROR>\n"
+    | 2271 ->
+        "<SYNTAX ERROR>\n"
+    | 2034 ->
+        "<SYNTAX ERROR>\n"
+    | 2059 ->
         "<SYNTAX ERROR>\n"
     | 1475 ->
         "<SYNTAX ERROR>\n"
@@ -956,47 +954,47 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1478 ->
         "<SYNTAX ERROR>\n"
-    | 2028 ->
-        "<SYNTAX ERROR>\n"
-    | 2029 ->
-        "<SYNTAX ERROR>\n"
-    | 2030 ->
-        "<SYNTAX ERROR>\n"
-    | 2031 ->
-        "<SYNTAX ERROR>\n"
-    | 2033 ->
-        "<SYNTAX ERROR>\n"
-    | 2048 ->
-        "<SYNTAX ERROR>\n"
-    | 2049 ->
-        "<SYNTAX ERROR>\n"
     | 2035 ->
         "<SYNTAX ERROR>\n"
     | 2036 ->
         "<SYNTAX ERROR>\n"
-    | 2038 ->
+    | 2037 ->
         "<SYNTAX ERROR>\n"
-    | 2039 ->
+    | 2038 ->
         "<SYNTAX ERROR>\n"
     | 2040 ->
         "<SYNTAX ERROR>\n"
-    | 2043 ->
+    | 2055 ->
         "<SYNTAX ERROR>\n"
-    | 2044 ->
+    | 2056 ->
+        "<SYNTAX ERROR>\n"
+    | 2042 ->
+        "<SYNTAX ERROR>\n"
+    | 2043 ->
         "<SYNTAX ERROR>\n"
     | 2045 ->
         "<SYNTAX ERROR>\n"
     | 2046 ->
         "<SYNTAX ERROR>\n"
-    | 2042 ->
+    | 2047 ->
         "<SYNTAX ERROR>\n"
-    | 2424 ->
+    | 2050 ->
+        "<SYNTAX ERROR>\n"
+    | 2051 ->
+        "<SYNTAX ERROR>\n"
+    | 2052 ->
+        "<SYNTAX ERROR>\n"
+    | 2053 ->
+        "<SYNTAX ERROR>\n"
+    | 2049 ->
+        "<SYNTAX ERROR>\n"
+    | 2431 ->
         "Expecting \"}\" to finish the block\n"
-    | 2158 ->
+    | 2165 ->
         "<SYNTAX ERROR>\n"
     | 1679 ->
         "<SYNTAX ERROR>\n"
-    | 1111 ->
+    | 1112 ->
         "<SYNTAX ERROR>\n"
     | 1501 ->
         "<SYNTAX ERROR>\n"
@@ -1008,7 +1006,7 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1521 ->
         "<SYNTAX ERROR>\n"
-    | 1153 ->
+    | 1154 ->
         "<SYNTAX ERROR>\n"
     | 1550 ->
         "<SYNTAX ERROR>\n"
@@ -1054,13 +1052,13 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1524 ->
         "<SYNTAX ERROR>\n"
-    | 1154 ->
+    | 1155 ->
         "<SYNTAX ERROR>\n"
     | 1336 ->
         "<SYNTAX ERROR>\n"
     | 1544 ->
         "<SYNTAX ERROR>\n"
-    | 1155 ->
+    | 1156 ->
         "<SYNTAX ERROR>\n"
     | 1332 ->
         "<SYNTAX ERROR>\n"
@@ -1100,15 +1098,15 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1339 ->
         "<SYNTAX ERROR>\n"
-    | 555 ->
+    | 556 ->
         "<SYNTAX ERROR>\n"
-    | 1032 ->
+    | 1033 ->
         "<SYNTAX ERROR>\n"
-    | 909 ->
-        "<SYNTAX ERROR>\n"
-    | 853 ->
+    | 910 ->
         "<SYNTAX ERROR>\n"
     | 854 ->
+        "<SYNTAX ERROR>\n"
+    | 855 ->
         "<SYNTAX ERROR>\n"
     | 1886 ->
         "<SYNTAX ERROR>\n"
@@ -1116,103 +1114,101 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1891 ->
         "<SYNTAX ERROR>\n"
-    | 2176 ->
+    | 2183 ->
         "<SYNTAX ERROR>\n"
-    | 902 ->
+    | 903 ->
         "<SYNTAX ERROR>\n"
     | 1777 ->
         "<SYNTAX ERROR>\n"
-    | 409 ->
+    | 411 ->
         "<SYNTAX ERROR>\n"
-    | 410 ->
+    | 412 ->
         "<SYNTAX ERROR>\n"
-    | 2384 ->
+    | 2391 ->
         "<SYNTAX ERROR>\n"
-    | 2386 ->
+    | 2393 ->
         "<SYNTAX ERROR>\n"
     | 1889 ->
         "<SYNTAX ERROR>\n"
-    | 2388 ->
+    | 2395 ->
         "<SYNTAX ERROR>\n"
     | 1894 ->
         "<SYNTAX ERROR>\n"
     | 1895 ->
         "<SYNTAX ERROR>\n"
-    | 2390 ->
+    | 2397 ->
         "<SYNTAX ERROR>\n"
-    | 1997 ->
-        "<SYNTAX ERROR>\n"
-    | 1972 ->
-        "<SYNTAX ERROR>\n"
-    | 1973 ->
-        "<SYNTAX ERROR>\n"
-    | 1974 ->
-        "<SYNTAX ERROR>\n"
-    | 1976 ->
+    | 2004 ->
         "<SYNTAX ERROR>\n"
     | 1979 ->
         "<SYNTAX ERROR>\n"
+    | 1980 ->
+        "<SYNTAX ERROR>\n"
+    | 1981 ->
+        "<SYNTAX ERROR>\n"
+    | 1983 ->
+        "<SYNTAX ERROR>\n"
     | 1986 ->
+        "<SYNTAX ERROR>\n"
+    | 1993 ->
+        "<SYNTAX ERROR>\n"
+    | 1996 ->
+        "<SYNTAX ERROR>\n"
+    | 1997 ->
+        "<SYNTAX ERROR>\n"
+    | 2186 ->
+        "<SYNTAX ERROR>\n"
+    | 2187 ->
+        "<SYNTAX ERROR>\n"
+    | 549 ->
+        "<SYNTAX ERROR>\n"
+    | 550 ->
+        "<SYNTAX ERROR>\n"
+    | 2302 ->
+        "<SYNTAX ERROR>\n"
+    | 2304 ->
+        "<SYNTAX ERROR>\n"
+    | 1984 ->
+        "<SYNTAX ERROR>\n"
+    | 2306 ->
         "<SYNTAX ERROR>\n"
     | 1989 ->
         "<SYNTAX ERROR>\n"
     | 1990 ->
         "<SYNTAX ERROR>\n"
-    | 2179 ->
+    | 2308 ->
         "<SYNTAX ERROR>\n"
-    | 2180 ->
+    | 1999 ->
         "<SYNTAX ERROR>\n"
-    | 548 ->
-        "<SYNTAX ERROR>\n"
-    | 549 ->
-        "<SYNTAX ERROR>\n"
-    | 2295 ->
-        "<SYNTAX ERROR>\n"
-    | 2297 ->
-        "<SYNTAX ERROR>\n"
-    | 1977 ->
-        "<SYNTAX ERROR>\n"
-    | 2299 ->
-        "<SYNTAX ERROR>\n"
-    | 1982 ->
-        "<SYNTAX ERROR>\n"
-    | 1983 ->
-        "<SYNTAX ERROR>\n"
-    | 2301 ->
-        "<SYNTAX ERROR>\n"
-    | 1992 ->
-        "<SYNTAX ERROR>\n"
-    | 1993 ->
+    | 2000 ->
         "<SYNTAX ERROR>\n"
     | 1898 ->
         "<SYNTAX ERROR>\n"
-    | 1967 ->
+    | 1974 ->
         "<SYNTAX ERROR>\n"
-    | 1968 ->
+    | 1975 ->
         "<SYNTAX ERROR>\n"
-    | 1969 ->
+    | 1976 ->
         "<SYNTAX ERROR>\n"
-    | 1971 ->
+    | 1978 ->
         "<SYNTAX ERROR>\n"
-    | 417 ->
+    | 419 ->
         "<SYNTAX ERROR>\n"
-    | 2128 ->
+    | 2135 ->
         "<SYNTAX ERROR>\n"
-    | 420 ->
+    | 422 ->
         "<SYNTAX ERROR>\n"
-    | 434 ->
-        "<SYNTAX ERROR>\n"
-    | 423 ->
-        "<SYNTAX ERROR>\n"
-    | 2348 ->
-        "<SYNTAX ERROR>\n"
-    | 2352 ->
-        "<SYNTAX ERROR>\n"
-    | 2349 ->
-        "<SYNTAX ERROR>\n"
-    | 2350 ->
+    | 436 ->
         "<SYNTAX ERROR>\n"
     | 425 ->
+        "<SYNTAX ERROR>\n"
+    | 2355 ->
+        "<SYNTAX ERROR>\n"
+    | 2359 ->
+        "<SYNTAX ERROR>\n"
+    | 2356 ->
+        "<SYNTAX ERROR>\n"
+    | 2357 ->
         "<SYNTAX ERROR>\n"
     | 427 ->
         "<SYNTAX ERROR>\n"
@@ -1220,49 +1216,49 @@ let message =
         "<SYNTAX ERROR>\n"
     | 431 ->
         "<SYNTAX ERROR>\n"
-    | 2135 ->
+    | 433 ->
         "<SYNTAX ERROR>\n"
-    | 435 ->
+    | 2142 ->
         "<SYNTAX ERROR>\n"
-    | 504 ->
+    | 437 ->
         "<SYNTAX ERROR>\n"
     | 505 ->
         "<SYNTAX ERROR>\n"
     | 506 ->
         "<SYNTAX ERROR>\n"
-    | 510 ->
+    | 508 ->
         "<SYNTAX ERROR>\n"
-    | 511 ->
+    | 512 ->
         "<SYNTAX ERROR>\n"
-    | 436 ->
-        "<SYNTAX ERROR>\n"
-    | 473 ->
-        "<SYNTAX ERROR>\n"
-    | 443 ->
-        "<SYNTAX ERROR>\n"
-    | 476 ->
+    | 513 ->
         "<SYNTAX ERROR>\n"
     | 438 ->
         "<SYNTAX ERROR>\n"
-    | 439 ->
+    | 477 ->
         "<SYNTAX ERROR>\n"
-    | 481 ->
+    | 463 ->
         "<SYNTAX ERROR>\n"
-    | 498 ->
+    | 462 ->
         "<SYNTAX ERROR>\n"
-    | 517 ->
+    | 252 ->
         "<SYNTAX ERROR>\n"
-    | 518 ->
+    | 482 ->
+        "<SYNTAX ERROR>\n"
+    | 499 ->
         "<SYNTAX ERROR>\n"
     | 519 ->
         "<SYNTAX ERROR>\n"
     | 520 ->
         "<SYNTAX ERROR>\n"
-    | 2136 ->
+    | 521 ->
         "<SYNTAX ERROR>\n"
-    | 2138 ->
+    | 522 ->
         "<SYNTAX ERROR>\n"
-    | 2127 ->
+    | 2143 ->
+        "<SYNTAX ERROR>\n"
+    | 2145 ->
+        "<SYNTAX ERROR>\n"
+    | 2134 ->
         "<SYNTAX ERROR>\n"
     | 1899 ->
         "<SYNTAX ERROR>\n"
@@ -1274,11 +1270,31 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1906 ->
         "<SYNTAX ERROR>\n"
-    | 1963 ->
+    | 1970 ->
         "<SYNTAX ERROR>\n"
-    | 1964 ->
+    | 1971 ->
         "<SYNTAX ERROR>\n"
-    | 1965 ->
+    | 1972 ->
+        "<SYNTAX ERROR>\n"
+    | 2020 ->
+        "<SYNTAX ERROR>\n"
+    | 2021 ->
+        "<SYNTAX ERROR>\n"
+    | 2022 ->
+        "<SYNTAX ERROR>\n"
+    | 2023 ->
+        "<SYNTAX ERROR>\n"
+    | 2024 ->
+        "<SYNTAX ERROR>\n"
+    | 2025 ->
+        "<SYNTAX ERROR>\n"
+    | 2026 ->
+        "<SYNTAX ERROR>\n"
+    | 1973 ->
+        "<SYNTAX ERROR>\n"
+    | 2011 ->
+        "<SYNTAX ERROR>\n"
+    | 2012 ->
         "<SYNTAX ERROR>\n"
     | 2013 ->
         "<SYNTAX ERROR>\n"
@@ -1286,87 +1302,85 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2015 ->
         "<SYNTAX ERROR>\n"
-    | 2016 ->
+    | 2028 ->
         "<SYNTAX ERROR>\n"
-    | 2017 ->
+    | 2149 ->
         "<SYNTAX ERROR>\n"
-    | 2018 ->
-        "<SYNTAX ERROR>\n"
-    | 2019 ->
-        "<SYNTAX ERROR>\n"
-    | 1966 ->
-        "<SYNTAX ERROR>\n"
-    | 2004 ->
-        "<SYNTAX ERROR>\n"
-    | 2005 ->
-        "<SYNTAX ERROR>\n"
-    | 2006 ->
-        "<SYNTAX ERROR>\n"
-    | 2007 ->
-        "<SYNTAX ERROR>\n"
-    | 2008 ->
-        "<SYNTAX ERROR>\n"
-    | 2021 ->
-        "<SYNTAX ERROR>\n"
-    | 2142 ->
-        "<SYNTAX ERROR>\n"
-    | 2143 ->
-        "<SYNTAX ERROR>\n"
-    | 2066 ->
-        "<SYNTAX ERROR>\n"
-    | 2069 ->
-        "<SYNTAX ERROR>\n"
-    | 2070 ->
-        "<SYNTAX ERROR>\n"
-    | 2071 ->
-        "<SYNTAX ERROR>\n"
-    | 2072 ->
+    | 2150 ->
         "<SYNTAX ERROR>\n"
     | 2073 ->
         "<SYNTAX ERROR>\n"
-    | 2074 ->
+    | 2076 ->
+        "<SYNTAX ERROR>\n"
+    | 2077 ->
         "<SYNTAX ERROR>\n"
     | 2078 ->
         "<SYNTAX ERROR>\n"
-    | 2083 ->
+    | 2079 ->
         "<SYNTAX ERROR>\n"
-    | 447 ->
+    | 2080 ->
         "<SYNTAX ERROR>\n"
-    | 448 ->
-        "<SYNTAX ERROR>\n"
-    | 449 ->
-        "<SYNTAX ERROR>\n"
-    | 2084 ->
+    | 2081 ->
         "<SYNTAX ERROR>\n"
     | 2085 ->
         "<SYNTAX ERROR>\n"
-    | 2086 ->
+    | 2090 ->
         "<SYNTAX ERROR>\n"
-    | 463 ->
+    | 455 ->
         "<SYNTAX ERROR>\n"
-    | 445 ->
+    | 456 ->
         "<SYNTAX ERROR>\n"
     | 2091 ->
-        "<SYNTAX ERROR>\n"
-    | 2100 ->
         "<SYNTAX ERROR>\n"
     | 2092 ->
         "<SYNTAX ERROR>\n"
     | 2093 ->
         "<SYNTAX ERROR>\n"
-    | 2095 ->
+    | 441 ->
         "<SYNTAX ERROR>\n"
-    | 2096 ->
+    | 466 ->
         "<SYNTAX ERROR>\n"
-    | 2097 ->
+    | 2098 ->
         "<SYNTAX ERROR>\n"
-    | 2147 ->
+    | 2107 ->
         "<SYNTAX ERROR>\n"
-    | 2148 ->
+    | 2099 ->
+        "<SYNTAX ERROR>\n"
+    | 2100 ->
         "<SYNTAX ERROR>\n"
     | 2102 ->
         "<SYNTAX ERROR>\n"
+    | 2103 ->
+        "<SYNTAX ERROR>\n"
+    | 2104 ->
+        "<SYNTAX ERROR>\n"
+    | 2154 ->
+        "<SYNTAX ERROR>\n"
+    | 2155 ->
+        "<SYNTAX ERROR>\n"
+    | 2109 ->
+        "<SYNTAX ERROR>\n"
+    | 2118 ->
+        "<SYNTAX ERROR>\n"
+    | 2119 ->
+        "<SYNTAX ERROR>\n"
+    | 2120 ->
+        "<SYNTAX ERROR>\n"
+    | 2121 ->
+        "<SYNTAX ERROR>\n"
+    | 2122 ->
+        "<SYNTAX ERROR>\n"
+    | 2123 ->
+        "<SYNTAX ERROR>\n"
+    | 2124 ->
+        "<SYNTAX ERROR>\n"
+    | 2110 ->
+        "<SYNTAX ERROR>\n"
     | 2111 ->
+        "<SYNTAX ERROR>\n"
+    | 2159 ->
+        "<SYNTAX ERROR>\n"
+    | 2160 ->
         "<SYNTAX ERROR>\n"
     | 2112 ->
         "<SYNTAX ERROR>\n"
@@ -1376,53 +1390,31 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2115 ->
         "<SYNTAX ERROR>\n"
-    | 2116 ->
+    | 538 ->
         "<SYNTAX ERROR>\n"
-    | 2117 ->
+    | 539 ->
         "<SYNTAX ERROR>\n"
-    | 2103 ->
+    | 543 ->
         "<SYNTAX ERROR>\n"
-    | 2104 ->
+    | 544 ->
         "<SYNTAX ERROR>\n"
-    | 2152 ->
+    | 2320 ->
         "<SYNTAX ERROR>\n"
-    | 2153 ->
+    | 2322 ->
         "<SYNTAX ERROR>\n"
-    | 2105 ->
+    | 2323 ->
         "<SYNTAX ERROR>\n"
-    | 2106 ->
-        "<SYNTAX ERROR>\n"
-    | 2107 ->
-        "<SYNTAX ERROR>\n"
-    | 2108 ->
-        "<SYNTAX ERROR>\n"
-    | 536 ->
-        "<SYNTAX ERROR>\n"
-    | 537 ->
-        "<SYNTAX ERROR>\n"
-    | 541 ->
-        "<SYNTAX ERROR>\n"
-    | 542 ->
-        "<SYNTAX ERROR>\n"
-    | 2313 ->
-        "<SYNTAX ERROR>\n"
-    | 2315 ->
-        "<SYNTAX ERROR>\n"
-    | 2316 ->
-        "<SYNTAX ERROR>\n"
-    | 2317 ->
-        "<SYNTAX ERROR>\n"
-    | 855 ->
+    | 2324 ->
         "<SYNTAX ERROR>\n"
     | 856 ->
         "<SYNTAX ERROR>\n"
-    | 858 ->
+    | 857 ->
         "<SYNTAX ERROR>\n"
     | 859 ->
         "<SYNTAX ERROR>\n"
-    | 1867 ->
+    | 860 ->
         "<SYNTAX ERROR>\n"
-    | 864 ->
+    | 1867 ->
         "<SYNTAX ERROR>\n"
     | 865 ->
         "<SYNTAX ERROR>\n"
@@ -1432,9 +1424,9 @@ let message =
         "<SYNTAX ERROR>\n"
     | 868 ->
         "<SYNTAX ERROR>\n"
-    | 1866 ->
+    | 869 ->
         "<SYNTAX ERROR>\n"
-    | 860 ->
+    | 1866 ->
         "<SYNTAX ERROR>\n"
     | 861 ->
         "<SYNTAX ERROR>\n"
@@ -1442,15 +1434,17 @@ let message =
         "<SYNTAX ERROR>\n"
     | 863 ->
         "<SYNTAX ERROR>\n"
+    | 864 ->
+        "<SYNTAX ERROR>\n"
     | 1883 ->
         "<SYNTAX ERROR>\n"
-    | 621 ->
+    | 622 ->
         "<SYNTAX ERROR>\n"
-    | 842 ->
-        "<SYNTAX ERROR>\n"
-    | 844 ->
+    | 843 ->
         "<SYNTAX ERROR>\n"
     | 845 ->
+        "<SYNTAX ERROR>\n"
+    | 846 ->
         "<SYNTAX ERROR>\n"
     | 1876 ->
         "<SYNTAX ERROR>\n"
@@ -1464,19 +1458,17 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1881 ->
         "<SYNTAX ERROR>\n"
-    | 869 ->
-        "<SYNTAX ERROR>\n"
     | 870 ->
         "<SYNTAX ERROR>\n"
     | 871 ->
         "<SYNTAX ERROR>\n"
     | 872 ->
         "<SYNTAX ERROR>\n"
-    | 875 ->
+    | 873 ->
         "<SYNTAX ERROR>\n"
     | 876 ->
         "<SYNTAX ERROR>\n"
-    | 1035 ->
+    | 877 ->
         "<SYNTAX ERROR>\n"
     | 1036 ->
         "<SYNTAX ERROR>\n"
@@ -1488,45 +1480,45 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1040 ->
         "<SYNTAX ERROR>\n"
-    | 1044 ->
+    | 1041 ->
         "<SYNTAX ERROR>\n"
-    | 1049 ->
-        "<SYNTAX ERROR>\n"
-    | 938 ->
-        "<SYNTAX ERROR>\n"
-    | 939 ->
-        "<SYNTAX ERROR>\n"
-    | 940 ->
+    | 1045 ->
         "<SYNTAX ERROR>\n"
     | 1050 ->
+        "<SYNTAX ERROR>\n"
+    | 942 ->
+        "<SYNTAX ERROR>\n"
+    | 943 ->
         "<SYNTAX ERROR>\n"
     | 1051 ->
         "<SYNTAX ERROR>\n"
     | 1052 ->
         "<SYNTAX ERROR>\n"
-    | 942 ->
+    | 1053 ->
         "<SYNTAX ERROR>\n"
-    | 930 ->
+    | 940 ->
         "<SYNTAX ERROR>\n"
-    | 1057 ->
+    | 932 ->
         "<SYNTAX ERROR>\n"
-    | 1146 ->
+    | 1058 ->
         "<SYNTAX ERROR>\n"
-    | 1059 ->
+    | 1147 ->
         "<SYNTAX ERROR>\n"
     | 1060 ->
         "<SYNTAX ERROR>\n"
-    | 1062 ->
+    | 1061 ->
         "<SYNTAX ERROR>\n"
-    | 1065 ->
+    | 1063 ->
+        "<SYNTAX ERROR>\n"
+    | 1066 ->
         "<SYNTAX ERROR>\n"
     | 1698 ->
         "<SYNTAX ERROR>\n"
-    | 1139 ->
-        "<SYNTAX ERROR>\n"
     | 1140 ->
         "<SYNTAX ERROR>\n"
-    | 1148 ->
+    | 1141 ->
+        "<SYNTAX ERROR>\n"
+    | 1149 ->
         "<SYNTAX ERROR>\n"
     | 1657 ->
         "<SYNTAX ERROR>\n"
@@ -1556,9 +1548,7 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1666 ->
         "<SYNTAX ERROR>\n"
-    | 1067 ->
-        "<SYNTAX ERROR>\n"
-    | 1075 ->
+    | 1068 ->
         "<SYNTAX ERROR>\n"
     | 1076 ->
         "<SYNTAX ERROR>\n"
@@ -1568,7 +1558,7 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1079 ->
         "<SYNTAX ERROR>\n"
-    | 1081 ->
+    | 1080 ->
         "<SYNTAX ERROR>\n"
     | 1082 ->
         "<SYNTAX ERROR>\n"
@@ -1576,23 +1566,25 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1084 ->
         "<SYNTAX ERROR>\n"
-    | 1090 ->
+    | 1085 ->
         "<SYNTAX ERROR>\n"
     | 1091 ->
         "<SYNTAX ERROR>\n"
-    | 1093 ->
+    | 1092 ->
         "<SYNTAX ERROR>\n"
     | 1094 ->
         "<SYNTAX ERROR>\n"
-    | 1098 ->
-        "<SYNTAX ERROR>\n"
-    | 1096 ->
+    | 1095 ->
         "<SYNTAX ERROR>\n"
     | 1099 ->
         "<SYNTAX ERROR>\n"
+    | 1097 ->
+        "<SYNTAX ERROR>\n"
     | 1100 ->
         "<SYNTAX ERROR>\n"
-    | 1071 ->
+    | 1101 ->
+        "<SYNTAX ERROR>\n"
+    | 1072 ->
         "<SYNTAX ERROR>\n"
     | 1681 ->
         "<SYNTAX ERROR>\n"
@@ -1600,21 +1592,21 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1685 ->
         "<SYNTAX ERROR>\n"
-    | 1068 ->
-        "<SYNTAX ERROR>\n"
     | 1069 ->
         "<SYNTAX ERROR>\n"
-    | 1074 ->
+    | 1070 ->
+        "<SYNTAX ERROR>\n"
+    | 1075 ->
         "<SYNTAX ERROR>\n"
     | 1649 ->
-        "<SYNTAX ERROR>\n"
-    | 1149 ->
         "<SYNTAX ERROR>\n"
     | 1150 ->
         "<SYNTAX ERROR>\n"
     | 1151 ->
         "<SYNTAX ERROR>\n"
     | 1152 ->
+        "<SYNTAX ERROR>\n"
+    | 1153 ->
         "<SYNTAX ERROR>\n"
     | 1587 ->
         "<SYNTAX ERROR>\n"
@@ -1624,9 +1616,9 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1609 ->
         "<SYNTAX ERROR>\n"
-    | 1144 ->
-        "<SYNTAX ERROR>\n"
     | 1145 ->
+        "<SYNTAX ERROR>\n"
+    | 1146 ->
         "<SYNTAX ERROR>\n"
     | 1618 ->
         "<SYNTAX ERROR>\n"
@@ -1674,39 +1666,37 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1643 ->
         "<SYNTAX ERROR>\n"
-    | 562 ->
+    | 563 ->
         "<SYNTAX ERROR>\n"
-    | 140 ->
+    | 151 ->
         "<SYNTAX ERROR>\n"
-    | 883 ->
+    | 884 ->
         "<SYNTAX ERROR>\n"
-    | 2598 ->
-        "<SYNTAX ERROR>\n"
-    | 924 ->
-        "<SYNTAX ERROR>\n"
-    | 919 ->
-        "<SYNTAX ERROR>\n"
-    | 2600 ->
-        "<SYNTAX ERROR>\n"
-    | 1735 ->
+    | 2606 ->
         "<SYNTAX ERROR>\n"
     | 925 ->
         "<SYNTAX ERROR>\n"
-    | 935 ->
+    | 920 ->
         "<SYNTAX ERROR>\n"
-    | 927 ->
+    | 2608 ->
+        "<SYNTAX ERROR>\n"
+    | 1735 ->
+        "<SYNTAX ERROR>\n"
+    | 926 ->
+        "<SYNTAX ERROR>\n"
+    | 937 ->
         "<SYNTAX ERROR>\n"
     | 928 ->
         "<SYNTAX ERROR>\n"
-    | 2599 ->
+    | 929 ->
         "<SYNTAX ERROR>\n"
-    | 951 ->
+    | 2607 ->
         "<SYNTAX ERROR>\n"
     | 952 ->
         "<SYNTAX ERROR>\n"
-    | 954 ->
+    | 953 ->
         "<SYNTAX ERROR>\n"
-    | 998 ->
+    | 955 ->
         "<SYNTAX ERROR>\n"
     | 999 ->
         "<SYNTAX ERROR>\n"
@@ -1722,15 +1712,15 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1005 ->
         "<SYNTAX ERROR>\n"
-    | 1011 ->
-        "<SYNTAX ERROR>\n"
-    | 1013 ->
-        "<SYNTAX ERROR>\n"
     | 1006 ->
+        "<SYNTAX ERROR>\n"
+    | 1012 ->
+        "<SYNTAX ERROR>\n"
+    | 1014 ->
         "<SYNTAX ERROR>\n"
     | 1007 ->
         "<SYNTAX ERROR>\n"
-    | 1018 ->
+    | 1008 ->
         "<SYNTAX ERROR>\n"
     | 1019 ->
         "<SYNTAX ERROR>\n"
@@ -1738,83 +1728,81 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1021 ->
         "<SYNTAX ERROR>\n"
+    | 1022 ->
+        "<SYNTAX ERROR>\n"
     | 1736 ->
         "<SYNTAX ERROR>\n"
     | 1737 ->
         "<SYNTAX ERROR>\n"
-    | 787 ->
-        "<SYNTAX ERROR>\n"
-    | 1024 ->
+    | 788 ->
         "<SYNTAX ERROR>\n"
     | 1025 ->
         "<SYNTAX ERROR>\n"
-    | 1707 ->
+    | 1026 ->
         "<SYNTAX ERROR>\n"
-    | 959 ->
+    | 1707 ->
         "<SYNTAX ERROR>\n"
     | 960 ->
         "<SYNTAX ERROR>\n"
-    | 962 ->
+    | 961 ->
         "<SYNTAX ERROR>\n"
     | 963 ->
         "<SYNTAX ERROR>\n"
-    | 969 ->
+    | 964 ->
         "<SYNTAX ERROR>\n"
-    | 967 ->
+    | 970 ->
         "<SYNTAX ERROR>\n"
-    | 965 ->
+    | 968 ->
         "<SYNTAX ERROR>\n"
-    | 982 ->
+    | 966 ->
         "<SYNTAX ERROR>\n"
     | 983 ->
         "<SYNTAX ERROR>\n"
-    | 975 ->
+    | 984 ->
         "<SYNTAX ERROR>\n"
     | 976 ->
         "<SYNTAX ERROR>\n"
-    | 980 ->
+    | 977 ->
         "<SYNTAX ERROR>\n"
     | 981 ->
         "<SYNTAX ERROR>\n"
-    | 979 ->
+    | 76 ->
         "<SYNTAX ERROR>\n"
-    | 977 ->
+    | 980 ->
         "<SYNTAX ERROR>\n"
     | 978 ->
         "<SYNTAX ERROR>\n"
-    | 106 ->
+    | 117 ->
         "<SYNTAX ERROR>\n"
-    | 263 ->
-        "<SYNTAX ERROR>\n"
-    | 986 ->
+    | 256 ->
         "<SYNTAX ERROR>\n"
     | 987 ->
         "<SYNTAX ERROR>\n"
-    | 264 ->
+    | 988 ->
         "<SYNTAX ERROR>\n"
-    | 265 ->
+    | 257 ->
         "<SYNTAX ERROR>\n"
-    | 406 ->
+    | 258 ->
         "<SYNTAX ERROR>\n"
-    | 407 ->
+    | 409 ->
         "<SYNTAX ERROR>\n"
-    | 408 ->
+    | 410 ->
         "<SYNTAX ERROR>\n"
-    | 2392 ->
+    | 2399 ->
         "<SYNTAX ERROR>\n"
-    | 543 ->
+    | 545 ->
         "<SYNTAX ERROR>\n"
-    | 2307 ->
+    | 2314 ->
         "<SYNTAX ERROR>\n"
-    | 2308 ->
+    | 2315 ->
         "<SYNTAX ERROR>\n"
-    | 2309 ->
+    | 2316 ->
         "<SYNTAX ERROR>\n"
-    | 2310 ->
+    | 2317 ->
         "<SYNTAX ERROR>\n"
-    | 2311 ->
+    | 2318 ->
         "<SYNTAX ERROR>\n"
-    | 2312 ->
+    | 2319 ->
         "<SYNTAX ERROR>\n"
     | 1917 ->
         "<SYNTAX ERROR>\n"
@@ -1828,19 +1816,19 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1921 ->
         "<SYNTAX ERROR>\n"
-    | 1939 ->
+    | 1946 ->
         "<SYNTAX ERROR>\n"
-    | 1940 ->
+    | 1947 ->
         "<SYNTAX ERROR>\n"
     | 1926 ->
         "<SYNTAX ERROR>\n"
     | 1927 ->
         "<SYNTAX ERROR>\n"
-    | 1937 ->
+    | 1944 ->
         "<SYNTAX ERROR>\n"
-    | 1938 ->
+    | 1929 ->
         "<SYNTAX ERROR>\n"
-    | 1936 ->
+    | 1943 ->
         "<SYNTAX ERROR>\n"
     | 1928 ->
         "<SYNTAX ERROR>\n"
@@ -1848,51 +1836,47 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1931 ->
         "<SYNTAX ERROR>\n"
-    | 1932 ->
-        "<SYNTAX ERROR>\n"
     | 1934 ->
-        "<SYNTAX ERROR>\n"
-    | 544 ->
-        "<SYNTAX ERROR>\n"
-    | 638 ->
-        "<SYNTAX ERROR>\n"
-    | 1944 ->
-        "<SYNTAX ERROR>\n"
-    | 1945 ->
-        "<SYNTAX ERROR>\n"
-    | 639 ->
-        "<SYNTAX ERROR>\n"
-    | 640 ->
-        "<SYNTAX ERROR>\n"
-    | 545 ->
         "<SYNTAX ERROR>\n"
     | 546 ->
         "<SYNTAX ERROR>\n"
+    | 639 ->
+        "<SYNTAX ERROR>\n"
+    | 1951 ->
+        "<SYNTAX ERROR>\n"
+    | 1952 ->
+        "<SYNTAX ERROR>\n"
+    | 640 ->
+        "<SYNTAX ERROR>\n"
+    | 641 ->
+        "<SYNTAX ERROR>\n"
     | 547 ->
         "<SYNTAX ERROR>\n"
-    | 2303 ->
+    | 548 ->
+        "<SYNTAX ERROR>\n"
+    | 2310 ->
         "<SYNTAX ERROR>\n"
     | 1907 ->
         "<SYNTAX ERROR>\n"
-    | 1954 ->
+    | 1961 ->
         "<SYNTAX ERROR>\n"
-    | 1955 ->
+    | 1962 ->
         "<SYNTAX ERROR>\n"
-    | 1956 ->
+    | 1963 ->
         "<SYNTAX ERROR>\n"
-    | 1957 ->
+    | 1964 ->
         "<SYNTAX ERROR>\n"
-    | 1958 ->
+    | 1965 ->
         "<SYNTAX ERROR>\n"
-    | 1959 ->
+    | 1966 ->
         "<SYNTAX ERROR>\n"
     | 1915 ->
         "<SYNTAX ERROR>\n"
-    | 2304 ->
+    | 2311 ->
         "<SYNTAX ERROR>\n"
     | 1908 ->
         "<SYNTAX ERROR>\n"
-    | 917 ->
+    | 918 ->
         "<SYNTAX ERROR>\n"
     | 1729 ->
         "<SYNTAX ERROR>\n"
@@ -1910,7 +1894,7 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1717 ->
         "<SYNTAX ERROR>\n"
-    | 937 ->
+    | 939 ->
         "<SYNTAX ERROR>\n"
     | 1720 ->
         "<SYNTAX ERROR>\n"
@@ -1928,307 +1912,299 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1743 ->
         "<SYNTAX ERROR>\n"
-    | 2605 ->
+    | 2613 ->
         "<SYNTAX ERROR>\n"
-    | 2607 ->
-        "<SYNTAX ERROR>\n"
-    | 275 ->
+    | 2615 ->
         "<SYNTAX ERROR>\n"
     | 279 ->
         "<SYNTAX ERROR>\n"
-    | 280 ->
+    | 283 ->
         "<SYNTAX ERROR>\n"
-    | 156 ->
+    | 284 ->
         "<SYNTAX ERROR>\n"
-    | 157 ->
+    | 195 ->
         "<SYNTAX ERROR>\n"
-    | 158 ->
+    | 77 ->
         "<SYNTAX ERROR>\n"
-    | 160 ->
+    | 78 ->
         "<SYNTAX ERROR>\n"
-    | 162 ->
+    | 80 ->
         "<SYNTAX ERROR>\n"
-    | 98 ->
+    | 196 ->
+        "<SYNTAX ERROR>\n"
+    | 113 ->
         "<SYNTAX ERROR>\n"
     | 9 ->
         "<SYNTAX ERROR>\n"
     | 10 ->
         "<SYNTAX ERROR>\n"
-    | 2539 ->
-        "<SYNTAX ERROR>\n"
-    | 102 ->
-        "<SYNTAX ERROR>\n"
-    | 104 ->
-        "<SYNTAX ERROR>\n"
-    | 2537 ->
-        "Expecting one of the following:\n  - \",\" to start the type in the tuple\n  - \")\" to finish the tuple type definition\n"
-    | 273 ->
-        "<SYNTAX ERROR>\n"
-    | 105 ->
+    | 2548 ->
         "<SYNTAX ERROR>\n"
     | 110 ->
         "<SYNTAX ERROR>\n"
-    | 111 ->
+    | 2546 ->
+        "Expecting one of the following:\n  - \",\" to start the type in the tuple\n  - \")\" to finish the tuple type definition\n"
+    | 277 ->
         "<SYNTAX ERROR>\n"
     | 116 ->
         "<SYNTAX ERROR>\n"
-    | 117 ->
+    | 121 ->
         "<SYNTAX ERROR>\n"
-    | 2534 ->
+    | 122 ->
+        "<SYNTAX ERROR>\n"
+    | 127 ->
+        "<SYNTAX ERROR>\n"
+    | 128 ->
+        "<SYNTAX ERROR>\n"
+    | 2543 ->
+        "<SYNTAX ERROR>\n"
+    | 2544 ->
+        "<SYNTAX ERROR>\n"
+    | 120 ->
+        "<SYNTAX ERROR>\n"
+    | 118 ->
+        "<SYNTAX ERROR>\n"
+    | 262 ->
+        "<SYNTAX ERROR>\n"
+    | 108 ->
+        "<SYNTAX ERROR>\n"
+    | 130 ->
         "<SYNTAX ERROR>\n"
     | 2535 ->
         "<SYNTAX ERROR>\n"
-    | 109 ->
+    | 2536 ->
         "<SYNTAX ERROR>\n"
-    | 107 ->
+    | 2537 ->
         "<SYNTAX ERROR>\n"
-    | 154 ->
+    | 2539 ->
         "<SYNTAX ERROR>\n"
-    | 100 ->
+    | 134 ->
         "<SYNTAX ERROR>\n"
-    | 119 ->
+    | 139 ->
         "<SYNTAX ERROR>\n"
-    | 2526 ->
+    | 140 ->
         "<SYNTAX ERROR>\n"
-    | 2527 ->
+    | 294 ->
+        "<SYNTAX ERROR>\n"
+    | 141 ->
+        "<SYNTAX ERROR>\n"
+    | 488 ->
+        "<SYNTAX ERROR>\n"
+    | 487 ->
+        "<SYNTAX ERROR>\n"
+    | 490 ->
+        "<SYNTAX ERROR>\n"
+    | 295 ->
+        "<SYNTAX ERROR>\n"
+    | 137 ->
+        "<SYNTAX ERROR>\n"
+    | 143 ->
         "<SYNTAX ERROR>\n"
     | 2528 ->
         "<SYNTAX ERROR>\n"
     | 2530 ->
         "<SYNTAX ERROR>\n"
-    | 123 ->
+    | 2531 ->
         "<SYNTAX ERROR>\n"
-    | 128 ->
+    | 157 ->
         "<SYNTAX ERROR>\n"
-    | 129 ->
-        "<SYNTAX ERROR>\n"
-    | 290 ->
-        "<SYNTAX ERROR>\n"
-    | 130 ->
-        "<SYNTAX ERROR>\n"
-    | 487 ->
-        "<SYNTAX ERROR>\n"
-    | 486 ->
-        "<SYNTAX ERROR>\n"
-    | 489 ->
-        "<SYNTAX ERROR>\n"
-    | 291 ->
-        "<SYNTAX ERROR>\n"
-    | 126 ->
-        "<SYNTAX ERROR>\n"
-    | 132 ->
-        "<SYNTAX ERROR>\n"
-    | 2519 ->
-        "<SYNTAX ERROR>\n"
-    | 2521 ->
-        "<SYNTAX ERROR>\n"
-    | 2522 ->
+    | 145 ->
         "<SYNTAX ERROR>\n"
     | 146 ->
         "<SYNTAX ERROR>\n"
-    | 134 ->
+    | 2526 ->
         "<SYNTAX ERROR>\n"
-    | 135 ->
+    | 148 ->
         "<SYNTAX ERROR>\n"
-    | 2517 ->
+    | 149 ->
         "<SYNTAX ERROR>\n"
-    | 137 ->
+    | 2522 ->
         "<SYNTAX ERROR>\n"
-    | 138 ->
+    | 2523 ->
         "<SYNTAX ERROR>\n"
-    | 2513 ->
-        "<SYNTAX ERROR>\n"
-    | 2514 ->
-        "<SYNTAX ERROR>\n"
-    | 2515 ->
-        "<SYNTAX ERROR>\n"
-    | 139 ->
-        "<SYNTAX ERROR>\n"
-    | 144 ->
+    | 2524 ->
         "<SYNTAX ERROR>\n"
     | 150 ->
         "<SYNTAX ERROR>\n"
-    | 2511 ->
+    | 155 ->
         "<SYNTAX ERROR>\n"
-    | 2507 ->
+    | 2520 ->
         "<SYNTAX ERROR>\n"
-    | 152 ->
+    | 2516 ->
         "<SYNTAX ERROR>\n"
-    | 2609 ->
+    | 2513 ->
         "<SYNTAX ERROR>\n"
-    | 2611 ->
+    | 2617 ->
         "<SYNTAX ERROR>\n"
-    | 2613 ->
+    | 2619 ->
         "<SYNTAX ERROR>\n"
-    | 2614 ->
+    | 2621 ->
         "<SYNTAX ERROR>\n"
-    | 782 ->
+    | 2622 ->
         "<SYNTAX ERROR>\n"
-    | 784 ->
-        "<SYNTAX ERROR>\n"
-    | 795 ->
+    | 783 ->
         "<SYNTAX ERROR>\n"
     | 785 ->
         "<SYNTAX ERROR>\n"
-    | 777 ->
+    | 796 ->
         "<SYNTAX ERROR>\n"
-    | 622 ->
+    | 786 ->
         "<SYNTAX ERROR>\n"
-    | 586 ->
+    | 778 ->
         "<SYNTAX ERROR>\n"
-    | 758 ->
+    | 623 ->
         "<SYNTAX ERROR>\n"
-    | 203 ->
+    | 587 ->
         "<SYNTAX ERROR>\n"
-    | 205 ->
+    | 759 ->
         "<SYNTAX ERROR>\n"
-    | 211 ->
+    | 193 ->
         "<SYNTAX ERROR>\n"
-    | 217 ->
+    | 198 ->
         "<SYNTAX ERROR>\n"
-    | 802 ->
+    | 204 ->
+        "<SYNTAX ERROR>\n"
+    | 210 ->
         "<SYNTAX ERROR>\n"
     | 803 ->
         "<SYNTAX ERROR>\n"
-    | 832 ->
+    | 804 ->
         "<SYNTAX ERROR>\n"
-    | 793 ->
+    | 833 ->
         "<SYNTAX ERROR>\n"
-    | 721 ->
+    | 794 ->
         "<SYNTAX ERROR>\n"
-    | 708 ->
+    | 722 ->
         "<SYNTAX ERROR>\n"
-    | 710 ->
-        "<SYNTAX ERROR>\n"
-    | 837 ->
-        "<SYNTAX ERROR>\n"
-    | 454 ->
-        "<SYNTAX ERROR>\n"
-    | 458 ->
-        "<SYNTAX ERROR>\n"
-    | 459 ->
-        "<SYNTAX ERROR>\n"
-    | 252 ->
-        "<SYNTAX ERROR>\n"
-    | 320 ->
-        "<SYNTAX ERROR>\n"
-    | 256 ->
-        "<SYNTAX ERROR>\n"
-    | 259 ->
-        "<SYNTAX ERROR>\n"
-    | 271 ->
-        "<SYNTAX ERROR>\n"
-    | 260 ->
-        "<SYNTAX ERROR>\n"
-    | 261 ->
-        "<SYNTAX ERROR>\n"
-    | 332 ->
-        "<SYNTAX ERROR>\n"
-    | 254 ->
-        "<SYNTAX ERROR>\n"
-    | 327 ->
-        "<SYNTAX ERROR>\n"
-    | 328 ->
-        "<SYNTAX ERROR>\n"
-    | 329 ->
-        "<SYNTAX ERROR>\n"
-    | 330 ->
-        "<SYNTAX ERROR>\n"
-    | 2403 ->
-        "<SYNTAX ERROR>\n"
-    | 287 ->
-        "<SYNTAX ERROR>\n"
-    | 288 ->
-        "<SYNTAX ERROR>\n"
-    | 294 ->
-        "<SYNTAX ERROR>\n"
-    | 296 ->
-        "<SYNTAX ERROR>\n"
-    | 298 ->
-        "<SYNTAX ERROR>\n"
-    | 299 ->
-        "<SYNTAX ERROR>\n"
-    | 295 ->
-        "<SYNTAX ERROR>\n"
-    | 304 ->
-        "<SYNTAX ERROR>\n"
-    | 307 ->
-        "<SYNTAX ERROR>\n"
-    | 306 ->
-        "<SYNTAX ERROR>\n"
-    | 309 ->
-        "<SYNTAX ERROR>\n"
-    | 315 ->
-        "<SYNTAX ERROR>\n"
-    | 316 ->
-        "<SYNTAX ERROR>\n"
-    | 317 ->
-        "<SYNTAX ERROR>\n"
-    | 310 ->
-        "<SYNTAX ERROR>\n"
-    | 311 ->
-        "<SYNTAX ERROR>\n"
-    | 313 ->
-        "<SYNTAX ERROR>\n"
-    | 728 ->
+    | 709 ->
         "<SYNTAX ERROR>\n"
     | 711 ->
         "<SYNTAX ERROR>\n"
-    | 713 ->
+    | 838 ->
         "<SYNTAX ERROR>\n"
-    | 698 ->
+    | 446 ->
         "<SYNTAX ERROR>\n"
-    | 667 ->
+    | 450 ->
         "<SYNTAX ERROR>\n"
-    | 688 ->
+    | 451 ->
         "<SYNTAX ERROR>\n"
-    | 679 ->
+    | 245 ->
         "<SYNTAX ERROR>\n"
-    | 219 ->
-        "<SYNTAX ERROR>\n"
-    | 222 ->
-        "<SYNTAX ERROR>\n"
-    | 223 ->
-        "<SYNTAX ERROR>\n"
-    | 229 ->
-        "<SYNTAX ERROR>\n"
-    | 237 ->
-        "<SYNTAX ERROR>\n"
-    | 238 ->
-        "<SYNTAX ERROR>\n"
-    | 240 ->
-        "<SYNTAX ERROR>\n"
-    | 247 ->
-        "<SYNTAX ERROR>\n"
-    | 248 ->
+    | 324 ->
         "<SYNTAX ERROR>\n"
     | 249 ->
         "<SYNTAX ERROR>\n"
-    | 250 ->
+    | 275 ->
         "<SYNTAX ERROR>\n"
-    | 2407 ->
+    | 253 ->
         "<SYNTAX ERROR>\n"
-    | 2408 ->
+    | 254 ->
+        "<SYNTAX ERROR>\n"
+    | 336 ->
+        "<SYNTAX ERROR>\n"
+    | 247 ->
+        "<SYNTAX ERROR>\n"
+    | 331 ->
+        "<SYNTAX ERROR>\n"
+    | 332 ->
+        "<SYNTAX ERROR>\n"
+    | 333 ->
+        "<SYNTAX ERROR>\n"
+    | 334 ->
+        "<SYNTAX ERROR>\n"
+    | 2410 ->
+        "<SYNTAX ERROR>\n"
+    | 291 ->
+        "<SYNTAX ERROR>\n"
+    | 292 ->
+        "<SYNTAX ERROR>\n"
+    | 298 ->
+        "<SYNTAX ERROR>\n"
+    | 300 ->
+        "<SYNTAX ERROR>\n"
+    | 302 ->
+        "<SYNTAX ERROR>\n"
+    | 303 ->
+        "<SYNTAX ERROR>\n"
+    | 299 ->
+        "<SYNTAX ERROR>\n"
+    | 308 ->
+        "<SYNTAX ERROR>\n"
+    | 311 ->
+        "<SYNTAX ERROR>\n"
+    | 310 ->
+        "<SYNTAX ERROR>\n"
+    | 313 ->
+        "<SYNTAX ERROR>\n"
+    | 319 ->
+        "<SYNTAX ERROR>\n"
+    | 320 ->
+        "<SYNTAX ERROR>\n"
+    | 321 ->
+        "<SYNTAX ERROR>\n"
+    | 314 ->
+        "<SYNTAX ERROR>\n"
+    | 315 ->
+        "<SYNTAX ERROR>\n"
+    | 317 ->
+        "<SYNTAX ERROR>\n"
+    | 729 ->
+        "<SYNTAX ERROR>\n"
+    | 712 ->
+        "<SYNTAX ERROR>\n"
+    | 714 ->
+        "<SYNTAX ERROR>\n"
+    | 699 ->
+        "<SYNTAX ERROR>\n"
+    | 668 ->
+        "<SYNTAX ERROR>\n"
+    | 689 ->
+        "<SYNTAX ERROR>\n"
+    | 680 ->
+        "<SYNTAX ERROR>\n"
+    | 212 ->
+        "<SYNTAX ERROR>\n"
+    | 215 ->
+        "<SYNTAX ERROR>\n"
+    | 216 ->
+        "<SYNTAX ERROR>\n"
+    | 222 ->
+        "<SYNTAX ERROR>\n"
+    | 230 ->
+        "<SYNTAX ERROR>\n"
+    | 231 ->
+        "<SYNTAX ERROR>\n"
+    | 233 ->
+        "<SYNTAX ERROR>\n"
+    | 240 ->
         "<SYNTAX ERROR>\n"
     | 241 ->
         "<SYNTAX ERROR>\n"
-    | 246 ->
+    | 242 ->
         "<SYNTAX ERROR>\n"
-    | 624 ->
+    | 243 ->
         "<SYNTAX ERROR>\n"
-    | 630 ->
+    | 2414 ->
         "<SYNTAX ERROR>\n"
-    | 719 ->
+    | 2415 ->
         "<SYNTAX ERROR>\n"
-    | 808 ->
+    | 234 ->
+        "<SYNTAX ERROR>\n"
+    | 239 ->
+        "<SYNTAX ERROR>\n"
+    | 625 ->
         "<SYNTAX ERROR>\n"
     | 631 ->
         "<SYNTAX ERROR>\n"
+    | 720 ->
+        "<SYNTAX ERROR>\n"
+    | 809 ->
+        "<SYNTAX ERROR>\n"
     | 632 ->
         "<SYNTAX ERROR>\n"
-    | 634 ->
+    | 633 ->
         "<SYNTAX ERROR>\n"
-    | 824 ->
+    | 635 ->
         "<SYNTAX ERROR>\n"
     | 825 ->
         "<SYNTAX ERROR>\n"
@@ -2240,111 +2216,113 @@ let message =
         "<SYNTAX ERROR>\n"
     | 829 ->
         "<SYNTAX ERROR>\n"
-    | 646 ->
-        "<SYNTAX ERROR>\n"
-    | 821 ->
-        "<SYNTAX ERROR>\n"
-    | 649 ->
-        "<SYNTAX ERROR>\n"
-    | 816 ->
-        "<SYNTAX ERROR>\n"
-    | 650 ->
-        "<SYNTAX ERROR>\n"
-    | 655 ->
-        "<SYNTAX ERROR>\n"
-    | 666 ->
-        "<SYNTAX ERROR>\n"
-    | 674 ->
-        "<SYNTAX ERROR>\n"
-    | 682 ->
-        "<SYNTAX ERROR>\n"
-    | 2410 ->
-        "<SYNTAX ERROR>\n"
-    | 2411 ->
-        "<SYNTAX ERROR>\n"
-    | 2412 ->
-        "<SYNTAX ERROR>\n"
-    | 2413 ->
-        "<SYNTAX ERROR>\n"
-    | 2414 ->
-        "<SYNTAX ERROR>\n"
-    | 2415 ->
-        "<SYNTAX ERROR>\n"
-    | 722 ->
-        "<SYNTAX ERROR>\n"
-    | 733 ->
-        "<SYNTAX ERROR>\n"
-    | 736 ->
-        "<SYNTAX ERROR>\n"
-    | 726 ->
-        "<SYNTAX ERROR>\n"
-    | 727 ->
+    | 830 ->
         "<SYNTAX ERROR>\n"
     | 647 ->
         "<SYNTAX ERROR>\n"
-    | 648 ->
+    | 822 ->
+        "<SYNTAX ERROR>\n"
+    | 650 ->
+        "<SYNTAX ERROR>\n"
+    | 817 ->
+        "<SYNTAX ERROR>\n"
+    | 651 ->
+        "<SYNTAX ERROR>\n"
+    | 656 ->
+        "<SYNTAX ERROR>\n"
+    | 667 ->
+        "<SYNTAX ERROR>\n"
+    | 675 ->
+        "<SYNTAX ERROR>\n"
+    | 683 ->
+        "<SYNTAX ERROR>\n"
+    | 2417 ->
+        "<SYNTAX ERROR>\n"
+    | 2418 ->
+        "<SYNTAX ERROR>\n"
+    | 2419 ->
+        "<SYNTAX ERROR>\n"
+    | 2420 ->
+        "<SYNTAX ERROR>\n"
+    | 2421 ->
+        "<SYNTAX ERROR>\n"
+    | 2422 ->
+        "<SYNTAX ERROR>\n"
+    | 723 ->
+        "<SYNTAX ERROR>\n"
+    | 734 ->
         "<SYNTAX ERROR>\n"
     | 737 ->
         "<SYNTAX ERROR>\n"
-    | 740 ->
+    | 727 ->
         "<SYNTAX ERROR>\n"
-    | 748 ->
+    | 728 ->
         "<SYNTAX ERROR>\n"
-    | 744 ->
+    | 648 ->
         "<SYNTAX ERROR>\n"
-    | 747 ->
+    | 649 ->
         "<SYNTAX ERROR>\n"
-    | 745 ->
-        "Expecting a valid list identifier\n"
-    | 746 ->
+    | 738 ->
+        "<SYNTAX ERROR>\n"
+    | 741 ->
         "<SYNTAX ERROR>\n"
     | 749 ->
         "<SYNTAX ERROR>\n"
-    | 652 ->
+    | 745 ->
         "<SYNTAX ERROR>\n"
-    | 653 ->
+    | 748 ->
         "<SYNTAX ERROR>\n"
-    | 664 ->
-        "<SYNTAX ERROR>\n"
-    | 659 ->
-        "<SYNTAX ERROR>\n"
-    | 660 ->
+    | 746 ->
+        "Expecting a valid list identifier\n"
+    | 747 ->
         "<SYNTAX ERROR>\n"
     | 750 ->
         "<SYNTAX ERROR>\n"
+    | 653 ->
+        "<SYNTAX ERROR>\n"
+    | 654 ->
+        "<SYNTAX ERROR>\n"
     | 665 ->
         "<SYNTAX ERROR>\n"
-    | 814 ->
+    | 660 ->
         "<SYNTAX ERROR>\n"
-    | 753 ->
+    | 661 ->
         "<SYNTAX ERROR>\n"
-    | 769 ->
+    | 751 ->
         "<SYNTAX ERROR>\n"
-    | 771 ->
+    | 666 ->
         "<SYNTAX ERROR>\n"
-    | 2617 ->
+    | 815 ->
         "<SYNTAX ERROR>\n"
-    | 2631 ->
+    | 754 ->
         "<SYNTAX ERROR>\n"
-    | 2618 ->
+    | 770 ->
         "<SYNTAX ERROR>\n"
-    | 2619 ->
+    | 772 ->
         "<SYNTAX ERROR>\n"
     | 2625 ->
         "<SYNTAX ERROR>\n"
+    | 2639 ->
+        "<SYNTAX ERROR>\n"
     | 2626 ->
         "<SYNTAX ERROR>\n"
-    | 2629 ->
+    | 2627 ->
+        "<SYNTAX ERROR>\n"
+    | 2633 ->
         "<SYNTAX ERROR>\n"
     | 2634 ->
         "<SYNTAX ERROR>\n"
-    | 2641 ->
-        "<SYNTAX ERROR>\n"
-    | 2640 ->
-        "<SYNTAX ERROR>\n"
     | 2637 ->
         "<SYNTAX ERROR>\n"
-    | 2638 ->
+    | 2642 ->
+        "<SYNTAX ERROR>\n"
+    | 2649 ->
+        "<SYNTAX ERROR>\n"
+    | 2648 ->
+        "<SYNTAX ERROR>\n"
+    | 2645 ->
+        "<SYNTAX ERROR>\n"
+    | 2646 ->
         "<SYNTAX ERROR>\n"
     | _ ->
         raise Not_found

--- a/src/reason_parser_message.ml
+++ b/src/reason_parser_message.ml
@@ -10,129 +10,129 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2 ->
         "<SYNTAX ERROR>\n"
-    | 2608 ->
+    | 2695 ->
         "<SYNTAX ERROR>\n"
-    | 574 ->
+    | 590 ->
         "Expecting one of the following:\n  - an identifier to access a member of an object\n  - \"[\" + expression + \"]\" to access an element of a list\n  - \"(\" + expression + \")\"\n  - \"{\" + expression + \"}\"\n"
-    | 575 ->
+    | 591 ->
         "Expecting an expression\n"
-    | 2292 ->
+    | 2356 ->
         "Expecting one of the following:\n  - an infix operation to connect two expressions\n  - \")\" to close the block\n"
-    | 2294 ->
+    | 2358 ->
         "Expecting an expression\n"
-    | 2295 ->
+    | 2359 ->
         "Expecting one of the following:\n  - an infix operation to connect two expressions\n  - \"}\" to close the block\n"
-    | 2297 ->
+    | 2361 ->
         "Expecting an expression\n"
-    | 2298 ->
+    | 2362 ->
         "Expecting one of the following:\n  - an infix operation to connect two expressions\n  - \"}\" to close the block\n"
-    | 1189 ->
+    | 1228 ->
         "Expecting an expression\n"
-    | 572 ->
+    | 588 ->
         "Expecting an identifier\n"
-    | 1122 ->
+    | 1161 ->
         "Expecting a structure item\n"
-    | 2613 ->
+    | 2700 ->
         "Invalid token\n"
+    | 1282 ->
+        "Expecting an expression\n"
+    | 1283 ->
+        "Expecting one of the following:\n  - The continuation of the previous expression\n  - \":\" to start the next expression\n"
+    | 1284 ->
+        "Expecting an expression\n"
     | 1243 ->
         "Expecting an expression\n"
-    | 1244 ->
-        "Expecting one of the following:\n  - The continuation of the previous expression\n  - \":\" to start the next expression\n"
+    | 1249 ->
+        "Expecting an expression\n"
+    | 1251 ->
+        "Expecting an expression\n"
     | 1245 ->
         "Expecting an expression\n"
-    | 1204 ->
+    | 1253 ->
         "Expecting an expression\n"
-    | 1210 ->
+    | 1255 ->
         "Expecting an expression\n"
-    | 1212 ->
-        "Expecting an expression\n"
-    | 1206 ->
-        "Expecting an expression\n"
-    | 1214 ->
-        "Expecting an expression\n"
-    | 1216 ->
-        "Expecting an expression\n"
-    | 1218 ->
+    | 1257 ->
         "Expecting an expression\n"
     | 15 ->
         "Expecting one of the following:\n  - \")\" to form a unit value \"()\"\n  - \"module\" to start a module expression\n  - an expression\n  - an operator to denote the prefix form of an operator\n"
-    | 1220 ->
+    | 1259 ->
         "Expecting an expression\n"
-    | 1226 ->
+    | 1265 ->
         "Expecting an expression\n"
-    | 1228 ->
+    | 1267 ->
         "Expecting an expression\n"
-    | 2409 ->
+    | 2473 ->
         "Expecting \"]\"\n"
     | 403 ->
         "Expecting an attributed id\n"
-    | 2516 ->
+    | 2580 ->
         "Expecting \"]\"\n"
     | 161 ->
         "Expecting an attribute id\n"
-    | 1191 ->
-        "Expecting an expression\n"
-    | 1208 ->
-        "Expecting an expression\n"
-    | 1222 ->
-        "Expecting an expression\n"
-    | 1224 ->
-        "Expecting an expression\n"
     | 1230 ->
         "Expecting an expression\n"
-    | 1232 ->
+    | 1247 ->
         "Expecting an expression\n"
-    | 854 ->
+    | 1261 ->
+        "Expecting an expression\n"
+    | 1263 ->
+        "Expecting an expression\n"
+    | 1269 ->
+        "Expecting an expression\n"
+    | 1271 ->
+        "Expecting an expression\n"
+    | 870 ->
         "<SYNTAX ERROR>\n"
-    | 855 ->
+    | 871 ->
         "<SYNTAX ERROR>\n"
-    | 2200 ->
+    | 2264 ->
         "<SYNTAX ERROR>\n"
-    | 856 ->
+    | 872 ->
         "<SYNTAX ERROR>\n"
-    | 858 ->
+    | 874 ->
         "<SYNTAX ERROR>\n"
-    | 2196 ->
+    | 2260 ->
         "<SYNTAX ERROR>\n"
-    | 2198 ->
+    | 2262 ->
         "<SYNTAX ERROR>\n"
-    | 2203 ->
+    | 2267 ->
         "<SYNTAX ERROR>\n"
-    | 2204 ->
+    | 2268 ->
         "<SYNTAX ERROR>\n"
-    | 2208 ->
+    | 2272 ->
         "<SYNTAX ERROR>\n"
-    | 2218 ->
+    | 2282 ->
         "<SYNTAX ERROR>\n"
-    | 2223 ->
+    | 2287 ->
         "<SYNTAX ERROR>\n"
-    | 1848 ->
+    | 1887 ->
         "<SYNTAX ERROR>\n"
-    | 1240 ->
+    | 1279 ->
         "<SYNTAX ERROR>\n"
-    | 1234 ->
+    | 1273 ->
         "<SYNTAX ERROR>\n"
-    | 1236 ->
+    | 1275 ->
         "<SYNTAX ERROR>\n"
-    | 1238 ->
+    | 1277 ->
         "<SYNTAX ERROR>\n"
     | 75 ->
         "<SYNTAX ERROR>\n"
-    | 955 ->
+    | 977 ->
         "<SYNTAX ERROR>\n"
-    | 956 ->
+    | 978 ->
         "<SYNTAX ERROR>\n"
     | 104 ->
         "Expecting one of the following:\n  - \"=\" to start the body of the type declaration\n  - \"constraint\" to add constraints to the type declaration\n  - \";\" to finish type declaratoin\n  - \"+=\" to form a string type extension\n  - \"and\" to declare another type\n"
     | 91 ->
         "<SYNTAX ERROR>\n"
-    | 2593 ->
+    | 2680 ->
         "<SYNTAX ERROR>\n"
-    | 2597 ->
+    | 2684 ->
         "<SYNTAX ERROR>\n"
-    | 2594 ->
+    | 2681 ->
         "<SYNTAX ERROR>\n"
-    | 2595 ->
+    | 2682 ->
         "<SYNTAX ERROR>\n"
     | 95 ->
         "<SYNTAX ERROR>\n"
@@ -142,139 +142,139 @@ let message =
         "<SYNTAX ERROR>\n"
     | 101 ->
         "<SYNTAX ERROR>\n"
-    | 1132 ->
+    | 1171 ->
         "<SYNTAX ERROR>\n"
     | 105 ->
         "<SYNTAX ERROR>\n"
-    | 2579 ->
+    | 2665 ->
         "<SYNTAX ERROR>\n"
-    | 2580 ->
+    | 2666 ->
         "<SYNTAX ERROR>\n"
-    | 2567 ->
+    | 2656 ->
         "<SYNTAX ERROR>\n"
-    | 2582 ->
+    | 2668 ->
         "<SYNTAX ERROR>\n"
-    | 2586 ->
+    | 2673 ->
         "<SYNTAX ERROR>\n"
-    | 2587 ->
+    | 2674 ->
         "<SYNTAX ERROR>\n"
-    | 2559 ->
+    | 2635 ->
         "<SYNTAX ERROR>\n"
     | 107 ->
         "<SYNTAX ERROR>\n"
-    | 2557 ->
+    | 2624 ->
         "<SYNTAX ERROR>\n"
-    | 2558 ->
+    | 2625 ->
         "<SYNTAX ERROR>\n"
-    | 2575 ->
+    | 2661 ->
         "Expecting at least one type field definition in the form of:\n  <field name> : <type>\n"
-    | 489 ->
+    | 504 ->
         "Expecting a type field definition in the form of:\n  <field name> : <type>\n"
-    | 490 ->
-        "Expecting \":\"\n"
-    | 491 ->
-        "Expecting a type name describing this field\n"
-    | 2576 ->
-        "Expecting one of the following:\n  - \",\" to finish current type field\n  - \"}\" to finish type definition\n"
     | 505 ->
+        "Expecting \":\"\n"
+    | 506 ->
+        "Expecting a type name describing this field\n"
+    | 2662 ->
+        "Expecting one of the following:\n  - \",\" to finish current type field\n  - \"}\" to finish type definition\n"
+    | 520 ->
         "Expecting one of the following:\n  - another type field definition\n  - \"}\" to finish entire type definition\n"
-    | 1137 ->
+    | 1176 ->
         "<SYNTAX ERROR>\n"
-    | 2564 ->
+    | 2653 ->
         "<SYNTAX ERROR>\n"
-    | 977 ->
+    | 999 ->
         "<SYNTAX ERROR>\n"
-    | 978 ->
+    | 1000 ->
         "<SYNTAX ERROR>\n"
-    | 979 ->
+    | 1001 ->
         "<SYNTAX ERROR>\n"
-    | 1133 ->
+    | 1172 ->
         "<SYNTAX ERROR>\n"
-    | 1135 ->
+    | 1174 ->
         "<SYNTAX ERROR>\n"
     | 163 ->
         "<SYNTAX ERROR>\n"
-    | 2511 ->
+    | 2575 ->
         "<SYNTAX ERROR>\n"
-    | 2510 ->
+    | 2574 ->
         "<SYNTAX ERROR>\n"
-    | 2513 ->
+    | 2577 ->
         "<SYNTAX ERROR>\n"
-    | 2452 ->
+    | 2516 ->
         "<SYNTAX ERROR>\n"
-    | 2453 ->
+    | 2517 ->
         "<SYNTAX ERROR>\n"
-    | 2454 ->
+    | 2518 ->
         "Expecting a sequence item\n"
-    | 1878 ->
+    | 1917 ->
         "Expecting one of the following:\n  - \"|\" to open the next pattern\n  - \"=>\" to start the body of the matched pattern\n  - \"when\" to start a contitional guard for the previous pattern\n"
-    | 2485 ->
+    | 2549 ->
         "Expecting the body of the matched pattern\n"
-    | 2514 ->
+    | 2578 ->
         "Expecting one of the following:\n  - \"}\" to finish the block\n  - \"|\" to start another pattern matching case\n"
-    | 2468 ->
+    | 2532 ->
         "<SYNTAX ERROR>\n"
-    | 2455 ->
+    | 2519 ->
         "<SYNTAX ERROR>\n"
-    | 2456 ->
+    | 2520 ->
         "<SYNTAX ERROR>\n"
-    | 2459 ->
+    | 2523 ->
         "<SYNTAX ERROR>\n"
-    | 2460 ->
+    | 2524 ->
         "<SYNTAX ERROR>\n"
-    | 2457 ->
+    | 2521 ->
         "<SYNTAX ERROR>\n"
-    | 2478 ->
+    | 2542 ->
         "<SYNTAX ERROR>\n"
-    | 2479 ->
+    | 2543 ->
         "<SYNTAX ERROR>\n"
-    | 2482 ->
+    | 2546 ->
         "<SYNTAX ERROR>\n"
-    | 2481 ->
+    | 2545 ->
         "<SYNTAX ERROR>\n"
-    | 1877 ->
+    | 1916 ->
         "Expecting a match case\n"
-    | 893 ->
+    | 909 ->
         "<SYNTAX ERROR>\n"
     | 124 ->
         "<SYNTAX ERROR>\n"
     | 125 ->
         "<SYNTAX ERROR>\n"
-    | 894 ->
+    | 910 ->
         "<SYNTAX ERROR>\n"
-    | 1852 ->
+    | 1891 ->
         "<SYNTAX ERROR>\n"
-    | 1855 ->
+    | 1894 ->
         "<SYNTAX ERROR>\n"
-    | 1869 ->
+    | 1908 ->
         "<SYNTAX ERROR>\n"
-    | 1857 ->
+    | 1896 ->
         "<SYNTAX ERROR>\n"
-    | 1858 ->
+    | 1897 ->
         "<SYNTAX ERROR>\n"
-    | 1861 ->
+    | 1900 ->
         "<SYNTAX ERROR>\n"
-    | 1863 ->
+    | 1902 ->
         "<SYNTAX ERROR>\n"
-    | 1864 ->
+    | 1903 ->
         "<SYNTAX ERROR>\n"
-    | 1866 ->
+    | 1905 ->
         "<SYNTAX ERROR>\n"
     | 168 ->
         "<SYNTAX ERROR>\n"
-    | 2494 ->
+    | 2558 ->
         "<SYNTAX ERROR>\n"
-    | 2495 ->
+    | 2559 ->
         "<SYNTAX ERROR>\n"
-    | 1121 ->
+    | 1160 ->
         "Incomplete module item, forgetting a \";\"?\n"
-    | 1176 ->
+    | 1215 ->
         "<SYNTAX ERROR>\n"
-    | 1179 ->
+    | 1218 ->
         "<SYNTAX ERROR>\n"
     | 6 ->
         "<SYNTAX ERROR>\n"
-    | 1201 ->
+    | 1240 ->
         "<SYNTAX ERROR>\n"
     | 395 ->
         "<SYNTAX ERROR>\n"
@@ -294,163 +294,163 @@ let message =
         "<SYNTAX ERROR>\n"
     | 408 ->
         "<SYNTAX ERROR>\n"
-    | 891 ->
+    | 907 ->
         "<SYNTAX ERROR>\n"
-    | 541 ->
+    | 557 ->
         "<SYNTAX ERROR>\n"
     | 16 ->
         "<SYNTAX ERROR>\n"
-    | 2605 ->
+    | 2692 ->
         "<SYNTAX ERROR>\n"
-    | 611 ->
+    | 627 ->
         "<SYNTAX ERROR>\n"
-    | 612 ->
+    | 628 ->
         "<SYNTAX ERROR>\n"
-    | 2247 ->
+    | 2311 ->
         "<SYNTAX ERROR>\n"
-    | 2249 ->
+    | 2313 ->
         "<SYNTAX ERROR>\n"
-    | 2250 ->
+    | 2314 ->
         "<SYNTAX ERROR>\n"
-    | 2252 ->
+    | 2316 ->
         "<SYNTAX ERROR>\n"
-    | 2253 ->
-        "<SYNTAX ERROR>\n"
-    | 1379 ->
-        "<SYNTAX ERROR>\n"
-    | 608 ->
-        "<SYNTAX ERROR>\n"
-    | 1437 ->
-        "<SYNTAX ERROR>\n"
-    | 1438 ->
-        "<SYNTAX ERROR>\n"
-    | 1439 ->
-        "<SYNTAX ERROR>\n"
-    | 1394 ->
-        "<SYNTAX ERROR>\n"
-    | 1400 ->
-        "<SYNTAX ERROR>\n"
-    | 1402 ->
-        "<SYNTAX ERROR>\n"
-    | 1396 ->
-        "<SYNTAX ERROR>\n"
-    | 1404 ->
-        "<SYNTAX ERROR>\n"
-    | 1406 ->
-        "<SYNTAX ERROR>\n"
-    | 1408 ->
-        "<SYNTAX ERROR>\n"
-    | 184 ->
-        "<SYNTAX ERROR>\n"
-    | 1410 ->
-        "<SYNTAX ERROR>\n"
-    | 1416 ->
+    | 2317 ->
         "<SYNTAX ERROR>\n"
     | 1418 ->
         "<SYNTAX ERROR>\n"
-    | 2412 ->
+    | 624 ->
         "<SYNTAX ERROR>\n"
-    | 340 ->
+    | 1476 ->
         "<SYNTAX ERROR>\n"
-    | 1381 ->
+    | 1477 ->
         "<SYNTAX ERROR>\n"
-    | 1398 ->
+    | 1478 ->
         "<SYNTAX ERROR>\n"
-    | 1412 ->
+    | 1433 ->
         "<SYNTAX ERROR>\n"
-    | 1414 ->
-        "<SYNTAX ERROR>\n"
-    | 1420 ->
-        "<SYNTAX ERROR>\n"
-    | 1422 ->
-        "<SYNTAX ERROR>\n"
-    | 904 ->
-        "<SYNTAX ERROR>\n"
-    | 905 ->
-        "<SYNTAX ERROR>\n"
-    | 1792 ->
-        "<SYNTAX ERROR>\n"
-    | 906 ->
-        "<SYNTAX ERROR>\n"
-    | 907 ->
-        "<SYNTAX ERROR>\n"
-    | 1785 ->
-        "<SYNTAX ERROR>\n"
-    | 1787 ->
-        "<SYNTAX ERROR>\n"
-    | 1795 ->
-        "<SYNTAX ERROR>\n"
-    | 1797 ->
-        "<SYNTAX ERROR>\n"
-    | 1812 ->
-        "<SYNTAX ERROR>\n"
-    | 1824 ->
-        "<SYNTAX ERROR>\n"
-    | 1829 ->
-        "<SYNTAX ERROR>\n"
-    | 2345 ->
-        "<SYNTAX ERROR>\n"
-    | 2350 ->
-        "<SYNTAX ERROR>\n"
-    | 2347 ->
-        "<SYNTAX ERROR>\n"
-    | 1259 ->
-        "<SYNTAX ERROR>\n"
-    | 2344 ->
-        "<SYNTAX ERROR>\n"
-    | 1430 ->
-        "<SYNTAX ERROR>\n"
-    | 1457 ->
-        "<SYNTAX ERROR>\n"
-    | 1278 ->
-        "<SYNTAX ERROR>\n"
-    | 1424 ->
-        "<SYNTAX ERROR>\n"
-    | 1426 ->
-        "<SYNTAX ERROR>\n"
-    | 1428 ->
-        "<SYNTAX ERROR>\n"
-    | 166 ->
-        "<SYNTAX ERROR>\n"
-    | 2500 ->
-        "<SYNTAX ERROR>\n"
-    | 2499 ->
-        "<SYNTAX ERROR>\n"
-    | 2502 ->
-        "<SYNTAX ERROR>\n"
-    | 1369 ->
-        "<SYNTAX ERROR>\n"
-    | 1370 ->
-        "<SYNTAX ERROR>\n"
-    | 1432 ->
-        "<SYNTAX ERROR>\n"
-    | 1435 ->
-        "<SYNTAX ERROR>\n"
-    | 1453 ->
+    | 1439 ->
         "<SYNTAX ERROR>\n"
     | 1441 ->
         "<SYNTAX ERROR>\n"
-    | 1442 ->
+    | 1435 ->
+        "<SYNTAX ERROR>\n"
+    | 1443 ->
         "<SYNTAX ERROR>\n"
     | 1445 ->
         "<SYNTAX ERROR>\n"
     | 1447 ->
         "<SYNTAX ERROR>\n"
-    | 1448 ->
+    | 184 ->
         "<SYNTAX ERROR>\n"
-    | 1450 ->
+    | 1449 ->
+        "<SYNTAX ERROR>\n"
+    | 1455 ->
+        "<SYNTAX ERROR>\n"
+    | 1457 ->
+        "<SYNTAX ERROR>\n"
+    | 2476 ->
+        "<SYNTAX ERROR>\n"
+    | 340 ->
+        "<SYNTAX ERROR>\n"
+    | 1420 ->
+        "<SYNTAX ERROR>\n"
+    | 1437 ->
+        "<SYNTAX ERROR>\n"
+    | 1451 ->
+        "<SYNTAX ERROR>\n"
+    | 1453 ->
+        "<SYNTAX ERROR>\n"
+    | 1459 ->
+        "<SYNTAX ERROR>\n"
+    | 1461 ->
+        "<SYNTAX ERROR>\n"
+    | 920 ->
+        "<SYNTAX ERROR>\n"
+    | 921 ->
+        "<SYNTAX ERROR>\n"
+    | 1831 ->
+        "<SYNTAX ERROR>\n"
+    | 922 ->
+        "<SYNTAX ERROR>\n"
+    | 923 ->
+        "<SYNTAX ERROR>\n"
+    | 1824 ->
+        "<SYNTAX ERROR>\n"
+    | 1826 ->
+        "<SYNTAX ERROR>\n"
+    | 1834 ->
+        "<SYNTAX ERROR>\n"
+    | 1836 ->
+        "<SYNTAX ERROR>\n"
+    | 1851 ->
+        "<SYNTAX ERROR>\n"
+    | 1863 ->
+        "<SYNTAX ERROR>\n"
+    | 1868 ->
+        "<SYNTAX ERROR>\n"
+    | 2409 ->
+        "<SYNTAX ERROR>\n"
+    | 2414 ->
+        "<SYNTAX ERROR>\n"
+    | 2411 ->
+        "<SYNTAX ERROR>\n"
+    | 1298 ->
+        "<SYNTAX ERROR>\n"
+    | 2408 ->
+        "<SYNTAX ERROR>\n"
+    | 1469 ->
+        "<SYNTAX ERROR>\n"
+    | 1496 ->
+        "<SYNTAX ERROR>\n"
+    | 1317 ->
+        "<SYNTAX ERROR>\n"
+    | 1463 ->
+        "<SYNTAX ERROR>\n"
+    | 1465 ->
+        "<SYNTAX ERROR>\n"
+    | 1467 ->
+        "<SYNTAX ERROR>\n"
+    | 166 ->
+        "<SYNTAX ERROR>\n"
+    | 2564 ->
+        "<SYNTAX ERROR>\n"
+    | 2563 ->
+        "<SYNTAX ERROR>\n"
+    | 2566 ->
+        "<SYNTAX ERROR>\n"
+    | 1408 ->
+        "<SYNTAX ERROR>\n"
+    | 1409 ->
+        "<SYNTAX ERROR>\n"
+    | 1471 ->
+        "<SYNTAX ERROR>\n"
+    | 1474 ->
+        "<SYNTAX ERROR>\n"
+    | 1492 ->
+        "<SYNTAX ERROR>\n"
+    | 1480 ->
+        "<SYNTAX ERROR>\n"
+    | 1481 ->
+        "<SYNTAX ERROR>\n"
+    | 1484 ->
+        "<SYNTAX ERROR>\n"
+    | 1486 ->
+        "<SYNTAX ERROR>\n"
+    | 1487 ->
+        "<SYNTAX ERROR>\n"
+    | 1489 ->
         "<SYNTAX ERROR>\n"
     | 173 ->
         "<SYNTAX ERROR>\n"
-    | 2446 ->
+    | 2510 ->
         "<SYNTAX ERROR>\n"
-    | 2447 ->
+    | 2511 ->
         "<SYNTAX ERROR>\n"
-    | 1310 ->
+    | 1349 ->
         "<SYNTAX ERROR>\n"
-    | 1318 ->
+    | 1357 ->
         "<SYNTAX ERROR>\n"
-    | 794 ->
+    | 810 ->
         "<SYNTAX ERROR>\n"
     | 187 ->
         "<SYNTAX ERROR>\n"
@@ -464,627 +464,429 @@ let message =
         "<SYNTAX ERROR>\n"
     | 180 ->
         "<SYNTAX ERROR>\n"
-    | 542 ->
+    | 558 ->
         "<SYNTAX ERROR>\n"
-    | 2331 ->
+    | 2395 ->
         "<SYNTAX ERROR>\n"
-    | 2333 ->
+    | 2397 ->
         "<SYNTAX ERROR>\n"
-    | 2335 ->
+    | 2399 ->
         "<SYNTAX ERROR>\n"
-    | 1789 ->
+    | 1828 ->
         "<SYNTAX ERROR>\n"
-    | 1790 ->
+    | 1829 ->
         "<SYNTAX ERROR>\n"
     | 415 ->
         "Expecting one of the following:\n  - \")\" to form a unit value \"()\"\n  - \"module\" to start a module expression\n  - an expression\n  - an operator to denote the prefix form of an operator\n"
-    | 2389 ->
+    | 2453 ->
         "<SYNTAX ERROR>\n"
-    | 722 ->
+    | 738 ->
         "<SYNTAX ERROR>\n"
     | 418 ->
         "Expecting a module expression\n"
-    | 2376 ->
+    | 2440 ->
         "<SYNTAX ERROR>\n"
-    | 2378 ->
+    | 2442 ->
         "<SYNTAX ERROR>\n"
-    | 2380 ->
+    | 2444 ->
         "<SYNTAX ERROR>\n"
-    | 2382 ->
+    | 2446 ->
         "<SYNTAX ERROR>\n"
-    | 2383 ->
+    | 2447 ->
         "<SYNTAX ERROR>\n"
-    | 2384 ->
+    | 2448 ->
         "<SYNTAX ERROR>\n"
-    | 2385 ->
+    | 2449 ->
         "<SYNTAX ERROR>\n"
-    | 2386 ->
+    | 2450 ->
         "<SYNTAX ERROR>\n"
-    | 2387 ->
+    | 2451 ->
         "<SYNTAX ERROR>\n"
-    | 1377 ->
+    | 1416 ->
         "<SYNTAX ERROR>\n"
-    | 2434 ->
+    | 2498 ->
         "<SYNTAX ERROR>\n"
     | 189 ->
         "<SYNTAX ERROR>\n"
-    | 557 ->
+    | 573 ->
+        "<SYNTAX ERROR>\n"
+    | 2368 ->
+        "<SYNTAX ERROR>\n"
+    | 574 ->
+        "<SYNTAX ERROR>\n"
+    | 1858 ->
+        "<SYNTAX ERROR>\n"
+    | 1857 ->
+        "<SYNTAX ERROR>\n"
+    | 1852 ->
+        "<SYNTAX ERROR>\n"
+    | 1853 ->
+        "<SYNTAX ERROR>\n"
+    | 592 ->
+        "<SYNTAX ERROR>\n"
+    | 601 ->
+        "<SYNTAX ERROR>\n"
+    | 611 ->
+        "<SYNTAX ERROR>\n"
+    | 629 ->
+        "<SYNTAX ERROR>\n"
+    | 630 ->
+        "<SYNTAX ERROR>\n"
+    | 632 ->
+        "<SYNTAX ERROR>\n"
+    | 633 ->
+        "<SYNTAX ERROR>\n"
+    | 2308 ->
+        "<SYNTAX ERROR>\n"
+    | 2294 ->
+        "<SYNTAX ERROR>\n"
+    | 638 ->
+        "<SYNTAX ERROR>\n"
+    | 639 ->
+        "<SYNTAX ERROR>\n"
+    | 640 ->
+        "<SYNTAX ERROR>\n"
+    | 641 ->
+        "<SYNTAX ERROR>\n"
+    | 2292 ->
+        "<SYNTAX ERROR>\n"
+    | 2293 ->
+        "<SYNTAX ERROR>\n"
+    | 634 ->
+        "<SYNTAX ERROR>\n"
+    | 635 ->
+        "<SYNTAX ERROR>\n"
+    | 636 ->
+        "<SYNTAX ERROR>\n"
+    | 637 ->
+        "<SYNTAX ERROR>\n"
+    | 2301 ->
+        "<SYNTAX ERROR>\n"
+    | 2302 ->
+        "<SYNTAX ERROR>\n"
+    | 2303 ->
         "<SYNTAX ERROR>\n"
     | 2304 ->
         "<SYNTAX ERROR>\n"
-    | 558 ->
+    | 2305 ->
         "<SYNTAX ERROR>\n"
-    | 1819 ->
-        "<SYNTAX ERROR>\n"
-    | 1818 ->
-        "<SYNTAX ERROR>\n"
-    | 1813 ->
-        "<SYNTAX ERROR>\n"
-    | 1814 ->
-        "<SYNTAX ERROR>\n"
-    | 576 ->
-        "<SYNTAX ERROR>\n"
-    | 585 ->
-        "<SYNTAX ERROR>\n"
-    | 595 ->
-        "<SYNTAX ERROR>\n"
-    | 613 ->
-        "<SYNTAX ERROR>\n"
-    | 614 ->
-        "<SYNTAX ERROR>\n"
-    | 616 ->
-        "<SYNTAX ERROR>\n"
-    | 617 ->
-        "<SYNTAX ERROR>\n"
-    | 2244 ->
-        "<SYNTAX ERROR>\n"
-    | 2230 ->
-        "<SYNTAX ERROR>\n"
-    | 622 ->
-        "<SYNTAX ERROR>\n"
-    | 623 ->
-        "<SYNTAX ERROR>\n"
-    | 624 ->
-        "<SYNTAX ERROR>\n"
-    | 625 ->
-        "<SYNTAX ERROR>\n"
-    | 2228 ->
-        "<SYNTAX ERROR>\n"
-    | 2229 ->
-        "<SYNTAX ERROR>\n"
-    | 618 ->
-        "<SYNTAX ERROR>\n"
-    | 619 ->
-        "<SYNTAX ERROR>\n"
-    | 620 ->
-        "<SYNTAX ERROR>\n"
-    | 621 ->
-        "<SYNTAX ERROR>\n"
-    | 2237 ->
-        "<SYNTAX ERROR>\n"
-    | 2238 ->
-        "<SYNTAX ERROR>\n"
-    | 2239 ->
-        "<SYNTAX ERROR>\n"
-    | 2240 ->
-        "<SYNTAX ERROR>\n"
-    | 2241 ->
-        "<SYNTAX ERROR>\n"
-    | 2242 ->
-        "<SYNTAX ERROR>\n"
-    | 895 ->
-        "<SYNTAX ERROR>\n"
-    | 896 ->
-        "<SYNTAX ERROR>\n"
-    | 897 ->
-        "<SYNTAX ERROR>\n"
-    | 898 ->
-        "<SYNTAX ERROR>\n"
-    | 899 ->
-        "<SYNTAX ERROR>\n"
-    | 900 ->
-        "<SYNTAX ERROR>\n"
-    | 2337 ->
-        "<SYNTAX ERROR>\n"
-    | 2338 ->
-        "<SYNTAX ERROR>\n"
-    | 2339 ->
-        "<SYNTAX ERROR>\n"
-    | 2340 ->
-        "<SYNTAX ERROR>\n"
-    | 2341 ->
-        "<SYNTAX ERROR>\n"
-    | 2342 ->
-        "<SYNTAX ERROR>\n"
-    | 1791 ->
-        "<SYNTAX ERROR>\n"
-    | 603 ->
-        "<SYNTAX ERROR>\n"
-    | 1365 ->
-        "<SYNTAX ERROR>\n"
-    | 1187 ->
-        "<SYNTAX ERROR>\n"
-    | 909 ->
-        "Incomplete let binding\n"
-    | 1288 ->
-        "<SYNTAX ERROR>\n"
-    | 1294 ->
-        "<SYNTAX ERROR>\n"
-    | 1289 ->
-        "<SYNTAX ERROR>\n"
-    | 1290 ->
-        "<SYNTAX ERROR>\n"
-    | 1291 ->
-        "<SYNTAX ERROR>\n"
-    | 1293 ->
-        "<SYNTAX ERROR>\n"
-    | 1163 ->
-        "<SYNTAX ERROR>\n"
-    | 910 ->
+    | 2306 ->
         "<SYNTAX ERROR>\n"
     | 911 ->
-        "<SYNTAX ERROR>\n"
-    | 1767 ->
-        "<SYNTAX ERROR>\n"
-    | 1768 ->
-        "<SYNTAX ERROR>\n"
-    | 1769 ->
-        "<SYNTAX ERROR>\n"
-    | 1770 ->
-        "<SYNTAX ERROR>\n"
-    | 1774 ->
-        "<SYNTAX ERROR>\n"
-    | 1771 ->
-        "<SYNTAX ERROR>\n"
-    | 1772 ->
-        "<SYNTAX ERROR>\n"
-    | 1773 ->
         "<SYNTAX ERROR>\n"
     | 912 ->
         "<SYNTAX ERROR>\n"
     | 913 ->
         "<SYNTAX ERROR>\n"
-    | 922 ->
+    | 914 ->
         "<SYNTAX ERROR>\n"
-    | 1760 ->
+    | 915 ->
         "<SYNTAX ERROR>\n"
-    | 1761 ->
+    | 916 ->
         "<SYNTAX ERROR>\n"
-    | 1762 ->
+    | 2401 ->
         "<SYNTAX ERROR>\n"
-    | 1778 ->
+    | 2402 ->
         "<SYNTAX ERROR>\n"
-    | 1141 ->
+    | 2403 ->
         "<SYNTAX ERROR>\n"
-    | 1142 ->
+    | 2404 ->
         "<SYNTAX ERROR>\n"
-    | 1164 ->
+    | 2405 ->
         "<SYNTAX ERROR>\n"
-    | 1284 ->
-        "Defining a function?\nExpecting one of the following:\n  - \"=>\" to start the function body\n  - an identifier to add a function parameter\n  - \":\" to specify the return type\n"
-    | 1252 ->
+    | 2406 ->
         "<SYNTAX ERROR>\n"
-    | 1169 ->
+    | 1830 ->
         "<SYNTAX ERROR>\n"
-    | 1170 ->
+    | 619 ->
         "<SYNTAX ERROR>\n"
-    | 1171 ->
+    | 1404 ->
         "<SYNTAX ERROR>\n"
-    | 1172 ->
+    | 1226 ->
         "<SYNTAX ERROR>\n"
-    | 1173 ->
-        "Expecting an expression as function body\n"
-    | 1247 ->
+    | 925 ->
+        "Incomplete let binding\n"
+    | 1327 ->
         "<SYNTAX ERROR>\n"
-    | 1248 ->
-        "Defining a function?\nExpecting \"=>\" to start the function body\n"
-    | 1249 ->
+    | 1333 ->
         "<SYNTAX ERROR>\n"
-    | 1250 ->
+    | 1328 ->
         "<SYNTAX ERROR>\n"
-    | 1165 ->
+    | 1329 ->
         "<SYNTAX ERROR>\n"
-    | 1166 ->
+    | 1330 ->
         "<SYNTAX ERROR>\n"
-    | 1167 ->
+    | 1332 ->
         "<SYNTAX ERROR>\n"
-    | 1168 ->
+    | 1202 ->
         "<SYNTAX ERROR>\n"
-    | 1257 ->
+    | 926 ->
         "<SYNTAX ERROR>\n"
-    | 1280 ->
+    | 927 ->
         "<SYNTAX ERROR>\n"
-    | 1281 ->
+    | 1806 ->
         "<SYNTAX ERROR>\n"
-    | 1261 ->
+    | 1807 ->
         "<SYNTAX ERROR>\n"
-    | 1262 ->
+    | 1808 ->
         "<SYNTAX ERROR>\n"
-    | 1263 ->
+    | 1809 ->
         "<SYNTAX ERROR>\n"
-    | 1266 ->
+    | 1813 ->
         "<SYNTAX ERROR>\n"
-    | 1267 ->
+    | 1810 ->
         "<SYNTAX ERROR>\n"
-    | 1268 ->
+    | 1811 ->
         "<SYNTAX ERROR>\n"
-    | 1271 ->
+    | 1812 ->
         "<SYNTAX ERROR>\n"
-    | 1272 ->
+    | 928 ->
         "<SYNTAX ERROR>\n"
-    | 1273 ->
+    | 929 ->
         "<SYNTAX ERROR>\n"
-    | 1274 ->
+    | 938 ->
         "<SYNTAX ERROR>\n"
-    | 1270 ->
+    | 1799 ->
         "<SYNTAX ERROR>\n"
-    | 1510 ->
-        "<SYNTAX ERROR>\n"
-    | 69 ->
-        "<SYNTAX ERROR>\n"
-    | 1711 ->
-        "<SYNTAX ERROR>\n"
-    | 191 ->
-        "<SYNTAX ERROR>\n"
-    | 2432 ->
-        "<SYNTAX ERROR>\n"
-    | 2433 ->
-        "<SYNTAX ERROR>\n"
-    | 2431 ->
-        "<SYNTAX ERROR>\n"
-    | 70 ->
-        "<SYNTAX ERROR>\n"
-    | 1062 ->
-        "<SYNTAX ERROR>\n"
-    | 1035 ->
-        "<SYNTAX ERROR>\n"
-    | 2603 ->
-        "<SYNTAX ERROR>\n"
-    | 18 ->
-        "<SYNTAX ERROR>\n"
-    | 164 ->
-        "<SYNTAX ERROR>\n"
-    | 2506 ->
-        "<SYNTAX ERROR>\n"
-    | 1798 ->
+    | 1800 ->
         "<SYNTAX ERROR>\n"
     | 1801 ->
         "<SYNTAX ERROR>\n"
-    | 1803 ->
+    | 1817 ->
         "<SYNTAX ERROR>\n"
-    | 1806 ->
-        "Expecting a type name\n"
-    | 176 ->
-        "Expecting an expression\n"
-    | 1391 ->
-        "Expecting an expression\n"
-    | 1367 ->
-        "Expecting an expression\n"
-    | 602 ->
+    | 1180 ->
         "<SYNTAX ERROR>\n"
-    | 1709 ->
-        "Expecting \"]\" to finish current floating attribute\n"
-    | 1037 ->
+    | 1181 ->
         "<SYNTAX ERROR>\n"
-    | 167 ->
-        "Expecting one of the following:\n  - an list item\n  - \"]\" to finish this list\n"
-    | 2212 ->
-        "Expecting one of the following:\n  - \",\" to separate two items in a list\n  - \"]\" to finish this list\n"
-    | 2213 ->
+    | 1203 ->
         "<SYNTAX ERROR>\n"
-    | 2209 ->
+    | 1323 ->
+        "Defining a function?\nExpecting one of the following:\n  - \"=>\" to start the function body\n  - an identifier to add a function parameter\n  - \":\" to specify the return type\n"
+    | 1291 ->
         "<SYNTAX ERROR>\n"
-    | 2210 ->
+    | 1208 ->
         "<SYNTAX ERROR>\n"
-    | 169 ->
+    | 1209 ->
         "<SYNTAX ERROR>\n"
-    | 170 ->
+    | 1210 ->
         "<SYNTAX ERROR>\n"
-    | 579 ->
+    | 1211 ->
         "<SYNTAX ERROR>\n"
-    | 171 ->
+    | 1212 ->
+        "Expecting an expression as function body\n"
+    | 1286 ->
         "<SYNTAX ERROR>\n"
-    | 2488 ->
+    | 1287 ->
+        "Defining a function?\nExpecting \"=>\" to start the function body\n"
+    | 1288 ->
         "<SYNTAX ERROR>\n"
-    | 174 ->
+    | 1289 ->
         "<SYNTAX ERROR>\n"
-    | 1346 ->
+    | 1204 ->
         "<SYNTAX ERROR>\n"
-    | 1347 ->
+    | 1205 ->
         "<SYNTAX ERROR>\n"
-    | 1348 ->
+    | 1206 ->
         "<SYNTAX ERROR>\n"
-    | 1349 ->
+    | 1207 ->
         "<SYNTAX ERROR>\n"
-    | 1350 ->
+    | 1296 ->
         "<SYNTAX ERROR>\n"
-    | 1351 ->
-        "<SYNTAX ERROR>\n"
-    | 1356 ->
-        "<SYNTAX ERROR>\n"
-    | 1357 ->
-        "<SYNTAX ERROR>\n"
-    | 1358 ->
-        "<SYNTAX ERROR>\n"
-    | 1359 ->
-        "<SYNTAX ERROR>\n"
-    | 1360 ->
-        "<SYNTAX ERROR>\n"
-    | 1363 ->
-        "<SYNTAX ERROR>\n"
-    | 1364 ->
-        "<SYNTAX ERROR>\n"
-    | 1456 ->
-        "<SYNTAX ERROR>\n"
-    | 1458 ->
-        "<SYNTAX ERROR>\n"
-    | 1459 ->
-        "<SYNTAX ERROR>\n"
-    | 1460 ->
-        "<SYNTAX ERROR>\n"
-    | 1355 ->
-        "<SYNTAX ERROR>\n"
-    | 2357 ->
-        "<SYNTAX ERROR>\n"
-    | 539 ->
-        "<SYNTAX ERROR>\n"
-    | 2287 ->
-        "<SYNTAX ERROR>\n"
-    | 2264 ->
-        "<SYNTAX ERROR>\n"
-    | 1461 ->
-        "<SYNTAX ERROR>\n"
-    | 1463 ->
-        "<SYNTAX ERROR>\n"
-    | 1464 ->
-        "<SYNTAX ERROR>\n"
-    | 1465 ->
-        "<SYNTAX ERROR>\n"
-    | 1466 ->
-        "<SYNTAX ERROR>\n"
-    | 1108 ->
-        "<SYNTAX ERROR>\n"
-    | 1110 ->
-        "<SYNTAX ERROR>\n"
-    | 1111 ->
-        "<SYNTAX ERROR>\n"
-    | 1468 ->
-        "<SYNTAX ERROR>\n"
-    | 1469 ->
-        "<SYNTAX ERROR>\n"
-    | 1470 ->
-        "<SYNTAX ERROR>\n"
-    | 1471 ->
-        "<SYNTAX ERROR>\n"
-    | 1474 ->
-        "<SYNTAX ERROR>\n"
-    | 1485 ->
-        "<SYNTAX ERROR>\n"
-    | 1475 ->
-        "<SYNTAX ERROR>\n"
-    | 1476 ->
-        "<SYNTAX ERROR>\n"
-    | 1477 ->
-        "<SYNTAX ERROR>\n"
-    | 1478 ->
-        "<SYNTAX ERROR>\n"
-    | 1479 ->
-        "<SYNTAX ERROR>\n"
-    | 1545 ->
-        "<SYNTAX ERROR>\n"
-    | 1489 ->
-        "<SYNTAX ERROR>\n"
-    | 1490 ->
-        "<SYNTAX ERROR>\n"
-    | 1491 ->
-        "<SYNTAX ERROR>\n"
-    | 1498 ->
-        "<SYNTAX ERROR>\n"
-    | 1499 ->
-        "<SYNTAX ERROR>\n"
-    | 1500 ->
-        "<SYNTAX ERROR>\n"
-    | 1492 ->
-        "<SYNTAX ERROR>\n"
-    | 1494 ->
-        "<SYNTAX ERROR>\n"
-    | 1495 ->
-        "<SYNTAX ERROR>\n"
-    | 1496 ->
-        "<SYNTAX ERROR>\n"
-    | 1497 ->
-        "<SYNTAX ERROR>\n"
-    | 1462 ->
-        "<SYNTAX ERROR>\n"
-    | 1846 ->
-        "<SYNTAX ERROR>\n"
-    | 1837 ->
-        "<SYNTAX ERROR>\n"
-    | 1835 ->
-        "<SYNTAX ERROR>\n"
-    | 1838 ->
-        "<SYNTAX ERROR>\n"
-    | 1839 ->
-        "<SYNTAX ERROR>\n"
-    | 1849 ->
-        "<SYNTAX ERROR>\n"
-    | 1850 ->
-        "<SYNTAX ERROR>\n"
-    | 587 ->
-        "<SYNTAX ERROR>\n"
-    | 2069 ->
-        "<SYNTAX ERROR>\n"
-    | 2075 ->
-        "<SYNTAX ERROR>\n"
-    | 2070 ->
-        "<SYNTAX ERROR>\n"
-    | 2071 ->
-        "<SYNTAX ERROR>\n"
-    | 2072 ->
-        "<SYNTAX ERROR>\n"
-    | 2074 ->
-        "<SYNTAX ERROR>\n"
-    | 2039 ->
-        "<SYNTAX ERROR>\n"
-    | 589 ->
-        "<SYNTAX ERROR>\n"
-    | 593 ->
-        "<SYNTAX ERROR>\n"
-    | 594 ->
-        "<SYNTAX ERROR>\n"
-    | 590 ->
-        "<SYNTAX ERROR>\n"
-    | 2274 ->
-        "<SYNTAX ERROR>\n"
-    | 2275 ->
-        "<SYNTAX ERROR>\n"
-    | 2278 ->
-        "<SYNTAX ERROR>\n"
-    | 2277 ->
-        "<SYNTAX ERROR>\n"
-    | 2040 ->
-        "<SYNTAX ERROR>\n"
-    | 2065 ->
-        "<SYNTAX ERROR>\n"
-    | 1481 ->
-        "<SYNTAX ERROR>\n"
-    | 1482 ->
-        "<SYNTAX ERROR>\n"
-    | 1483 ->
-        "<SYNTAX ERROR>\n"
-    | 1484 ->
-        "<SYNTAX ERROR>\n"
-    | 2041 ->
-        "<SYNTAX ERROR>\n"
-    | 2042 ->
-        "<SYNTAX ERROR>\n"
-    | 2043 ->
-        "<SYNTAX ERROR>\n"
-    | 2044 ->
-        "<SYNTAX ERROR>\n"
-    | 2046 ->
-        "<SYNTAX ERROR>\n"
-    | 2061 ->
-        "<SYNTAX ERROR>\n"
-    | 2062 ->
-        "<SYNTAX ERROR>\n"
-    | 2048 ->
-        "<SYNTAX ERROR>\n"
-    | 2049 ->
-        "<SYNTAX ERROR>\n"
-    | 2051 ->
-        "<SYNTAX ERROR>\n"
-    | 2052 ->
-        "<SYNTAX ERROR>\n"
-    | 2053 ->
-        "<SYNTAX ERROR>\n"
-    | 2056 ->
-        "<SYNTAX ERROR>\n"
-    | 2057 ->
-        "<SYNTAX ERROR>\n"
-    | 2058 ->
-        "<SYNTAX ERROR>\n"
-    | 2059 ->
-        "<SYNTAX ERROR>\n"
-    | 2055 ->
-        "<SYNTAX ERROR>\n"
-    | 2437 ->
-        "Expecting \"}\" to finish the block\n"
-    | 2171 ->
-        "<SYNTAX ERROR>\n"
-    | 1685 ->
-        "<SYNTAX ERROR>\n"
-    | 1118 ->
-        "<SYNTAX ERROR>\n"
-    | 1507 ->
-        "<SYNTAX ERROR>\n"
-    | 1504 ->
-        "<SYNTAX ERROR>\n"
-    | 1523 ->
-        "<SYNTAX ERROR>\n"
-    | 1524 ->
-        "<SYNTAX ERROR>\n"
-    | 1527 ->
-        "<SYNTAX ERROR>\n"
-    | 1160 ->
-        "<SYNTAX ERROR>\n"
-    | 1556 ->
-        "<SYNTAX ERROR>\n"
-    | 1559 ->
-        "<SYNTAX ERROR>\n"
-    | 1581 ->
-        "<SYNTAX ERROR>\n"
-    | 1560 ->
-        "<SYNTAX ERROR>\n"
-    | 1566 ->
-        "<SYNTAX ERROR>\n"
-    | 1567 ->
-        "<SYNTAX ERROR>\n"
-    | 1571 ->
-        "<SYNTAX ERROR>\n"
-    | 1572 ->
-        "<SYNTAX ERROR>\n"
-    | 1573 ->
-        "<SYNTAX ERROR>\n"
-    | 1562 ->
-        "<SYNTAX ERROR>\n"
-    | 1580 ->
-        "<SYNTAX ERROR>\n"
-    | 1577 ->
-        "<SYNTAX ERROR>\n"
-    | 1578 ->
-        "<SYNTAX ERROR>\n"
-    | 1579 ->
-        "<SYNTAX ERROR>\n"
-    | 1586 ->
-        "<SYNTAX ERROR>\n"
-    | 1587 ->
-        "<SYNTAX ERROR>\n"
-    | 1588 ->
-        "<SYNTAX ERROR>\n"
-    | 1308 ->
+    | 1319 ->
         "<SYNTAX ERROR>\n"
     | 1320 ->
-        "<SYNTAX ERROR>\n"
-    | 1546 ->
-        "<SYNTAX ERROR>\n"
-    | 1529 ->
-        "<SYNTAX ERROR>\n"
-    | 1530 ->
-        "<SYNTAX ERROR>\n"
-    | 1161 ->
-        "<SYNTAX ERROR>\n"
-    | 1342 ->
-        "<SYNTAX ERROR>\n"
-    | 1550 ->
-        "<SYNTAX ERROR>\n"
-    | 1162 ->
-        "<SYNTAX ERROR>\n"
-    | 1338 ->
-        "<SYNTAX ERROR>\n"
-    | 1339 ->
-        "<SYNTAX ERROR>\n"
-    | 1298 ->
         "<SYNTAX ERROR>\n"
     | 1300 ->
         "<SYNTAX ERROR>\n"
     | 1301 ->
         "<SYNTAX ERROR>\n"
-    | 1326 ->
-        "<SYNTAX ERROR>\n"
     | 1302 ->
         "<SYNTAX ERROR>\n"
-    | 1303 ->
+    | 1305 ->
         "<SYNTAX ERROR>\n"
-    | 1304 ->
+    | 1306 ->
+        "<SYNTAX ERROR>\n"
+    | 1307 ->
+        "<SYNTAX ERROR>\n"
+    | 1310 ->
+        "<SYNTAX ERROR>\n"
+    | 1311 ->
+        "<SYNTAX ERROR>\n"
+    | 1312 ->
+        "<SYNTAX ERROR>\n"
+    | 1313 ->
+        "<SYNTAX ERROR>\n"
+    | 1309 ->
+        "<SYNTAX ERROR>\n"
+    | 1549 ->
+        "<SYNTAX ERROR>\n"
+    | 69 ->
+        "<SYNTAX ERROR>\n"
+    | 1750 ->
+        "<SYNTAX ERROR>\n"
+    | 191 ->
+        "<SYNTAX ERROR>\n"
+    | 2496 ->
+        "<SYNTAX ERROR>\n"
+    | 2497 ->
+        "<SYNTAX ERROR>\n"
+    | 2495 ->
+        "<SYNTAX ERROR>\n"
+    | 70 ->
+        "<SYNTAX ERROR>\n"
+    | 1101 ->
+        "<SYNTAX ERROR>\n"
+    | 1057 ->
+        "<SYNTAX ERROR>\n"
+    | 2690 ->
+        "<SYNTAX ERROR>\n"
+    | 18 ->
+        "<SYNTAX ERROR>\n"
+    | 164 ->
+        "<SYNTAX ERROR>\n"
+    | 2570 ->
+        "<SYNTAX ERROR>\n"
+    | 1837 ->
+        "<SYNTAX ERROR>\n"
+    | 1840 ->
+        "<SYNTAX ERROR>\n"
+    | 1842 ->
+        "<SYNTAX ERROR>\n"
+    | 1845 ->
+        "Expecting a type name\n"
+    | 176 ->
+        "Expecting an expression\n"
+    | 1430 ->
+        "Expecting an expression\n"
+    | 1406 ->
+        "Expecting an expression\n"
+    | 618 ->
+        "<SYNTAX ERROR>\n"
+    | 1748 ->
+        "Expecting \"]\" to finish current floating attribute\n"
+    | 1059 ->
+        "<SYNTAX ERROR>\n"
+    | 167 ->
+        "Expecting one of the following:\n  - an list item\n  - \"]\" to finish this list\n"
+    | 2276 ->
+        "Expecting one of the following:\n  - \",\" to separate two items in a list\n  - \"]\" to finish this list\n"
+    | 2277 ->
+        "<SYNTAX ERROR>\n"
+    | 2273 ->
+        "<SYNTAX ERROR>\n"
+    | 2274 ->
+        "<SYNTAX ERROR>\n"
+    | 169 ->
+        "<SYNTAX ERROR>\n"
+    | 170 ->
+        "<SYNTAX ERROR>\n"
+    | 595 ->
+        "<SYNTAX ERROR>\n"
+    | 171 ->
+        "<SYNTAX ERROR>\n"
+    | 2552 ->
+        "<SYNTAX ERROR>\n"
+    | 174 ->
+        "<SYNTAX ERROR>\n"
+    | 1385 ->
+        "<SYNTAX ERROR>\n"
+    | 1386 ->
+        "<SYNTAX ERROR>\n"
+    | 1387 ->
+        "<SYNTAX ERROR>\n"
+    | 1388 ->
+        "<SYNTAX ERROR>\n"
+    | 1389 ->
+        "<SYNTAX ERROR>\n"
+    | 1390 ->
+        "<SYNTAX ERROR>\n"
+    | 1395 ->
+        "<SYNTAX ERROR>\n"
+    | 1396 ->
+        "<SYNTAX ERROR>\n"
+    | 1397 ->
+        "<SYNTAX ERROR>\n"
+    | 1398 ->
+        "<SYNTAX ERROR>\n"
+    | 1399 ->
+        "<SYNTAX ERROR>\n"
+    | 1402 ->
+        "<SYNTAX ERROR>\n"
+    | 1403 ->
+        "<SYNTAX ERROR>\n"
+    | 1495 ->
+        "<SYNTAX ERROR>\n"
+    | 1497 ->
+        "<SYNTAX ERROR>\n"
+    | 1498 ->
+        "<SYNTAX ERROR>\n"
+    | 1499 ->
+        "<SYNTAX ERROR>\n"
+    | 1394 ->
+        "<SYNTAX ERROR>\n"
+    | 2421 ->
+        "<SYNTAX ERROR>\n"
+    | 555 ->
+        "<SYNTAX ERROR>\n"
+    | 2351 ->
+        "<SYNTAX ERROR>\n"
+    | 2328 ->
+        "<SYNTAX ERROR>\n"
+    | 1500 ->
+        "<SYNTAX ERROR>\n"
+    | 1502 ->
+        "<SYNTAX ERROR>\n"
+    | 1503 ->
+        "<SYNTAX ERROR>\n"
+    | 1504 ->
+        "<SYNTAX ERROR>\n"
+    | 1505 ->
+        "<SYNTAX ERROR>\n"
+    | 1147 ->
+        "<SYNTAX ERROR>\n"
+    | 1149 ->
+        "<SYNTAX ERROR>\n"
+    | 1150 ->
+        "<SYNTAX ERROR>\n"
+    | 1507 ->
+        "<SYNTAX ERROR>\n"
+    | 1508 ->
+        "<SYNTAX ERROR>\n"
+    | 1509 ->
+        "<SYNTAX ERROR>\n"
+    | 1510 ->
+        "<SYNTAX ERROR>\n"
+    | 1513 ->
+        "<SYNTAX ERROR>\n"
+    | 1524 ->
+        "<SYNTAX ERROR>\n"
+    | 1514 ->
+        "<SYNTAX ERROR>\n"
+    | 1515 ->
+        "<SYNTAX ERROR>\n"
+    | 1516 ->
+        "<SYNTAX ERROR>\n"
+    | 1517 ->
+        "<SYNTAX ERROR>\n"
+    | 1518 ->
+        "<SYNTAX ERROR>\n"
+    | 1584 ->
         "<SYNTAX ERROR>\n"
     | 1528 ->
         "<SYNTAX ERROR>\n"
-    | 1830 ->
+    | 1529 ->
         "<SYNTAX ERROR>\n"
-    | 1831 ->
+    | 1530 ->
         "<SYNTAX ERROR>\n"
-    | 1832 ->
+    | 1537 ->
+        "<SYNTAX ERROR>\n"
+    | 1538 ->
+        "<SYNTAX ERROR>\n"
+    | 1539 ->
+        "<SYNTAX ERROR>\n"
+    | 1531 ->
+        "<SYNTAX ERROR>\n"
+    | 1533 ->
         "<SYNTAX ERROR>\n"
     | 1534 ->
         "<SYNTAX ERROR>\n"
@@ -1092,109 +894,307 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1536 ->
         "<SYNTAX ERROR>\n"
-    | 1333 ->
+    | 1501 ->
         "<SYNTAX ERROR>\n"
-    | 1334 ->
+    | 1885 ->
         "<SYNTAX ERROR>\n"
-    | 1345 ->
+    | 1876 ->
         "<SYNTAX ERROR>\n"
-    | 561 ->
+    | 1874 ->
         "<SYNTAX ERROR>\n"
-    | 1039 ->
+    | 1877 ->
         "<SYNTAX ERROR>\n"
-    | 915 ->
+    | 1878 ->
         "<SYNTAX ERROR>\n"
-    | 859 ->
+    | 1888 ->
         "<SYNTAX ERROR>\n"
-    | 860 ->
+    | 1889 ->
         "<SYNTAX ERROR>\n"
-    | 1892 ->
+    | 603 ->
         "<SYNTAX ERROR>\n"
-    | 1894 ->
+    | 2108 ->
         "<SYNTAX ERROR>\n"
-    | 1897 ->
+    | 2114 ->
         "<SYNTAX ERROR>\n"
-    | 2189 ->
+    | 2109 ->
         "<SYNTAX ERROR>\n"
-    | 908 ->
+    | 2110 ->
         "<SYNTAX ERROR>\n"
-    | 1783 ->
+    | 2111 ->
+        "<SYNTAX ERROR>\n"
+    | 2113 ->
+        "<SYNTAX ERROR>\n"
+    | 2078 ->
+        "<SYNTAX ERROR>\n"
+    | 605 ->
+        "<SYNTAX ERROR>\n"
+    | 609 ->
+        "<SYNTAX ERROR>\n"
+    | 610 ->
+        "<SYNTAX ERROR>\n"
+    | 606 ->
+        "<SYNTAX ERROR>\n"
+    | 2338 ->
+        "<SYNTAX ERROR>\n"
+    | 2339 ->
+        "<SYNTAX ERROR>\n"
+    | 2342 ->
+        "<SYNTAX ERROR>\n"
+    | 2341 ->
+        "<SYNTAX ERROR>\n"
+    | 2079 ->
+        "<SYNTAX ERROR>\n"
+    | 2104 ->
+        "<SYNTAX ERROR>\n"
+    | 1520 ->
+        "<SYNTAX ERROR>\n"
+    | 1521 ->
+        "<SYNTAX ERROR>\n"
+    | 1522 ->
+        "<SYNTAX ERROR>\n"
+    | 1523 ->
+        "<SYNTAX ERROR>\n"
+    | 2080 ->
+        "<SYNTAX ERROR>\n"
+    | 2081 ->
+        "<SYNTAX ERROR>\n"
+    | 2082 ->
+        "<SYNTAX ERROR>\n"
+    | 2083 ->
+        "<SYNTAX ERROR>\n"
+    | 2085 ->
+        "<SYNTAX ERROR>\n"
+    | 2100 ->
+        "<SYNTAX ERROR>\n"
+    | 2101 ->
+        "<SYNTAX ERROR>\n"
+    | 2087 ->
+        "<SYNTAX ERROR>\n"
+    | 2088 ->
+        "<SYNTAX ERROR>\n"
+    | 2090 ->
+        "<SYNTAX ERROR>\n"
+    | 2091 ->
+        "<SYNTAX ERROR>\n"
+    | 2092 ->
+        "<SYNTAX ERROR>\n"
+    | 2095 ->
+        "<SYNTAX ERROR>\n"
+    | 2096 ->
+        "<SYNTAX ERROR>\n"
+    | 2097 ->
+        "<SYNTAX ERROR>\n"
+    | 2098 ->
+        "<SYNTAX ERROR>\n"
+    | 2094 ->
+        "<SYNTAX ERROR>\n"
+    | 2501 ->
+        "Expecting \"}\" to finish the block\n"
+    | 2235 ->
+        "<SYNTAX ERROR>\n"
+    | 1724 ->
+        "<SYNTAX ERROR>\n"
+    | 1157 ->
+        "<SYNTAX ERROR>\n"
+    | 1546 ->
+        "<SYNTAX ERROR>\n"
+    | 1543 ->
+        "<SYNTAX ERROR>\n"
+    | 1562 ->
+        "<SYNTAX ERROR>\n"
+    | 1563 ->
+        "<SYNTAX ERROR>\n"
+    | 1566 ->
+        "<SYNTAX ERROR>\n"
+    | 1199 ->
+        "<SYNTAX ERROR>\n"
+    | 1595 ->
+        "<SYNTAX ERROR>\n"
+    | 1598 ->
+        "<SYNTAX ERROR>\n"
+    | 1620 ->
+        "<SYNTAX ERROR>\n"
+    | 1599 ->
+        "<SYNTAX ERROR>\n"
+    | 1605 ->
+        "<SYNTAX ERROR>\n"
+    | 1606 ->
+        "<SYNTAX ERROR>\n"
+    | 1610 ->
+        "<SYNTAX ERROR>\n"
+    | 1611 ->
+        "<SYNTAX ERROR>\n"
+    | 1612 ->
+        "<SYNTAX ERROR>\n"
+    | 1601 ->
+        "<SYNTAX ERROR>\n"
+    | 1619 ->
+        "<SYNTAX ERROR>\n"
+    | 1616 ->
+        "<SYNTAX ERROR>\n"
+    | 1617 ->
+        "<SYNTAX ERROR>\n"
+    | 1618 ->
+        "<SYNTAX ERROR>\n"
+    | 1625 ->
+        "<SYNTAX ERROR>\n"
+    | 1626 ->
+        "<SYNTAX ERROR>\n"
+    | 1627 ->
+        "<SYNTAX ERROR>\n"
+    | 1347 ->
+        "<SYNTAX ERROR>\n"
+    | 1359 ->
+        "<SYNTAX ERROR>\n"
+    | 1585 ->
+        "<SYNTAX ERROR>\n"
+    | 1568 ->
+        "<SYNTAX ERROR>\n"
+    | 1569 ->
+        "<SYNTAX ERROR>\n"
+    | 1200 ->
+        "<SYNTAX ERROR>\n"
+    | 1381 ->
+        "<SYNTAX ERROR>\n"
+    | 1589 ->
+        "<SYNTAX ERROR>\n"
+    | 1201 ->
+        "<SYNTAX ERROR>\n"
+    | 1377 ->
+        "<SYNTAX ERROR>\n"
+    | 1378 ->
+        "<SYNTAX ERROR>\n"
+    | 1337 ->
+        "<SYNTAX ERROR>\n"
+    | 1339 ->
+        "<SYNTAX ERROR>\n"
+    | 1340 ->
+        "<SYNTAX ERROR>\n"
+    | 1365 ->
+        "<SYNTAX ERROR>\n"
+    | 1341 ->
+        "<SYNTAX ERROR>\n"
+    | 1342 ->
+        "<SYNTAX ERROR>\n"
+    | 1343 ->
+        "<SYNTAX ERROR>\n"
+    | 1567 ->
+        "<SYNTAX ERROR>\n"
+    | 1869 ->
+        "<SYNTAX ERROR>\n"
+    | 1870 ->
+        "<SYNTAX ERROR>\n"
+    | 1871 ->
+        "<SYNTAX ERROR>\n"
+    | 1573 ->
+        "<SYNTAX ERROR>\n"
+    | 1574 ->
+        "<SYNTAX ERROR>\n"
+    | 1575 ->
+        "<SYNTAX ERROR>\n"
+    | 1372 ->
+        "<SYNTAX ERROR>\n"
+    | 1373 ->
+        "<SYNTAX ERROR>\n"
+    | 1384 ->
+        "<SYNTAX ERROR>\n"
+    | 577 ->
+        "<SYNTAX ERROR>\n"
+    | 1061 ->
+        "<SYNTAX ERROR>\n"
+    | 931 ->
+        "<SYNTAX ERROR>\n"
+    | 875 ->
+        "<SYNTAX ERROR>\n"
+    | 876 ->
+        "<SYNTAX ERROR>\n"
+    | 1931 ->
+        "<SYNTAX ERROR>\n"
+    | 1933 ->
+        "<SYNTAX ERROR>\n"
+    | 1936 ->
+        "<SYNTAX ERROR>\n"
+    | 2253 ->
+        "<SYNTAX ERROR>\n"
+    | 924 ->
+        "<SYNTAX ERROR>\n"
+    | 1822 ->
         "<SYNTAX ERROR>\n"
     | 411 ->
         "<SYNTAX ERROR>\n"
     | 412 ->
         "<SYNTAX ERROR>\n"
-    | 2397 ->
+    | 2461 ->
         "<SYNTAX ERROR>\n"
-    | 2399 ->
+    | 2463 ->
         "<SYNTAX ERROR>\n"
-    | 1895 ->
+    | 1934 ->
         "<SYNTAX ERROR>\n"
-    | 2401 ->
+    | 2465 ->
         "<SYNTAX ERROR>\n"
-    | 1900 ->
+    | 1939 ->
         "<SYNTAX ERROR>\n"
-    | 1901 ->
+    | 1940 ->
         "<SYNTAX ERROR>\n"
-    | 2403 ->
+    | 2467 ->
         "<SYNTAX ERROR>\n"
-    | 2010 ->
+    | 2049 ->
         "<SYNTAX ERROR>\n"
-    | 1985 ->
+    | 2024 ->
         "<SYNTAX ERROR>\n"
-    | 1986 ->
+    | 2025 ->
         "<SYNTAX ERROR>\n"
-    | 1987 ->
+    | 2026 ->
         "<SYNTAX ERROR>\n"
-    | 1989 ->
+    | 2028 ->
         "<SYNTAX ERROR>\n"
-    | 1992 ->
+    | 2031 ->
         "<SYNTAX ERROR>\n"
-    | 1999 ->
+    | 2038 ->
         "<SYNTAX ERROR>\n"
-    | 2002 ->
+    | 2041 ->
         "<SYNTAX ERROR>\n"
-    | 2003 ->
+    | 2042 ->
         "<SYNTAX ERROR>\n"
-    | 2192 ->
+    | 2256 ->
         "<SYNTAX ERROR>\n"
-    | 2193 ->
+    | 2257 ->
         "<SYNTAX ERROR>\n"
-    | 554 ->
+    | 570 ->
         "<SYNTAX ERROR>\n"
-    | 555 ->
+    | 571 ->
         "<SYNTAX ERROR>\n"
-    | 2308 ->
+    | 2372 ->
         "<SYNTAX ERROR>\n"
-    | 2310 ->
+    | 2374 ->
         "<SYNTAX ERROR>\n"
-    | 1990 ->
+    | 2029 ->
         "<SYNTAX ERROR>\n"
-    | 2312 ->
+    | 2376 ->
         "<SYNTAX ERROR>\n"
-    | 1995 ->
+    | 2034 ->
         "<SYNTAX ERROR>\n"
-    | 1996 ->
+    | 2035 ->
         "<SYNTAX ERROR>\n"
-    | 2314 ->
+    | 2378 ->
         "<SYNTAX ERROR>\n"
-    | 2005 ->
+    | 2044 ->
         "<SYNTAX ERROR>\n"
-    | 2006 ->
+    | 2045 ->
         "<SYNTAX ERROR>\n"
-    | 1904 ->
+    | 1943 ->
         "<SYNTAX ERROR>\n"
-    | 1980 ->
+    | 2019 ->
         "<SYNTAX ERROR>\n"
-    | 1981 ->
+    | 2020 ->
         "<SYNTAX ERROR>\n"
-    | 1982 ->
+    | 2021 ->
         "<SYNTAX ERROR>\n"
-    | 1984 ->
+    | 2023 ->
         "<SYNTAX ERROR>\n"
     | 419 ->
         "<SYNTAX ERROR>\n"
-    | 2141 ->
+    | 2205 ->
         "<SYNTAX ERROR>\n"
     | 422 ->
         "<SYNTAX ERROR>\n"
@@ -1202,13 +1202,13 @@ let message =
         "<SYNTAX ERROR>\n"
     | 425 ->
         "<SYNTAX ERROR>\n"
-    | 2361 ->
+    | 2425 ->
         "<SYNTAX ERROR>\n"
-    | 2365 ->
+    | 2429 ->
         "<SYNTAX ERROR>\n"
-    | 2362 ->
+    | 2426 ->
         "<SYNTAX ERROR>\n"
-    | 2363 ->
+    | 2427 ->
         "<SYNTAX ERROR>\n"
     | 427 ->
         "<SYNTAX ERROR>\n"
@@ -1218,147 +1218,103 @@ let message =
         "<SYNTAX ERROR>\n"
     | 433 ->
         "<SYNTAX ERROR>\n"
-    | 2148 ->
+    | 2212 ->
         "<SYNTAX ERROR>\n"
     | 437 ->
-        "<SYNTAX ERROR>\n"
-    | 510 ->
-        "<SYNTAX ERROR>\n"
-    | 511 ->
-        "<SYNTAX ERROR>\n"
-    | 513 ->
-        "<SYNTAX ERROR>\n"
-    | 517 ->
-        "<SYNTAX ERROR>\n"
-    | 518 ->
-        "<SYNTAX ERROR>\n"
-    | 438 ->
-        "<SYNTAX ERROR>\n"
-    | 479 ->
-        "<SYNTAX ERROR>\n"
-    | 468 ->
-        "<SYNTAX ERROR>\n"
-    | 463 ->
-        "<SYNTAX ERROR>\n"
-    | 464 ->
-        "<SYNTAX ERROR>\n"
-    | 487 ->
-        "<SYNTAX ERROR>\n"
-    | 504 ->
-        "<SYNTAX ERROR>\n"
-    | 524 ->
         "<SYNTAX ERROR>\n"
     | 525 ->
         "<SYNTAX ERROR>\n"
     | 526 ->
         "<SYNTAX ERROR>\n"
-    | 527 ->
+    | 528 ->
         "<SYNTAX ERROR>\n"
-    | 2149 ->
+    | 533 ->
         "<SYNTAX ERROR>\n"
-    | 2151 ->
+    | 534 ->
         "<SYNTAX ERROR>\n"
-    | 2140 ->
+    | 438 ->
         "<SYNTAX ERROR>\n"
-    | 1905 ->
+    | 497 ->
         "<SYNTAX ERROR>\n"
-    | 1906 ->
+    | 476 ->
         "<SYNTAX ERROR>\n"
-    | 1909 ->
+    | 465 ->
         "<SYNTAX ERROR>\n"
-    | 1910 ->
+    | 466 ->
         "<SYNTAX ERROR>\n"
-    | 1912 ->
+    | 502 ->
         "<SYNTAX ERROR>\n"
-    | 1976 ->
+    | 519 ->
         "<SYNTAX ERROR>\n"
-    | 1977 ->
+    | 540 ->
         "<SYNTAX ERROR>\n"
-    | 1978 ->
+    | 541 ->
         "<SYNTAX ERROR>\n"
-    | 2026 ->
+    | 542 ->
         "<SYNTAX ERROR>\n"
-    | 2027 ->
+    | 543 ->
         "<SYNTAX ERROR>\n"
-    | 2028 ->
+    | 2213 ->
         "<SYNTAX ERROR>\n"
-    | 2029 ->
+    | 2215 ->
         "<SYNTAX ERROR>\n"
-    | 2030 ->
+    | 2204 ->
         "<SYNTAX ERROR>\n"
-    | 2031 ->
+    | 1944 ->
         "<SYNTAX ERROR>\n"
-    | 2032 ->
+    | 1945 ->
         "<SYNTAX ERROR>\n"
-    | 1979 ->
+    | 1948 ->
+        "<SYNTAX ERROR>\n"
+    | 1949 ->
+        "<SYNTAX ERROR>\n"
+    | 1951 ->
+        "<SYNTAX ERROR>\n"
+    | 2015 ->
+        "<SYNTAX ERROR>\n"
+    | 2016 ->
         "<SYNTAX ERROR>\n"
     | 2017 ->
         "<SYNTAX ERROR>\n"
+    | 2065 ->
+        "<SYNTAX ERROR>\n"
+    | 2066 ->
+        "<SYNTAX ERROR>\n"
+    | 2067 ->
+        "<SYNTAX ERROR>\n"
+    | 2068 ->
+        "<SYNTAX ERROR>\n"
+    | 2069 ->
+        "<SYNTAX ERROR>\n"
+    | 2070 ->
+        "<SYNTAX ERROR>\n"
+    | 2071 ->
+        "<SYNTAX ERROR>\n"
     | 2018 ->
         "<SYNTAX ERROR>\n"
-    | 2019 ->
+    | 2056 ->
         "<SYNTAX ERROR>\n"
-    | 2020 ->
+    | 2057 ->
         "<SYNTAX ERROR>\n"
-    | 2021 ->
+    | 2058 ->
         "<SYNTAX ERROR>\n"
-    | 2034 ->
+    | 2059 ->
         "<SYNTAX ERROR>\n"
-    | 2155 ->
+    | 2060 ->
         "<SYNTAX ERROR>\n"
-    | 2156 ->
+    | 2073 ->
         "<SYNTAX ERROR>\n"
-    | 2079 ->
+    | 2219 ->
         "<SYNTAX ERROR>\n"
-    | 2082 ->
+    | 2220 ->
         "<SYNTAX ERROR>\n"
-    | 2083 ->
+    | 2118 ->
         "<SYNTAX ERROR>\n"
-    | 2084 ->
+    | 2121 ->
         "<SYNTAX ERROR>\n"
-    | 2085 ->
+    | 2122 ->
         "<SYNTAX ERROR>\n"
-    | 2086 ->
-        "<SYNTAX ERROR>\n"
-    | 2087 ->
-        "<SYNTAX ERROR>\n"
-    | 2091 ->
-        "<SYNTAX ERROR>\n"
-    | 2096 ->
-        "<SYNTAX ERROR>\n"
-    | 455 ->
-        "<SYNTAX ERROR>\n"
-    | 456 ->
-        "<SYNTAX ERROR>\n"
-    | 2097 ->
-        "<SYNTAX ERROR>\n"
-    | 2098 ->
-        "<SYNTAX ERROR>\n"
-    | 2099 ->
-        "<SYNTAX ERROR>\n"
-    | 441 ->
-        "<SYNTAX ERROR>\n"
-    | 470 ->
-        "<SYNTAX ERROR>\n"
-    | 2104 ->
-        "<SYNTAX ERROR>\n"
-    | 2113 ->
-        "<SYNTAX ERROR>\n"
-    | 2105 ->
-        "<SYNTAX ERROR>\n"
-    | 2106 ->
-        "<SYNTAX ERROR>\n"
-    | 2108 ->
-        "<SYNTAX ERROR>\n"
-    | 2109 ->
-        "<SYNTAX ERROR>\n"
-    | 2110 ->
-        "<SYNTAX ERROR>\n"
-    | 2160 ->
-        "<SYNTAX ERROR>\n"
-    | 2161 ->
-        "<SYNTAX ERROR>\n"
-    | 2115 ->
+    | 2123 ->
         "<SYNTAX ERROR>\n"
     | 2124 ->
         "<SYNTAX ERROR>\n"
@@ -1366,299 +1322,315 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2126 ->
         "<SYNTAX ERROR>\n"
-    | 2127 ->
-        "<SYNTAX ERROR>\n"
-    | 2128 ->
-        "<SYNTAX ERROR>\n"
-    | 2129 ->
-        "<SYNTAX ERROR>\n"
     | 2130 ->
         "<SYNTAX ERROR>\n"
-    | 2116 ->
+    | 2131 ->
         "<SYNTAX ERROR>\n"
-    | 2117 ->
+    | 455 ->
         "<SYNTAX ERROR>\n"
-    | 2165 ->
+    | 456 ->
         "<SYNTAX ERROR>\n"
-    | 2166 ->
+    | 2132 ->
         "<SYNTAX ERROR>\n"
-    | 2118 ->
+    | 2133 ->
         "<SYNTAX ERROR>\n"
-    | 2119 ->
+    | 2134 ->
         "<SYNTAX ERROR>\n"
-    | 2120 ->
+    | 441 ->
         "<SYNTAX ERROR>\n"
-    | 2121 ->
+    | 2145 ->
         "<SYNTAX ERROR>\n"
-    | 543 ->
+    | 2168 ->
         "<SYNTAX ERROR>\n"
-    | 544 ->
+    | 2177 ->
         "<SYNTAX ERROR>\n"
-    | 548 ->
+    | 2169 ->
         "<SYNTAX ERROR>\n"
-    | 549 ->
+    | 2170 ->
         "<SYNTAX ERROR>\n"
-    | 2326 ->
+    | 2172 ->
         "<SYNTAX ERROR>\n"
-    | 2328 ->
+    | 2173 ->
         "<SYNTAX ERROR>\n"
-    | 2329 ->
+    | 2174 ->
         "<SYNTAX ERROR>\n"
-    | 2330 ->
+    | 2224 ->
         "<SYNTAX ERROR>\n"
-    | 861 ->
+    | 2225 ->
         "<SYNTAX ERROR>\n"
-    | 862 ->
+    | 2179 ->
         "<SYNTAX ERROR>\n"
-    | 864 ->
+    | 2188 ->
         "<SYNTAX ERROR>\n"
-    | 865 ->
+    | 2189 ->
         "<SYNTAX ERROR>\n"
-    | 1873 ->
+    | 2190 ->
         "<SYNTAX ERROR>\n"
-    | 870 ->
+    | 2191 ->
         "<SYNTAX ERROR>\n"
-    | 871 ->
+    | 2192 ->
         "<SYNTAX ERROR>\n"
-    | 872 ->
+    | 2193 ->
         "<SYNTAX ERROR>\n"
-    | 873 ->
+    | 2194 ->
         "<SYNTAX ERROR>\n"
-    | 874 ->
+    | 2180 ->
         "<SYNTAX ERROR>\n"
-    | 1872 ->
+    | 2181 ->
         "<SYNTAX ERROR>\n"
-    | 866 ->
+    | 2229 ->
         "<SYNTAX ERROR>\n"
-    | 867 ->
+    | 2230 ->
         "<SYNTAX ERROR>\n"
-    | 868 ->
+    | 2182 ->
         "<SYNTAX ERROR>\n"
-    | 869 ->
+    | 2183 ->
         "<SYNTAX ERROR>\n"
-    | 1889 ->
+    | 2184 ->
         "<SYNTAX ERROR>\n"
-    | 627 ->
+    | 2185 ->
         "<SYNTAX ERROR>\n"
-    | 848 ->
+    | 559 ->
         "<SYNTAX ERROR>\n"
-    | 850 ->
+    | 560 ->
         "<SYNTAX ERROR>\n"
-    | 851 ->
+    | 564 ->
         "<SYNTAX ERROR>\n"
-    | 1882 ->
+    | 565 ->
         "<SYNTAX ERROR>\n"
-    | 1883 ->
+    | 2390 ->
         "<SYNTAX ERROR>\n"
-    | 1884 ->
+    | 2392 ->
         "<SYNTAX ERROR>\n"
-    | 1885 ->
+    | 2393 ->
         "<SYNTAX ERROR>\n"
-    | 1886 ->
-        "<SYNTAX ERROR>\n"
-    | 1887 ->
-        "<SYNTAX ERROR>\n"
-    | 875 ->
-        "<SYNTAX ERROR>\n"
-    | 876 ->
+    | 2394 ->
         "<SYNTAX ERROR>\n"
     | 877 ->
         "<SYNTAX ERROR>\n"
     | 878 ->
         "<SYNTAX ERROR>\n"
+    | 880 ->
+        "<SYNTAX ERROR>\n"
     | 881 ->
+        "<SYNTAX ERROR>\n"
+    | 1912 ->
+        "<SYNTAX ERROR>\n"
+    | 886 ->
+        "<SYNTAX ERROR>\n"
+    | 887 ->
+        "<SYNTAX ERROR>\n"
+    | 888 ->
+        "<SYNTAX ERROR>\n"
+    | 889 ->
+        "<SYNTAX ERROR>\n"
+    | 890 ->
+        "<SYNTAX ERROR>\n"
+    | 1911 ->
         "<SYNTAX ERROR>\n"
     | 882 ->
         "<SYNTAX ERROR>\n"
-    | 1042 ->
+    | 883 ->
         "<SYNTAX ERROR>\n"
-    | 1043 ->
+    | 884 ->
         "<SYNTAX ERROR>\n"
-    | 1044 ->
+    | 885 ->
         "<SYNTAX ERROR>\n"
-    | 1045 ->
+    | 1928 ->
         "<SYNTAX ERROR>\n"
-    | 1046 ->
+    | 643 ->
         "<SYNTAX ERROR>\n"
-    | 1047 ->
+    | 864 ->
         "<SYNTAX ERROR>\n"
-    | 1051 ->
+    | 866 ->
         "<SYNTAX ERROR>\n"
-    | 1056 ->
+    | 867 ->
         "<SYNTAX ERROR>\n"
-    | 948 ->
+    | 1921 ->
         "<SYNTAX ERROR>\n"
-    | 949 ->
+    | 1922 ->
         "<SYNTAX ERROR>\n"
-    | 1057 ->
+    | 1923 ->
         "<SYNTAX ERROR>\n"
-    | 1058 ->
+    | 1924 ->
         "<SYNTAX ERROR>\n"
-    | 1059 ->
+    | 1925 ->
         "<SYNTAX ERROR>\n"
-    | 946 ->
+    | 1926 ->
         "<SYNTAX ERROR>\n"
-    | 937 ->
+    | 891 ->
+        "<SYNTAX ERROR>\n"
+    | 892 ->
+        "<SYNTAX ERROR>\n"
+    | 893 ->
+        "<SYNTAX ERROR>\n"
+    | 894 ->
+        "<SYNTAX ERROR>\n"
+    | 897 ->
+        "<SYNTAX ERROR>\n"
+    | 898 ->
         "<SYNTAX ERROR>\n"
     | 1064 ->
         "<SYNTAX ERROR>\n"
-    | 1153 ->
+    | 1065 ->
         "<SYNTAX ERROR>\n"
     | 1066 ->
         "<SYNTAX ERROR>\n"
     | 1067 ->
         "<SYNTAX ERROR>\n"
+    | 1068 ->
+        "<SYNTAX ERROR>\n"
     | 1069 ->
         "<SYNTAX ERROR>\n"
-    | 1072 ->
-        "<SYNTAX ERROR>\n"
-    | 1704 ->
-        "<SYNTAX ERROR>\n"
-    | 1146 ->
-        "<SYNTAX ERROR>\n"
-    | 1147 ->
-        "<SYNTAX ERROR>\n"
-    | 1155 ->
-        "<SYNTAX ERROR>\n"
-    | 1663 ->
-        "<SYNTAX ERROR>\n"
-    | 1664 ->
-        "<SYNTAX ERROR>\n"
-    | 1665 ->
-        "<SYNTAX ERROR>\n"
-    | 1666 ->
-        "<SYNTAX ERROR>\n"
-    | 1627 ->
-        "<SYNTAX ERROR>\n"
-    | 1628 ->
-        "<SYNTAX ERROR>\n"
-    | 1667 ->
-        "<SYNTAX ERROR>\n"
-    | 1668 ->
-        "<SYNTAX ERROR>\n"
-    | 1670 ->
-        "<SYNTAX ERROR>\n"
-    | 1632 ->
-        "<SYNTAX ERROR>\n"
-    | 1633 ->
-        "<SYNTAX ERROR>\n"
-    | 1674 ->
-        "<SYNTAX ERROR>\n"
-    | 1671 ->
-        "<SYNTAX ERROR>\n"
-    | 1672 ->
+    | 1073 ->
         "<SYNTAX ERROR>\n"
     | 1074 ->
         "<SYNTAX ERROR>\n"
-    | 1082 ->
+    | 954 ->
         "<SYNTAX ERROR>\n"
-    | 1083 ->
-        "<SYNTAX ERROR>\n"
-    | 1084 ->
-        "<SYNTAX ERROR>\n"
-    | 1085 ->
-        "<SYNTAX ERROR>\n"
-    | 1086 ->
-        "<SYNTAX ERROR>\n"
-    | 1088 ->
-        "<SYNTAX ERROR>\n"
-    | 1089 ->
-        "<SYNTAX ERROR>\n"
-    | 1090 ->
-        "<SYNTAX ERROR>\n"
-    | 1091 ->
-        "<SYNTAX ERROR>\n"
-    | 1097 ->
-        "<SYNTAX ERROR>\n"
-    | 1098 ->
-        "<SYNTAX ERROR>\n"
-    | 1100 ->
-        "<SYNTAX ERROR>\n"
-    | 1101 ->
-        "<SYNTAX ERROR>\n"
-    | 1105 ->
-        "<SYNTAX ERROR>\n"
-    | 1103 ->
-        "<SYNTAX ERROR>\n"
-    | 1106 ->
-        "<SYNTAX ERROR>\n"
-    | 1107 ->
-        "<SYNTAX ERROR>\n"
-    | 1078 ->
-        "<SYNTAX ERROR>\n"
-    | 1687 ->
-        "<SYNTAX ERROR>\n"
-    | 1688 ->
-        "<SYNTAX ERROR>\n"
-    | 1691 ->
+    | 955 ->
         "<SYNTAX ERROR>\n"
     | 1075 ->
         "<SYNTAX ERROR>\n"
     | 1076 ->
         "<SYNTAX ERROR>\n"
-    | 1081 ->
+    | 1077 ->
         "<SYNTAX ERROR>\n"
-    | 1655 ->
+    | 952 ->
         "<SYNTAX ERROR>\n"
-    | 1156 ->
+    | 1084 ->
         "<SYNTAX ERROR>\n"
-    | 1157 ->
+    | 1103 ->
         "<SYNTAX ERROR>\n"
-    | 1158 ->
+    | 1192 ->
         "<SYNTAX ERROR>\n"
-    | 1159 ->
+    | 1105 ->
         "<SYNTAX ERROR>\n"
-    | 1593 ->
+    | 1106 ->
         "<SYNTAX ERROR>\n"
-    | 1596 ->
+    | 1108 ->
         "<SYNTAX ERROR>\n"
-    | 1614 ->
+    | 1111 ->
         "<SYNTAX ERROR>\n"
-    | 1615 ->
+    | 1743 ->
         "<SYNTAX ERROR>\n"
-    | 1151 ->
+    | 1185 ->
         "<SYNTAX ERROR>\n"
-    | 1152 ->
+    | 1186 ->
         "<SYNTAX ERROR>\n"
-    | 1624 ->
+    | 1194 ->
         "<SYNTAX ERROR>\n"
-    | 1600 ->
+    | 1702 ->
         "<SYNTAX ERROR>\n"
-    | 1604 ->
+    | 1703 ->
         "<SYNTAX ERROR>\n"
-    | 1606 ->
+    | 1704 ->
         "<SYNTAX ERROR>\n"
-    | 1607 ->
+    | 1705 ->
         "<SYNTAX ERROR>\n"
-    | 1617 ->
+    | 1666 ->
         "<SYNTAX ERROR>\n"
-    | 1608 ->
+    | 1667 ->
         "<SYNTAX ERROR>\n"
-    | 1609 ->
+    | 1706 ->
         "<SYNTAX ERROR>\n"
-    | 1610 ->
+    | 1707 ->
         "<SYNTAX ERROR>\n"
-    | 1625 ->
+    | 1709 ->
         "<SYNTAX ERROR>\n"
-    | 1642 ->
+    | 1671 ->
         "<SYNTAX ERROR>\n"
-    | 1626 ->
+    | 1672 ->
         "<SYNTAX ERROR>\n"
-    | 1651 ->
+    | 1713 ->
         "<SYNTAX ERROR>\n"
-    | 1634 ->
+    | 1710 ->
         "<SYNTAX ERROR>\n"
-    | 1652 ->
+    | 1711 ->
+        "<SYNTAX ERROR>\n"
+    | 1113 ->
+        "<SYNTAX ERROR>\n"
+    | 1121 ->
+        "<SYNTAX ERROR>\n"
+    | 1122 ->
+        "<SYNTAX ERROR>\n"
+    | 1123 ->
+        "<SYNTAX ERROR>\n"
+    | 1124 ->
+        "<SYNTAX ERROR>\n"
+    | 1125 ->
+        "<SYNTAX ERROR>\n"
+    | 1127 ->
+        "<SYNTAX ERROR>\n"
+    | 1128 ->
+        "<SYNTAX ERROR>\n"
+    | 1129 ->
+        "<SYNTAX ERROR>\n"
+    | 1130 ->
+        "<SYNTAX ERROR>\n"
+    | 1136 ->
+        "<SYNTAX ERROR>\n"
+    | 1137 ->
+        "<SYNTAX ERROR>\n"
+    | 1139 ->
+        "<SYNTAX ERROR>\n"
+    | 1140 ->
+        "<SYNTAX ERROR>\n"
+    | 1144 ->
+        "<SYNTAX ERROR>\n"
+    | 1142 ->
+        "<SYNTAX ERROR>\n"
+    | 1145 ->
+        "<SYNTAX ERROR>\n"
+    | 1146 ->
+        "<SYNTAX ERROR>\n"
+    | 1117 ->
+        "<SYNTAX ERROR>\n"
+    | 1726 ->
+        "<SYNTAX ERROR>\n"
+    | 1727 ->
+        "<SYNTAX ERROR>\n"
+    | 1730 ->
+        "<SYNTAX ERROR>\n"
+    | 1114 ->
+        "<SYNTAX ERROR>\n"
+    | 1115 ->
+        "<SYNTAX ERROR>\n"
+    | 1120 ->
+        "<SYNTAX ERROR>\n"
+    | 1694 ->
+        "<SYNTAX ERROR>\n"
+    | 1195 ->
+        "<SYNTAX ERROR>\n"
+    | 1196 ->
+        "<SYNTAX ERROR>\n"
+    | 1197 ->
+        "<SYNTAX ERROR>\n"
+    | 1198 ->
+        "<SYNTAX ERROR>\n"
+    | 1632 ->
+        "<SYNTAX ERROR>\n"
+    | 1635 ->
         "<SYNTAX ERROR>\n"
     | 1653 ->
         "<SYNTAX ERROR>\n"
-    | 1641 ->
+    | 1654 ->
         "<SYNTAX ERROR>\n"
-    | 1638 ->
+    | 1190 ->
+        "<SYNTAX ERROR>\n"
+    | 1191 ->
+        "<SYNTAX ERROR>\n"
+    | 1663 ->
         "<SYNTAX ERROR>\n"
     | 1639 ->
         "<SYNTAX ERROR>\n"
-    | 1640 ->
+    | 1643 ->
+        "<SYNTAX ERROR>\n"
+    | 1645 ->
+        "<SYNTAX ERROR>\n"
+    | 1646 ->
+        "<SYNTAX ERROR>\n"
+    | 1656 ->
         "<SYNTAX ERROR>\n"
     | 1647 ->
         "<SYNTAX ERROR>\n"
@@ -1666,119 +1638,147 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1649 ->
         "<SYNTAX ERROR>\n"
-    | 568 ->
+    | 1664 ->
+        "<SYNTAX ERROR>\n"
+    | 1681 ->
+        "<SYNTAX ERROR>\n"
+    | 1665 ->
+        "<SYNTAX ERROR>\n"
+    | 1690 ->
+        "<SYNTAX ERROR>\n"
+    | 1673 ->
+        "<SYNTAX ERROR>\n"
+    | 1691 ->
+        "<SYNTAX ERROR>\n"
+    | 1692 ->
+        "<SYNTAX ERROR>\n"
+    | 1680 ->
+        "<SYNTAX ERROR>\n"
+    | 1677 ->
+        "<SYNTAX ERROR>\n"
+    | 1678 ->
+        "<SYNTAX ERROR>\n"
+    | 1679 ->
+        "<SYNTAX ERROR>\n"
+    | 1686 ->
+        "<SYNTAX ERROR>\n"
+    | 1687 ->
+        "<SYNTAX ERROR>\n"
+    | 1688 ->
+        "<SYNTAX ERROR>\n"
+    | 584 ->
         "<SYNTAX ERROR>\n"
     | 151 ->
         "<SYNTAX ERROR>\n"
-    | 889 ->
+    | 905 ->
         "<SYNTAX ERROR>\n"
-    | 2616 ->
+    | 2703 ->
         "<SYNTAX ERROR>\n"
-    | 930 ->
+    | 946 ->
         "<SYNTAX ERROR>\n"
-    | 925 ->
+    | 941 ->
         "<SYNTAX ERROR>\n"
-    | 2618 ->
+    | 2705 ->
         "<SYNTAX ERROR>\n"
-    | 1741 ->
+    | 1780 ->
         "<SYNTAX ERROR>\n"
-    | 931 ->
+    | 947 ->
         "<SYNTAX ERROR>\n"
-    | 942 ->
+    | 973 ->
         "<SYNTAX ERROR>\n"
-    | 933 ->
+    | 949 ->
         "<SYNTAX ERROR>\n"
-    | 934 ->
+    | 950 ->
         "<SYNTAX ERROR>\n"
-    | 2617 ->
+    | 2704 ->
         "<SYNTAX ERROR>\n"
-    | 958 ->
+    | 980 ->
         "<SYNTAX ERROR>\n"
-    | 959 ->
+    | 981 ->
         "<SYNTAX ERROR>\n"
-    | 961 ->
-        "<SYNTAX ERROR>\n"
-    | 1005 ->
-        "<SYNTAX ERROR>\n"
-    | 1006 ->
-        "<SYNTAX ERROR>\n"
-    | 1007 ->
-        "<SYNTAX ERROR>\n"
-    | 1008 ->
-        "<SYNTAX ERROR>\n"
-    | 1009 ->
-        "<SYNTAX ERROR>\n"
-    | 1010 ->
-        "<SYNTAX ERROR>\n"
-    | 1011 ->
-        "<SYNTAX ERROR>\n"
-    | 1012 ->
-        "<SYNTAX ERROR>\n"
-    | 1018 ->
-        "<SYNTAX ERROR>\n"
-    | 1020 ->
-        "<SYNTAX ERROR>\n"
-    | 1013 ->
-        "<SYNTAX ERROR>\n"
-    | 1014 ->
-        "<SYNTAX ERROR>\n"
-    | 1025 ->
-        "<SYNTAX ERROR>\n"
-    | 1026 ->
+    | 983 ->
         "<SYNTAX ERROR>\n"
     | 1027 ->
         "<SYNTAX ERROR>\n"
     | 1028 ->
         "<SYNTAX ERROR>\n"
-    | 1742 ->
+    | 1029 ->
         "<SYNTAX ERROR>\n"
-    | 1743 ->
-        "<SYNTAX ERROR>\n"
-    | 793 ->
+    | 1030 ->
         "<SYNTAX ERROR>\n"
     | 1031 ->
         "<SYNTAX ERROR>\n"
     | 1032 ->
         "<SYNTAX ERROR>\n"
-    | 1713 ->
+    | 1033 ->
         "<SYNTAX ERROR>\n"
-    | 966 ->
+    | 1034 ->
         "<SYNTAX ERROR>\n"
-    | 967 ->
+    | 1040 ->
         "<SYNTAX ERROR>\n"
-    | 969 ->
+    | 1042 ->
         "<SYNTAX ERROR>\n"
-    | 970 ->
+    | 1035 ->
         "<SYNTAX ERROR>\n"
-    | 976 ->
+    | 1036 ->
         "<SYNTAX ERROR>\n"
-    | 974 ->
+    | 1047 ->
         "<SYNTAX ERROR>\n"
-    | 972 ->
+    | 1048 ->
+        "<SYNTAX ERROR>\n"
+    | 1049 ->
+        "<SYNTAX ERROR>\n"
+    | 1050 ->
+        "<SYNTAX ERROR>\n"
+    | 1781 ->
+        "<SYNTAX ERROR>\n"
+    | 1782 ->
+        "<SYNTAX ERROR>\n"
+    | 809 ->
+        "<SYNTAX ERROR>\n"
+    | 1053 ->
+        "<SYNTAX ERROR>\n"
+    | 1054 ->
+        "<SYNTAX ERROR>\n"
+    | 1752 ->
+        "<SYNTAX ERROR>\n"
+    | 988 ->
         "<SYNTAX ERROR>\n"
     | 989 ->
         "<SYNTAX ERROR>\n"
-    | 990 ->
+    | 991 ->
         "<SYNTAX ERROR>\n"
-    | 982 ->
+    | 992 ->
         "<SYNTAX ERROR>\n"
-    | 983 ->
+    | 998 ->
         "<SYNTAX ERROR>\n"
-    | 987 ->
+    | 996 ->
+        "<SYNTAX ERROR>\n"
+    | 994 ->
+        "<SYNTAX ERROR>\n"
+    | 1011 ->
+        "<SYNTAX ERROR>\n"
+    | 1012 ->
+        "<SYNTAX ERROR>\n"
+    | 1004 ->
+        "<SYNTAX ERROR>\n"
+    | 1005 ->
+        "<SYNTAX ERROR>\n"
+    | 1009 ->
         "<SYNTAX ERROR>\n"
     | 76 ->
         "<SYNTAX ERROR>\n"
-    | 986 ->
+    | 1008 ->
         "<SYNTAX ERROR>\n"
-    | 984 ->
+    | 1006 ->
         "<SYNTAX ERROR>\n"
     | 117 ->
         "<SYNTAX ERROR>\n"
     | 256 ->
         "<SYNTAX ERROR>\n"
-    | 993 ->
+    | 1015 ->
         "<SYNTAX ERROR>\n"
-    | 994 ->
+    | 1016 ->
         "<SYNTAX ERROR>\n"
     | 257 ->
         "<SYNTAX ERROR>\n"
@@ -1788,133 +1788,133 @@ let message =
         "<SYNTAX ERROR>\n"
     | 410 ->
         "<SYNTAX ERROR>\n"
-    | 2405 ->
+    | 2469 ->
         "<SYNTAX ERROR>\n"
-    | 550 ->
+    | 566 ->
         "<SYNTAX ERROR>\n"
-    | 2320 ->
+    | 2384 ->
         "<SYNTAX ERROR>\n"
-    | 2321 ->
+    | 2385 ->
         "<SYNTAX ERROR>\n"
-    | 2322 ->
+    | 2386 ->
         "<SYNTAX ERROR>\n"
-    | 2323 ->
+    | 2387 ->
         "<SYNTAX ERROR>\n"
-    | 2324 ->
+    | 2388 ->
         "<SYNTAX ERROR>\n"
-    | 2325 ->
+    | 2389 ->
         "<SYNTAX ERROR>\n"
-    | 1923 ->
+    | 1962 ->
         "<SYNTAX ERROR>\n"
-    | 1924 ->
+    | 1963 ->
         "<SYNTAX ERROR>\n"
-    | 1926 ->
+    | 1965 ->
         "<SYNTAX ERROR>\n"
-    | 1931 ->
-        "<SYNTAX ERROR>\n"
-    | 1929 ->
-        "<SYNTAX ERROR>\n"
-    | 1927 ->
-        "<SYNTAX ERROR>\n"
-    | 1952 ->
-        "<SYNTAX ERROR>\n"
-    | 1953 ->
-        "<SYNTAX ERROR>\n"
-    | 1932 ->
-        "<SYNTAX ERROR>\n"
-    | 1933 ->
-        "<SYNTAX ERROR>\n"
-    | 1950 ->
-        "<SYNTAX ERROR>\n"
-    | 1935 ->
-        "<SYNTAX ERROR>\n"
-    | 1949 ->
-        "<SYNTAX ERROR>\n"
-    | 1934 ->
-        "<SYNTAX ERROR>\n"
-    | 1936 ->
-        "<SYNTAX ERROR>\n"
-    | 1937 ->
-        "<SYNTAX ERROR>\n"
-    | 1940 ->
-        "<SYNTAX ERROR>\n"
-    | 551 ->
-        "<SYNTAX ERROR>\n"
-    | 644 ->
-        "<SYNTAX ERROR>\n"
-    | 1957 ->
-        "<SYNTAX ERROR>\n"
-    | 1958 ->
-        "<SYNTAX ERROR>\n"
-    | 645 ->
-        "<SYNTAX ERROR>\n"
-    | 646 ->
-        "<SYNTAX ERROR>\n"
-    | 552 ->
-        "<SYNTAX ERROR>\n"
-    | 553 ->
-        "<SYNTAX ERROR>\n"
-    | 2316 ->
-        "<SYNTAX ERROR>\n"
-    | 1913 ->
-        "<SYNTAX ERROR>\n"
-    | 1967 ->
+    | 1970 ->
         "<SYNTAX ERROR>\n"
     | 1968 ->
         "<SYNTAX ERROR>\n"
-    | 1969 ->
+    | 1966 ->
         "<SYNTAX ERROR>\n"
-    | 1970 ->
+    | 1991 ->
+        "<SYNTAX ERROR>\n"
+    | 1992 ->
         "<SYNTAX ERROR>\n"
     | 1971 ->
         "<SYNTAX ERROR>\n"
     | 1972 ->
         "<SYNTAX ERROR>\n"
-    | 1921 ->
+    | 1989 ->
         "<SYNTAX ERROR>\n"
-    | 2317 ->
+    | 1974 ->
         "<SYNTAX ERROR>\n"
-    | 1914 ->
+    | 1988 ->
         "<SYNTAX ERROR>\n"
-    | 923 ->
+    | 1973 ->
         "<SYNTAX ERROR>\n"
-    | 1735 ->
+    | 1975 ->
         "<SYNTAX ERROR>\n"
-    | 1734 ->
+    | 1976 ->
         "<SYNTAX ERROR>\n"
-    | 1716 ->
+    | 1979 ->
         "<SYNTAX ERROR>\n"
-    | 1717 ->
+    | 567 ->
         "<SYNTAX ERROR>\n"
-    | 1718 ->
+    | 660 ->
         "<SYNTAX ERROR>\n"
-    | 1719 ->
+    | 1996 ->
         "<SYNTAX ERROR>\n"
-    | 1720 ->
+    | 1997 ->
         "<SYNTAX ERROR>\n"
-    | 1723 ->
+    | 661 ->
         "<SYNTAX ERROR>\n"
-    | 945 ->
+    | 662 ->
         "<SYNTAX ERROR>\n"
-    | 1726 ->
+    | 568 ->
         "<SYNTAX ERROR>\n"
-    | 1727 ->
+    | 569 ->
         "<SYNTAX ERROR>\n"
-    | 1747 ->
+    | 2380 ->
         "<SYNTAX ERROR>\n"
-    | 1729 ->
+    | 1952 ->
         "<SYNTAX ERROR>\n"
-    | 1654 ->
+    | 2006 ->
         "<SYNTAX ERROR>\n"
-    | 1730 ->
+    | 2007 ->
         "<SYNTAX ERROR>\n"
-    | 1748 ->
+    | 2008 ->
         "<SYNTAX ERROR>\n"
-    | 1749 ->
+    | 2009 ->
         "<SYNTAX ERROR>\n"
-    | 2623 ->
+    | 2010 ->
         "<SYNTAX ERROR>\n"
-    | 2625 ->
+    | 2011 ->
+        "<SYNTAX ERROR>\n"
+    | 1960 ->
+        "<SYNTAX ERROR>\n"
+    | 2381 ->
+        "<SYNTAX ERROR>\n"
+    | 1953 ->
+        "<SYNTAX ERROR>\n"
+    | 939 ->
+        "<SYNTAX ERROR>\n"
+    | 1774 ->
+        "<SYNTAX ERROR>\n"
+    | 1773 ->
+        "<SYNTAX ERROR>\n"
+    | 1755 ->
+        "<SYNTAX ERROR>\n"
+    | 1756 ->
+        "<SYNTAX ERROR>\n"
+    | 1757 ->
+        "<SYNTAX ERROR>\n"
+    | 1758 ->
+        "<SYNTAX ERROR>\n"
+    | 1759 ->
+        "<SYNTAX ERROR>\n"
+    | 1762 ->
+        "<SYNTAX ERROR>\n"
+    | 951 ->
+        "<SYNTAX ERROR>\n"
+    | 1765 ->
+        "<SYNTAX ERROR>\n"
+    | 1766 ->
+        "<SYNTAX ERROR>\n"
+    | 1786 ->
+        "<SYNTAX ERROR>\n"
+    | 1768 ->
+        "<SYNTAX ERROR>\n"
+    | 1693 ->
+        "<SYNTAX ERROR>\n"
+    | 1769 ->
+        "<SYNTAX ERROR>\n"
+    | 1787 ->
+        "<SYNTAX ERROR>\n"
+    | 1788 ->
+        "<SYNTAX ERROR>\n"
+    | 2710 ->
+        "<SYNTAX ERROR>\n"
+    | 2712 ->
         "<SYNTAX ERROR>\n"
     | 279 ->
         "<SYNTAX ERROR>\n"
@@ -1938,11 +1938,11 @@ let message =
         "<SYNTAX ERROR>\n"
     | 10 ->
         "<SYNTAX ERROR>\n"
-    | 2554 ->
+    | 2618 ->
         "<SYNTAX ERROR>\n"
     | 110 ->
         "<SYNTAX ERROR>\n"
-    | 2552 ->
+    | 2616 ->
         "Expecting one of the following:\n  - \",\" to start the type in the tuple\n  - \")\" to finish the tuple type definition\n"
     | 277 ->
         "<SYNTAX ERROR>\n"
@@ -1956,9 +1956,9 @@ let message =
         "<SYNTAX ERROR>\n"
     | 128 ->
         "<SYNTAX ERROR>\n"
-    | 2549 ->
+    | 2613 ->
         "<SYNTAX ERROR>\n"
-    | 2550 ->
+    | 2614 ->
         "<SYNTAX ERROR>\n"
     | 120 ->
         "<SYNTAX ERROR>\n"
@@ -1970,13 +1970,13 @@ let message =
         "<SYNTAX ERROR>\n"
     | 130 ->
         "<SYNTAX ERROR>\n"
-    | 2541 ->
+    | 2605 ->
         "<SYNTAX ERROR>\n"
-    | 2542 ->
+    | 2606 ->
         "<SYNTAX ERROR>\n"
-    | 2543 ->
+    | 2607 ->
         "<SYNTAX ERROR>\n"
-    | 2545 ->
+    | 2609 ->
         "<SYNTAX ERROR>\n"
     | 134 ->
         "<SYNTAX ERROR>\n"
@@ -1988,11 +1988,11 @@ let message =
         "<SYNTAX ERROR>\n"
     | 141 ->
         "<SYNTAX ERROR>\n"
-    | 493 ->
+    | 508 ->
         "<SYNTAX ERROR>\n"
-    | 492 ->
+    | 507 ->
         "<SYNTAX ERROR>\n"
-    | 495 ->
+    | 510 ->
         "<SYNTAX ERROR>\n"
     | 295 ->
         "<SYNTAX ERROR>\n"
@@ -2000,11 +2000,11 @@ let message =
         "<SYNTAX ERROR>\n"
     | 143 ->
         "<SYNTAX ERROR>\n"
-    | 2534 ->
+    | 2598 ->
         "<SYNTAX ERROR>\n"
-    | 2536 ->
+    | 2600 ->
         "<SYNTAX ERROR>\n"
-    | 2537 ->
+    | 2601 ->
         "<SYNTAX ERROR>\n"
     | 157 ->
         "<SYNTAX ERROR>\n"
@@ -2012,51 +2012,51 @@ let message =
         "<SYNTAX ERROR>\n"
     | 146 ->
         "<SYNTAX ERROR>\n"
-    | 2532 ->
+    | 2596 ->
         "<SYNTAX ERROR>\n"
     | 148 ->
         "<SYNTAX ERROR>\n"
     | 149 ->
         "<SYNTAX ERROR>\n"
-    | 2528 ->
+    | 2592 ->
         "<SYNTAX ERROR>\n"
-    | 2529 ->
+    | 2593 ->
         "<SYNTAX ERROR>\n"
-    | 2530 ->
+    | 2594 ->
         "<SYNTAX ERROR>\n"
     | 150 ->
         "<SYNTAX ERROR>\n"
     | 155 ->
         "<SYNTAX ERROR>\n"
-    | 2526 ->
+    | 2590 ->
         "<SYNTAX ERROR>\n"
-    | 2522 ->
+    | 2586 ->
         "<SYNTAX ERROR>\n"
-    | 2519 ->
+    | 2583 ->
         "<SYNTAX ERROR>\n"
-    | 2627 ->
+    | 2714 ->
         "<SYNTAX ERROR>\n"
-    | 2629 ->
+    | 2716 ->
         "<SYNTAX ERROR>\n"
-    | 2631 ->
+    | 2718 ->
         "<SYNTAX ERROR>\n"
-    | 2632 ->
+    | 2719 ->
         "<SYNTAX ERROR>\n"
-    | 788 ->
+    | 804 ->
         "<SYNTAX ERROR>\n"
-    | 790 ->
+    | 806 ->
         "<SYNTAX ERROR>\n"
-    | 801 ->
+    | 817 ->
         "<SYNTAX ERROR>\n"
-    | 791 ->
+    | 807 ->
         "<SYNTAX ERROR>\n"
-    | 783 ->
+    | 799 ->
         "<SYNTAX ERROR>\n"
-    | 628 ->
+    | 644 ->
         "<SYNTAX ERROR>\n"
-    | 592 ->
+    | 608 ->
         "<SYNTAX ERROR>\n"
-    | 764 ->
+    | 780 ->
         "<SYNTAX ERROR>\n"
     | 193 ->
         "<SYNTAX ERROR>\n"
@@ -2066,21 +2066,21 @@ let message =
         "<SYNTAX ERROR>\n"
     | 210 ->
         "<SYNTAX ERROR>\n"
-    | 808 ->
+    | 824 ->
         "<SYNTAX ERROR>\n"
-    | 809 ->
+    | 825 ->
         "<SYNTAX ERROR>\n"
-    | 838 ->
+    | 854 ->
         "<SYNTAX ERROR>\n"
-    | 799 ->
+    | 815 ->
         "<SYNTAX ERROR>\n"
-    | 727 ->
+    | 743 ->
         "<SYNTAX ERROR>\n"
-    | 714 ->
+    | 730 ->
         "<SYNTAX ERROR>\n"
-    | 716 ->
+    | 732 ->
         "<SYNTAX ERROR>\n"
-    | 843 ->
+    | 859 ->
         "<SYNTAX ERROR>\n"
     | 446 ->
         "<SYNTAX ERROR>\n"
@@ -2112,7 +2112,7 @@ let message =
         "<SYNTAX ERROR>\n"
     | 334 ->
         "<SYNTAX ERROR>\n"
-    | 2416 ->
+    | 2480 ->
         "<SYNTAX ERROR>\n"
     | 291 ->
         "<SYNTAX ERROR>\n"
@@ -2148,19 +2148,19 @@ let message =
         "<SYNTAX ERROR>\n"
     | 317 ->
         "<SYNTAX ERROR>\n"
-    | 734 ->
+    | 750 ->
         "<SYNTAX ERROR>\n"
-    | 717 ->
+    | 733 ->
         "<SYNTAX ERROR>\n"
-    | 719 ->
+    | 735 ->
         "<SYNTAX ERROR>\n"
-    | 704 ->
+    | 720 ->
         "<SYNTAX ERROR>\n"
-    | 673 ->
+    | 689 ->
         "<SYNTAX ERROR>\n"
-    | 694 ->
+    | 710 ->
         "<SYNTAX ERROR>\n"
-    | 685 ->
+    | 701 ->
         "<SYNTAX ERROR>\n"
     | 212 ->
         "<SYNTAX ERROR>\n"
@@ -2184,145 +2184,145 @@ let message =
         "<SYNTAX ERROR>\n"
     | 243 ->
         "<SYNTAX ERROR>\n"
-    | 2420 ->
+    | 2484 ->
         "<SYNTAX ERROR>\n"
-    | 2421 ->
+    | 2485 ->
         "<SYNTAX ERROR>\n"
     | 234 ->
         "<SYNTAX ERROR>\n"
     | 239 ->
         "<SYNTAX ERROR>\n"
-    | 630 ->
-        "<SYNTAX ERROR>\n"
-    | 636 ->
-        "<SYNTAX ERROR>\n"
-    | 725 ->
-        "<SYNTAX ERROR>\n"
-    | 814 ->
-        "<SYNTAX ERROR>\n"
-    | 637 ->
-        "<SYNTAX ERROR>\n"
-    | 638 ->
-        "<SYNTAX ERROR>\n"
-    | 640 ->
-        "<SYNTAX ERROR>\n"
-    | 830 ->
-        "<SYNTAX ERROR>\n"
-    | 831 ->
-        "<SYNTAX ERROR>\n"
-    | 832 ->
-        "<SYNTAX ERROR>\n"
-    | 833 ->
-        "<SYNTAX ERROR>\n"
-    | 834 ->
-        "<SYNTAX ERROR>\n"
-    | 835 ->
+    | 646 ->
         "<SYNTAX ERROR>\n"
     | 652 ->
         "<SYNTAX ERROR>\n"
-    | 827 ->
+    | 741 ->
         "<SYNTAX ERROR>\n"
-    | 655 ->
-        "<SYNTAX ERROR>\n"
-    | 822 ->
-        "<SYNTAX ERROR>\n"
-    | 656 ->
-        "<SYNTAX ERROR>\n"
-    | 661 ->
-        "<SYNTAX ERROR>\n"
-    | 672 ->
-        "<SYNTAX ERROR>\n"
-    | 680 ->
-        "<SYNTAX ERROR>\n"
-    | 688 ->
-        "<SYNTAX ERROR>\n"
-    | 2423 ->
-        "<SYNTAX ERROR>\n"
-    | 2424 ->
-        "<SYNTAX ERROR>\n"
-    | 2425 ->
-        "<SYNTAX ERROR>\n"
-    | 2426 ->
-        "<SYNTAX ERROR>\n"
-    | 2427 ->
-        "<SYNTAX ERROR>\n"
-    | 2428 ->
-        "<SYNTAX ERROR>\n"
-    | 728 ->
-        "<SYNTAX ERROR>\n"
-    | 739 ->
-        "<SYNTAX ERROR>\n"
-    | 742 ->
-        "<SYNTAX ERROR>\n"
-    | 732 ->
-        "<SYNTAX ERROR>\n"
-    | 733 ->
+    | 830 ->
         "<SYNTAX ERROR>\n"
     | 653 ->
         "<SYNTAX ERROR>\n"
     | 654 ->
         "<SYNTAX ERROR>\n"
-    | 743 ->
+    | 656 ->
         "<SYNTAX ERROR>\n"
-    | 746 ->
+    | 846 ->
         "<SYNTAX ERROR>\n"
-    | 754 ->
+    | 847 ->
         "<SYNTAX ERROR>\n"
-    | 750 ->
+    | 848 ->
         "<SYNTAX ERROR>\n"
-    | 753 ->
+    | 849 ->
         "<SYNTAX ERROR>\n"
-    | 751 ->
-        "Expecting a valid list identifier\n"
-    | 752 ->
+    | 850 ->
         "<SYNTAX ERROR>\n"
-    | 755 ->
+    | 851 ->
         "<SYNTAX ERROR>\n"
-    | 658 ->
+    | 668 ->
         "<SYNTAX ERROR>\n"
-    | 659 ->
-        "<SYNTAX ERROR>\n"
-    | 670 ->
-        "<SYNTAX ERROR>\n"
-    | 665 ->
-        "<SYNTAX ERROR>\n"
-    | 666 ->
-        "<SYNTAX ERROR>\n"
-    | 756 ->
+    | 843 ->
         "<SYNTAX ERROR>\n"
     | 671 ->
         "<SYNTAX ERROR>\n"
-    | 820 ->
+    | 838 ->
+        "<SYNTAX ERROR>\n"
+    | 672 ->
+        "<SYNTAX ERROR>\n"
+    | 677 ->
+        "<SYNTAX ERROR>\n"
+    | 688 ->
+        "<SYNTAX ERROR>\n"
+    | 696 ->
+        "<SYNTAX ERROR>\n"
+    | 704 ->
+        "<SYNTAX ERROR>\n"
+    | 2487 ->
+        "<SYNTAX ERROR>\n"
+    | 2488 ->
+        "<SYNTAX ERROR>\n"
+    | 2489 ->
+        "<SYNTAX ERROR>\n"
+    | 2490 ->
+        "<SYNTAX ERROR>\n"
+    | 2491 ->
+        "<SYNTAX ERROR>\n"
+    | 2492 ->
+        "<SYNTAX ERROR>\n"
+    | 744 ->
+        "<SYNTAX ERROR>\n"
+    | 755 ->
+        "<SYNTAX ERROR>\n"
+    | 758 ->
+        "<SYNTAX ERROR>\n"
+    | 748 ->
+        "<SYNTAX ERROR>\n"
+    | 749 ->
+        "<SYNTAX ERROR>\n"
+    | 669 ->
+        "<SYNTAX ERROR>\n"
+    | 670 ->
         "<SYNTAX ERROR>\n"
     | 759 ->
         "<SYNTAX ERROR>\n"
+    | 762 ->
+        "<SYNTAX ERROR>\n"
+    | 770 ->
+        "<SYNTAX ERROR>\n"
+    | 766 ->
+        "<SYNTAX ERROR>\n"
+    | 769 ->
+        "<SYNTAX ERROR>\n"
+    | 767 ->
+        "Expecting a valid list identifier\n"
+    | 768 ->
+        "<SYNTAX ERROR>\n"
+    | 771 ->
+        "<SYNTAX ERROR>\n"
+    | 674 ->
+        "<SYNTAX ERROR>\n"
+    | 675 ->
+        "<SYNTAX ERROR>\n"
+    | 686 ->
+        "<SYNTAX ERROR>\n"
+    | 681 ->
+        "<SYNTAX ERROR>\n"
+    | 682 ->
+        "<SYNTAX ERROR>\n"
+    | 772 ->
+        "<SYNTAX ERROR>\n"
+    | 687 ->
+        "<SYNTAX ERROR>\n"
+    | 836 ->
+        "<SYNTAX ERROR>\n"
     | 775 ->
         "<SYNTAX ERROR>\n"
-    | 777 ->
+    | 791 ->
         "<SYNTAX ERROR>\n"
-    | 2635 ->
+    | 793 ->
         "<SYNTAX ERROR>\n"
-    | 2649 ->
+    | 2722 ->
         "<SYNTAX ERROR>\n"
-    | 2636 ->
+    | 2736 ->
         "<SYNTAX ERROR>\n"
-    | 2637 ->
+    | 2723 ->
         "<SYNTAX ERROR>\n"
-    | 2643 ->
+    | 2724 ->
         "<SYNTAX ERROR>\n"
-    | 2644 ->
+    | 2730 ->
         "<SYNTAX ERROR>\n"
-    | 2647 ->
+    | 2731 ->
         "<SYNTAX ERROR>\n"
-    | 2652 ->
+    | 2734 ->
         "<SYNTAX ERROR>\n"
-    | 2659 ->
+    | 2739 ->
         "<SYNTAX ERROR>\n"
-    | 2658 ->
+    | 2746 ->
         "<SYNTAX ERROR>\n"
-    | 2655 ->
+    | 2745 ->
         "<SYNTAX ERROR>\n"
-    | 2656 ->
+    | 2742 ->
+        "<SYNTAX ERROR>\n"
+    | 2743 ->
         "<SYNTAX ERROR>\n"
     | _ ->
         raise Not_found

--- a/src/reason_parser_message.ml
+++ b/src/reason_parser_message.ml
@@ -10,129 +10,129 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2 ->
         "<SYNTAX ERROR>\n"
-    | 2598 ->
+    | 2616 ->
         "<SYNTAX ERROR>\n"
-    | 569 ->
+    | 578 ->
         "Expecting one of the following:\n  - an identifier to access a member of an object\n  - \"[\" + expression + \"]\" to access an element of a list\n  - \"(\" + expression + \")\"\n  - \"{\" + expression + \"}\"\n"
-    | 570 ->
+    | 579 ->
         "Expecting an expression\n"
-    | 2286 ->
+    | 2295 ->
         "Expecting one of the following:\n  - an infix operation to connect two expressions\n  - \")\" to close the block\n"
-    | 2288 ->
+    | 2297 ->
         "Expecting an expression\n"
-    | 2289 ->
+    | 2298 ->
         "Expecting one of the following:\n  - an infix operation to connect two expressions\n  - \"}\" to close the block\n"
-    | 2291 ->
+    | 2300 ->
         "Expecting an expression\n"
-    | 2292 ->
+    | 2301 ->
         "Expecting one of the following:\n  - an infix operation to connect two expressions\n  - \"}\" to close the block\n"
-    | 1183 ->
+    | 1192 ->
         "Expecting an expression\n"
-    | 567 ->
+    | 576 ->
         "Expecting an identifier\n"
-    | 1116 ->
+    | 1125 ->
         "Expecting a structure item\n"
-    | 2603 ->
+    | 2621 ->
         "Invalid token\n"
-    | 1237 ->
+    | 1246 ->
         "Expecting an expression\n"
-    | 1238 ->
+    | 1247 ->
         "Expecting one of the following:\n  - The continuation of the previous expression\n  - \":\" to start the next expression\n"
-    | 1239 ->
+    | 1248 ->
         "Expecting an expression\n"
-    | 1198 ->
+    | 1207 ->
         "Expecting an expression\n"
-    | 1204 ->
+    | 1213 ->
         "Expecting an expression\n"
-    | 1206 ->
+    | 1215 ->
         "Expecting an expression\n"
-    | 1200 ->
+    | 1209 ->
         "Expecting an expression\n"
-    | 1208 ->
+    | 1217 ->
         "Expecting an expression\n"
-    | 1210 ->
+    | 1219 ->
         "Expecting an expression\n"
-    | 1212 ->
+    | 1221 ->
         "Expecting an expression\n"
     | 15 ->
         "Expecting one of the following:\n  - \")\" to form a unit value \"()\"\n  - \"module\" to start a module expression\n  - an expression\n  - an operator to denote the prefix form of an operator\n"
-    | 1214 ->
+    | 1223 ->
         "Expecting an expression\n"
-    | 1220 ->
+    | 1229 ->
         "Expecting an expression\n"
-    | 1222 ->
+    | 1231 ->
         "Expecting an expression\n"
-    | 2403 ->
+    | 2412 ->
         "Expecting \"]\"\n"
     | 403 ->
         "Expecting an attributed id\n"
-    | 2510 ->
+    | 2519 ->
         "Expecting \"]\"\n"
     | 161 ->
         "Expecting an attribute id\n"
-    | 1185 ->
+    | 1194 ->
         "Expecting an expression\n"
-    | 1202 ->
+    | 1211 ->
         "Expecting an expression\n"
-    | 1216 ->
+    | 1225 ->
         "Expecting an expression\n"
-    | 1218 ->
+    | 1227 ->
         "Expecting an expression\n"
-    | 1224 ->
+    | 1233 ->
         "Expecting an expression\n"
-    | 1226 ->
+    | 1235 ->
         "Expecting an expression\n"
-    | 849 ->
+    | 858 ->
         "<SYNTAX ERROR>\n"
-    | 850 ->
+    | 859 ->
         "<SYNTAX ERROR>\n"
-    | 2194 ->
+    | 2203 ->
         "<SYNTAX ERROR>\n"
-    | 851 ->
+    | 860 ->
         "<SYNTAX ERROR>\n"
-    | 853 ->
+    | 862 ->
         "<SYNTAX ERROR>\n"
-    | 2190 ->
+    | 2199 ->
         "<SYNTAX ERROR>\n"
-    | 2192 ->
+    | 2201 ->
         "<SYNTAX ERROR>\n"
-    | 2197 ->
+    | 2206 ->
         "<SYNTAX ERROR>\n"
-    | 2198 ->
+    | 2207 ->
         "<SYNTAX ERROR>\n"
-    | 2202 ->
+    | 2211 ->
         "<SYNTAX ERROR>\n"
-    | 2212 ->
+    | 2221 ->
         "<SYNTAX ERROR>\n"
-    | 2217 ->
+    | 2226 ->
         "<SYNTAX ERROR>\n"
-    | 1842 ->
+    | 1851 ->
         "<SYNTAX ERROR>\n"
-    | 1234 ->
+    | 1243 ->
         "<SYNTAX ERROR>\n"
-    | 1228 ->
+    | 1237 ->
         "<SYNTAX ERROR>\n"
-    | 1230 ->
+    | 1239 ->
         "<SYNTAX ERROR>\n"
-    | 1232 ->
+    | 1241 ->
         "<SYNTAX ERROR>\n"
     | 75 ->
         "<SYNTAX ERROR>\n"
-    | 949 ->
+    | 958 ->
         "<SYNTAX ERROR>\n"
-    | 950 ->
+    | 959 ->
         "<SYNTAX ERROR>\n"
     | 104 ->
         "Expecting one of the following:\n  - \"=\" to start the body of the type declaration\n  - \"constraint\" to add constraints to the type declaration\n  - \";\" to finish type declaratoin\n  - \"+=\" to form a string type extension\n  - \"and\" to declare another type\n"
     | 91 ->
         "<SYNTAX ERROR>\n"
-    | 2583 ->
+    | 2601 ->
         "<SYNTAX ERROR>\n"
-    | 2587 ->
+    | 2605 ->
         "<SYNTAX ERROR>\n"
-    | 2584 ->
+    | 2602 ->
         "<SYNTAX ERROR>\n"
-    | 2585 ->
+    | 2603 ->
         "<SYNTAX ERROR>\n"
     | 95 ->
         "<SYNTAX ERROR>\n"
@@ -142,139 +142,139 @@ let message =
         "<SYNTAX ERROR>\n"
     | 101 ->
         "<SYNTAX ERROR>\n"
-    | 1126 ->
+    | 1135 ->
         "<SYNTAX ERROR>\n"
     | 105 ->
         "<SYNTAX ERROR>\n"
-    | 2569 ->
+    | 2586 ->
         "<SYNTAX ERROR>\n"
-    | 2570 ->
+    | 2587 ->
         "<SYNTAX ERROR>\n"
-    | 2560 ->
+    | 2574 ->
         "<SYNTAX ERROR>\n"
-    | 2572 ->
+    | 2589 ->
         "<SYNTAX ERROR>\n"
-    | 2576 ->
+    | 2594 ->
         "<SYNTAX ERROR>\n"
-    | 2577 ->
+    | 2595 ->
         "<SYNTAX ERROR>\n"
-    | 2552 ->
+    | 2566 ->
         "<SYNTAX ERROR>\n"
     | 107 ->
         "<SYNTAX ERROR>\n"
-    | 2551 ->
+    | 2561 ->
         "<SYNTAX ERROR>\n"
-    | 115 ->
+    | 2562 ->
         "<SYNTAX ERROR>\n"
-    | 2565 ->
+    | 2582 ->
         "Expecting at least one type field definition in the form of:\n  <field name> : <type>\n"
-    | 484 ->
+    | 492 ->
         "Expecting a type field definition in the form of:\n  <field name> : <type>\n"
-    | 485 ->
+    | 493 ->
         "Expecting \":\"\n"
-    | 486 ->
+    | 494 ->
         "Expecting a type name describing this field\n"
-    | 2566 ->
+    | 2583 ->
         "Expecting one of the following:\n  - \",\" to finish current type field\n  - \"}\" to finish type definition\n"
-    | 500 ->
+    | 508 ->
         "Expecting one of the following:\n  - another type field definition\n  - \"}\" to finish entire type definition\n"
-    | 1131 ->
+    | 1140 ->
         "<SYNTAX ERROR>\n"
-    | 2557 ->
+    | 2571 ->
         "<SYNTAX ERROR>\n"
-    | 971 ->
+    | 980 ->
         "<SYNTAX ERROR>\n"
-    | 972 ->
+    | 981 ->
         "<SYNTAX ERROR>\n"
-    | 973 ->
+    | 982 ->
         "<SYNTAX ERROR>\n"
-    | 1127 ->
+    | 1136 ->
         "<SYNTAX ERROR>\n"
-    | 1129 ->
+    | 1138 ->
         "<SYNTAX ERROR>\n"
     | 163 ->
         "<SYNTAX ERROR>\n"
-    | 2505 ->
+    | 2514 ->
         "<SYNTAX ERROR>\n"
-    | 2504 ->
+    | 2513 ->
         "<SYNTAX ERROR>\n"
-    | 2507 ->
+    | 2516 ->
         "<SYNTAX ERROR>\n"
-    | 2446 ->
+    | 2455 ->
         "<SYNTAX ERROR>\n"
-    | 2447 ->
+    | 2456 ->
         "<SYNTAX ERROR>\n"
-    | 2448 ->
+    | 2457 ->
         "Expecting a sequence item\n"
-    | 1872 ->
+    | 1881 ->
         "Expecting one of the following:\n  - \"|\" to open the next pattern\n  - \"=>\" to start the body of the matched pattern\n  - \"when\" to start a contitional guard for the previous pattern\n"
-    | 2479 ->
+    | 2488 ->
         "Expecting the body of the matched pattern\n"
-    | 2508 ->
+    | 2517 ->
         "Expecting one of the following:\n  - \"}\" to finish the block\n  - \"|\" to start another pattern matching case\n"
+    | 2471 ->
+        "<SYNTAX ERROR>\n"
+    | 2458 ->
+        "<SYNTAX ERROR>\n"
+    | 2459 ->
+        "<SYNTAX ERROR>\n"
     | 2462 ->
         "<SYNTAX ERROR>\n"
-    | 2449 ->
+    | 2463 ->
         "<SYNTAX ERROR>\n"
-    | 2450 ->
+    | 2460 ->
         "<SYNTAX ERROR>\n"
-    | 2453 ->
+    | 2481 ->
         "<SYNTAX ERROR>\n"
-    | 2454 ->
+    | 2482 ->
         "<SYNTAX ERROR>\n"
-    | 2451 ->
+    | 2485 ->
         "<SYNTAX ERROR>\n"
-    | 2472 ->
+    | 2484 ->
         "<SYNTAX ERROR>\n"
-    | 2473 ->
-        "<SYNTAX ERROR>\n"
-    | 2476 ->
-        "<SYNTAX ERROR>\n"
-    | 2475 ->
-        "<SYNTAX ERROR>\n"
-    | 1871 ->
+    | 1880 ->
         "Expecting a match case\n"
-    | 888 ->
+    | 897 ->
         "<SYNTAX ERROR>\n"
     | 124 ->
         "<SYNTAX ERROR>\n"
     | 125 ->
         "<SYNTAX ERROR>\n"
-    | 889 ->
-        "<SYNTAX ERROR>\n"
-    | 1846 ->
-        "<SYNTAX ERROR>\n"
-    | 1849 ->
-        "<SYNTAX ERROR>\n"
-    | 1863 ->
-        "<SYNTAX ERROR>\n"
-    | 1851 ->
-        "<SYNTAX ERROR>\n"
-    | 1852 ->
+    | 898 ->
         "<SYNTAX ERROR>\n"
     | 1855 ->
         "<SYNTAX ERROR>\n"
-    | 1857 ->
-        "<SYNTAX ERROR>\n"
     | 1858 ->
+        "<SYNTAX ERROR>\n"
+    | 1872 ->
         "<SYNTAX ERROR>\n"
     | 1860 ->
         "<SYNTAX ERROR>\n"
+    | 1861 ->
+        "<SYNTAX ERROR>\n"
+    | 1864 ->
+        "<SYNTAX ERROR>\n"
+    | 1866 ->
+        "<SYNTAX ERROR>\n"
+    | 1867 ->
+        "<SYNTAX ERROR>\n"
+    | 1869 ->
+        "<SYNTAX ERROR>\n"
     | 168 ->
         "<SYNTAX ERROR>\n"
-    | 2488 ->
+    | 2497 ->
         "<SYNTAX ERROR>\n"
-    | 2489 ->
+    | 2498 ->
         "<SYNTAX ERROR>\n"
-    | 1115 ->
+    | 1124 ->
         "Incomplete module item, forgetting a \";\"?\n"
-    | 1170 ->
+    | 1179 ->
         "<SYNTAX ERROR>\n"
-    | 1173 ->
+    | 1182 ->
         "<SYNTAX ERROR>\n"
     | 6 ->
         "<SYNTAX ERROR>\n"
-    | 1195 ->
+    | 1204 ->
         "<SYNTAX ERROR>\n"
     | 395 ->
         "<SYNTAX ERROR>\n"
@@ -294,163 +294,163 @@ let message =
         "<SYNTAX ERROR>\n"
     | 408 ->
         "<SYNTAX ERROR>\n"
-    | 886 ->
+    | 895 ->
         "<SYNTAX ERROR>\n"
-    | 536 ->
+    | 545 ->
         "<SYNTAX ERROR>\n"
     | 16 ->
         "<SYNTAX ERROR>\n"
-    | 2595 ->
+    | 2613 ->
         "<SYNTAX ERROR>\n"
-    | 606 ->
+    | 615 ->
         "<SYNTAX ERROR>\n"
-    | 607 ->
+    | 616 ->
         "<SYNTAX ERROR>\n"
-    | 2241 ->
+    | 2250 ->
         "<SYNTAX ERROR>\n"
-    | 2243 ->
+    | 2252 ->
         "<SYNTAX ERROR>\n"
-    | 2244 ->
+    | 2253 ->
         "<SYNTAX ERROR>\n"
-    | 2246 ->
+    | 2255 ->
         "<SYNTAX ERROR>\n"
-    | 2247 ->
+    | 2256 ->
         "<SYNTAX ERROR>\n"
-    | 1373 ->
+    | 1382 ->
         "<SYNTAX ERROR>\n"
-    | 603 ->
+    | 612 ->
         "<SYNTAX ERROR>\n"
-    | 1431 ->
-        "<SYNTAX ERROR>\n"
-    | 1432 ->
-        "<SYNTAX ERROR>\n"
-    | 1433 ->
-        "<SYNTAX ERROR>\n"
-    | 1388 ->
-        "<SYNTAX ERROR>\n"
-    | 1394 ->
-        "<SYNTAX ERROR>\n"
-    | 1396 ->
-        "<SYNTAX ERROR>\n"
-    | 1390 ->
-        "<SYNTAX ERROR>\n"
-    | 1398 ->
-        "<SYNTAX ERROR>\n"
-    | 1400 ->
-        "<SYNTAX ERROR>\n"
-    | 1402 ->
-        "<SYNTAX ERROR>\n"
-    | 184 ->
-        "<SYNTAX ERROR>\n"
-    | 1404 ->
-        "<SYNTAX ERROR>\n"
-    | 1410 ->
-        "<SYNTAX ERROR>\n"
-    | 1412 ->
-        "<SYNTAX ERROR>\n"
-    | 2406 ->
-        "<SYNTAX ERROR>\n"
-    | 340 ->
-        "<SYNTAX ERROR>\n"
-    | 1375 ->
-        "<SYNTAX ERROR>\n"
-    | 1392 ->
-        "<SYNTAX ERROR>\n"
-    | 1406 ->
-        "<SYNTAX ERROR>\n"
-    | 1408 ->
-        "<SYNTAX ERROR>\n"
-    | 1414 ->
-        "<SYNTAX ERROR>\n"
-    | 1416 ->
-        "<SYNTAX ERROR>\n"
-    | 899 ->
-        "<SYNTAX ERROR>\n"
-    | 900 ->
-        "<SYNTAX ERROR>\n"
-    | 1786 ->
-        "<SYNTAX ERROR>\n"
-    | 901 ->
-        "<SYNTAX ERROR>\n"
-    | 902 ->
-        "<SYNTAX ERROR>\n"
-    | 1779 ->
-        "<SYNTAX ERROR>\n"
-    | 1781 ->
-        "<SYNTAX ERROR>\n"
-    | 1789 ->
-        "<SYNTAX ERROR>\n"
-    | 1791 ->
-        "<SYNTAX ERROR>\n"
-    | 1806 ->
-        "<SYNTAX ERROR>\n"
-    | 1818 ->
-        "<SYNTAX ERROR>\n"
-    | 1823 ->
-        "<SYNTAX ERROR>\n"
-    | 2339 ->
-        "<SYNTAX ERROR>\n"
-    | 2344 ->
-        "<SYNTAX ERROR>\n"
-    | 2341 ->
-        "<SYNTAX ERROR>\n"
-    | 1253 ->
-        "<SYNTAX ERROR>\n"
-    | 2338 ->
-        "<SYNTAX ERROR>\n"
-    | 1424 ->
-        "<SYNTAX ERROR>\n"
-    | 1451 ->
-        "<SYNTAX ERROR>\n"
-    | 1272 ->
-        "<SYNTAX ERROR>\n"
-    | 1418 ->
-        "<SYNTAX ERROR>\n"
-    | 1420 ->
-        "<SYNTAX ERROR>\n"
-    | 1422 ->
-        "<SYNTAX ERROR>\n"
-    | 166 ->
-        "<SYNTAX ERROR>\n"
-    | 2494 ->
-        "<SYNTAX ERROR>\n"
-    | 2493 ->
-        "<SYNTAX ERROR>\n"
-    | 2496 ->
-        "<SYNTAX ERROR>\n"
-    | 1363 ->
-        "<SYNTAX ERROR>\n"
-    | 1364 ->
-        "<SYNTAX ERROR>\n"
-    | 1426 ->
-        "<SYNTAX ERROR>\n"
-    | 1429 ->
-        "<SYNTAX ERROR>\n"
-    | 1447 ->
-        "<SYNTAX ERROR>\n"
-    | 1435 ->
-        "<SYNTAX ERROR>\n"
-    | 1436 ->
-        "<SYNTAX ERROR>\n"
-    | 1439 ->
+    | 1440 ->
         "<SYNTAX ERROR>\n"
     | 1441 ->
         "<SYNTAX ERROR>\n"
     | 1442 ->
         "<SYNTAX ERROR>\n"
+    | 1397 ->
+        "<SYNTAX ERROR>\n"
+    | 1403 ->
+        "<SYNTAX ERROR>\n"
+    | 1405 ->
+        "<SYNTAX ERROR>\n"
+    | 1399 ->
+        "<SYNTAX ERROR>\n"
+    | 1407 ->
+        "<SYNTAX ERROR>\n"
+    | 1409 ->
+        "<SYNTAX ERROR>\n"
+    | 1411 ->
+        "<SYNTAX ERROR>\n"
+    | 184 ->
+        "<SYNTAX ERROR>\n"
+    | 1413 ->
+        "<SYNTAX ERROR>\n"
+    | 1419 ->
+        "<SYNTAX ERROR>\n"
+    | 1421 ->
+        "<SYNTAX ERROR>\n"
+    | 2415 ->
+        "<SYNTAX ERROR>\n"
+    | 340 ->
+        "<SYNTAX ERROR>\n"
+    | 1384 ->
+        "<SYNTAX ERROR>\n"
+    | 1401 ->
+        "<SYNTAX ERROR>\n"
+    | 1415 ->
+        "<SYNTAX ERROR>\n"
+    | 1417 ->
+        "<SYNTAX ERROR>\n"
+    | 1423 ->
+        "<SYNTAX ERROR>\n"
+    | 1425 ->
+        "<SYNTAX ERROR>\n"
+    | 908 ->
+        "<SYNTAX ERROR>\n"
+    | 909 ->
+        "<SYNTAX ERROR>\n"
+    | 1795 ->
+        "<SYNTAX ERROR>\n"
+    | 910 ->
+        "<SYNTAX ERROR>\n"
+    | 911 ->
+        "<SYNTAX ERROR>\n"
+    | 1788 ->
+        "<SYNTAX ERROR>\n"
+    | 1790 ->
+        "<SYNTAX ERROR>\n"
+    | 1798 ->
+        "<SYNTAX ERROR>\n"
+    | 1800 ->
+        "<SYNTAX ERROR>\n"
+    | 1815 ->
+        "<SYNTAX ERROR>\n"
+    | 1827 ->
+        "<SYNTAX ERROR>\n"
+    | 1832 ->
+        "<SYNTAX ERROR>\n"
+    | 2348 ->
+        "<SYNTAX ERROR>\n"
+    | 2353 ->
+        "<SYNTAX ERROR>\n"
+    | 2350 ->
+        "<SYNTAX ERROR>\n"
+    | 1262 ->
+        "<SYNTAX ERROR>\n"
+    | 2347 ->
+        "<SYNTAX ERROR>\n"
+    | 1433 ->
+        "<SYNTAX ERROR>\n"
+    | 1460 ->
+        "<SYNTAX ERROR>\n"
+    | 1281 ->
+        "<SYNTAX ERROR>\n"
+    | 1427 ->
+        "<SYNTAX ERROR>\n"
+    | 1429 ->
+        "<SYNTAX ERROR>\n"
+    | 1431 ->
+        "<SYNTAX ERROR>\n"
+    | 166 ->
+        "<SYNTAX ERROR>\n"
+    | 2503 ->
+        "<SYNTAX ERROR>\n"
+    | 2502 ->
+        "<SYNTAX ERROR>\n"
+    | 2505 ->
+        "<SYNTAX ERROR>\n"
+    | 1372 ->
+        "<SYNTAX ERROR>\n"
+    | 1373 ->
+        "<SYNTAX ERROR>\n"
+    | 1435 ->
+        "<SYNTAX ERROR>\n"
+    | 1438 ->
+        "<SYNTAX ERROR>\n"
+    | 1456 ->
+        "<SYNTAX ERROR>\n"
     | 1444 ->
+        "<SYNTAX ERROR>\n"
+    | 1445 ->
+        "<SYNTAX ERROR>\n"
+    | 1448 ->
+        "<SYNTAX ERROR>\n"
+    | 1450 ->
+        "<SYNTAX ERROR>\n"
+    | 1451 ->
+        "<SYNTAX ERROR>\n"
+    | 1453 ->
         "<SYNTAX ERROR>\n"
     | 173 ->
         "<SYNTAX ERROR>\n"
-    | 2440 ->
+    | 2449 ->
         "<SYNTAX ERROR>\n"
-    | 2441 ->
+    | 2450 ->
         "<SYNTAX ERROR>\n"
-    | 1304 ->
+    | 1313 ->
         "<SYNTAX ERROR>\n"
-    | 1312 ->
+    | 1321 ->
         "<SYNTAX ERROR>\n"
-    | 789 ->
+    | 798 ->
         "<SYNTAX ERROR>\n"
     | 187 ->
         "<SYNTAX ERROR>\n"
@@ -464,341 +464,331 @@ let message =
         "<SYNTAX ERROR>\n"
     | 180 ->
         "<SYNTAX ERROR>\n"
-    | 537 ->
+    | 546 ->
         "<SYNTAX ERROR>\n"
-    | 2325 ->
+    | 2334 ->
         "<SYNTAX ERROR>\n"
-    | 2327 ->
+    | 2336 ->
         "<SYNTAX ERROR>\n"
-    | 2329 ->
+    | 2338 ->
         "<SYNTAX ERROR>\n"
-    | 1783 ->
+    | 1792 ->
         "<SYNTAX ERROR>\n"
-    | 1784 ->
+    | 1793 ->
         "<SYNTAX ERROR>\n"
     | 415 ->
         "Expecting one of the following:\n  - \")\" to form a unit value \"()\"\n  - \"module\" to start a module expression\n  - an expression\n  - an operator to denote the prefix form of an operator\n"
-    | 2383 ->
+    | 2392 ->
         "<SYNTAX ERROR>\n"
-    | 717 ->
+    | 726 ->
         "<SYNTAX ERROR>\n"
     | 418 ->
         "Expecting a module expression\n"
-    | 2370 ->
-        "<SYNTAX ERROR>\n"
-    | 2372 ->
-        "<SYNTAX ERROR>\n"
-    | 2374 ->
-        "<SYNTAX ERROR>\n"
-    | 2376 ->
-        "<SYNTAX ERROR>\n"
-    | 2377 ->
-        "<SYNTAX ERROR>\n"
-    | 2378 ->
-        "<SYNTAX ERROR>\n"
     | 2379 ->
-        "<SYNTAX ERROR>\n"
-    | 2380 ->
         "<SYNTAX ERROR>\n"
     | 2381 ->
         "<SYNTAX ERROR>\n"
-    | 1371 ->
+    | 2383 ->
         "<SYNTAX ERROR>\n"
-    | 2428 ->
+    | 2385 ->
+        "<SYNTAX ERROR>\n"
+    | 2386 ->
+        "<SYNTAX ERROR>\n"
+    | 2387 ->
+        "<SYNTAX ERROR>\n"
+    | 2388 ->
+        "<SYNTAX ERROR>\n"
+    | 2389 ->
+        "<SYNTAX ERROR>\n"
+    | 2390 ->
+        "<SYNTAX ERROR>\n"
+    | 1380 ->
+        "<SYNTAX ERROR>\n"
+    | 2437 ->
         "<SYNTAX ERROR>\n"
     | 189 ->
         "<SYNTAX ERROR>\n"
-    | 552 ->
+    | 561 ->
         "<SYNTAX ERROR>\n"
-    | 2298 ->
+    | 2307 ->
         "<SYNTAX ERROR>\n"
-    | 553 ->
+    | 562 ->
         "<SYNTAX ERROR>\n"
-    | 1813 ->
+    | 1822 ->
         "<SYNTAX ERROR>\n"
-    | 1812 ->
+    | 1821 ->
         "<SYNTAX ERROR>\n"
-    | 1807 ->
+    | 1816 ->
         "<SYNTAX ERROR>\n"
-    | 1808 ->
-        "<SYNTAX ERROR>\n"
-    | 571 ->
+    | 1817 ->
         "<SYNTAX ERROR>\n"
     | 580 ->
         "<SYNTAX ERROR>\n"
-    | 590 ->
+    | 589 ->
         "<SYNTAX ERROR>\n"
-    | 608 ->
-        "<SYNTAX ERROR>\n"
-    | 609 ->
-        "<SYNTAX ERROR>\n"
-    | 611 ->
-        "<SYNTAX ERROR>\n"
-    | 612 ->
-        "<SYNTAX ERROR>\n"
-    | 2238 ->
-        "<SYNTAX ERROR>\n"
-    | 2224 ->
+    | 599 ->
         "<SYNTAX ERROR>\n"
     | 617 ->
         "<SYNTAX ERROR>\n"
     | 618 ->
         "<SYNTAX ERROR>\n"
-    | 619 ->
-        "<SYNTAX ERROR>\n"
     | 620 ->
         "<SYNTAX ERROR>\n"
-    | 2222 ->
+    | 621 ->
         "<SYNTAX ERROR>\n"
-    | 2223 ->
+    | 2247 ->
         "<SYNTAX ERROR>\n"
-    | 613 ->
+    | 2233 ->
         "<SYNTAX ERROR>\n"
-    | 614 ->
+    | 626 ->
         "<SYNTAX ERROR>\n"
-    | 615 ->
+    | 627 ->
         "<SYNTAX ERROR>\n"
-    | 616 ->
+    | 628 ->
+        "<SYNTAX ERROR>\n"
+    | 629 ->
         "<SYNTAX ERROR>\n"
     | 2231 ->
         "<SYNTAX ERROR>\n"
     | 2232 ->
         "<SYNTAX ERROR>\n"
-    | 2233 ->
+    | 622 ->
         "<SYNTAX ERROR>\n"
-    | 2234 ->
+    | 623 ->
         "<SYNTAX ERROR>\n"
-    | 2235 ->
+    | 624 ->
         "<SYNTAX ERROR>\n"
-    | 2236 ->
+    | 625 ->
         "<SYNTAX ERROR>\n"
-    | 890 ->
+    | 2240 ->
         "<SYNTAX ERROR>\n"
-    | 891 ->
+    | 2241 ->
         "<SYNTAX ERROR>\n"
-    | 892 ->
+    | 2242 ->
         "<SYNTAX ERROR>\n"
-    | 893 ->
+    | 2243 ->
         "<SYNTAX ERROR>\n"
-    | 894 ->
+    | 2244 ->
         "<SYNTAX ERROR>\n"
-    | 895 ->
+    | 2245 ->
         "<SYNTAX ERROR>\n"
-    | 2331 ->
+    | 899 ->
         "<SYNTAX ERROR>\n"
-    | 2332 ->
+    | 900 ->
         "<SYNTAX ERROR>\n"
-    | 2333 ->
+    | 901 ->
         "<SYNTAX ERROR>\n"
-    | 2334 ->
+    | 902 ->
         "<SYNTAX ERROR>\n"
-    | 2335 ->
-        "<SYNTAX ERROR>\n"
-    | 2336 ->
-        "<SYNTAX ERROR>\n"
-    | 1785 ->
-        "<SYNTAX ERROR>\n"
-    | 598 ->
-        "<SYNTAX ERROR>\n"
-    | 1359 ->
-        "<SYNTAX ERROR>\n"
-    | 1181 ->
+    | 903 ->
         "<SYNTAX ERROR>\n"
     | 904 ->
+        "<SYNTAX ERROR>\n"
+    | 2340 ->
+        "<SYNTAX ERROR>\n"
+    | 2341 ->
+        "<SYNTAX ERROR>\n"
+    | 2342 ->
+        "<SYNTAX ERROR>\n"
+    | 2343 ->
+        "<SYNTAX ERROR>\n"
+    | 2344 ->
+        "<SYNTAX ERROR>\n"
+    | 2345 ->
+        "<SYNTAX ERROR>\n"
+    | 1794 ->
+        "<SYNTAX ERROR>\n"
+    | 607 ->
+        "<SYNTAX ERROR>\n"
+    | 1368 ->
+        "<SYNTAX ERROR>\n"
+    | 1190 ->
+        "<SYNTAX ERROR>\n"
+    | 913 ->
         "Incomplete let binding\n"
-    | 1282 ->
+    | 1291 ->
         "<SYNTAX ERROR>\n"
-    | 1288 ->
+    | 1297 ->
         "<SYNTAX ERROR>\n"
-    | 1283 ->
+    | 1292 ->
         "<SYNTAX ERROR>\n"
-    | 1284 ->
+    | 1293 ->
         "<SYNTAX ERROR>\n"
-    | 1285 ->
+    | 1294 ->
         "<SYNTAX ERROR>\n"
-    | 1287 ->
+    | 1296 ->
         "<SYNTAX ERROR>\n"
-    | 1157 ->
+    | 1166 ->
         "<SYNTAX ERROR>\n"
-    | 905 ->
+    | 914 ->
         "<SYNTAX ERROR>\n"
-    | 906 ->
+    | 915 ->
         "<SYNTAX ERROR>\n"
-    | 1761 ->
+    | 1770 ->
         "<SYNTAX ERROR>\n"
-    | 1762 ->
+    | 1771 ->
+        "<SYNTAX ERROR>\n"
+    | 1772 ->
+        "<SYNTAX ERROR>\n"
+    | 1773 ->
+        "<SYNTAX ERROR>\n"
+    | 1777 ->
+        "<SYNTAX ERROR>\n"
+    | 1774 ->
+        "<SYNTAX ERROR>\n"
+    | 1775 ->
+        "<SYNTAX ERROR>\n"
+    | 1776 ->
+        "<SYNTAX ERROR>\n"
+    | 916 ->
+        "<SYNTAX ERROR>\n"
+    | 917 ->
+        "<SYNTAX ERROR>\n"
+    | 926 ->
         "<SYNTAX ERROR>\n"
     | 1763 ->
         "<SYNTAX ERROR>\n"
     | 1764 ->
         "<SYNTAX ERROR>\n"
-    | 1768 ->
-        "<SYNTAX ERROR>\n"
     | 1765 ->
         "<SYNTAX ERROR>\n"
-    | 1766 ->
+    | 1781 ->
         "<SYNTAX ERROR>\n"
-    | 1767 ->
+    | 1144 ->
         "<SYNTAX ERROR>\n"
-    | 907 ->
-        "<SYNTAX ERROR>\n"
-    | 908 ->
-        "<SYNTAX ERROR>\n"
-    | 917 ->
-        "<SYNTAX ERROR>\n"
-    | 1754 ->
-        "<SYNTAX ERROR>\n"
-    | 1755 ->
-        "<SYNTAX ERROR>\n"
-    | 1756 ->
-        "<SYNTAX ERROR>\n"
-    | 1772 ->
-        "<SYNTAX ERROR>\n"
-    | 1135 ->
-        "<SYNTAX ERROR>\n"
-    | 1136 ->
-        "<SYNTAX ERROR>\n"
-    | 1158 ->
-        "<SYNTAX ERROR>\n"
-    | 1278 ->
-        "Defining a function?\nExpecting one of the following:\n  - \"=>\" to start the function body\n  - an identifier to add a function parameter\n  - \":\" to specify the return type\n"
-    | 1246 ->
-        "<SYNTAX ERROR>\n"
-    | 1163 ->
-        "<SYNTAX ERROR>\n"
-    | 1164 ->
-        "<SYNTAX ERROR>\n"
-    | 1165 ->
-        "<SYNTAX ERROR>\n"
-    | 1166 ->
+    | 1145 ->
         "<SYNTAX ERROR>\n"
     | 1167 ->
-        "Expecting an expression as function body\n"
-    | 1241 ->
         "<SYNTAX ERROR>\n"
-    | 1242 ->
-        "Defining a function?\nExpecting \"=>\" to start the function body\n"
-    | 1243 ->
-        "<SYNTAX ERROR>\n"
-    | 1244 ->
-        "<SYNTAX ERROR>\n"
-    | 1159 ->
-        "<SYNTAX ERROR>\n"
-    | 1160 ->
-        "<SYNTAX ERROR>\n"
-    | 1161 ->
-        "<SYNTAX ERROR>\n"
-    | 1162 ->
-        "<SYNTAX ERROR>\n"
-    | 1251 ->
-        "<SYNTAX ERROR>\n"
-    | 1274 ->
-        "<SYNTAX ERROR>\n"
-    | 1275 ->
-        "<SYNTAX ERROR>\n"
+    | 1287 ->
+        "Defining a function?\nExpecting one of the following:\n  - \"=>\" to start the function body\n  - an identifier to add a function parameter\n  - \":\" to specify the return type\n"
     | 1255 ->
         "<SYNTAX ERROR>\n"
-    | 1256 ->
+    | 1172 ->
         "<SYNTAX ERROR>\n"
-    | 1257 ->
+    | 1173 ->
+        "<SYNTAX ERROR>\n"
+    | 1174 ->
+        "<SYNTAX ERROR>\n"
+    | 1175 ->
+        "<SYNTAX ERROR>\n"
+    | 1176 ->
+        "Expecting an expression as function body\n"
+    | 1250 ->
+        "<SYNTAX ERROR>\n"
+    | 1251 ->
+        "Defining a function?\nExpecting \"=>\" to start the function body\n"
+    | 1252 ->
+        "<SYNTAX ERROR>\n"
+    | 1253 ->
+        "<SYNTAX ERROR>\n"
+    | 1168 ->
+        "<SYNTAX ERROR>\n"
+    | 1169 ->
+        "<SYNTAX ERROR>\n"
+    | 1170 ->
+        "<SYNTAX ERROR>\n"
+    | 1171 ->
         "<SYNTAX ERROR>\n"
     | 1260 ->
         "<SYNTAX ERROR>\n"
-    | 1261 ->
+    | 1283 ->
         "<SYNTAX ERROR>\n"
-    | 1262 ->
+    | 1284 ->
+        "<SYNTAX ERROR>\n"
+    | 1264 ->
         "<SYNTAX ERROR>\n"
     | 1265 ->
         "<SYNTAX ERROR>\n"
     | 1266 ->
         "<SYNTAX ERROR>\n"
-    | 1267 ->
+    | 1269 ->
         "<SYNTAX ERROR>\n"
-    | 1268 ->
+    | 1270 ->
         "<SYNTAX ERROR>\n"
-    | 1264 ->
+    | 1271 ->
         "<SYNTAX ERROR>\n"
-    | 1504 ->
+    | 1274 ->
+        "<SYNTAX ERROR>\n"
+    | 1275 ->
+        "<SYNTAX ERROR>\n"
+    | 1276 ->
+        "<SYNTAX ERROR>\n"
+    | 1277 ->
+        "<SYNTAX ERROR>\n"
+    | 1273 ->
+        "<SYNTAX ERROR>\n"
+    | 1513 ->
         "<SYNTAX ERROR>\n"
     | 69 ->
         "<SYNTAX ERROR>\n"
-    | 1705 ->
+    | 1714 ->
         "<SYNTAX ERROR>\n"
     | 191 ->
         "<SYNTAX ERROR>\n"
-    | 2426 ->
+    | 2435 ->
         "<SYNTAX ERROR>\n"
-    | 2427 ->
+    | 2436 ->
         "<SYNTAX ERROR>\n"
-    | 2425 ->
+    | 2434 ->
         "<SYNTAX ERROR>\n"
     | 70 ->
         "<SYNTAX ERROR>\n"
-    | 1056 ->
+    | 1065 ->
         "<SYNTAX ERROR>\n"
-    | 1029 ->
+    | 1038 ->
         "<SYNTAX ERROR>\n"
-    | 2593 ->
+    | 2611 ->
         "<SYNTAX ERROR>\n"
     | 18 ->
         "<SYNTAX ERROR>\n"
     | 164 ->
         "<SYNTAX ERROR>\n"
-    | 2500 ->
+    | 2509 ->
         "<SYNTAX ERROR>\n"
-    | 1792 ->
+    | 1801 ->
         "<SYNTAX ERROR>\n"
-    | 1795 ->
+    | 1804 ->
         "<SYNTAX ERROR>\n"
-    | 1797 ->
+    | 1806 ->
         "<SYNTAX ERROR>\n"
-    | 1800 ->
+    | 1809 ->
         "Expecting a type name\n"
     | 176 ->
         "Expecting an expression\n"
-    | 1385 ->
+    | 1394 ->
         "Expecting an expression\n"
-    | 1361 ->
+    | 1370 ->
         "Expecting an expression\n"
-    | 597 ->
+    | 606 ->
         "<SYNTAX ERROR>\n"
-    | 1703 ->
+    | 1712 ->
         "Expecting \"]\" to finish current floating attribute\n"
-    | 1031 ->
+    | 1040 ->
         "<SYNTAX ERROR>\n"
     | 167 ->
         "Expecting one of the following:\n  - an list item\n  - \"]\" to finish this list\n"
-    | 2206 ->
+    | 2215 ->
         "Expecting one of the following:\n  - \",\" to separate two items in a list\n  - \"]\" to finish this list\n"
-    | 2207 ->
+    | 2216 ->
         "<SYNTAX ERROR>\n"
-    | 2203 ->
+    | 2212 ->
         "<SYNTAX ERROR>\n"
-    | 2204 ->
+    | 2213 ->
         "<SYNTAX ERROR>\n"
     | 169 ->
         "<SYNTAX ERROR>\n"
     | 170 ->
         "<SYNTAX ERROR>\n"
-    | 574 ->
+    | 583 ->
         "<SYNTAX ERROR>\n"
     | 171 ->
         "<SYNTAX ERROR>\n"
-    | 2482 ->
+    | 2491 ->
         "<SYNTAX ERROR>\n"
     | 174 ->
         "<SYNTAX ERROR>\n"
-    | 1340 ->
-        "<SYNTAX ERROR>\n"
-    | 1341 ->
-        "<SYNTAX ERROR>\n"
-    | 1342 ->
-        "<SYNTAX ERROR>\n"
-    | 1343 ->
-        "<SYNTAX ERROR>\n"
-    | 1344 ->
-        "<SYNTAX ERROR>\n"
-    | 1345 ->
+    | 1349 ->
         "<SYNTAX ERROR>\n"
     | 1350 ->
         "<SYNTAX ERROR>\n"
@@ -810,59 +800,53 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1354 ->
         "<SYNTAX ERROR>\n"
-    | 1357 ->
+    | 1359 ->
         "<SYNTAX ERROR>\n"
-    | 1358 ->
+    | 1360 ->
         "<SYNTAX ERROR>\n"
-    | 1450 ->
+    | 1361 ->
         "<SYNTAX ERROR>\n"
-    | 1452 ->
+    | 1362 ->
         "<SYNTAX ERROR>\n"
-    | 1453 ->
+    | 1363 ->
         "<SYNTAX ERROR>\n"
-    | 1454 ->
+    | 1366 ->
         "<SYNTAX ERROR>\n"
-    | 1349 ->
-        "<SYNTAX ERROR>\n"
-    | 2351 ->
-        "<SYNTAX ERROR>\n"
-    | 534 ->
-        "<SYNTAX ERROR>\n"
-    | 2281 ->
-        "<SYNTAX ERROR>\n"
-    | 2258 ->
-        "<SYNTAX ERROR>\n"
-    | 1455 ->
-        "<SYNTAX ERROR>\n"
-    | 1457 ->
-        "<SYNTAX ERROR>\n"
-    | 1458 ->
+    | 1367 ->
         "<SYNTAX ERROR>\n"
     | 1459 ->
         "<SYNTAX ERROR>\n"
-    | 1460 ->
-        "<SYNTAX ERROR>\n"
-    | 1102 ->
-        "<SYNTAX ERROR>\n"
-    | 1104 ->
-        "<SYNTAX ERROR>\n"
-    | 1105 ->
+    | 1461 ->
         "<SYNTAX ERROR>\n"
     | 1462 ->
         "<SYNTAX ERROR>\n"
     | 1463 ->
         "<SYNTAX ERROR>\n"
+    | 1358 ->
+        "<SYNTAX ERROR>\n"
+    | 2360 ->
+        "<SYNTAX ERROR>\n"
+    | 543 ->
+        "<SYNTAX ERROR>\n"
+    | 2290 ->
+        "<SYNTAX ERROR>\n"
+    | 2267 ->
+        "<SYNTAX ERROR>\n"
     | 1464 ->
         "<SYNTAX ERROR>\n"
-    | 1465 ->
+    | 1466 ->
+        "<SYNTAX ERROR>\n"
+    | 1467 ->
         "<SYNTAX ERROR>\n"
     | 1468 ->
         "<SYNTAX ERROR>\n"
-    | 1479 ->
-        "<SYNTAX ERROR>\n"
     | 1469 ->
         "<SYNTAX ERROR>\n"
-    | 1470 ->
+    | 1111 ->
+        "<SYNTAX ERROR>\n"
+    | 1113 ->
+        "<SYNTAX ERROR>\n"
+    | 1114 ->
         "<SYNTAX ERROR>\n"
     | 1471 ->
         "<SYNTAX ERROR>\n"
@@ -870,13 +854,23 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1473 ->
         "<SYNTAX ERROR>\n"
-    | 1539 ->
+    | 1474 ->
         "<SYNTAX ERROR>\n"
-    | 1483 ->
+    | 1477 ->
         "<SYNTAX ERROR>\n"
-    | 1484 ->
+    | 1488 ->
         "<SYNTAX ERROR>\n"
-    | 1485 ->
+    | 1478 ->
+        "<SYNTAX ERROR>\n"
+    | 1479 ->
+        "<SYNTAX ERROR>\n"
+    | 1480 ->
+        "<SYNTAX ERROR>\n"
+    | 1481 ->
+        "<SYNTAX ERROR>\n"
+    | 1482 ->
+        "<SYNTAX ERROR>\n"
+    | 1548 ->
         "<SYNTAX ERROR>\n"
     | 1492 ->
         "<SYNTAX ERROR>\n"
@@ -884,93 +878,83 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1494 ->
         "<SYNTAX ERROR>\n"
-    | 1486 ->
+    | 1501 ->
         "<SYNTAX ERROR>\n"
-    | 1488 ->
+    | 1502 ->
         "<SYNTAX ERROR>\n"
-    | 1489 ->
+    | 1503 ->
         "<SYNTAX ERROR>\n"
-    | 1490 ->
+    | 1495 ->
         "<SYNTAX ERROR>\n"
-    | 1491 ->
+    | 1497 ->
         "<SYNTAX ERROR>\n"
-    | 1456 ->
+    | 1498 ->
+        "<SYNTAX ERROR>\n"
+    | 1499 ->
+        "<SYNTAX ERROR>\n"
+    | 1500 ->
+        "<SYNTAX ERROR>\n"
+    | 1465 ->
+        "<SYNTAX ERROR>\n"
+    | 1849 ->
         "<SYNTAX ERROR>\n"
     | 1840 ->
         "<SYNTAX ERROR>\n"
-    | 1831 ->
+    | 1838 ->
         "<SYNTAX ERROR>\n"
-    | 1829 ->
+    | 1841 ->
         "<SYNTAX ERROR>\n"
-    | 1832 ->
+    | 1842 ->
         "<SYNTAX ERROR>\n"
-    | 1833 ->
+    | 1852 ->
         "<SYNTAX ERROR>\n"
-    | 1843 ->
+    | 1853 ->
         "<SYNTAX ERROR>\n"
-    | 1844 ->
+    | 591 ->
         "<SYNTAX ERROR>\n"
-    | 582 ->
+    | 2072 ->
         "<SYNTAX ERROR>\n"
-    | 2063 ->
+    | 2078 ->
         "<SYNTAX ERROR>\n"
-    | 2069 ->
+    | 2073 ->
         "<SYNTAX ERROR>\n"
-    | 2064 ->
+    | 2074 ->
         "<SYNTAX ERROR>\n"
-    | 2065 ->
+    | 2075 ->
         "<SYNTAX ERROR>\n"
-    | 2066 ->
-        "<SYNTAX ERROR>\n"
-    | 2068 ->
-        "<SYNTAX ERROR>\n"
-    | 2033 ->
-        "<SYNTAX ERROR>\n"
-    | 584 ->
-        "<SYNTAX ERROR>\n"
-    | 588 ->
-        "<SYNTAX ERROR>\n"
-    | 589 ->
-        "<SYNTAX ERROR>\n"
-    | 585 ->
-        "<SYNTAX ERROR>\n"
-    | 2268 ->
-        "<SYNTAX ERROR>\n"
-    | 2269 ->
-        "<SYNTAX ERROR>\n"
-    | 2272 ->
-        "<SYNTAX ERROR>\n"
-    | 2271 ->
-        "<SYNTAX ERROR>\n"
-    | 2034 ->
-        "<SYNTAX ERROR>\n"
-    | 2059 ->
-        "<SYNTAX ERROR>\n"
-    | 1475 ->
-        "<SYNTAX ERROR>\n"
-    | 1476 ->
-        "<SYNTAX ERROR>\n"
-    | 1477 ->
-        "<SYNTAX ERROR>\n"
-    | 1478 ->
-        "<SYNTAX ERROR>\n"
-    | 2035 ->
-        "<SYNTAX ERROR>\n"
-    | 2036 ->
-        "<SYNTAX ERROR>\n"
-    | 2037 ->
-        "<SYNTAX ERROR>\n"
-    | 2038 ->
-        "<SYNTAX ERROR>\n"
-    | 2040 ->
-        "<SYNTAX ERROR>\n"
-    | 2055 ->
-        "<SYNTAX ERROR>\n"
-    | 2056 ->
+    | 2077 ->
         "<SYNTAX ERROR>\n"
     | 2042 ->
         "<SYNTAX ERROR>\n"
+    | 593 ->
+        "<SYNTAX ERROR>\n"
+    | 597 ->
+        "<SYNTAX ERROR>\n"
+    | 598 ->
+        "<SYNTAX ERROR>\n"
+    | 594 ->
+        "<SYNTAX ERROR>\n"
+    | 2277 ->
+        "<SYNTAX ERROR>\n"
+    | 2278 ->
+        "<SYNTAX ERROR>\n"
+    | 2281 ->
+        "<SYNTAX ERROR>\n"
+    | 2280 ->
+        "<SYNTAX ERROR>\n"
     | 2043 ->
+        "<SYNTAX ERROR>\n"
+    | 2068 ->
+        "<SYNTAX ERROR>\n"
+    | 1484 ->
+        "<SYNTAX ERROR>\n"
+    | 1485 ->
+        "<SYNTAX ERROR>\n"
+    | 1486 ->
+        "<SYNTAX ERROR>\n"
+    | 1487 ->
+        "<SYNTAX ERROR>\n"
+    | 2044 ->
         "<SYNTAX ERROR>\n"
     | 2045 ->
         "<SYNTAX ERROR>\n"
@@ -978,63 +962,73 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2047 ->
         "<SYNTAX ERROR>\n"
-    | 2050 ->
+    | 2049 ->
+        "<SYNTAX ERROR>\n"
+    | 2064 ->
+        "<SYNTAX ERROR>\n"
+    | 2065 ->
         "<SYNTAX ERROR>\n"
     | 2051 ->
         "<SYNTAX ERROR>\n"
     | 2052 ->
         "<SYNTAX ERROR>\n"
-    | 2053 ->
+    | 2054 ->
         "<SYNTAX ERROR>\n"
-    | 2049 ->
+    | 2055 ->
         "<SYNTAX ERROR>\n"
-    | 2431 ->
+    | 2056 ->
+        "<SYNTAX ERROR>\n"
+    | 2059 ->
+        "<SYNTAX ERROR>\n"
+    | 2060 ->
+        "<SYNTAX ERROR>\n"
+    | 2061 ->
+        "<SYNTAX ERROR>\n"
+    | 2062 ->
+        "<SYNTAX ERROR>\n"
+    | 2058 ->
+        "<SYNTAX ERROR>\n"
+    | 2440 ->
         "Expecting \"}\" to finish the block\n"
-    | 2165 ->
+    | 2174 ->
         "<SYNTAX ERROR>\n"
-    | 1679 ->
+    | 1688 ->
         "<SYNTAX ERROR>\n"
-    | 1112 ->
+    | 1121 ->
         "<SYNTAX ERROR>\n"
-    | 1501 ->
+    | 1510 ->
         "<SYNTAX ERROR>\n"
-    | 1498 ->
+    | 1507 ->
         "<SYNTAX ERROR>\n"
-    | 1517 ->
+    | 1526 ->
         "<SYNTAX ERROR>\n"
-    | 1518 ->
+    | 1527 ->
         "<SYNTAX ERROR>\n"
-    | 1521 ->
+    | 1530 ->
         "<SYNTAX ERROR>\n"
-    | 1154 ->
+    | 1163 ->
         "<SYNTAX ERROR>\n"
-    | 1550 ->
+    | 1559 ->
         "<SYNTAX ERROR>\n"
-    | 1553 ->
+    | 1562 ->
         "<SYNTAX ERROR>\n"
-    | 1575 ->
+    | 1584 ->
         "<SYNTAX ERROR>\n"
-    | 1554 ->
+    | 1563 ->
         "<SYNTAX ERROR>\n"
-    | 1560 ->
+    | 1569 ->
         "<SYNTAX ERROR>\n"
-    | 1561 ->
-        "<SYNTAX ERROR>\n"
-    | 1565 ->
-        "<SYNTAX ERROR>\n"
-    | 1566 ->
-        "<SYNTAX ERROR>\n"
-    | 1567 ->
-        "<SYNTAX ERROR>\n"
-    | 1556 ->
+    | 1570 ->
         "<SYNTAX ERROR>\n"
     | 1574 ->
         "<SYNTAX ERROR>\n"
-    | 1571 ->
+    | 1575 ->
         "<SYNTAX ERROR>\n"
-    | 1572 ->
+    | 1576 ->
         "<SYNTAX ERROR>\n"
-    | 1573 ->
+    | 1565 ->
+        "<SYNTAX ERROR>\n"
+    | 1583 ->
         "<SYNTAX ERROR>\n"
     | 1580 ->
         "<SYNTAX ERROR>\n"
@@ -1042,159 +1036,165 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1582 ->
         "<SYNTAX ERROR>\n"
-    | 1302 ->
+    | 1589 ->
         "<SYNTAX ERROR>\n"
-    | 1314 ->
+    | 1590 ->
         "<SYNTAX ERROR>\n"
-    | 1540 ->
+    | 1591 ->
         "<SYNTAX ERROR>\n"
-    | 1523 ->
+    | 1311 ->
         "<SYNTAX ERROR>\n"
-    | 1524 ->
+    | 1323 ->
         "<SYNTAX ERROR>\n"
-    | 1155 ->
+    | 1549 ->
+        "<SYNTAX ERROR>\n"
+    | 1532 ->
+        "<SYNTAX ERROR>\n"
+    | 1533 ->
+        "<SYNTAX ERROR>\n"
+    | 1164 ->
+        "<SYNTAX ERROR>\n"
+    | 1345 ->
+        "<SYNTAX ERROR>\n"
+    | 1553 ->
+        "<SYNTAX ERROR>\n"
+    | 1165 ->
+        "<SYNTAX ERROR>\n"
+    | 1341 ->
+        "<SYNTAX ERROR>\n"
+    | 1342 ->
+        "<SYNTAX ERROR>\n"
+    | 1301 ->
+        "<SYNTAX ERROR>\n"
+    | 1303 ->
+        "<SYNTAX ERROR>\n"
+    | 1304 ->
+        "<SYNTAX ERROR>\n"
+    | 1329 ->
+        "<SYNTAX ERROR>\n"
+    | 1305 ->
+        "<SYNTAX ERROR>\n"
+    | 1306 ->
+        "<SYNTAX ERROR>\n"
+    | 1307 ->
+        "<SYNTAX ERROR>\n"
+    | 1531 ->
+        "<SYNTAX ERROR>\n"
+    | 1833 ->
+        "<SYNTAX ERROR>\n"
+    | 1834 ->
+        "<SYNTAX ERROR>\n"
+    | 1835 ->
+        "<SYNTAX ERROR>\n"
+    | 1537 ->
+        "<SYNTAX ERROR>\n"
+    | 1538 ->
+        "<SYNTAX ERROR>\n"
+    | 1539 ->
         "<SYNTAX ERROR>\n"
     | 1336 ->
         "<SYNTAX ERROR>\n"
-    | 1544 ->
+    | 1337 ->
         "<SYNTAX ERROR>\n"
-    | 1156 ->
+    | 1348 ->
         "<SYNTAX ERROR>\n"
-    | 1332 ->
+    | 565 ->
         "<SYNTAX ERROR>\n"
-    | 1333 ->
+    | 1042 ->
         "<SYNTAX ERROR>\n"
-    | 1292 ->
+    | 919 ->
         "<SYNTAX ERROR>\n"
-    | 1294 ->
+    | 863 ->
         "<SYNTAX ERROR>\n"
-    | 1295 ->
+    | 864 ->
         "<SYNTAX ERROR>\n"
-    | 1320 ->
+    | 1895 ->
         "<SYNTAX ERROR>\n"
-    | 1296 ->
+    | 1897 ->
         "<SYNTAX ERROR>\n"
-    | 1297 ->
+    | 1900 ->
         "<SYNTAX ERROR>\n"
-    | 1298 ->
+    | 2192 ->
         "<SYNTAX ERROR>\n"
-    | 1522 ->
+    | 912 ->
         "<SYNTAX ERROR>\n"
-    | 1824 ->
-        "<SYNTAX ERROR>\n"
-    | 1825 ->
-        "<SYNTAX ERROR>\n"
-    | 1826 ->
-        "<SYNTAX ERROR>\n"
-    | 1528 ->
-        "<SYNTAX ERROR>\n"
-    | 1529 ->
-        "<SYNTAX ERROR>\n"
-    | 1530 ->
-        "<SYNTAX ERROR>\n"
-    | 1327 ->
-        "<SYNTAX ERROR>\n"
-    | 1328 ->
-        "<SYNTAX ERROR>\n"
-    | 1339 ->
-        "<SYNTAX ERROR>\n"
-    | 556 ->
-        "<SYNTAX ERROR>\n"
-    | 1033 ->
-        "<SYNTAX ERROR>\n"
-    | 910 ->
-        "<SYNTAX ERROR>\n"
-    | 854 ->
-        "<SYNTAX ERROR>\n"
-    | 855 ->
-        "<SYNTAX ERROR>\n"
-    | 1886 ->
-        "<SYNTAX ERROR>\n"
-    | 1888 ->
-        "<SYNTAX ERROR>\n"
-    | 1891 ->
-        "<SYNTAX ERROR>\n"
-    | 2183 ->
-        "<SYNTAX ERROR>\n"
-    | 903 ->
-        "<SYNTAX ERROR>\n"
-    | 1777 ->
+    | 1786 ->
         "<SYNTAX ERROR>\n"
     | 411 ->
         "<SYNTAX ERROR>\n"
     | 412 ->
         "<SYNTAX ERROR>\n"
-    | 2391 ->
+    | 2400 ->
         "<SYNTAX ERROR>\n"
-    | 2393 ->
+    | 2402 ->
         "<SYNTAX ERROR>\n"
-    | 1889 ->
+    | 1898 ->
         "<SYNTAX ERROR>\n"
-    | 2395 ->
+    | 2404 ->
         "<SYNTAX ERROR>\n"
-    | 1894 ->
+    | 1903 ->
         "<SYNTAX ERROR>\n"
-    | 1895 ->
+    | 1904 ->
         "<SYNTAX ERROR>\n"
-    | 2397 ->
+    | 2406 ->
         "<SYNTAX ERROR>\n"
-    | 2004 ->
+    | 2013 ->
         "<SYNTAX ERROR>\n"
-    | 1979 ->
-        "<SYNTAX ERROR>\n"
-    | 1980 ->
-        "<SYNTAX ERROR>\n"
-    | 1981 ->
-        "<SYNTAX ERROR>\n"
-    | 1983 ->
-        "<SYNTAX ERROR>\n"
-    | 1986 ->
-        "<SYNTAX ERROR>\n"
-    | 1993 ->
-        "<SYNTAX ERROR>\n"
-    | 1996 ->
-        "<SYNTAX ERROR>\n"
-    | 1997 ->
-        "<SYNTAX ERROR>\n"
-    | 2186 ->
-        "<SYNTAX ERROR>\n"
-    | 2187 ->
-        "<SYNTAX ERROR>\n"
-    | 549 ->
-        "<SYNTAX ERROR>\n"
-    | 550 ->
-        "<SYNTAX ERROR>\n"
-    | 2302 ->
-        "<SYNTAX ERROR>\n"
-    | 2304 ->
-        "<SYNTAX ERROR>\n"
-    | 1984 ->
-        "<SYNTAX ERROR>\n"
-    | 2306 ->
+    | 1988 ->
         "<SYNTAX ERROR>\n"
     | 1989 ->
         "<SYNTAX ERROR>\n"
     | 1990 ->
         "<SYNTAX ERROR>\n"
-    | 2308 ->
+    | 1992 ->
+        "<SYNTAX ERROR>\n"
+    | 1995 ->
+        "<SYNTAX ERROR>\n"
+    | 2002 ->
+        "<SYNTAX ERROR>\n"
+    | 2005 ->
+        "<SYNTAX ERROR>\n"
+    | 2006 ->
+        "<SYNTAX ERROR>\n"
+    | 2195 ->
+        "<SYNTAX ERROR>\n"
+    | 2196 ->
+        "<SYNTAX ERROR>\n"
+    | 558 ->
+        "<SYNTAX ERROR>\n"
+    | 559 ->
+        "<SYNTAX ERROR>\n"
+    | 2311 ->
+        "<SYNTAX ERROR>\n"
+    | 2313 ->
+        "<SYNTAX ERROR>\n"
+    | 1993 ->
+        "<SYNTAX ERROR>\n"
+    | 2315 ->
+        "<SYNTAX ERROR>\n"
+    | 1998 ->
         "<SYNTAX ERROR>\n"
     | 1999 ->
         "<SYNTAX ERROR>\n"
-    | 2000 ->
+    | 2317 ->
         "<SYNTAX ERROR>\n"
-    | 1898 ->
+    | 2008 ->
         "<SYNTAX ERROR>\n"
-    | 1974 ->
+    | 2009 ->
         "<SYNTAX ERROR>\n"
-    | 1975 ->
+    | 1907 ->
         "<SYNTAX ERROR>\n"
-    | 1976 ->
+    | 1983 ->
         "<SYNTAX ERROR>\n"
-    | 1978 ->
+    | 1984 ->
+        "<SYNTAX ERROR>\n"
+    | 1985 ->
+        "<SYNTAX ERROR>\n"
+    | 1987 ->
         "<SYNTAX ERROR>\n"
     | 419 ->
         "<SYNTAX ERROR>\n"
-    | 2135 ->
+    | 2144 ->
         "<SYNTAX ERROR>\n"
     | 422 ->
         "<SYNTAX ERROR>\n"
@@ -1202,13 +1202,13 @@ let message =
         "<SYNTAX ERROR>\n"
     | 425 ->
         "<SYNTAX ERROR>\n"
-    | 2355 ->
+    | 2364 ->
         "<SYNTAX ERROR>\n"
-    | 2359 ->
+    | 2368 ->
         "<SYNTAX ERROR>\n"
-    | 2356 ->
+    | 2365 ->
         "<SYNTAX ERROR>\n"
-    | 2357 ->
+    | 2366 ->
         "<SYNTAX ERROR>\n"
     | 427 ->
         "<SYNTAX ERROR>\n"
@@ -1218,63 +1218,79 @@ let message =
         "<SYNTAX ERROR>\n"
     | 433 ->
         "<SYNTAX ERROR>\n"
-    | 2142 ->
+    | 2151 ->
         "<SYNTAX ERROR>\n"
     | 437 ->
         "<SYNTAX ERROR>\n"
-    | 505 ->
-        "<SYNTAX ERROR>\n"
-    | 506 ->
-        "<SYNTAX ERROR>\n"
-    | 508 ->
-        "<SYNTAX ERROR>\n"
-    | 512 ->
-        "<SYNTAX ERROR>\n"
     | 513 ->
         "<SYNTAX ERROR>\n"
-    | 438 ->
+    | 514 ->
         "<SYNTAX ERROR>\n"
-    | 477 ->
-        "<SYNTAX ERROR>\n"
-    | 463 ->
-        "<SYNTAX ERROR>\n"
-    | 462 ->
-        "<SYNTAX ERROR>\n"
-    | 252 ->
-        "<SYNTAX ERROR>\n"
-    | 482 ->
-        "<SYNTAX ERROR>\n"
-    | 499 ->
-        "<SYNTAX ERROR>\n"
-    | 519 ->
-        "<SYNTAX ERROR>\n"
-    | 520 ->
+    | 516 ->
         "<SYNTAX ERROR>\n"
     | 521 ->
         "<SYNTAX ERROR>\n"
     | 522 ->
         "<SYNTAX ERROR>\n"
+    | 438 ->
+        "<SYNTAX ERROR>\n"
+    | 482 ->
+        "<SYNTAX ERROR>\n"
+    | 468 ->
+        "<SYNTAX ERROR>\n"
+    | 463 ->
+        "<SYNTAX ERROR>\n"
+    | 464 ->
+        "<SYNTAX ERROR>\n"
+    | 490 ->
+        "<SYNTAX ERROR>\n"
+    | 507 ->
+        "<SYNTAX ERROR>\n"
+    | 528 ->
+        "<SYNTAX ERROR>\n"
+    | 529 ->
+        "<SYNTAX ERROR>\n"
+    | 530 ->
+        "<SYNTAX ERROR>\n"
+    | 531 ->
+        "<SYNTAX ERROR>\n"
+    | 2152 ->
+        "<SYNTAX ERROR>\n"
+    | 2154 ->
+        "<SYNTAX ERROR>\n"
     | 2143 ->
         "<SYNTAX ERROR>\n"
-    | 2145 ->
+    | 1908 ->
         "<SYNTAX ERROR>\n"
-    | 2134 ->
+    | 1909 ->
         "<SYNTAX ERROR>\n"
-    | 1899 ->
+    | 1912 ->
         "<SYNTAX ERROR>\n"
-    | 1900 ->
+    | 1913 ->
         "<SYNTAX ERROR>\n"
-    | 1903 ->
+    | 1915 ->
         "<SYNTAX ERROR>\n"
-    | 1904 ->
+    | 1979 ->
         "<SYNTAX ERROR>\n"
-    | 1906 ->
+    | 1980 ->
         "<SYNTAX ERROR>\n"
-    | 1970 ->
+    | 1981 ->
         "<SYNTAX ERROR>\n"
-    | 1971 ->
+    | 2029 ->
         "<SYNTAX ERROR>\n"
-    | 1972 ->
+    | 2030 ->
+        "<SYNTAX ERROR>\n"
+    | 2031 ->
+        "<SYNTAX ERROR>\n"
+    | 2032 ->
+        "<SYNTAX ERROR>\n"
+    | 2033 ->
+        "<SYNTAX ERROR>\n"
+    | 2034 ->
+        "<SYNTAX ERROR>\n"
+    | 2035 ->
+        "<SYNTAX ERROR>\n"
+    | 1982 ->
         "<SYNTAX ERROR>\n"
     | 2020 ->
         "<SYNTAX ERROR>\n"
@@ -1286,85 +1302,85 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2024 ->
         "<SYNTAX ERROR>\n"
-    | 2025 ->
+    | 2037 ->
         "<SYNTAX ERROR>\n"
-    | 2026 ->
+    | 2158 ->
         "<SYNTAX ERROR>\n"
-    | 1973 ->
+    | 2159 ->
         "<SYNTAX ERROR>\n"
-    | 2011 ->
-        "<SYNTAX ERROR>\n"
-    | 2012 ->
-        "<SYNTAX ERROR>\n"
-    | 2013 ->
-        "<SYNTAX ERROR>\n"
-    | 2014 ->
-        "<SYNTAX ERROR>\n"
-    | 2015 ->
-        "<SYNTAX ERROR>\n"
-    | 2028 ->
-        "<SYNTAX ERROR>\n"
-    | 2149 ->
-        "<SYNTAX ERROR>\n"
-    | 2150 ->
-        "<SYNTAX ERROR>\n"
-    | 2073 ->
-        "<SYNTAX ERROR>\n"
-    | 2076 ->
-        "<SYNTAX ERROR>\n"
-    | 2077 ->
-        "<SYNTAX ERROR>\n"
-    | 2078 ->
-        "<SYNTAX ERROR>\n"
-    | 2079 ->
-        "<SYNTAX ERROR>\n"
-    | 2080 ->
-        "<SYNTAX ERROR>\n"
-    | 2081 ->
+    | 2082 ->
         "<SYNTAX ERROR>\n"
     | 2085 ->
         "<SYNTAX ERROR>\n"
+    | 2086 ->
+        "<SYNTAX ERROR>\n"
+    | 2087 ->
+        "<SYNTAX ERROR>\n"
+    | 2088 ->
+        "<SYNTAX ERROR>\n"
+    | 2089 ->
+        "<SYNTAX ERROR>\n"
     | 2090 ->
+        "<SYNTAX ERROR>\n"
+    | 2094 ->
+        "<SYNTAX ERROR>\n"
+    | 2099 ->
         "<SYNTAX ERROR>\n"
     | 455 ->
         "<SYNTAX ERROR>\n"
     | 456 ->
         "<SYNTAX ERROR>\n"
-    | 2091 ->
-        "<SYNTAX ERROR>\n"
-    | 2092 ->
-        "<SYNTAX ERROR>\n"
-    | 2093 ->
-        "<SYNTAX ERROR>\n"
-    | 441 ->
-        "<SYNTAX ERROR>\n"
-    | 466 ->
-        "<SYNTAX ERROR>\n"
-    | 2098 ->
-        "<SYNTAX ERROR>\n"
-    | 2107 ->
-        "<SYNTAX ERROR>\n"
-    | 2099 ->
-        "<SYNTAX ERROR>\n"
     | 2100 ->
+        "<SYNTAX ERROR>\n"
+    | 2101 ->
         "<SYNTAX ERROR>\n"
     | 2102 ->
         "<SYNTAX ERROR>\n"
-    | 2103 ->
+    | 441 ->
         "<SYNTAX ERROR>\n"
-    | 2104 ->
+    | 471 ->
         "<SYNTAX ERROR>\n"
-    | 2154 ->
+    | 2107 ->
         "<SYNTAX ERROR>\n"
-    | 2155 ->
+    | 2116 ->
+        "<SYNTAX ERROR>\n"
+    | 2108 ->
         "<SYNTAX ERROR>\n"
     | 2109 ->
         "<SYNTAX ERROR>\n"
+    | 2111 ->
+        "<SYNTAX ERROR>\n"
+    | 2112 ->
+        "<SYNTAX ERROR>\n"
+    | 2113 ->
+        "<SYNTAX ERROR>\n"
+    | 2163 ->
+        "<SYNTAX ERROR>\n"
+    | 2164 ->
+        "<SYNTAX ERROR>\n"
     | 2118 ->
+        "<SYNTAX ERROR>\n"
+    | 2127 ->
+        "<SYNTAX ERROR>\n"
+    | 2128 ->
+        "<SYNTAX ERROR>\n"
+    | 2129 ->
+        "<SYNTAX ERROR>\n"
+    | 2130 ->
+        "<SYNTAX ERROR>\n"
+    | 2131 ->
+        "<SYNTAX ERROR>\n"
+    | 2132 ->
+        "<SYNTAX ERROR>\n"
+    | 2133 ->
         "<SYNTAX ERROR>\n"
     | 2119 ->
         "<SYNTAX ERROR>\n"
     | 2120 ->
+        "<SYNTAX ERROR>\n"
+    | 2168 ->
+        "<SYNTAX ERROR>\n"
+    | 2169 ->
         "<SYNTAX ERROR>\n"
     | 2121 ->
         "<SYNTAX ERROR>\n"
@@ -1374,89 +1390,43 @@ let message =
         "<SYNTAX ERROR>\n"
     | 2124 ->
         "<SYNTAX ERROR>\n"
-    | 2110 ->
+    | 547 ->
         "<SYNTAX ERROR>\n"
-    | 2111 ->
+    | 548 ->
         "<SYNTAX ERROR>\n"
-    | 2159 ->
+    | 552 ->
         "<SYNTAX ERROR>\n"
-    | 2160 ->
+    | 553 ->
         "<SYNTAX ERROR>\n"
-    | 2112 ->
+    | 2329 ->
         "<SYNTAX ERROR>\n"
-    | 2113 ->
+    | 2331 ->
         "<SYNTAX ERROR>\n"
-    | 2114 ->
+    | 2332 ->
         "<SYNTAX ERROR>\n"
-    | 2115 ->
-        "<SYNTAX ERROR>\n"
-    | 538 ->
-        "<SYNTAX ERROR>\n"
-    | 539 ->
-        "<SYNTAX ERROR>\n"
-    | 543 ->
-        "<SYNTAX ERROR>\n"
-    | 544 ->
-        "<SYNTAX ERROR>\n"
-    | 2320 ->
-        "<SYNTAX ERROR>\n"
-    | 2322 ->
-        "<SYNTAX ERROR>\n"
-    | 2323 ->
-        "<SYNTAX ERROR>\n"
-    | 2324 ->
-        "<SYNTAX ERROR>\n"
-    | 856 ->
-        "<SYNTAX ERROR>\n"
-    | 857 ->
-        "<SYNTAX ERROR>\n"
-    | 859 ->
-        "<SYNTAX ERROR>\n"
-    | 860 ->
-        "<SYNTAX ERROR>\n"
-    | 1867 ->
+    | 2333 ->
         "<SYNTAX ERROR>\n"
     | 865 ->
         "<SYNTAX ERROR>\n"
     | 866 ->
         "<SYNTAX ERROR>\n"
-    | 867 ->
-        "<SYNTAX ERROR>\n"
     | 868 ->
         "<SYNTAX ERROR>\n"
     | 869 ->
         "<SYNTAX ERROR>\n"
-    | 1866 ->
-        "<SYNTAX ERROR>\n"
-    | 861 ->
-        "<SYNTAX ERROR>\n"
-    | 862 ->
-        "<SYNTAX ERROR>\n"
-    | 863 ->
-        "<SYNTAX ERROR>\n"
-    | 864 ->
-        "<SYNTAX ERROR>\n"
-    | 1883 ->
-        "<SYNTAX ERROR>\n"
-    | 622 ->
-        "<SYNTAX ERROR>\n"
-    | 843 ->
-        "<SYNTAX ERROR>\n"
-    | 845 ->
-        "<SYNTAX ERROR>\n"
-    | 846 ->
-        "<SYNTAX ERROR>\n"
     | 1876 ->
         "<SYNTAX ERROR>\n"
-    | 1877 ->
+    | 874 ->
         "<SYNTAX ERROR>\n"
-    | 1878 ->
+    | 875 ->
         "<SYNTAX ERROR>\n"
-    | 1879 ->
+    | 876 ->
         "<SYNTAX ERROR>\n"
-    | 1880 ->
+    | 877 ->
         "<SYNTAX ERROR>\n"
-    | 1881 ->
+    | 878 ->
+        "<SYNTAX ERROR>\n"
+    | 1875 ->
         "<SYNTAX ERROR>\n"
     | 870 ->
         "<SYNTAX ERROR>\n"
@@ -1466,199 +1436,223 @@ let message =
         "<SYNTAX ERROR>\n"
     | 873 ->
         "<SYNTAX ERROR>\n"
-    | 876 ->
+    | 1892 ->
         "<SYNTAX ERROR>\n"
-    | 877 ->
+    | 631 ->
         "<SYNTAX ERROR>\n"
-    | 1036 ->
+    | 852 ->
         "<SYNTAX ERROR>\n"
-    | 1037 ->
+    | 854 ->
         "<SYNTAX ERROR>\n"
-    | 1038 ->
+    | 855 ->
         "<SYNTAX ERROR>\n"
-    | 1039 ->
+    | 1885 ->
         "<SYNTAX ERROR>\n"
-    | 1040 ->
+    | 1886 ->
         "<SYNTAX ERROR>\n"
-    | 1041 ->
+    | 1887 ->
+        "<SYNTAX ERROR>\n"
+    | 1888 ->
+        "<SYNTAX ERROR>\n"
+    | 1889 ->
+        "<SYNTAX ERROR>\n"
+    | 1890 ->
+        "<SYNTAX ERROR>\n"
+    | 879 ->
+        "<SYNTAX ERROR>\n"
+    | 880 ->
+        "<SYNTAX ERROR>\n"
+    | 881 ->
+        "<SYNTAX ERROR>\n"
+    | 882 ->
+        "<SYNTAX ERROR>\n"
+    | 885 ->
+        "<SYNTAX ERROR>\n"
+    | 886 ->
         "<SYNTAX ERROR>\n"
     | 1045 ->
         "<SYNTAX ERROR>\n"
+    | 1046 ->
+        "<SYNTAX ERROR>\n"
+    | 1047 ->
+        "<SYNTAX ERROR>\n"
+    | 1048 ->
+        "<SYNTAX ERROR>\n"
+    | 1049 ->
+        "<SYNTAX ERROR>\n"
     | 1050 ->
         "<SYNTAX ERROR>\n"
-    | 942 ->
+    | 1054 ->
         "<SYNTAX ERROR>\n"
-    | 943 ->
+    | 1059 ->
         "<SYNTAX ERROR>\n"
-    | 1051 ->
+    | 951 ->
         "<SYNTAX ERROR>\n"
-    | 1052 ->
-        "<SYNTAX ERROR>\n"
-    | 1053 ->
-        "<SYNTAX ERROR>\n"
-    | 940 ->
-        "<SYNTAX ERROR>\n"
-    | 932 ->
-        "<SYNTAX ERROR>\n"
-    | 1058 ->
-        "<SYNTAX ERROR>\n"
-    | 1147 ->
+    | 952 ->
         "<SYNTAX ERROR>\n"
     | 1060 ->
         "<SYNTAX ERROR>\n"
     | 1061 ->
         "<SYNTAX ERROR>\n"
-    | 1063 ->
+    | 1062 ->
         "<SYNTAX ERROR>\n"
-    | 1066 ->
+    | 949 ->
         "<SYNTAX ERROR>\n"
-    | 1698 ->
+    | 941 ->
         "<SYNTAX ERROR>\n"
-    | 1140 ->
+    | 1067 ->
         "<SYNTAX ERROR>\n"
-    | 1141 ->
-        "<SYNTAX ERROR>\n"
-    | 1149 ->
-        "<SYNTAX ERROR>\n"
-    | 1657 ->
-        "<SYNTAX ERROR>\n"
-    | 1658 ->
-        "<SYNTAX ERROR>\n"
-    | 1659 ->
-        "<SYNTAX ERROR>\n"
-    | 1660 ->
-        "<SYNTAX ERROR>\n"
-    | 1621 ->
-        "<SYNTAX ERROR>\n"
-    | 1622 ->
-        "<SYNTAX ERROR>\n"
-    | 1661 ->
-        "<SYNTAX ERROR>\n"
-    | 1662 ->
-        "<SYNTAX ERROR>\n"
-    | 1664 ->
-        "<SYNTAX ERROR>\n"
-    | 1626 ->
-        "<SYNTAX ERROR>\n"
-    | 1627 ->
-        "<SYNTAX ERROR>\n"
-    | 1668 ->
-        "<SYNTAX ERROR>\n"
-    | 1665 ->
-        "<SYNTAX ERROR>\n"
-    | 1666 ->
-        "<SYNTAX ERROR>\n"
-    | 1068 ->
-        "<SYNTAX ERROR>\n"
-    | 1076 ->
-        "<SYNTAX ERROR>\n"
-    | 1077 ->
-        "<SYNTAX ERROR>\n"
-    | 1078 ->
-        "<SYNTAX ERROR>\n"
-    | 1079 ->
-        "<SYNTAX ERROR>\n"
-    | 1080 ->
-        "<SYNTAX ERROR>\n"
-    | 1082 ->
-        "<SYNTAX ERROR>\n"
-    | 1083 ->
-        "<SYNTAX ERROR>\n"
-    | 1084 ->
-        "<SYNTAX ERROR>\n"
-    | 1085 ->
-        "<SYNTAX ERROR>\n"
-    | 1091 ->
-        "<SYNTAX ERROR>\n"
-    | 1092 ->
-        "<SYNTAX ERROR>\n"
-    | 1094 ->
-        "<SYNTAX ERROR>\n"
-    | 1095 ->
-        "<SYNTAX ERROR>\n"
-    | 1099 ->
-        "<SYNTAX ERROR>\n"
-    | 1097 ->
-        "<SYNTAX ERROR>\n"
-    | 1100 ->
-        "<SYNTAX ERROR>\n"
-    | 1101 ->
-        "<SYNTAX ERROR>\n"
-    | 1072 ->
-        "<SYNTAX ERROR>\n"
-    | 1681 ->
-        "<SYNTAX ERROR>\n"
-    | 1682 ->
-        "<SYNTAX ERROR>\n"
-    | 1685 ->
+    | 1156 ->
         "<SYNTAX ERROR>\n"
     | 1069 ->
         "<SYNTAX ERROR>\n"
     | 1070 ->
         "<SYNTAX ERROR>\n"
+    | 1072 ->
+        "<SYNTAX ERROR>\n"
     | 1075 ->
         "<SYNTAX ERROR>\n"
-    | 1649 ->
+    | 1707 ->
+        "<SYNTAX ERROR>\n"
+    | 1149 ->
         "<SYNTAX ERROR>\n"
     | 1150 ->
         "<SYNTAX ERROR>\n"
-    | 1151 ->
+    | 1158 ->
         "<SYNTAX ERROR>\n"
-    | 1152 ->
+    | 1666 ->
         "<SYNTAX ERROR>\n"
-    | 1153 ->
+    | 1667 ->
         "<SYNTAX ERROR>\n"
-    | 1587 ->
+    | 1668 ->
         "<SYNTAX ERROR>\n"
-    | 1590 ->
+    | 1669 ->
         "<SYNTAX ERROR>\n"
-    | 1608 ->
+    | 1630 ->
         "<SYNTAX ERROR>\n"
-    | 1609 ->
+    | 1631 ->
         "<SYNTAX ERROR>\n"
-    | 1145 ->
+    | 1670 ->
         "<SYNTAX ERROR>\n"
-    | 1146 ->
+    | 1671 ->
         "<SYNTAX ERROR>\n"
-    | 1618 ->
-        "<SYNTAX ERROR>\n"
-    | 1594 ->
-        "<SYNTAX ERROR>\n"
-    | 1598 ->
-        "<SYNTAX ERROR>\n"
-    | 1600 ->
-        "<SYNTAX ERROR>\n"
-    | 1601 ->
-        "<SYNTAX ERROR>\n"
-    | 1611 ->
-        "<SYNTAX ERROR>\n"
-    | 1602 ->
-        "<SYNTAX ERROR>\n"
-    | 1603 ->
-        "<SYNTAX ERROR>\n"
-    | 1604 ->
-        "<SYNTAX ERROR>\n"
-    | 1619 ->
-        "<SYNTAX ERROR>\n"
-    | 1636 ->
-        "<SYNTAX ERROR>\n"
-    | 1620 ->
-        "<SYNTAX ERROR>\n"
-    | 1645 ->
-        "<SYNTAX ERROR>\n"
-    | 1628 ->
-        "<SYNTAX ERROR>\n"
-    | 1646 ->
-        "<SYNTAX ERROR>\n"
-    | 1647 ->
+    | 1673 ->
         "<SYNTAX ERROR>\n"
     | 1635 ->
         "<SYNTAX ERROR>\n"
-    | 1632 ->
+    | 1636 ->
         "<SYNTAX ERROR>\n"
-    | 1633 ->
+    | 1677 ->
         "<SYNTAX ERROR>\n"
-    | 1634 ->
+    | 1674 ->
+        "<SYNTAX ERROR>\n"
+    | 1675 ->
+        "<SYNTAX ERROR>\n"
+    | 1077 ->
+        "<SYNTAX ERROR>\n"
+    | 1085 ->
+        "<SYNTAX ERROR>\n"
+    | 1086 ->
+        "<SYNTAX ERROR>\n"
+    | 1087 ->
+        "<SYNTAX ERROR>\n"
+    | 1088 ->
+        "<SYNTAX ERROR>\n"
+    | 1089 ->
+        "<SYNTAX ERROR>\n"
+    | 1091 ->
+        "<SYNTAX ERROR>\n"
+    | 1092 ->
+        "<SYNTAX ERROR>\n"
+    | 1093 ->
+        "<SYNTAX ERROR>\n"
+    | 1094 ->
+        "<SYNTAX ERROR>\n"
+    | 1100 ->
+        "<SYNTAX ERROR>\n"
+    | 1101 ->
+        "<SYNTAX ERROR>\n"
+    | 1103 ->
+        "<SYNTAX ERROR>\n"
+    | 1104 ->
+        "<SYNTAX ERROR>\n"
+    | 1108 ->
+        "<SYNTAX ERROR>\n"
+    | 1106 ->
+        "<SYNTAX ERROR>\n"
+    | 1109 ->
+        "<SYNTAX ERROR>\n"
+    | 1110 ->
+        "<SYNTAX ERROR>\n"
+    | 1081 ->
+        "<SYNTAX ERROR>\n"
+    | 1690 ->
+        "<SYNTAX ERROR>\n"
+    | 1691 ->
+        "<SYNTAX ERROR>\n"
+    | 1694 ->
+        "<SYNTAX ERROR>\n"
+    | 1078 ->
+        "<SYNTAX ERROR>\n"
+    | 1079 ->
+        "<SYNTAX ERROR>\n"
+    | 1084 ->
+        "<SYNTAX ERROR>\n"
+    | 1658 ->
+        "<SYNTAX ERROR>\n"
+    | 1159 ->
+        "<SYNTAX ERROR>\n"
+    | 1160 ->
+        "<SYNTAX ERROR>\n"
+    | 1161 ->
+        "<SYNTAX ERROR>\n"
+    | 1162 ->
+        "<SYNTAX ERROR>\n"
+    | 1596 ->
+        "<SYNTAX ERROR>\n"
+    | 1599 ->
+        "<SYNTAX ERROR>\n"
+    | 1617 ->
+        "<SYNTAX ERROR>\n"
+    | 1618 ->
+        "<SYNTAX ERROR>\n"
+    | 1154 ->
+        "<SYNTAX ERROR>\n"
+    | 1155 ->
+        "<SYNTAX ERROR>\n"
+    | 1627 ->
+        "<SYNTAX ERROR>\n"
+    | 1603 ->
+        "<SYNTAX ERROR>\n"
+    | 1607 ->
+        "<SYNTAX ERROR>\n"
+    | 1609 ->
+        "<SYNTAX ERROR>\n"
+    | 1610 ->
+        "<SYNTAX ERROR>\n"
+    | 1620 ->
+        "<SYNTAX ERROR>\n"
+    | 1611 ->
+        "<SYNTAX ERROR>\n"
+    | 1612 ->
+        "<SYNTAX ERROR>\n"
+    | 1613 ->
+        "<SYNTAX ERROR>\n"
+    | 1628 ->
+        "<SYNTAX ERROR>\n"
+    | 1645 ->
+        "<SYNTAX ERROR>\n"
+    | 1629 ->
+        "<SYNTAX ERROR>\n"
+    | 1654 ->
+        "<SYNTAX ERROR>\n"
+    | 1637 ->
+        "<SYNTAX ERROR>\n"
+    | 1655 ->
+        "<SYNTAX ERROR>\n"
+    | 1656 ->
+        "<SYNTAX ERROR>\n"
+    | 1644 ->
         "<SYNTAX ERROR>\n"
     | 1641 ->
         "<SYNTAX ERROR>\n"
@@ -1666,119 +1660,125 @@ let message =
         "<SYNTAX ERROR>\n"
     | 1643 ->
         "<SYNTAX ERROR>\n"
-    | 563 ->
+    | 1650 ->
+        "<SYNTAX ERROR>\n"
+    | 1651 ->
+        "<SYNTAX ERROR>\n"
+    | 1652 ->
+        "<SYNTAX ERROR>\n"
+    | 572 ->
         "<SYNTAX ERROR>\n"
     | 151 ->
         "<SYNTAX ERROR>\n"
-    | 884 ->
+    | 893 ->
         "<SYNTAX ERROR>\n"
-    | 2606 ->
+    | 2624 ->
         "<SYNTAX ERROR>\n"
-    | 925 ->
-        "<SYNTAX ERROR>\n"
-    | 920 ->
-        "<SYNTAX ERROR>\n"
-    | 2608 ->
-        "<SYNTAX ERROR>\n"
-    | 1735 ->
-        "<SYNTAX ERROR>\n"
-    | 926 ->
-        "<SYNTAX ERROR>\n"
-    | 937 ->
-        "<SYNTAX ERROR>\n"
-    | 928 ->
+    | 934 ->
         "<SYNTAX ERROR>\n"
     | 929 ->
         "<SYNTAX ERROR>\n"
-    | 2607 ->
+    | 2626 ->
         "<SYNTAX ERROR>\n"
-    | 952 ->
+    | 1744 ->
         "<SYNTAX ERROR>\n"
-    | 953 ->
+    | 935 ->
         "<SYNTAX ERROR>\n"
-    | 955 ->
+    | 946 ->
         "<SYNTAX ERROR>\n"
-    | 999 ->
+    | 937 ->
         "<SYNTAX ERROR>\n"
-    | 1000 ->
+    | 938 ->
         "<SYNTAX ERROR>\n"
-    | 1001 ->
-        "<SYNTAX ERROR>\n"
-    | 1002 ->
-        "<SYNTAX ERROR>\n"
-    | 1003 ->
-        "<SYNTAX ERROR>\n"
-    | 1004 ->
-        "<SYNTAX ERROR>\n"
-    | 1005 ->
-        "<SYNTAX ERROR>\n"
-    | 1006 ->
-        "<SYNTAX ERROR>\n"
-    | 1012 ->
-        "<SYNTAX ERROR>\n"
-    | 1014 ->
-        "<SYNTAX ERROR>\n"
-    | 1007 ->
-        "<SYNTAX ERROR>\n"
-    | 1008 ->
-        "<SYNTAX ERROR>\n"
-    | 1019 ->
-        "<SYNTAX ERROR>\n"
-    | 1020 ->
-        "<SYNTAX ERROR>\n"
-    | 1021 ->
-        "<SYNTAX ERROR>\n"
-    | 1022 ->
-        "<SYNTAX ERROR>\n"
-    | 1736 ->
-        "<SYNTAX ERROR>\n"
-    | 1737 ->
-        "<SYNTAX ERROR>\n"
-    | 788 ->
-        "<SYNTAX ERROR>\n"
-    | 1025 ->
-        "<SYNTAX ERROR>\n"
-    | 1026 ->
-        "<SYNTAX ERROR>\n"
-    | 1707 ->
-        "<SYNTAX ERROR>\n"
-    | 960 ->
+    | 2625 ->
         "<SYNTAX ERROR>\n"
     | 961 ->
         "<SYNTAX ERROR>\n"
-    | 963 ->
+    | 962 ->
         "<SYNTAX ERROR>\n"
     | 964 ->
         "<SYNTAX ERROR>\n"
+    | 1008 ->
+        "<SYNTAX ERROR>\n"
+    | 1009 ->
+        "<SYNTAX ERROR>\n"
+    | 1010 ->
+        "<SYNTAX ERROR>\n"
+    | 1011 ->
+        "<SYNTAX ERROR>\n"
+    | 1012 ->
+        "<SYNTAX ERROR>\n"
+    | 1013 ->
+        "<SYNTAX ERROR>\n"
+    | 1014 ->
+        "<SYNTAX ERROR>\n"
+    | 1015 ->
+        "<SYNTAX ERROR>\n"
+    | 1021 ->
+        "<SYNTAX ERROR>\n"
+    | 1023 ->
+        "<SYNTAX ERROR>\n"
+    | 1016 ->
+        "<SYNTAX ERROR>\n"
+    | 1017 ->
+        "<SYNTAX ERROR>\n"
+    | 1028 ->
+        "<SYNTAX ERROR>\n"
+    | 1029 ->
+        "<SYNTAX ERROR>\n"
+    | 1030 ->
+        "<SYNTAX ERROR>\n"
+    | 1031 ->
+        "<SYNTAX ERROR>\n"
+    | 1745 ->
+        "<SYNTAX ERROR>\n"
+    | 1746 ->
+        "<SYNTAX ERROR>\n"
+    | 797 ->
+        "<SYNTAX ERROR>\n"
+    | 1034 ->
+        "<SYNTAX ERROR>\n"
+    | 1035 ->
+        "<SYNTAX ERROR>\n"
+    | 1716 ->
+        "<SYNTAX ERROR>\n"
+    | 969 ->
+        "<SYNTAX ERROR>\n"
     | 970 ->
         "<SYNTAX ERROR>\n"
-    | 968 ->
+    | 972 ->
         "<SYNTAX ERROR>\n"
-    | 966 ->
+    | 973 ->
         "<SYNTAX ERROR>\n"
-    | 983 ->
-        "<SYNTAX ERROR>\n"
-    | 984 ->
-        "<SYNTAX ERROR>\n"
-    | 976 ->
+    | 979 ->
         "<SYNTAX ERROR>\n"
     | 977 ->
         "<SYNTAX ERROR>\n"
-    | 981 ->
+    | 975 ->
+        "<SYNTAX ERROR>\n"
+    | 992 ->
+        "<SYNTAX ERROR>\n"
+    | 993 ->
+        "<SYNTAX ERROR>\n"
+    | 985 ->
+        "<SYNTAX ERROR>\n"
+    | 986 ->
+        "<SYNTAX ERROR>\n"
+    | 990 ->
         "<SYNTAX ERROR>\n"
     | 76 ->
         "<SYNTAX ERROR>\n"
-    | 980 ->
+    | 989 ->
         "<SYNTAX ERROR>\n"
-    | 978 ->
+    | 987 ->
         "<SYNTAX ERROR>\n"
     | 117 ->
         "<SYNTAX ERROR>\n"
     | 256 ->
         "<SYNTAX ERROR>\n"
-    | 987 ->
+    | 996 ->
         "<SYNTAX ERROR>\n"
-    | 988 ->
+    | 997 ->
         "<SYNTAX ERROR>\n"
     | 257 ->
         "<SYNTAX ERROR>\n"
@@ -1788,133 +1788,133 @@ let message =
         "<SYNTAX ERROR>\n"
     | 410 ->
         "<SYNTAX ERROR>\n"
-    | 2399 ->
+    | 2408 ->
         "<SYNTAX ERROR>\n"
-    | 545 ->
+    | 554 ->
         "<SYNTAX ERROR>\n"
-    | 2314 ->
+    | 2323 ->
         "<SYNTAX ERROR>\n"
-    | 2315 ->
+    | 2324 ->
         "<SYNTAX ERROR>\n"
-    | 2316 ->
+    | 2325 ->
         "<SYNTAX ERROR>\n"
-    | 2317 ->
+    | 2326 ->
         "<SYNTAX ERROR>\n"
-    | 2318 ->
+    | 2327 ->
         "<SYNTAX ERROR>\n"
-    | 2319 ->
-        "<SYNTAX ERROR>\n"
-    | 1917 ->
-        "<SYNTAX ERROR>\n"
-    | 1918 ->
-        "<SYNTAX ERROR>\n"
-    | 1920 ->
-        "<SYNTAX ERROR>\n"
-    | 1925 ->
-        "<SYNTAX ERROR>\n"
-    | 1923 ->
-        "<SYNTAX ERROR>\n"
-    | 1921 ->
-        "<SYNTAX ERROR>\n"
-    | 1946 ->
-        "<SYNTAX ERROR>\n"
-    | 1947 ->
+    | 2328 ->
         "<SYNTAX ERROR>\n"
     | 1926 ->
         "<SYNTAX ERROR>\n"
     | 1927 ->
         "<SYNTAX ERROR>\n"
-    | 1944 ->
-        "<SYNTAX ERROR>\n"
     | 1929 ->
-        "<SYNTAX ERROR>\n"
-    | 1943 ->
-        "<SYNTAX ERROR>\n"
-    | 1928 ->
-        "<SYNTAX ERROR>\n"
-    | 1930 ->
-        "<SYNTAX ERROR>\n"
-    | 1931 ->
         "<SYNTAX ERROR>\n"
     | 1934 ->
         "<SYNTAX ERROR>\n"
-    | 546 ->
+    | 1932 ->
         "<SYNTAX ERROR>\n"
-    | 639 ->
+    | 1930 ->
         "<SYNTAX ERROR>\n"
-    | 1951 ->
+    | 1955 ->
+        "<SYNTAX ERROR>\n"
+    | 1956 ->
+        "<SYNTAX ERROR>\n"
+    | 1935 ->
+        "<SYNTAX ERROR>\n"
+    | 1936 ->
+        "<SYNTAX ERROR>\n"
+    | 1953 ->
+        "<SYNTAX ERROR>\n"
+    | 1938 ->
         "<SYNTAX ERROR>\n"
     | 1952 ->
         "<SYNTAX ERROR>\n"
-    | 640 ->
+    | 1937 ->
         "<SYNTAX ERROR>\n"
-    | 641 ->
+    | 1939 ->
         "<SYNTAX ERROR>\n"
-    | 547 ->
+    | 1940 ->
         "<SYNTAX ERROR>\n"
-    | 548 ->
+    | 1943 ->
         "<SYNTAX ERROR>\n"
-    | 2310 ->
+    | 555 ->
         "<SYNTAX ERROR>\n"
-    | 1907 ->
+    | 648 ->
+        "<SYNTAX ERROR>\n"
+    | 1960 ->
         "<SYNTAX ERROR>\n"
     | 1961 ->
         "<SYNTAX ERROR>\n"
-    | 1962 ->
+    | 649 ->
         "<SYNTAX ERROR>\n"
-    | 1963 ->
+    | 650 ->
         "<SYNTAX ERROR>\n"
-    | 1964 ->
+    | 556 ->
         "<SYNTAX ERROR>\n"
-    | 1965 ->
+    | 557 ->
         "<SYNTAX ERROR>\n"
-    | 1966 ->
+    | 2319 ->
         "<SYNTAX ERROR>\n"
-    | 1915 ->
+    | 1916 ->
         "<SYNTAX ERROR>\n"
-    | 2311 ->
+    | 1970 ->
         "<SYNTAX ERROR>\n"
-    | 1908 ->
+    | 1971 ->
         "<SYNTAX ERROR>\n"
-    | 918 ->
+    | 1972 ->
         "<SYNTAX ERROR>\n"
-    | 1729 ->
+    | 1973 ->
         "<SYNTAX ERROR>\n"
-    | 1728 ->
+    | 1974 ->
         "<SYNTAX ERROR>\n"
-    | 1710 ->
+    | 1975 ->
         "<SYNTAX ERROR>\n"
-    | 1711 ->
+    | 1924 ->
         "<SYNTAX ERROR>\n"
-    | 1712 ->
+    | 2320 ->
         "<SYNTAX ERROR>\n"
-    | 1713 ->
+    | 1917 ->
         "<SYNTAX ERROR>\n"
-    | 1714 ->
+    | 927 ->
         "<SYNTAX ERROR>\n"
-    | 1717 ->
+    | 1738 ->
         "<SYNTAX ERROR>\n"
-    | 939 ->
+    | 1737 ->
+        "<SYNTAX ERROR>\n"
+    | 1719 ->
         "<SYNTAX ERROR>\n"
     | 1720 ->
         "<SYNTAX ERROR>\n"
     | 1721 ->
         "<SYNTAX ERROR>\n"
-    | 1741 ->
+    | 1722 ->
         "<SYNTAX ERROR>\n"
     | 1723 ->
         "<SYNTAX ERROR>\n"
-    | 1648 ->
+    | 1726 ->
         "<SYNTAX ERROR>\n"
-    | 1724 ->
+    | 948 ->
         "<SYNTAX ERROR>\n"
-    | 1742 ->
+    | 1729 ->
         "<SYNTAX ERROR>\n"
-    | 1743 ->
+    | 1730 ->
         "<SYNTAX ERROR>\n"
-    | 2613 ->
+    | 1750 ->
         "<SYNTAX ERROR>\n"
-    | 2615 ->
+    | 1732 ->
+        "<SYNTAX ERROR>\n"
+    | 1657 ->
+        "<SYNTAX ERROR>\n"
+    | 1733 ->
+        "<SYNTAX ERROR>\n"
+    | 1751 ->
+        "<SYNTAX ERROR>\n"
+    | 1752 ->
+        "<SYNTAX ERROR>\n"
+    | 2631 ->
+        "<SYNTAX ERROR>\n"
+    | 2633 ->
         "<SYNTAX ERROR>\n"
     | 279 ->
         "<SYNTAX ERROR>\n"
@@ -1938,11 +1938,11 @@ let message =
         "<SYNTAX ERROR>\n"
     | 10 ->
         "<SYNTAX ERROR>\n"
-    | 2548 ->
+    | 2557 ->
         "<SYNTAX ERROR>\n"
     | 110 ->
         "<SYNTAX ERROR>\n"
-    | 2546 ->
+    | 2555 ->
         "Expecting one of the following:\n  - \",\" to start the type in the tuple\n  - \")\" to finish the tuple type definition\n"
     | 277 ->
         "<SYNTAX ERROR>\n"
@@ -1956,9 +1956,9 @@ let message =
         "<SYNTAX ERROR>\n"
     | 128 ->
         "<SYNTAX ERROR>\n"
-    | 2543 ->
+    | 2552 ->
         "<SYNTAX ERROR>\n"
-    | 2544 ->
+    | 2553 ->
         "<SYNTAX ERROR>\n"
     | 120 ->
         "<SYNTAX ERROR>\n"
@@ -1970,13 +1970,13 @@ let message =
         "<SYNTAX ERROR>\n"
     | 130 ->
         "<SYNTAX ERROR>\n"
-    | 2535 ->
+    | 2544 ->
         "<SYNTAX ERROR>\n"
-    | 2536 ->
+    | 2545 ->
         "<SYNTAX ERROR>\n"
-    | 2537 ->
+    | 2546 ->
         "<SYNTAX ERROR>\n"
-    | 2539 ->
+    | 2548 ->
         "<SYNTAX ERROR>\n"
     | 134 ->
         "<SYNTAX ERROR>\n"
@@ -1988,11 +1988,11 @@ let message =
         "<SYNTAX ERROR>\n"
     | 141 ->
         "<SYNTAX ERROR>\n"
-    | 488 ->
+    | 496 ->
         "<SYNTAX ERROR>\n"
-    | 487 ->
+    | 495 ->
         "<SYNTAX ERROR>\n"
-    | 490 ->
+    | 498 ->
         "<SYNTAX ERROR>\n"
     | 295 ->
         "<SYNTAX ERROR>\n"
@@ -2000,11 +2000,11 @@ let message =
         "<SYNTAX ERROR>\n"
     | 143 ->
         "<SYNTAX ERROR>\n"
-    | 2528 ->
+    | 2537 ->
         "<SYNTAX ERROR>\n"
-    | 2530 ->
+    | 2539 ->
         "<SYNTAX ERROR>\n"
-    | 2531 ->
+    | 2540 ->
         "<SYNTAX ERROR>\n"
     | 157 ->
         "<SYNTAX ERROR>\n"
@@ -2012,51 +2012,51 @@ let message =
         "<SYNTAX ERROR>\n"
     | 146 ->
         "<SYNTAX ERROR>\n"
-    | 2526 ->
+    | 2535 ->
         "<SYNTAX ERROR>\n"
     | 148 ->
         "<SYNTAX ERROR>\n"
     | 149 ->
         "<SYNTAX ERROR>\n"
-    | 2522 ->
+    | 2531 ->
         "<SYNTAX ERROR>\n"
-    | 2523 ->
+    | 2532 ->
         "<SYNTAX ERROR>\n"
-    | 2524 ->
+    | 2533 ->
         "<SYNTAX ERROR>\n"
     | 150 ->
         "<SYNTAX ERROR>\n"
     | 155 ->
         "<SYNTAX ERROR>\n"
-    | 2520 ->
+    | 2529 ->
         "<SYNTAX ERROR>\n"
-    | 2516 ->
+    | 2525 ->
         "<SYNTAX ERROR>\n"
-    | 2513 ->
+    | 2522 ->
         "<SYNTAX ERROR>\n"
-    | 2617 ->
+    | 2635 ->
         "<SYNTAX ERROR>\n"
-    | 2619 ->
+    | 2637 ->
         "<SYNTAX ERROR>\n"
-    | 2621 ->
+    | 2639 ->
         "<SYNTAX ERROR>\n"
-    | 2622 ->
+    | 2640 ->
         "<SYNTAX ERROR>\n"
-    | 783 ->
+    | 792 ->
         "<SYNTAX ERROR>\n"
-    | 785 ->
+    | 794 ->
         "<SYNTAX ERROR>\n"
-    | 796 ->
+    | 805 ->
         "<SYNTAX ERROR>\n"
-    | 786 ->
+    | 795 ->
         "<SYNTAX ERROR>\n"
-    | 778 ->
+    | 787 ->
         "<SYNTAX ERROR>\n"
-    | 623 ->
+    | 632 ->
         "<SYNTAX ERROR>\n"
-    | 587 ->
+    | 596 ->
         "<SYNTAX ERROR>\n"
-    | 759 ->
+    | 768 ->
         "<SYNTAX ERROR>\n"
     | 193 ->
         "<SYNTAX ERROR>\n"
@@ -2066,21 +2066,21 @@ let message =
         "<SYNTAX ERROR>\n"
     | 210 ->
         "<SYNTAX ERROR>\n"
+    | 812 ->
+        "<SYNTAX ERROR>\n"
+    | 813 ->
+        "<SYNTAX ERROR>\n"
+    | 842 ->
+        "<SYNTAX ERROR>\n"
     | 803 ->
         "<SYNTAX ERROR>\n"
-    | 804 ->
+    | 731 ->
         "<SYNTAX ERROR>\n"
-    | 833 ->
+    | 718 ->
         "<SYNTAX ERROR>\n"
-    | 794 ->
+    | 720 ->
         "<SYNTAX ERROR>\n"
-    | 722 ->
-        "<SYNTAX ERROR>\n"
-    | 709 ->
-        "<SYNTAX ERROR>\n"
-    | 711 ->
-        "<SYNTAX ERROR>\n"
-    | 838 ->
+    | 847 ->
         "<SYNTAX ERROR>\n"
     | 446 ->
         "<SYNTAX ERROR>\n"
@@ -2112,7 +2112,7 @@ let message =
         "<SYNTAX ERROR>\n"
     | 334 ->
         "<SYNTAX ERROR>\n"
-    | 2410 ->
+    | 2419 ->
         "<SYNTAX ERROR>\n"
     | 291 ->
         "<SYNTAX ERROR>\n"
@@ -2148,19 +2148,19 @@ let message =
         "<SYNTAX ERROR>\n"
     | 317 ->
         "<SYNTAX ERROR>\n"
-    | 729 ->
+    | 738 ->
         "<SYNTAX ERROR>\n"
-    | 712 ->
+    | 721 ->
         "<SYNTAX ERROR>\n"
-    | 714 ->
+    | 723 ->
         "<SYNTAX ERROR>\n"
-    | 699 ->
+    | 708 ->
         "<SYNTAX ERROR>\n"
-    | 668 ->
+    | 677 ->
+        "<SYNTAX ERROR>\n"
+    | 698 ->
         "<SYNTAX ERROR>\n"
     | 689 ->
-        "<SYNTAX ERROR>\n"
-    | 680 ->
         "<SYNTAX ERROR>\n"
     | 212 ->
         "<SYNTAX ERROR>\n"
@@ -2184,145 +2184,145 @@ let message =
         "<SYNTAX ERROR>\n"
     | 243 ->
         "<SYNTAX ERROR>\n"
-    | 2414 ->
+    | 2423 ->
         "<SYNTAX ERROR>\n"
-    | 2415 ->
+    | 2424 ->
         "<SYNTAX ERROR>\n"
     | 234 ->
         "<SYNTAX ERROR>\n"
     | 239 ->
         "<SYNTAX ERROR>\n"
-    | 625 ->
+    | 634 ->
         "<SYNTAX ERROR>\n"
-    | 631 ->
+    | 640 ->
         "<SYNTAX ERROR>\n"
-    | 720 ->
+    | 729 ->
         "<SYNTAX ERROR>\n"
-    | 809 ->
+    | 818 ->
         "<SYNTAX ERROR>\n"
-    | 632 ->
+    | 641 ->
         "<SYNTAX ERROR>\n"
-    | 633 ->
+    | 642 ->
         "<SYNTAX ERROR>\n"
-    | 635 ->
+    | 644 ->
         "<SYNTAX ERROR>\n"
-    | 825 ->
+    | 834 ->
         "<SYNTAX ERROR>\n"
-    | 826 ->
+    | 835 ->
         "<SYNTAX ERROR>\n"
-    | 827 ->
+    | 836 ->
         "<SYNTAX ERROR>\n"
-    | 828 ->
+    | 837 ->
         "<SYNTAX ERROR>\n"
-    | 829 ->
+    | 838 ->
         "<SYNTAX ERROR>\n"
-    | 830 ->
-        "<SYNTAX ERROR>\n"
-    | 647 ->
-        "<SYNTAX ERROR>\n"
-    | 822 ->
-        "<SYNTAX ERROR>\n"
-    | 650 ->
-        "<SYNTAX ERROR>\n"
-    | 817 ->
-        "<SYNTAX ERROR>\n"
-    | 651 ->
+    | 839 ->
         "<SYNTAX ERROR>\n"
     | 656 ->
         "<SYNTAX ERROR>\n"
-    | 667 ->
+    | 831 ->
         "<SYNTAX ERROR>\n"
-    | 675 ->
+    | 659 ->
         "<SYNTAX ERROR>\n"
-    | 683 ->
+    | 826 ->
         "<SYNTAX ERROR>\n"
-    | 2417 ->
+    | 660 ->
         "<SYNTAX ERROR>\n"
-    | 2418 ->
+    | 665 ->
         "<SYNTAX ERROR>\n"
-    | 2419 ->
+    | 676 ->
         "<SYNTAX ERROR>\n"
-    | 2420 ->
+    | 684 ->
         "<SYNTAX ERROR>\n"
-    | 2421 ->
+    | 692 ->
         "<SYNTAX ERROR>\n"
-    | 2422 ->
+    | 2426 ->
         "<SYNTAX ERROR>\n"
-    | 723 ->
+    | 2427 ->
         "<SYNTAX ERROR>\n"
-    | 734 ->
+    | 2428 ->
+        "<SYNTAX ERROR>\n"
+    | 2429 ->
+        "<SYNTAX ERROR>\n"
+    | 2430 ->
+        "<SYNTAX ERROR>\n"
+    | 2431 ->
+        "<SYNTAX ERROR>\n"
+    | 732 ->
+        "<SYNTAX ERROR>\n"
+    | 743 ->
+        "<SYNTAX ERROR>\n"
+    | 746 ->
+        "<SYNTAX ERROR>\n"
+    | 736 ->
         "<SYNTAX ERROR>\n"
     | 737 ->
         "<SYNTAX ERROR>\n"
-    | 727 ->
+    | 657 ->
         "<SYNTAX ERROR>\n"
-    | 728 ->
+    | 658 ->
         "<SYNTAX ERROR>\n"
-    | 648 ->
-        "<SYNTAX ERROR>\n"
-    | 649 ->
-        "<SYNTAX ERROR>\n"
-    | 738 ->
-        "<SYNTAX ERROR>\n"
-    | 741 ->
-        "<SYNTAX ERROR>\n"
-    | 749 ->
-        "<SYNTAX ERROR>\n"
-    | 745 ->
-        "<SYNTAX ERROR>\n"
-    | 748 ->
-        "<SYNTAX ERROR>\n"
-    | 746 ->
-        "Expecting a valid list identifier\n"
     | 747 ->
         "<SYNTAX ERROR>\n"
     | 750 ->
         "<SYNTAX ERROR>\n"
-    | 653 ->
-        "<SYNTAX ERROR>\n"
-    | 654 ->
-        "<SYNTAX ERROR>\n"
-    | 665 ->
-        "<SYNTAX ERROR>\n"
-    | 660 ->
-        "<SYNTAX ERROR>\n"
-    | 661 ->
-        "<SYNTAX ERROR>\n"
-    | 751 ->
-        "<SYNTAX ERROR>\n"
-    | 666 ->
-        "<SYNTAX ERROR>\n"
-    | 815 ->
+    | 758 ->
         "<SYNTAX ERROR>\n"
     | 754 ->
         "<SYNTAX ERROR>\n"
-    | 770 ->
+    | 757 ->
         "<SYNTAX ERROR>\n"
-    | 772 ->
+    | 755 ->
+        "Expecting a valid list identifier\n"
+    | 756 ->
         "<SYNTAX ERROR>\n"
-    | 2625 ->
+    | 759 ->
         "<SYNTAX ERROR>\n"
-    | 2639 ->
+    | 662 ->
         "<SYNTAX ERROR>\n"
-    | 2626 ->
+    | 663 ->
         "<SYNTAX ERROR>\n"
-    | 2627 ->
+    | 674 ->
         "<SYNTAX ERROR>\n"
-    | 2633 ->
+    | 669 ->
         "<SYNTAX ERROR>\n"
-    | 2634 ->
+    | 670 ->
         "<SYNTAX ERROR>\n"
-    | 2637 ->
+    | 760 ->
         "<SYNTAX ERROR>\n"
-    | 2642 ->
+    | 675 ->
         "<SYNTAX ERROR>\n"
-    | 2649 ->
+    | 824 ->
         "<SYNTAX ERROR>\n"
-    | 2648 ->
+    | 763 ->
+        "<SYNTAX ERROR>\n"
+    | 779 ->
+        "<SYNTAX ERROR>\n"
+    | 781 ->
+        "<SYNTAX ERROR>\n"
+    | 2643 ->
+        "<SYNTAX ERROR>\n"
+    | 2657 ->
+        "<SYNTAX ERROR>\n"
+    | 2644 ->
         "<SYNTAX ERROR>\n"
     | 2645 ->
         "<SYNTAX ERROR>\n"
-    | 2646 ->
+    | 2651 ->
+        "<SYNTAX ERROR>\n"
+    | 2652 ->
+        "<SYNTAX ERROR>\n"
+    | 2655 ->
+        "<SYNTAX ERROR>\n"
+    | 2660 ->
+        "<SYNTAX ERROR>\n"
+    | 2667 ->
+        "<SYNTAX ERROR>\n"
+    | 2666 ->
+        "<SYNTAX ERROR>\n"
+    | 2663 ->
+        "<SYNTAX ERROR>\n"
+    | 2664 ->
         "<SYNTAX ERROR>\n"
     | _ ->
         raise Not_found

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2019,7 +2019,7 @@ class printer  ()= object(self:'self)
     let (arityAttrs, docAtrs, stdAttrs) = partitionAttributes pcd_attributes in
     let prefix = if polymorphic then "`" else "" in
     let sourceMappedName = SourceMap (pcd_name.loc, atom (prefix ^ pcd_name.txt)) in
-    let nameOf = makeList ~postSpace:true [sourceMappedName; atom "of"] in
+    let nameOf = makeList ~postSpace:true [sourceMappedName] in
     let barName =
       let lst = if print_bar then [atom "|"; sourceMappedName] else [sourceMappedName] in
       makeList ~postSpace:true lst in


### PR DESCRIPTION
Changes: 
- remove of from lexer
- remove of from messages file
- remove of from tests
- remove of from printer
- remove of from parser generator

Most important part is the change within reason_parser.mly.

Thanks @yunxing for the tips. 