### PR TITLE
[Reason] Add package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "reason",
+  "version": "1.2.0",
+  "description": "Reason Meta Language Toolchain",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/reason.git"
+  },
+  "config": {},
+  "keywords": [
+    "reason"
+  ],
+  "author": "",
+  "license": "BSD",
+  "homepage": "https://github.com/facebook/reason",
+  "dependencies": {
+    "BetterErrors": "https://github.com/npm-ml/BetterErrors.git#npm-1.2.0",
+    "ocaml-findlib": "https://github.com/npm-ml/ocaml-findlib.git#npm-1.6.1",
+    "menhir": "https://github.com/npm-ml/menhir.git#20160303",
+    "ocaml": "https://github.com/npm-ml/ocaml.git#npm-4.02.3",
+    "easy-format": "https://github.com/npm-ml/easy-format.git#npm-1.2.0",
+    "merlin-extend": "https://github.com/npm-ml/merlin-extend.git#npm-0.0.1"
+  },
+  "scripts": {
+    "clean": ". dependencyEnv && make clean",
+    "postinstall": ". dependencyEnv && make build_without_utop",
+    "ocamlbuildhelp": ". dependencyEnv && ocamlbuild --help"
+  }
+}


### PR DESCRIPTION
Summary:Since all of Reason's important dependencies have been converted
into npm packages, it means that people can `npm install reason`, once
we add this `package.json` file.

This will not install `rtop` - I knowingly removed `rtop` support from the `npm`
installation of `Reason` (because we haven't yet converted the `Reason`
dependencies to `npm` packages).


@chenglou  @yunxing  @bsansouci  @SanderSpies 


Once this PR is merged, you should be able to do `npm install https://github.com/facebook/reason` and it should install a completely sandboxed version of `Reason` with a completely sandboxed version of the `4.02.3` compiler.