### PR TITLE
Remove usage of backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ brew install opam
 
 opam init
 # Add this to your ~/.bashrc (or ~/.zshrc):
-#   eval `opam config env`
+#   eval $(opam config env)
 
 opam update
 opam switch 4.02.3
-eval `opam config env`
+eval $(opam config env)
 opam pin add -y merlin 'https://github.com/the-lambda-church/merlin.git#reason-0.0.1'
 opam pin add -y merlin_extend 'https://github.com/let-def/merlin-extend.git#reason-0.0.1'
 opam pin add -y reason 'https://github.com/facebook/reason.git#0.0.6'
@@ -40,7 +40,7 @@ Test the [installation](#install-stable) by compiling the following program:
 
 
 ```sh
-echo print_string \"Hello world\" > Hello.re
+echo 'print_string "Hello world"' > Hello.re
 
 rebuild Hello.native # Automatically generates Hello.native from Hello.re
 


### PR DESCRIPTION
**I admit a somehow frivolous PR here. But is it that frivolous to display good habits? :) **

There are several reason to always prefer the other form
for command output substiution.  See e.g.

  http://unix.stackexchange.com/questions/126927/have-backticks-i-e-cmd-in-sh-shells-been-deprecated

for a starting point.