### PR TITLE
Switch to using string_after helper function

### DIFF
--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -1440,7 +1440,7 @@ let formatComment_ txt =
        let numLeadingSpaceForThisLine = numLeadingSpace s in
        if String.length s == 0 then ""
        else (String.make leftPad ' ') ^
-              (Str.string_after s (min attemptRemoveCount numLeadingSpaceForThisLine)) in
+              (string_after s (min attemptRemoveCount numLeadingSpaceForThisLine)) in
      let lines = zero :: List.map padNonOpeningLine (one::tl) in
      makeList ~inline:(true, true) ~indent:0 ~break:Always_rec (List.map atom lines)
 


### PR DESCRIPTION
Looks like #643 added Str back which breaks the build since #659 removed the Str dependency from Reason. This switches to a helper function which uses String directly.