### PR TITLE
Add support for `begin` and `end` as variable names

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,8 @@
+{
+  "name": "reason",
+  "dependencies": {
+    "@opam-alpha/camlp4": {
+      "version": "4.4.27"
+    }
+  }
+}


### PR DESCRIPTION
Use the operator swapping infrastructure to provide support for `begin` and `end`.

The challenge here is make sure the programs written in Reason with `begin` or `end`
as variable names are still representable in ocaml.

The approach is:
- During parse time, whenever we see a `begin/end` in reason, we change it to "_begin_ / _end_" in the
  AST.

- During print time, whenever we see a `_begin_/_end_` in AST, we change it to "begin / end" in the
  reason.

In this way, reason programs with "begin/end" will be formatted as "_begin_/_end_" in ocaml.

The downside with this approach is that, in some rare cases, if one writes both "begin/end" and "_being_/_end_" in reason, both will be formatted to "begin/end" (since during printing time, we format "_begin_/_end_" to "begin/end") and the compilation will likely to fail.

This fixes #603

cc @jordwalke 