### PR TITLE
Remove Str dependency

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,3 +1,3 @@
-PKG utop str merlin_extend compiler-libs easy-format re.str
+PKG utop merlin_extend compiler-libs easy-format re.str
 B _build/src
 S src

--- a/_tags
+++ b/_tags
@@ -4,9 +4,9 @@ true: warn(@5@8@10@11@12@14@23-24@26@29@40), bin_annot, safe_string, debug
 <node_modules/**>: -traverse
 "formatTest": -traverse
 "src": include
-<src/*>: package(menhirLib unix compiler-libs.common ocamlbuild findlib easy-format str BetterErrors merlin_extend re.str)
-<src/reason_utop.*>: package(menhirLib utop str re.str)
+<src/*>: package(menhirLib unix compiler-libs.common ocamlbuild findlib easy-format BetterErrors merlin_extend re.str)
+<src/reason_utop.*>: package(menhirLib utop)
 
-<src_gen/*>: package(sedlex str)
+<src_gen/*>: package(sedlex)
 
 <src_test/*>|<src_test/**/*>: debug, reason, package(oUnit)

--- a/pkg/META.in
+++ b/pkg/META.in
@@ -10,7 +10,6 @@ archive(syntax, preprocessor, utf8) = "-ignore"
 preprocessor = "ocamlreason_preprocessor_where_does_this_end_up"
 
 # Toplevel
-archive(byte, toploop) = "@compiler-libs/ocamlcommon.cma @str/str.cma"
 archive(byte, toploop) += "@easy-format/easy_format.cmo reason.cma"
 archive(byte, toploop) += "@menhirLib/menhirLib.cmo"
 archive(byte, toploop, -pkg_utop) += "reason_toploop.cmo"

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -1265,6 +1265,8 @@ let smallestLeadingSpaces strs =
   in
   smallestLeadingSpaces 99999 strs
 
+let string_after s n = String.sub s n (String.length s - n)
+
 let formatItemComment (str, commLoc, physCommLoc) =
   let commLines = Re_str.split_delim (Re_str.regexp "\n") ("/*" ^ str ^ "*/") in
   match commLines with
@@ -1285,7 +1287,7 @@ let formatItemComment (str, commLoc, physCommLoc) =
       let numLeadingSpaceForThisLine = numLeadingSpace s in
       if String.length s == 0 then ""
       else (String.make leftPad ' ') ^
-        (Str.string_after s (min attemptRemoveCount numLeadingSpaceForThisLine)) in
+        (string_after s (min attemptRemoveCount numLeadingSpaceForThisLine)) in
     let lines = zero :: List.map padNonOpeningLine (one::tl) in
     (* Use the Str module for regex splitting *)
     makeEasyList ~inline:(true, true) ~indent:0 ~break:Always_rec (List.map easyAtom lines)


### PR DESCRIPTION
@yunxing pointed out that this dep should probably be removed entirely.

This isn't strictly necessary for compile to JS because the function used doesn't call into C, but it prevents warnings and would make it much more obvious if a Str regex function gets added in the future.