### PR TITLE
Add missing paren in mlCompared

### DIFF
--- a/mlCompared.html
+++ b/mlCompared.html
@@ -739,7 +739,7 @@ let res = match x with
 type myVariant =
    | HasNothing
    | HasSingleInt int
-   | HasSingleTuple int, int)
+   | HasSingleTuple (int, int)
    | HasMultipleInts int int
    | HasMultipleTuples
       (int, int) (int, int);


### PR DESCRIPTION
Was just flicking through the docs of interest, and spotted what I assume (possibly incorrectly) is a typo.