### PR TITLE
[Reason] Add utop back to main library, but only when available.

### DIFF
--- a/pkg/META.in
+++ b/pkg/META.in
@@ -25,3 +25,13 @@ package "lib" (
   archive(native) = "reason.cmxa"
   archive(native, plugin) = "reason.cmxs"
 )
+
+package "lib_without_utop" (
+  version = "%{version}%"
+  description = "Library version of reason without utop - suitable for compilation to JS"
+  requires = "compiler-libs.common easy-format BetterErrors menhirLib"
+
+  archive(byte) = "reason_without_utop.cma"
+  archive(native) = "reason_without_utop.cmxa"
+  archive(native, plugin) = "reason_without_utop.cmxs"
+)

--- a/src/reason_without_utop.mllib
+++ b/src/reason_without_utop.mllib
@@ -6,5 +6,4 @@ Reason_config
 Syntax_util
 Reason_util
 Reason_toolchain
-Reason_utop
 Reason_parser_message


### PR DESCRIPTION
Summary:

Intelligently switches between `reason.mllib` and
`reason_without_utop.mllib` in order to generate `reason.cma` library -
depending on `utop` being installed.

The previous attempt to simply delete `reason_utop` from the library
form was not correct, because `rtop` loads the `reason.cma` library and
expects that `reason_utop` will setup `utop` correctly.

Even if `utop` is available, we still always want to generate a library
form that is guaranteed to not have `utop` installed. So we compile a
sub-library called `reason.lib_without_utop`, which will never have `utop`
even if `utop` is available. This is simply useful for being able to
compile `Reason` into JS - other than that, this sub-library isn't super
useful yet.

Test Plan:

Reviewers:

CC: