### PR TITLE
Add convenient symlinks to binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,27 @@ SHELL=bash -o pipefail
 
 default: build test
 
-build_without_utop: compile_error
+setup_convenient_bin_links:
+	mkdir -p $(shell pwd)/_build/bin
+	ln -fs $(shell pwd)/_build/src/refmt_impl.native $(shell pwd)/_build/bin/refmt
+	ln -fs $(shell pwd)/_build/_reasonbuild/_build/myocamlbuild $(shell pwd)/_build/bin/reasonbuild
+	ln -fs $(shell pwd)/_build/src/ocamlmerlin_reason.native $(shell pwd)/_build/bin/ocamlmerlin-reason
+	ln -fs $(shell pwd)/_build/src/reason_error_reporter.native $(shell pwd)/_build/bin/refmterr
+	ln -fs $(shell pwd)/_build/src/reason_format_type.native $(shell pwd)/_build/bin/refmttype
+	ln -fs $(shell pwd)/_build/src/rebuild.sh $(shell pwd)/_build/bin/rebuild
+	ln -fs $(shell pwd)/_build/src/redoc.sh $(shell pwd)/_build/bin/redoc
+	ln -fs $(shell pwd)/_build/src/refmt_impl.native $(shell pwd)/_build/bin/refmt
+	ln -fs $(shell pwd)/_build/src/refmt_merlin_impl.sh $(shell pwd)/_build/bin/refmt_merlin
+	ln -fs $(shell pwd)/_build/src/reopt.sh $(shell pwd)/_build/bin/reopt
+	ln -fs $(shell pwd)/_build/src/reup.sh $(shell pwd)/_build/bin/reup
+
+build_without_utop: compile_error setup_convenient_bin_links
 	cp pkg/META.in pkg/META
 	ocaml pkg/build.ml native=true native-dynlink=true utop=false
 	chmod +x $(shell pwd)/_build/src/refmt_merlin_impl.sh
 	ln -fs $(shell pwd)/_build/src/refmt_merlin_impl.sh refmt_merlin_impl.sh
 
-build: compile_error
+build: compile_error setup_convenient_bin_links
 	cp pkg/META.in pkg/META
 	ocaml pkg/build.ml native=true native-dynlink=true utop=true
 	chmod +x $(shell pwd)/_build/src/refmt_merlin_impl.sh

--- a/package.json
+++ b/package.json
@@ -21,7 +21,17 @@
     "easy-format": "https://github.com/npm-ml/easy-format.git#npm-1.2.0",
     "merlin-extend": "https://github.com/npm-ml/merlin-extend.git#npm-0.0.1"
   },
+  "exportedEnvVars": {
+    "PATH": {
+      "val": "./_build/bin/",
+      "resolveAsRelativePath": true,
+      "global": true,
+      "globalCollisionBehavior": "joinPath"
+    }
+  },
   "scripts": {
+    "whereisocamlc": ". dependencyEnv && which ocamlc",
+    "whereisreason": ". dependencyEnv && which refmt",
     "clean": ". dependencyEnv && make clean",
     "postinstall": ". dependencyEnv && make build_without_utop",
     "ocamlbuildhelp": ". dependencyEnv && ocamlbuild --help"


### PR DESCRIPTION
Summary: This helps when we're not using an opam installation. The opam
.install file is what creates all the nice names such as `refmt`, but
since we won't always be using `opam` to bootstrap reason on `npm`, it's
nice to have some convenient renamed binary links.

Test Plan:

Reviewers: yunxing

CC: