### PR TITLE
Remove 'of' usage inside atom-reason.

### DIFF
--- a/editorSupport/atom-reason/src/Atom.re
+++ b/editorSupport/atom-reason/src/Atom.re
@@ -39,10 +39,10 @@ let trimTrailingWhiteSpace (s: string) => Js.to_string (
 
 let module JsonType = {
   type t =
-    | JsonString of string
-    | JsonNum of float
-    | JsonBool of bool
-    | JsonArray of (array t)
+    | JsonString string
+    | JsonNum float
+    | JsonBool bool
+    | JsonArray (array t)
     | JsonNull
     | Empty;
 };

--- a/editorSupport/atom-reason/src/Nuclide.re
+++ b/editorSupport/atom-reason/src/Nuclide.re
@@ -44,8 +44,8 @@ let module Diagnostic = {
       trace: option (array Trace.t)
     };
     type t =
-      | FileDiagnosticMessage of fileDiagnosticMessage
-      | ProjectDiagnosticMessage of projectDiagnosticMessage;
+      | FileDiagnosticMessage fileDiagnosticMessage
+      | ProjectDiagnosticMessage projectDiagnosticMessage;
   };
 };
 


### PR DESCRIPTION
The `npm install` step for atom-reason doesn't work at the moment, because of the `of` keyword usage. This PR removes the 'of' keyword.