### PR TITLE
[Prepare Repo for being an npm package]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,12 @@ SHELL=bash -o pipefail
 
 default: build test
 
+build_without_utop: compile_error
+	cp pkg/META.in pkg/META
+	ocaml pkg/build.ml native=true native-dynlink=true utop=false
+	chmod +x $(shell pwd)/_build/src/refmt_merlin_impl.sh
+	ln -fs $(shell pwd)/_build/src/refmt_merlin_impl.sh refmt_merlin_impl.sh
+
 build: compile_error
 	cp pkg/META.in pkg/META
 	ocaml pkg/build.ml native=true native-dynlink=true utop=true

--- a/_tags
+++ b/_tags
@@ -1,6 +1,7 @@
 true: warn(@5@8@10@11@12@14@23-24@26@29@40), bin_annot, safe_string, debug
 
 <editorSupport/**>: -traverse
+<node_modules/**>: -traverse
 "formatTest": -traverse
 "src": include
 <src/*>: package(menhirLib unix compiler-libs.common ocamlbuild findlib easy-format str BetterErrors merlin_extend)

--- a/src/reason.mllib
+++ b/src/reason.mllib
@@ -6,5 +6,4 @@ Reason_config
 Syntax_util
 Reason_util
 Reason_toolchain
-Reason_utop
 Reason_parser_message


### PR DESCRIPTION
Summary:

- utop and many of its dependencies are not yet converted to an npm
package, so we make a `make` target without `rtop`/`utop` support.

- We need to therefore not export the `Reason_utop` module as part of
  the `Reason` library because that module won't even be built if
  building without `utop` support (such as when building npm from
  `Reason`.) No one is likely depending on that module being packaged in
  the Reason library - it's mainly just for building the `rtop` binary.

Is this the best way to do this? No, the best way would be to get utop + rtop installed as a result of `npm install reason`, but it will take some more time to port all of utop to a set of `npm` packages.

Reviewers: @chenglou @bsansouci @SanderSpies @yunxing 