### PR TITLE
Use built in variable for make

### DIFF
--- a/opam
+++ b/opam
@@ -11,7 +11,7 @@ dev-repo: "git://github.com/facebook/reason.git"
 tags: [ "syntax" ]
 substs: [ "pkg/META" ]
 build: [
-  ["make" "compile_error"]
+  [make "compile_error"]
   ["ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
                          "native-dynlink=%{ocaml-native-dynlink}%"
                          "utop=%{utop:installed}%"]


### PR DESCRIPTION
Fixes this warning:

>  Command 'make' called directly, use the built-in variable instead

Based this fix on what I saw in https://github.com/AltGr/Camelus/issues/2

I'm not sure how to test this locally, would appreciate if someone could double check this is good.