### PR TITLE
fixes #572 remove extra "values" from tuple syntax example in Type Definitions

### DIFF
--- a/mlCompared.html
+++ b/mlCompared.html
@@ -341,7 +341,7 @@ let myFuncs = {
 
 With `Reason`, types generally look like the values they represent.  There is
 only one syntactic pattern to learn for each kind of type. Whereas in `OCaml`,
-there are separate syntaxes for tuple types `(x * y)` and tuple values values
+there are separate syntaxes for tuple types `(x * y)` and tuple values
 `(x, y)`).
 
 > <table>


### PR DESCRIPTION
> Whereas in `OCaml`,
> there are separate syntaxes for tuple types `(x * y)` and tuple values **values**
> `(x, y)`).

=>

> Whereas  in `OCaml`,
> there are separate syntaxes for tuple types `(x * y)` and tuple values
> `(x, y)`).