### PR TITLE
[atom-reason] Fix nuclide type hint squashed layout

### DIFF
--- a/editorSupport/atom-reason/styles/fix-nuclide.less
+++ b/editorSupport/atom-reason/styles/fix-nuclide.less
@@ -1,0 +1,5 @@
+// TODO: remove this.
+// https://github.com/facebook/nuclide/issues/659#issuecomment-238198585
+.nuclide-type-hint-text-editor atom-text-editor::shadow .editor-contents--private > .scroll-view > .lines > div > div {
+  position: relative!important;
+}


### PR DESCRIPTION
See issue https://github.com/facebook/nuclide/issues/659#issuecomment-238198585
Fixes #663

Not sure how it acts on atom 1.8 though.