### PR TITLE
Switch all string regex functions to use ocaml-re

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,3 +1,3 @@
-PKG utop str merlin_extend compiler-libs easy-format
+PKG utop str merlin_extend compiler-libs easy-format re.str
 B _build/src
 S src

--- a/_tags
+++ b/_tags
@@ -4,8 +4,8 @@ true: warn(@5@8@10@11@12@14@23-24@26@29@40), bin_annot, safe_string, debug
 <node_modules/**>: -traverse
 "formatTest": -traverse
 "src": include
-<src/*>: package(menhirLib unix compiler-libs.common ocamlbuild findlib easy-format str BetterErrors merlin_extend)
-<src/reason_utop.*>: package(menhirLib utop str)
+<src/*>: package(menhirLib unix compiler-libs.common ocamlbuild findlib easy-format str BetterErrors merlin_extend re.str)
+<src/reason_utop.*>: package(menhirLib utop str re.str)
 
 <src_gen/*>: package(sedlex str)
 

--- a/opam
+++ b/opam
@@ -26,6 +26,7 @@ depends: [
   "utop"         {>= "1.17"}
   "BetterErrors" {>= "0.0.1"}
   "menhir"       {>= "20160303"}
+  "re"           {>= "1.5.0"}
 ]
 depopts: [
 ]

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "ocaml": "https://github.com/npm-ml/ocaml.git#npm-4.02.3",
     "easy-format": "https://github.com/npm-ml/easy-format.git#npm-1.2.0",
     "merlin-extend": "https://github.com/npm-ml/merlin-extend.git#npm-0.0.1",
-    "dependency-env": "https://github.com/npm-ml/dependency-env.git"
+    "dependency-env": "https://github.com/npm-ml/dependency-env.git",
+    "re": "https://github.com/npm-ml/re.git#npm-1.6.0"
   },
   "exportedEnvVars": {
     "PATH": {

--- a/pkg/META.in
+++ b/pkg/META.in
@@ -19,7 +19,7 @@ archive(byte, toploop, pkg_utop) += "reason_utop.cmo"
 package "lib" (
   version = "%{version}%"
   description = "Library version of reason"
-  requires = "compiler-libs.common easy-format BetterErrors menhirLib"
+  requires = "compiler-libs.common easy-format BetterErrors menhirLib re.str"
 
   archive(byte) = "reason.cma"
   archive(native) = "reason.cmxa"
@@ -29,7 +29,7 @@ package "lib" (
 package "lib_without_utop" (
   version = "%{version}%"
   description = "Library version of reason without utop - suitable for compilation to JS"
-  requires = "compiler-libs.common easy-format BetterErrors menhirLib"
+  requires = "compiler-libs.common easy-format BetterErrors menhirLib re.str"
 
   archive(byte) = "reason_without_utop.cma"
   archive(native) = "reason_without_utop.cmxa"

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -452,7 +452,7 @@ let rules = [
 ]
 (* without_prefixed_backslashes removes any prefixing backslashes *)
 let without_prefixed_backslashes str =
-  Str.replace_first (Str.regexp "\\\\*\\(.*\\)") ("\\1") str
+  Re_str.replace_first (Re_str.regexp "\\\\*\\(.*\\)") ("\\1") str
 
 (* Assuming it's an infix function application. *)
 let associatedInfixFunctionPrecedence s =
@@ -1167,7 +1167,7 @@ let isListy = function
 
 
 let strip_trailing_whitespace str =
-   Str.global_replace (Str.regexp " +$") "" str
+   Re_str.global_replace (Re_str.regexp " +$") "" str
 
 let easyFormatToFormatter f x =
   let buf = Buffer.create 1000 in
@@ -1235,20 +1235,20 @@ let space = " "
 (* Can't you tell the difference? *)
 let tab = "	"
 let lineZeroHasMeaningfulContent str =
-  not (Str.string_match (Str.regexp ("^/[\\*" ^ space ^ tab ^ "]*$")) str 0)
+  not (Re_str.string_match (Re_str.regexp ("^/[\\*" ^ space ^ tab ^ "]*$")) str 0)
 
 let beginsWithStar str =
-  Str.string_match (Str.regexp ("^[" ^ space ^ tab ^ "]*\\*")) str 0
+  Re_str.string_match (Re_str.regexp ("^[" ^ space ^ tab ^ "]*\\*")) str 0
 
 let numLeadingSpace str =
   (* Actually, always true *)
-  if Str.string_match (Str.regexp ("^[" ^ space ^ tab ^ "]*")) str 0 then
-    String.length (Str.matched_string str)
+  if Re_str.string_match (Re_str.regexp ("^[" ^ space ^ tab ^ "]*")) str 0 then
+    String.length (Re_str.matched_string str)
   else 0
 
 let spaceBeforeMeaningfulContent str =
-  if Str.string_match (Str.regexp ("^/[\\*" ^ space ^ tab ^ "]*")) str 0 then
-    String.length (Str.matched_string str)
+  if Re_str.string_match (Re_str.regexp ("^/[\\*" ^ space ^ tab ^ "]*")) str 0 then
+    String.length (Re_str.matched_string str)
   else 0
 
 (* Computes the smallest leading spaces for non-empty lines *)
@@ -1266,7 +1266,7 @@ let smallestLeadingSpaces strs =
   smallestLeadingSpaces 99999 strs
 
 let formatItemComment (str, commLoc, physCommLoc) =
-  let commLines = Str.split_delim (Str.regexp "\n") ("/*" ^ str ^ "*/") in
+  let commLines = Re_str.split_delim (Re_str.regexp "\n") ("/*" ^ str ^ "*/") in
   match commLines with
   | [] -> easyAtom ""
   | [hd] ->


### PR DESCRIPTION
This removes the c regex dependency that str uses and allows pretty printer
to be compiled by js_of_ocaml and run in the browser.

I am pretty far from an expert in ocaml build systems, so I sort of just ended up adding "re.str" to every meta file that looked relevant. I may have over-applied or missed some places. If so, please let me know and I'll update accordingly!