### PR TITLE
Increase expressivity of arity conversion file

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/arityConversion.re
+++ b/formatTest/typeCheckedTests/expected_output/arityConversion.re
@@ -18,3 +18,23 @@ Test.And (1, 2);
 Test.Or (1, 2);
 
 Some 1;
+
+let module M = {
+  type t = | TupleConstructorInModule (int, int);
+  type t2 = | TupleConstructor2 (int, int);
+  type t3 = | TupleConstructor3 (int, int);
+};
+
+type t2 = | TupleConstructor2 (int, int);
+
+type t3 = | TupleConstructor3 (int, int);
+
+M.TupleConstructorInModule (1, 2);
+
+M.TupleConstructor2 (1, 2);
+
+TupleConstructor2 (1, 2);
+
+M.TupleConstructor3 1 2 [@implicit_arity];
+
+TupleConstructor3 (1, 2);

--- a/formatTest/typeCheckedTests/input/arity.txt
+++ b/formatTest/typeCheckedTests/input/arity.txt
@@ -1,3 +1,6 @@
 And
 TupleConstructor
 Or
+M.TupleConstructorInModule
+TupleConstructor2
+.TupleConstructor3

--- a/formatTest/typeCheckedTests/input/arityConversion.ml
+++ b/formatTest/typeCheckedTests/input/arityConversion.ml
@@ -12,3 +12,20 @@ end;;
 let _ = Test.And (1, 2)
 let _ = Test.Or (1, 2)
 let _ = Some 1
+
+module M = struct
+  type t = TupleConstructorInModule of (int * int)
+  type t2 = TupleConstructor2 of (int * int)
+  type t3 = TupleConstructor3 of (int * int)
+end
+
+type t2 = TupleConstructor2 of (int * int)
+type t3 = TupleConstructor3 of (int * int)
+
+let _ = M.TupleConstructorInModule (1,2)
+
+let _ = M.TupleConstructor2 (1,2)
+let _ = TupleConstructor2 (1,2)
+
+let _ = M.TupleConstructor3 (1,2)
+let _ = TupleConstructor3 (1,2)


### PR DESCRIPTION
The heuristics file for unary arity constructors passed via `-heuristics-file file` only supports the constructor name and ignore any paths. This expressivity is not enough if there are different constructors with the same name in different modules.

This adds support for specific paths, as in `M.TupleConstructorInModule`, to specify that we refer to the constructor inside module `M`.
There is also support for `.Constructor` which is a variant of `Constructor` that explicitly identifies direct uses of a constructor, without a module path. This is required to specify that a direct constructor has arity 1, without affecting constructors with the same name accessed via a module path.
