### PR TITLE
Activate atom plugin for ocaml too.

### DIFF
--- a/editorSupport/atom-reason/package.json
+++ b/editorSupport/atom-reason/package.json
@@ -8,7 +8,8 @@
     "Reason"
   ],
   "activationHooks": [
-    "language-reason:grammar-used"
+    "language-reason:grammar-used",
+    "language-ocaml:grammar-used"
   ],
   "devDependencies": {
     "jengaboot": "0.0.22"


### PR DESCRIPTION
Here is my photo after 2 hours of trying to understand why atom-reason loads in reason repo but does not in flow repo: ლ(ಠ益ಠლ)