### PR TITLE
Provide functions to pretty print the ast to string

### DIFF
--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -891,10 +891,8 @@ let configure ~width ~assumeExplicitArity ~constructorLists = (
   configuredSettings := {defaultSettings with width; assumeExplicitArity; constructorLists}
 )
 
-let string_of_formatter (f: (Format.formatter -> 'a -> 'b)) x =
-  ignore (flush_str_formatter ());
-  f str_formatter x;
-  flush_str_formatter ()
+let string_of_formatter f x =
+  Format.asprintf "%a" f x
 
 let createFormatter () =
 let module Formatter = struct

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -891,6 +891,11 @@ let configure ~width ~assumeExplicitArity ~constructorLists = (
   configuredSettings := {defaultSettings with width; assumeExplicitArity; constructorLists}
 )
 
+let string_of_formatter (f: (Format.formatter -> 'a -> 'b)) x =
+  ignore (flush_str_formatter ());
+  f str_formatter x;
+  flush_str_formatter ()
+
 let createFormatter () =
 let module Formatter = struct
 


### PR DESCRIPTION
Gives an alternative to printing to stdout. I think this could also be achieved without a new function by moving the responsibility of flush to the caller.