### PR TITLE
List `opam update` before `opam switch` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ opam init
 # Add this to your ~/.bashrc (or ~/.zshrc):
 #   eval `opam config env`
 
+opam update
 opam switch 4.02.3
 eval `opam config env`
-opam update
 opam pin add -y merlin 'https://github.com/the-lambda-church/merlin.git#reason-0.0.1'
 opam pin add -y merlin_extend 'https://github.com/let-def/merlin-extend.git#reason-0.0.1'
 opam pin add -y reason 'https://github.com/facebook/reason.git#0.0.6'


### PR DESCRIPTION
If you have an existing opam installation, 4.02.3 may not be an existing compiler. Running `opam update` before trying to switch to it fixes the problem.