### PR TITLE
Give a syntax error when `of` is used before a constructor argument.

### DIFF
--- a/src/reason_lexer.mll
+++ b/src/reason_lexer.mll
@@ -103,6 +103,7 @@ let keyword_table =
     "new", NEW;
     "nonrec", NONREC;
     "object", OBJECT;
+    "of", OF;
     "open", OPEN;
     "or", OR;
 (*  "parser", PARSER; *)

--- a/src/reason_parser.messages
+++ b/src/reason_parser.messages
@@ -1,6 +1,6 @@
 use_file: SHARP LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2751.
+## Ends in an error in state: 2753.
 ##
 ## _use_file -> toplevel_directive SEMI . use_file [ # ]
 ##
@@ -12,7 +12,7 @@ use_file: SHARP LIDENT SEMI WITH
 
 use_file: SHARP LIDENT TRUE WITH
 ##
-## Ends in an error in state: 2750.
+## Ends in an error in state: 2752.
 ##
 ## _use_file -> toplevel_directive . SEMI use_file [ # ]
 ## _use_file -> toplevel_directive . EOF [ # ]
@@ -25,7 +25,7 @@ use_file: SHARP LIDENT TRUE WITH
 
 use_file: UIDENT RPAREN
 ##
-## Ends in an error in state: 2753.
+## Ends in an error in state: 2755.
 ##
 ## _use_file -> structure_item . SEMI use_file [ # ]
 ## _use_file -> structure_item . EOF [ # ]
@@ -37,28 +37,28 @@ use_file: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 948, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 918, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 928, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 957, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 927, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2742, spurious reduction of production post_item_attributes ->
-## In state 2743, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 2744, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 2722, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 2716, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 2746, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 2723, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 949, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 919, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 929, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 958, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 928, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2744, spurious reduction of production post_item_attributes ->
+## In state 2745, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 2746, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 2724, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 2718, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 2748, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 2725, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 use_file: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2754.
+## Ends in an error in state: 2756.
 ##
 ## _use_file -> structure_item SEMI . use_file [ # ]
 ##
@@ -70,7 +70,7 @@ use_file: UIDENT SEMI WITH
 
 use_file: WITH
 ##
-## Ends in an error in state: 2747.
+## Ends in an error in state: 2749.
 ##
 ## use_file' -> . use_file [ # ]
 ##
@@ -82,7 +82,7 @@ use_file: WITH
 
 toplevel_phrase: SHARP UIDENT EOF
 ##
-## Ends in an error in state: 2714.
+## Ends in an error in state: 2716.
 ##
 ## _toplevel_phrase -> toplevel_directive . SEMI [ # ]
 ##
@@ -93,14 +93,14 @@ toplevel_phrase: SHARP UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2614, spurious reduction of production toplevel_directive -> SHARP ident
+## In state 2616, spurious reduction of production toplevel_directive -> SHARP ident
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 ##
-## Ends in an error in state: 2621.
+## Ends in an error in state: 2623.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ SEMI EOF DOT ]
 ## val_longident -> mod_longident DOT . val_ident [ SEMI EOF ]
@@ -113,7 +113,7 @@ toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 
 toplevel_phrase: SHARP UIDENT UIDENT WITH
 ##
-## Ends in an error in state: 2620.
+## Ends in an error in state: 2622.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ SEMI EOF DOT ]
 ## toplevel_directive -> SHARP ident mod_longident . [ SEMI EOF ]
@@ -127,7 +127,7 @@ toplevel_phrase: SHARP UIDENT UIDENT WITH
 
 toplevel_phrase: SHARP UIDENT WITH
 ##
-## Ends in an error in state: 2614.
+## Ends in an error in state: 2616.
 ##
 ## toplevel_directive -> SHARP ident . [ SEMI EOF ]
 ## toplevel_directive -> SHARP ident . STRING [ SEMI EOF ]
@@ -145,7 +145,7 @@ toplevel_phrase: SHARP UIDENT WITH
 
 toplevel_phrase: SHARP WITH
 ##
-## Ends in an error in state: 2613.
+## Ends in an error in state: 2615.
 ##
 ## toplevel_directive -> SHARP . ident [ SEMI EOF ]
 ## toplevel_directive -> SHARP . ident STRING [ SEMI EOF ]
@@ -163,7 +163,7 @@ toplevel_phrase: SHARP WITH
 
 toplevel_phrase: UIDENT RPAREN
 ##
-## Ends in an error in state: 2717.
+## Ends in an error in state: 2719.
 ##
 ## _toplevel_phrase -> structure_item . SEMI [ # ]
 ##
@@ -174,28 +174,28 @@ toplevel_phrase: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 948, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 918, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 928, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 957, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 927, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2742, spurious reduction of production post_item_attributes ->
-## In state 2743, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 2744, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 2722, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 2716, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 2746, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 2723, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 949, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 919, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 929, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 958, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 928, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2744, spurious reduction of production post_item_attributes ->
+## In state 2745, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 2746, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 2724, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 2718, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 2748, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 2725, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: WITH
 ##
-## Ends in an error in state: 2576.
+## Ends in an error in state: 2578.
 ##
 ## toplevel_phrase' -> . toplevel_phrase [ # ]
 ##
@@ -207,7 +207,7 @@ toplevel_phrase: WITH
 
 parse_pattern: EXCEPTION WITH
 ##
-## Ends in an error in state: 642.
+## Ends in an error in state: 643.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -219,7 +219,7 @@ parse_pattern: EXCEPTION WITH
 
 parse_pattern: LAZY WITH
 ##
-## Ends in an error in state: 619.
+## Ends in an error in state: 620.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -231,7 +231,7 @@ parse_pattern: LAZY WITH
 
 parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ##
-## Ends in an error in state: 699.
+## Ends in an error in state: 700.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error RBRACE COMMA BAR ]
 ## lbl_pattern -> label_longident COLON pattern . [ error RBRACE COMMA ]
@@ -243,14 +243,14 @@ parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 573, spurious reduction of production pattern -> pattern_without_or
+## In state 574, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 531.
+## Ends in an error in state: 532.
 ##
 ## lbl_pattern -> label_longident COLON . pattern [ error RBRACE COMMA ]
 ##
@@ -262,7 +262,7 @@ parse_pattern: LBRACE LIDENT COLON WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 616.
+## Ends in an error in state: 617.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -275,7 +275,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 526.
+## Ends in an error in state: 527.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA UNDERSCORE . opt_comma [ error RBRACE ]
 ##
@@ -287,7 +287,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 
 parse_pattern: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 525.
+## Ends in an error in state: 526.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA . [ error RBRACE ]
 ## lbl_pattern_list -> lbl_pattern COMMA . UNDERSCORE opt_comma [ error RBRACE ]
@@ -301,7 +301,7 @@ parse_pattern: LBRACE LIDENT COMMA WITH
 
 parse_pattern: LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 530.
+## Ends in an error in state: 531.
 ##
 ## lbl_pattern -> label_longident . COLON pattern [ error RBRACE COMMA ]
 ## lbl_pattern -> label_longident . [ error RBRACE COMMA ]
@@ -314,7 +314,7 @@ parse_pattern: LBRACE LIDENT WITH
 
 parse_pattern: LBRACE WITH
 ##
-## Ends in an error in state: 615.
+## Ends in an error in state: 616.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -327,7 +327,7 @@ parse_pattern: LBRACE WITH
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 612.
+## Ends in an error in state: 613.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET BAR ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT pattern . [ error SEMI RBRACKET ]
@@ -339,14 +339,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 573, spurious reduction of production pattern -> pattern_without_or
+## In state 574, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT WITH
 ##
-## Ends in an error in state: 611.
+## Ends in an error in state: 612.
 ##
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT . pattern [ error SEMI RBRACKET ]
 ##
@@ -358,7 +358,7 @@ Expecting a valid list identifier
 
 parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 613.
+## Ends in an error in state: 614.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ COMMA ]
@@ -371,14 +371,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 573, spurious reduction of production pattern -> pattern_without_or
+## In state 574, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 610.
+## Ends in an error in state: 611.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ COMMA ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA . DOTDOTDOT pattern [ error SEMI RBRACKET ]
@@ -392,7 +392,7 @@ parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKET UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 614.
+## Ends in an error in state: 615.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern . [ COMMA ]
@@ -405,14 +405,14 @@ parse_pattern: LBRACKET UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 573, spurious reduction of production pattern -> pattern_without_or
+## In state 574, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 606.
+## Ends in an error in state: 607.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -425,7 +425,7 @@ parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LBRACKET WITH
 ##
-## Ends in an error in state: 603.
+## Ends in an error in state: 604.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -439,7 +439,7 @@ parse_pattern: LBRACKET WITH
 
 parse_pattern: LBRACKETBAR MINUS WITH
 ##
-## Ends in an error in state: 513.
+## Ends in an error in state: 514.
 ##
 ## signed_constant -> MINUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> MINUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -455,7 +455,7 @@ parse_pattern: LBRACKETBAR MINUS WITH
 
 parse_pattern: LBRACKETBAR PLUS WITH
 ##
-## Ends in an error in state: 512.
+## Ends in an error in state: 513.
 ##
 ## signed_constant -> PLUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> PLUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -471,7 +471,7 @@ parse_pattern: LBRACKETBAR PLUS WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 593.
+## Ends in an error in state: 594.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -483,14 +483,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 573, spurious reduction of production pattern -> pattern_without_or
+## In state 574, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 592.
+## Ends in an error in state: 593.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ error SEMI COMMA BARRBRACKET ]
 ##
@@ -502,7 +502,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 602.
+## Ends in an error in state: 603.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -514,14 +514,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 573, spurious reduction of production pattern -> pattern_without_or
+## In state 574, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 599.
+## Ends in an error in state: 600.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -534,7 +534,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LBRACKETBAR WITH
 ##
-## Ends in an error in state: 588.
+## Ends in an error in state: 589.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -548,7 +548,7 @@ parse_pattern: LBRACKETBAR WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 2412.
+## Ends in an error in state: 2414.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -566,7 +566,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 2411.
+## Ends in an error in state: 2413.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -579,7 +579,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2410.
+## Ends in an error in state: 2412.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -597,7 +597,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2409.
+## Ends in an error in state: 2411.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -610,7 +610,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2408.
+## Ends in an error in state: 2410.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -623,7 +623,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2407.
+## Ends in an error in state: 2409.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -636,7 +636,7 @@ parse_pattern: LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN EXCEPTION WITH
 ##
-## Ends in an error in state: 540.
+## Ends in an error in state: 541.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -648,7 +648,7 @@ parse_pattern: LPAREN EXCEPTION WITH
 
 parse_pattern: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 532.
+## Ends in an error in state: 533.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -660,7 +660,7 @@ parse_pattern: LPAREN LAZY WITH
 
 parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 521.
+## Ends in an error in state: 522.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -673,7 +673,7 @@ parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 516.
+## Ends in an error in state: 517.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -686,7 +686,7 @@ parse_pattern: LPAREN LBRACE WITH
 
 parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 701.
+## Ends in an error in state: 702.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -699,7 +699,7 @@ parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LPAREN LBRACKET WITH
 ##
-## Ends in an error in state: 514.
+## Ends in an error in state: 515.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -713,7 +713,7 @@ parse_pattern: LPAREN LBRACKET WITH
 
 parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 706.
+## Ends in an error in state: 707.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -726,7 +726,7 @@ parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LPAREN LBRACKETBAR WITH
 ##
-## Ends in an error in state: 511.
+## Ends in an error in state: 512.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -740,7 +740,7 @@ parse_pattern: LPAREN LBRACKETBAR WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 714.
+## Ends in an error in state: 715.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -758,7 +758,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCOR
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 713.
+## Ends in an error in state: 714.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -771,7 +771,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 712.
+## Ends in an error in state: 713.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -789,7 +789,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 711.
+## Ends in an error in state: 712.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -802,7 +802,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 710.
+## Ends in an error in state: 711.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -815,7 +815,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 709.
+## Ends in an error in state: 710.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -828,7 +828,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 499.
+## Ends in an error in state: 500.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -841,7 +841,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 497.
+## Ends in an error in state: 498.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -855,7 +855,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 
 parse_pattern: LPAREN LPAREN MODULE WITH
 ##
-## Ends in an error in state: 496.
+## Ends in an error in state: 497.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -869,7 +869,7 @@ parse_pattern: LPAREN LPAREN MODULE WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 681.
+## Ends in an error in state: 682.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -884,7 +884,7 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 585.
+## Ends in an error in state: 586.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -896,23 +896,23 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 667, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
-## In state 674, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 673, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 677, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 668, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
+## In state 675, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 674, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 678, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 495.
+## Ends in an error in state: 496.
 ##
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -936,7 +936,7 @@ parse_pattern: LPAREN LPAREN WITH
 
 parse_pattern: LPAREN MINUS WITH
 ##
-## Ends in an error in state: 489.
+## Ends in an error in state: 490.
 ##
 ## operator -> MINUS . [ RPAREN ]
 ## signed_constant -> MINUS . INT [ error RPAREN LBRACKETAT DOTDOT COMMA COLONCOLON COLON BAR AS ]
@@ -953,7 +953,7 @@ parse_pattern: LPAREN MINUS WITH
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 237.
+## Ends in an error in state: 238.
 ##
 ## package_type -> mty_longident . [ error RPAREN ]
 ## package_type -> mty_longident . WITH package_type_cstrs [ error RPAREN ]
@@ -965,15 +965,15 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 233, spurious reduction of production ident -> UIDENT
-## In state 507, spurious reduction of production mty_longident -> ident
+## In state 234, spurious reduction of production ident -> UIDENT
+## In state 508, spurious reduction of production mty_longident -> ident
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WHILE
 ##
-## Ends in an error in state: 233.
+## Ends in an error in state: 234.
 ##
 ## ident -> UIDENT . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -987,7 +987,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WHILE
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2405.
+## Ends in an error in state: 2407.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ error RPAREN ]
 ##
@@ -999,7 +999,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2404.
+## Ends in an error in state: 2406.
 ##
 ## package_type_cstrs -> package_type_cstr . [ error RPAREN ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ error RPAREN ]
@@ -1011,20 +1011,20 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 331, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 690, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 684, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 686, spurious reduction of production _core_type -> core_type2
-## In state 697, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 685, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2402, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 332, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 691, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 685, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 687, spurious reduction of production _core_type -> core_type2
+## In state 698, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 686, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 2404, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 241.
+## Ends in an error in state: 242.
 ##
 ## package_type_cstr -> TYPE label_longident EQUAL . core_type [ error RPAREN AND ]
 ##
@@ -1036,7 +1036,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL WITH
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT WITH
 ##
-## Ends in an error in state: 240.
+## Ends in an error in state: 241.
 ##
 ## package_type_cstr -> TYPE label_longident . EQUAL core_type [ error RPAREN AND ]
 ##
@@ -1048,7 +1048,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT WITH
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 239.
+## Ends in an error in state: 240.
 ##
 ## package_type_cstr -> TYPE . label_longident EQUAL core_type [ error RPAREN AND ]
 ##
@@ -1060,7 +1060,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE WITH
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH WITH
 ##
-## Ends in an error in state: 238.
+## Ends in an error in state: 239.
 ##
 ## package_type -> mty_longident WITH . package_type_cstrs [ error RPAREN ]
 ##
@@ -1072,7 +1072,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH WITH
 
 parse_pattern: LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 232.
+## Ends in an error in state: 233.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1085,7 +1085,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON WITH
 
 parse_pattern: LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 230.
+## Ends in an error in state: 231.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . COLON package_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1099,7 +1099,7 @@ parse_pattern: LPAREN MODULE UIDENT WITH
 
 parse_pattern: LPAREN MODULE WITH
 ##
-## Ends in an error in state: 229.
+## Ends in an error in state: 230.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT COLON package_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1113,7 +1113,7 @@ parse_pattern: LPAREN MODULE WITH
 
 parse_pattern: LPAREN PLUS WITH
 ##
-## Ends in an error in state: 221.
+## Ends in an error in state: 222.
 ##
 ## operator -> PLUS . [ RPAREN ]
 ## signed_constant -> PLUS . INT [ error RPAREN LBRACKETAT DOTDOT COMMA COLONCOLON COLON BAR AS ]
@@ -1130,7 +1130,7 @@ parse_pattern: LPAREN PLUS WITH
 
 parse_pattern: LPAREN SHARP UIDENT DOT WITH
 ##
-## Ends in an error in state: 215.
+## Ends in an error in state: 216.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -1144,7 +1144,7 @@ parse_pattern: LPAREN SHARP UIDENT DOT WITH
 
 parse_pattern: LPAREN SHARP UIDENT WITH
 ##
-## Ends in an error in state: 214.
+## Ends in an error in state: 215.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -1164,7 +1164,7 @@ parse_pattern: LPAREN SHARP UIDENT WITH
 
 parse_pattern: LPAREN SHARP WITH
 ##
-## Ends in an error in state: 211.
+## Ends in an error in state: 212.
 ##
 ## _simple_pattern_not_ident -> SHARP . type_longident [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ##
@@ -1176,7 +1176,7 @@ parse_pattern: LPAREN SHARP WITH
 
 parse_pattern: LPAREN STRING DOTDOT WITH
 ##
-## Ends in an error in state: 545.
+## Ends in an error in state: 546.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ##
@@ -1188,7 +1188,7 @@ parse_pattern: LPAREN STRING DOTDOT WITH
 
 parse_pattern: LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 554.
+## Ends in an error in state: 555.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ error WITH UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS AND ]
 ##
@@ -1200,7 +1200,7 @@ parse_pattern: LPAREN UIDENT DOT WITH
 
 parse_pattern: LPAREN UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 533.
+## Ends in an error in state: 534.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1222,7 +1222,7 @@ parse_pattern: LPAREN UIDENT LPAREN WITH
 
 parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 564.
+## Ends in an error in state: 565.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1235,7 +1235,7 @@ parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 594.
+## Ends in an error in state: 595.
 ##
 ## _or_pattern -> pattern BAR . pattern [ error SEMI RPAREN RBRACKET RBRACE COMMA COLON BARRBRACKET BAR ]
 ##
@@ -1247,7 +1247,7 @@ parse_pattern: LPAREN UNDERSCORE BAR WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BACKQUOTE LIDENT GREATER
 ##
-## Ends in an error in state: 309.
+## Ends in an error in state: 310.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET tag_field . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## row_field -> tag_field . [ BAR ]
@@ -1259,15 +1259,15 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BACKQUOTE LIDENT GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 172, spurious reduction of production attributes ->
-## In state 2439, spurious reduction of production tag_field -> name_tag attributes
+## In state 173, spurious reduction of production attributes ->
+## In state 2441, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 307.
+## Ends in an error in state: 308.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET BAR row_field_list . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -1280,7 +1280,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BAR UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BAR WITH
 ##
-## Ends in an error in state: 306.
+## Ends in an error in state: 307.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET BAR . row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1292,7 +1292,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BAR WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 313.
+## Ends in an error in state: 314.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR row_field_list . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -1305,7 +1305,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 312.
+## Ends in an error in state: 313.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR . row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1317,7 +1317,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE BAR WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE WITH
 ##
-## Ends in an error in state: 311.
+## Ends in an error in state: 312.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field . BAR row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1329,7 +1329,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET WITH
 ##
-## Ends in an error in state: 305.
+## Ends in an error in state: 306.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET . tag_field RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> LBRACKET . BAR row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
@@ -1343,7 +1343,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER BAR ASSERT
 ##
-## Ends in an error in state: 302.
+## Ends in an error in state: 303.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar . row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1355,7 +1355,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER BAR ASSERT
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 303.
+## Ends in an error in state: 304.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar row_field_list . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -1368,7 +1368,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER WITH
 ##
-## Ends in an error in state: 300.
+## Ends in an error in state: 301.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER . opt_bar row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
@@ -1381,7 +1381,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS BAR ASSERT
 ##
-## Ends in an error in state: 291.
+## Ends in an error in state: 292.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar . row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar . row_field_list GREATER name_tag_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
@@ -1394,7 +1394,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS BAR ASSERT
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 ##
-## Ends in an error in state: 295.
+## Ends in an error in state: 296.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER name_tag_list . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## name_tag_list -> name_tag_list . name_tag [ RBRACKET BACKQUOTE ]
@@ -1407,7 +1407,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE GREATER BACKQUOTE
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE GREATER WITH
 ##
-## Ends in an error in state: 294.
+## Ends in an error in state: 295.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER . name_tag_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1419,7 +1419,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE GREATER WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE WITH
 ##
-## Ends in an error in state: 292.
+## Ends in an error in state: 293.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . GREATER name_tag_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
@@ -1433,7 +1433,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS WITH
 ##
-## Ends in an error in state: 290.
+## Ends in an error in state: 291.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS . opt_bar row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS . opt_bar row_field_list GREATER name_tag_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
@@ -1446,7 +1446,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LESS DOTDOT WITH
 ##
-## Ends in an error in state: 284.
+## Ends in an error in state: 285.
 ##
 ## _non_arrowed_simple_core_type -> LESS meth_list . GREATER [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1458,7 +1458,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LESS DOTDOT WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LESS WITH
 ##
-## Ends in an error in state: 283.
+## Ends in an error in state: 284.
 ##
 ## _non_arrowed_simple_core_type -> LESS . meth_list GREATER [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1470,7 +1470,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LESS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2400.
+## Ends in an error in state: 2402.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1482,7 +1482,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 ##
-## Ends in an error in state: 326.
+## Ends in an error in state: 327.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1494,7 +1494,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE QUESTION EQU
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 ##
-## Ends in an error in state: 325.
+## Ends in an error in state: 326.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION . EQUALGREATER core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1506,7 +1506,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE QUESTION WIT
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 324.
+## Ends in an error in state: 325.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . QUESTION EQUALGREATER core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
@@ -1520,7 +1520,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 323.
+## Ends in an error in state: 324.
 ##
 ## _core_type2 -> LIDENT COLONCOLON . non_arrowed_core_type QUESTION EQUALGREATER core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ## _core_type2 -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
@@ -1545,7 +1545,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT SHARP WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 328.
+## Ends in an error in state: 329.
 ##
 ## _non_arrowed_non_simple_core_type -> type_longident non_arrowed_simple_core_type_list . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
@@ -1558,7 +1558,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT UNDERSCORE WHILE
 
 parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE UIDENT COLONGREATER
 ##
-## Ends in an error in state: 246.
+## Ends in an error in state: 247.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN MODULE package_type . RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1569,16 +1569,16 @@ parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE UIDENT COLONGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 129, spurious reduction of production ident -> UIDENT
-## In state 252, spurious reduction of production mty_longident -> ident
-## In state 132, spurious reduction of production package_type -> mty_longident
+## In state 130, spurious reduction of production ident -> UIDENT
+## In state 253, spurious reduction of production mty_longident -> ident
+## In state 133, spurious reduction of production package_type -> mty_longident
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE WITH
 ##
-## Ends in an error in state: 245.
+## Ends in an error in state: 246.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN MODULE . package_type RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1590,7 +1590,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 267.
+## Ends in an error in state: 268.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN core_type_comma_list . RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## core_type_comma_list -> core_type_comma_list . COMMA core_type [ RPAREN COMMA ]
@@ -1602,13 +1602,13 @@ parse_pattern: LPAREN UNDERSCORE COLON LPAREN UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 280, spurious reduction of production core_type_comma_list -> core_type
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 281, spurious reduction of production core_type_comma_list -> core_type
 ##
 
 <SYNTAX ERROR>
@@ -1627,7 +1627,7 @@ parse_pattern: LPAREN UNDERSCORE COLON QUOTE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON SHARP LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 316.
+## Ends in an error in state: 317.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP class_longident non_arrowed_simple_core_type_list . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
@@ -1640,7 +1640,7 @@ parse_pattern: LPAREN UNDERSCORE COLON SHARP LIDENT UNDERSCORE WHILE
 
 parse_pattern: LPAREN UNDERSCORE COLON SHARP WITH
 ##
-## Ends in an error in state: 242.
+## Ends in an error in state: 243.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP . class_longident non_arrowed_simple_core_type_list [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> SHARP . class_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
@@ -1653,7 +1653,7 @@ parse_pattern: LPAREN UNDERSCORE COLON SHARP WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS QUOTE WITH
 ##
-## Ends in an error in state: 692.
+## Ends in an error in state: 693.
 ##
 ## _core_type -> core_type2 AS QUOTE . ident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AND ]
 ##
@@ -1665,7 +1665,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS QUOTE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS WITH
 ##
-## Ends in an error in state: 691.
+## Ends in an error in state: 692.
 ##
 ## _core_type -> core_type2 AS . QUOTE ident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AND ]
 ##
@@ -1677,7 +1677,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 687.
+## Ends in an error in state: 688.
 ##
 ## _core_type2 -> core_type2 EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1689,7 +1689,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 722.
+## Ends in an error in state: 723.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1704,7 +1704,7 @@ parse_pattern: LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 587.
+## Ends in an error in state: 588.
 ##
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1716,7 +1716,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 666.
+## Ends in an error in state: 667.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ RPAREN COMMA ]
 ##
@@ -1728,7 +1728,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ##
-## Ends in an error in state: 717.
+## Ends in an error in state: 718.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -1740,18 +1740,18 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 654, spurious reduction of production pattern -> pattern_without_or
-## In state 665, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 674, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 673, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 677, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 655, spurious reduction of production pattern -> pattern_without_or
+## In state 666, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 675, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 674, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 678, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 676.
+## Ends in an error in state: 677.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1763,7 +1763,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 675.
+## Ends in an error in state: 676.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint . COMMA pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1774,17 +1774,17 @@ parse_pattern: LPAREN UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 573, spurious reduction of production pattern -> pattern_without_or
-## In state 719, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 674, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 673, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 574, spurious reduction of production pattern -> pattern_without_or
+## In state 720, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 675, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 674, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN WITH
 ##
-## Ends in an error in state: 209.
+## Ends in an error in state: 210.
 ##
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -1808,7 +1808,7 @@ parse_pattern: LPAREN WITH
 
 parse_pattern: MINUS WITH
 ##
-## Ends in an error in state: 203.
+## Ends in an error in state: 204.
 ##
 ## signed_constant -> MINUS . INT [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOTDOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## signed_constant -> MINUS . FLOAT [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOTDOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1824,7 +1824,7 @@ parse_pattern: MINUS WITH
 
 parse_pattern: PLUS WITH
 ##
-## Ends in an error in state: 197.
+## Ends in an error in state: 198.
 ##
 ## signed_constant -> PLUS . INT [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOTDOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## signed_constant -> PLUS . FLOAT [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOTDOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1840,7 +1840,7 @@ parse_pattern: PLUS WITH
 
 parse_pattern: SHARP WITH
 ##
-## Ends in an error in state: 192.
+## Ends in an error in state: 193.
 ##
 ## _simple_pattern_not_ident -> SHARP . type_longident [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ##
@@ -1852,7 +1852,7 @@ parse_pattern: SHARP WITH
 
 parse_pattern: STRING DOTDOT WITH
 ##
-## Ends in an error in state: 630.
+## Ends in an error in state: 631.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ##
@@ -1864,7 +1864,7 @@ parse_pattern: STRING DOTDOT WITH
 
 parse_pattern: UIDENT DOT WITH
 ##
-## Ends in an error in state: 635.
+## Ends in an error in state: 636.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ WITH WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS AND ]
 ##
@@ -1876,7 +1876,7 @@ parse_pattern: UIDENT DOT WITH
 
 parse_pattern: UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 487.
+## Ends in an error in state: 488.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1898,7 +1898,7 @@ parse_pattern: UIDENT LPAREN WITH
 
 parse_pattern: UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 650.
+## Ends in an error in state: 651.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1911,7 +1911,7 @@ parse_pattern: UIDENT UNDERSCORE WITH
 
 parse_pattern: UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 668.
+## Ends in an error in state: 669.
 ##
 ## _or_pattern -> pattern BAR . pattern [ WHEN SEMI RPAREN RBRACKET IN EQUALGREATER EQUAL EOF COMMA COLON BAR ]
 ##
@@ -1923,7 +1923,7 @@ parse_pattern: UNDERSCORE BAR WITH
 
 parse_pattern: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2573.
+## Ends in an error in state: 2575.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EOF BAR ]
 ## parse_pattern -> pattern . EOF [ # ]
@@ -1935,14 +1935,14 @@ parse_pattern: UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 654, spurious reduction of production pattern -> pattern_without_or
+## In state 655, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: WITH
 ##
-## Ends in an error in state: 2572.
+## Ends in an error in state: 2574.
 ##
 ## parse_pattern' -> . parse_pattern [ # ]
 ##
@@ -1954,7 +1954,7 @@ parse_pattern: WITH
 
 parse_expression: UIDENT SEMI
 ##
-## Ends in an error in state: 2570.
+## Ends in an error in state: 2572.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -1988,21 +1988,21 @@ parse_expression: UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 948, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 918, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 928, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 957, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 927, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 949, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 919, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 929, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 958, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 928, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 parse_expression: WITH
 ##
-## Ends in an error in state: 2568.
+## Ends in an error in state: 2570.
 ##
 ## parse_expression' -> . parse_expression [ # ]
 ##
@@ -2014,7 +2014,7 @@ parse_expression: WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 2433.
+## Ends in an error in state: 2435.
 ##
 ## tag_field -> name_tag opt_ampersand . amper_type_list attributes [ RBRACKET GREATER BAR ]
 ##
@@ -2026,7 +2026,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 ##
-## Ends in an error in state: 2436.
+## Ends in an error in state: 2438.
 ##
 ## amper_type_list -> amper_type_list AMPERSAND . core_type [ RBRACKET LBRACKETAT GREATER BAR AMPERSAND ]
 ##
@@ -2038,7 +2038,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ##
-## Ends in an error in state: 2440.
+## Ends in an error in state: 2442.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET tag_field . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field -> tag_field . [ BAR ]
@@ -2050,15 +2050,15 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 172, spurious reduction of production attributes ->
-## In state 2439, spurious reduction of production tag_field -> name_tag attributes
+## In state 173, spurious reduction of production attributes ->
+## In state 2441, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: LBRACKET BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 167.
+## Ends in an error in state: 168.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET BAR row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2071,7 +2071,7 @@ parse_core_type: LBRACKET BAR UNDERSCORE WITH
 
 parse_core_type: LBRACKET BAR WITH
 ##
-## Ends in an error in state: 162.
+## Ends in an error in state: 163.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET BAR . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2083,7 +2083,7 @@ parse_core_type: LBRACKET BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 2444.
+## Ends in an error in state: 2446.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2096,7 +2096,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 2443.
+## Ends in an error in state: 2445.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2108,7 +2108,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE WITH
 ##
-## Ends in an error in state: 2442.
+## Ends in an error in state: 2444.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field . BAR row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2120,7 +2120,7 @@ parse_core_type: LBRACKET UNDERSCORE WITH
 
 parse_core_type: LBRACKET WITH
 ##
-## Ends in an error in state: 161.
+## Ends in an error in state: 162.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET . tag_field RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKET . BAR row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2134,7 +2134,7 @@ parse_core_type: LBRACKET WITH
 
 parse_core_type: LBRACKETGREATER BAR ASSERT
 ##
-## Ends in an error in state: 160.
+## Ends in an error in state: 161.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2146,7 +2146,7 @@ parse_core_type: LBRACKETGREATER BAR ASSERT
 
 parse_core_type: LBRACKETGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 2446.
+## Ends in an error in state: 2448.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2159,7 +2159,7 @@ parse_core_type: LBRACKETGREATER UNDERSCORE WITH
 
 parse_core_type: LBRACKETGREATER WITH
 ##
-## Ends in an error in state: 158.
+## Ends in an error in state: 159.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER . opt_bar row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2172,7 +2172,7 @@ parse_core_type: LBRACKETGREATER WITH
 
 parse_core_type: LBRACKETLESS BAR ASSERT
 ##
-## Ends in an error in state: 157.
+## Ends in an error in state: 158.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar . row_field_list GREATER name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2185,7 +2185,7 @@ parse_core_type: LBRACKETLESS BAR ASSERT
 
 parse_core_type: LBRACKETLESS UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 169.
+## Ends in an error in state: 170.
 ##
 ## row_field_list -> row_field_list BAR . row_field [ RBRACKET GREATER BAR ]
 ##
@@ -2197,7 +2197,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2451.
+## Ends in an error in state: 2453.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER name_tag_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## name_tag_list -> name_tag_list . name_tag [ RBRACKET BACKQUOTE ]
@@ -2210,7 +2210,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 ##
-## Ends in an error in state: 2450.
+## Ends in an error in state: 2452.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER . name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2222,7 +2222,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE WITH
 ##
-## Ends in an error in state: 2448.
+## Ends in an error in state: 2450.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . GREATER name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2236,7 +2236,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE WITH
 
 parse_core_type: LBRACKETLESS WITH
 ##
-## Ends in an error in state: 155.
+## Ends in an error in state: 156.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS . opt_bar row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS . opt_bar row_field_list GREATER name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2249,7 +2249,7 @@ parse_core_type: LBRACKETLESS WITH
 
 parse_core_type: LESS DOTDOT WITH
 ##
-## Ends in an error in state: 149.
+## Ends in an error in state: 150.
 ##
 ## _non_arrowed_simple_core_type -> LESS meth_list . GREATER [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2261,7 +2261,7 @@ parse_core_type: LESS DOTDOT WITH
 
 parse_core_type: LESS LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 ##
-## Ends in an error in state: 287.
+## Ends in an error in state: 288.
 ##
 ## meth_list -> field COMMA . meth_list [ GREATER ]
 ## opt_comma -> COMMA . [ GREATER ]
@@ -2274,7 +2274,7 @@ parse_core_type: LESS LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 ##
-## Ends in an error in state: 1324.
+## Ends in an error in state: 1326.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ##
@@ -2286,7 +2286,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1323.
+## Ends in an error in state: 1325.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -2299,7 +2299,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE WITH
 ##
-## Ends in an error in state: 1212.
+## Ends in an error in state: 1213.
 ##
 ## typevar_list -> typevar_list QUOTE . ident [ QUOTE DOT ]
 ##
@@ -2311,7 +2311,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE WITH
 ##
-## Ends in an error in state: 153.
+## Ends in an error in state: 154.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ RBRACE LBRACKETAT GREATER EQUALGREATER EQUAL COMMA COLONGREATER AS ]
 ## typevar_list -> QUOTE . ident [ QUOTE DOT ]
@@ -2324,7 +2324,7 @@ parse_core_type: LESS LIDENT COLON QUOTE WITH
 
 parse_core_type: LESS LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 286.
+## Ends in an error in state: 287.
 ##
 ## meth_list -> field . COMMA meth_list [ GREATER ]
 ## meth_list -> field . opt_comma [ GREATER ]
@@ -2336,24 +2336,24 @@ parse_core_type: LESS LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1329, spurious reduction of production _poly_type -> core_type
-## In state 1330, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1328, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 2453, spurious reduction of production attributes ->
-## In state 2454, spurious reduction of production field -> label COLON poly_type attributes
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1331, spurious reduction of production _poly_type -> core_type
+## In state 1332, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1330, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 2455, spurious reduction of production attributes ->
+## In state 2456, spurious reduction of production field -> label COLON poly_type attributes
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: LESS LIDENT COLON WITH
 ##
-## Ends in an error in state: 152.
+## Ends in an error in state: 153.
 ##
 ## field -> label COLON . poly_type attributes [ GREATER COMMA ]
 ##
@@ -2365,7 +2365,7 @@ parse_core_type: LESS LIDENT COLON WITH
 
 parse_core_type: LESS LIDENT WITH
 ##
-## Ends in an error in state: 151.
+## Ends in an error in state: 152.
 ##
 ## field -> label . COLON poly_type attributes [ GREATER COMMA ]
 ##
@@ -2377,7 +2377,7 @@ parse_core_type: LESS LIDENT WITH
 
 parse_core_type: LESS WITH
 ##
-## Ends in an error in state: 146.
+## Ends in an error in state: 147.
 ##
 ## _non_arrowed_simple_core_type -> LESS . meth_list GREATER [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2389,7 +2389,7 @@ parse_core_type: LESS WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2459.
+## Ends in an error in state: 2461.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2401,7 +2401,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 ##
-## Ends in an error in state: 2457.
+## Ends in an error in state: 2459.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2413,7 +2413,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 ##
-## Ends in an error in state: 2456.
+## Ends in an error in state: 2458.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION . EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2425,7 +2425,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2455.
+## Ends in an error in state: 2457.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . QUESTION EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2439,7 +2439,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE WITH
 
 parse_core_type: LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 142.
+## Ends in an error in state: 143.
 ##
 ## _core_type2 -> LIDENT COLONCOLON . non_arrowed_core_type QUESTION EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## _core_type2 -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2452,7 +2452,7 @@ parse_core_type: LIDENT COLONCOLON WITH
 
 parse_core_type: LIDENT SHARP WITH
 ##
-## Ends in an error in state: 121.
+## Ends in an error in state: 122.
 ##
 ## _non_arrowed_simple_core_type -> SHARP . class_longident [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2464,7 +2464,7 @@ parse_core_type: LIDENT SHARP WITH
 
 parse_core_type: LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 254.
+## Ends in an error in state: 255.
 ##
 ## _non_arrowed_non_simple_core_type -> type_longident non_arrowed_simple_core_type_list . [ WITH SEMI RPAREN RBRACKET RBRACE QUESTION LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2477,7 +2477,7 @@ parse_core_type: LIDENT UNDERSCORE WHILE
 
 parse_core_type: LPAREN MODULE UIDENT COLONGREATER
 ##
-## Ends in an error in state: 130.
+## Ends in an error in state: 131.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN MODULE package_type . RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2488,16 +2488,16 @@ parse_core_type: LPAREN MODULE UIDENT COLONGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 129, spurious reduction of production ident -> UIDENT
-## In state 252, spurious reduction of production mty_longident -> ident
-## In state 132, spurious reduction of production package_type -> mty_longident
+## In state 130, spurious reduction of production ident -> UIDENT
+## In state 253, spurious reduction of production mty_longident -> ident
+## In state 133, spurious reduction of production package_type -> mty_longident
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: LPAREN MODULE UIDENT SEMI
 ##
-## Ends in an error in state: 132.
+## Ends in an error in state: 133.
 ##
 ## package_type -> mty_longident . [ RPAREN COLONGREATER ]
 ## package_type -> mty_longident . WITH package_type_cstrs [ RPAREN COLONGREATER ]
@@ -2509,15 +2509,15 @@ parse_core_type: LPAREN MODULE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 129, spurious reduction of production ident -> UIDENT
-## In state 252, spurious reduction of production mty_longident -> ident
+## In state 130, spurious reduction of production ident -> UIDENT
+## In state 253, spurious reduction of production mty_longident -> ident
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2464.
+## Ends in an error in state: 2466.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ RPAREN COLONGREATER ]
 ##
@@ -2529,7 +2529,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER A
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2463.
+## Ends in an error in state: 2465.
 ##
 ## package_type_cstrs -> package_type_cstr . [ RPAREN COLONGREATER ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ RPAREN COLONGREATER ]
@@ -2541,20 +2541,20 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER W
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2461, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 2463, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 140.
+## Ends in an error in state: 141.
 ##
 ## package_type_cstr -> TYPE label_longident EQUAL . core_type [ RPAREN COLONGREATER AND ]
 ##
@@ -2566,7 +2566,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL WITH
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT WITH
 ##
-## Ends in an error in state: 139.
+## Ends in an error in state: 140.
 ##
 ## package_type_cstr -> TYPE label_longident . EQUAL core_type [ RPAREN COLONGREATER AND ]
 ##
@@ -2578,7 +2578,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT WITH
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 134.
+## Ends in an error in state: 135.
 ##
 ## package_type_cstr -> TYPE . label_longident EQUAL core_type [ RPAREN COLONGREATER AND ]
 ##
@@ -2590,7 +2590,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE WITH
 
 parse_core_type: LPAREN MODULE UIDENT WITH WITH
 ##
-## Ends in an error in state: 133.
+## Ends in an error in state: 134.
 ##
 ## package_type -> mty_longident WITH . package_type_cstrs [ RPAREN COLONGREATER ]
 ##
@@ -2602,7 +2602,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH WITH
 
 parse_core_type: LPAREN MODULE WITH
 ##
-## Ends in an error in state: 128.
+## Ends in an error in state: 129.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN MODULE . package_type RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2614,7 +2614,7 @@ parse_core_type: LPAREN MODULE WITH
 
 parse_core_type: LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 269.
+## Ends in an error in state: 270.
 ##
 ## core_type_comma_list -> core_type_comma_list COMMA . core_type [ RPAREN COMMA ]
 ##
@@ -2626,7 +2626,7 @@ parse_core_type: LPAREN UNDERSCORE COMMA WITH
 
 parse_core_type: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1267.
+## Ends in an error in state: 1269.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN core_type_comma_list . RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## core_type_comma_list -> core_type_comma_list . COMMA core_type [ RPAREN COMMA ]
@@ -2638,13 +2638,13 @@ parse_core_type: LPAREN UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 280, spurious reduction of production core_type_comma_list -> core_type
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 281, spurious reduction of production core_type_comma_list -> core_type
 ##
 
 Expecting one of the following:
@@ -2653,7 +2653,7 @@ Expecting one of the following:
 
 parse_core_type: QUOTE WITH
 ##
-## Ends in an error in state: 123.
+## Ends in an error in state: 124.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2665,7 +2665,7 @@ parse_core_type: QUOTE WITH
 
 parse_core_type: SHARP LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 2466.
+## Ends in an error in state: 2468.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP class_longident non_arrowed_simple_core_type_list . [ WITH SEMI RPAREN RBRACKET RBRACE QUESTION LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2704,7 +2704,7 @@ parse_core_type: SHARP UIDENT WITH
 
 parse_core_type: SHARP WITH
 ##
-## Ends in an error in state: 119.
+## Ends in an error in state: 120.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP . class_longident non_arrowed_simple_core_type_list [ WITH SEMI RPAREN RBRACKET RBRACE QUESTION LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> SHARP . class_longident [ WITH SEMI RPAREN RBRACKET RBRACE QUESTION LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2717,7 +2717,7 @@ parse_core_type: SHARP WITH
 
 parse_core_type: UIDENT DOT WITH
 ##
-## Ends in an error in state: 195.
+## Ends in an error in state: 196.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ RPAREN LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ RPAREN DOT ]
@@ -2776,7 +2776,7 @@ parse_core_type: UIDENT LPAREN WITH
 
 parse_core_type: UIDENT WITH
 ##
-## Ends in an error in state: 194.
+## Ends in an error in state: 195.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -2796,7 +2796,7 @@ parse_core_type: UIDENT WITH
 
 parse_core_type: UNDERSCORE AS QUOTE WITH
 ##
-## Ends in an error in state: 276.
+## Ends in an error in state: 277.
 ##
 ## _core_type -> core_type2 AS QUOTE . ident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AND AMPERSAND ]
 ##
@@ -2808,7 +2808,7 @@ parse_core_type: UNDERSCORE AS QUOTE WITH
 
 parse_core_type: UNDERSCORE AS WITH
 ##
-## Ends in an error in state: 275.
+## Ends in an error in state: 276.
 ##
 ## _core_type -> core_type2 AS . QUOTE ident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AND AMPERSAND ]
 ##
@@ -2820,7 +2820,7 @@ parse_core_type: UNDERSCORE AS WITH
 
 parse_core_type: UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 271.
+## Ends in an error in state: 272.
 ##
 ## _core_type2 -> core_type2 EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2832,7 +2832,7 @@ parse_core_type: UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2566.
+## Ends in an error in state: 2568.
 ##
 ## parse_core_type -> core_type . EOF [ # ]
 ##
@@ -2843,19 +2843,19 @@ parse_core_type: UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: WITH
 ##
-## Ends in an error in state: 2564.
+## Ends in an error in state: 2566.
 ##
 ## parse_core_type' -> . parse_core_type [ # ]
 ##
@@ -2867,7 +2867,7 @@ parse_core_type: WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 ##
-## Ends in an error in state: 2086.
+## Ends in an error in state: 2088.
 ##
 ## and_class_description -> AND . class_description_details post_item_attributes [ SEMI AND ]
 ##
@@ -2879,7 +2879,7 @@ interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ##
-## Ends in an error in state: 2085.
+## Ends in an error in state: 2087.
 ##
 ## _signature_item -> many_class_descriptions . [ SEMI ]
 ## many_class_descriptions -> many_class_descriptions . and_class_description [ SEMI AND ]
@@ -2891,22 +2891,22 @@ interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1793, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1797, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1791, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1795, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1806, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1804, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
-## In state 2058, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
-## In state 2059, spurious reduction of production post_item_attributes ->
-## In state 2060, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
+## In state 1795, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1799, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1793, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1797, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1808, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1806, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 2060, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
+## In state 2061, spurious reduction of production post_item_attributes ->
+## In state 2062, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 2057.
+## Ends in an error in state: 2059.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters COLON . class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -2918,7 +2918,7 @@ interface: CLASS LIDENT COLON WITH
 
 interface: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1610.
+## Ends in an error in state: 1612.
 ##
 ## type_parameter -> type_variance . type_variable [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLON CHAR BACKQUOTE ]
 ##
@@ -2930,7 +2930,7 @@ interface: CLASS LIDENT PLUS WITH
 
 interface: CLASS LIDENT WITH
 ##
-## Ends in an error in state: 2056.
+## Ends in an error in state: 2058.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters . COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS COLON ]
@@ -2943,7 +2943,7 @@ interface: CLASS LIDENT WITH
 
 interface: CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 2054.
+## Ends in an error in state: 2056.
 ##
 ## class_description_details -> virtual_flag . LIDENT class_type_parameters COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -2955,7 +2955,7 @@ interface: CLASS VIRTUAL LET
 
 interface: CLASS WITH
 ##
-## Ends in an error in state: 2045.
+## Ends in an error in state: 2047.
 ##
 ## many_class_descriptions -> CLASS . class_description_details post_item_attributes [ SEMI AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ SEMI AND ]
@@ -2968,7 +2968,7 @@ interface: CLASS WITH
 
 interface: EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1370.
+## Ends in an error in state: 1372.
 ##
 ## extension_constructor_declaration -> UIDENT . generalized_constructor_arguments attributes [ SEMI LBRACKETATAT BAR ]
 ##
@@ -2980,7 +2980,7 @@ interface: EXCEPTION UIDENT WITH
 
 interface: EXCEPTION WITH
 ##
-## Ends in an error in state: 2042.
+## Ends in an error in state: 2044.
 ##
 ## sig_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ SEMI ]
 ##
@@ -2992,7 +2992,7 @@ interface: EXCEPTION WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2037.
+## Ends in an error in state: 2039.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3004,7 +3004,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2036.
+## Ends in an error in state: 2038.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3015,19 +3015,19 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 2035.
+## Ends in an error in state: 2037.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3039,7 +3039,7 @@ interface: EXTERNAL LIDENT COLON WITH
 
 interface: EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 2034.
+## Ends in an error in state: 2036.
 ##
 ## _signature_item -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3051,7 +3051,7 @@ interface: EXTERNAL LIDENT WITH
 
 interface: EXTERNAL WITH
 ##
-## Ends in an error in state: 2033.
+## Ends in an error in state: 2035.
 ##
 ## _signature_item -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3063,7 +3063,7 @@ interface: EXTERNAL WITH
 
 interface: INCLUDE LBRACE OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2061.
+## Ends in an error in state: 2063.
 ##
 ## signature -> signature_item . SEMI signature [ error RBRACE ]
 ##
@@ -3074,18 +3074,18 @@ interface: INCLUDE LBRACE OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1396, spurious reduction of production post_item_attributes ->
-## In state 1397, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 2066, spurious reduction of production _signature_item -> open_statement
-## In state 2093, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 2067, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 1398, spurious reduction of production post_item_attributes ->
+## In state 1399, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 2068, spurious reduction of production _signature_item -> open_statement
+## In state 2095, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 2069, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2062.
+## Ends in an error in state: 2064.
 ##
 ## signature -> signature_item SEMI . signature [ error RBRACE ]
 ##
@@ -3097,7 +3097,7 @@ interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 
 interface: INCLUDE LBRACE WITH
 ##
-## Ends in an error in state: 1402.
+## Ends in an error in state: 1404.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LBRACE . signature error [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3110,7 +3110,7 @@ interface: INCLUDE LBRACE WITH
 
 interface: INCLUDE LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 1246.
+## Ends in an error in state: 1247.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _simple_module_type -> LBRACE . signature error [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3123,7 +3123,7 @@ interface: INCLUDE LPAREN LBRACE WITH
 
 interface: INCLUDE LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 2112.
+## Ends in an error in state: 2114.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3139,7 +3139,7 @@ interface: INCLUDE LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 2103.
+## Ends in an error in state: 2105.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3155,7 +3155,7 @@ interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 2111.
+## Ends in an error in state: 2113.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3170,7 +3170,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LID
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2110.
+## Ends in an error in state: 2112.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3182,7 +3182,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WIT
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2109.
+## Ends in an error in state: 2111.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3194,7 +3194,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2108.
+## Ends in an error in state: 2110.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3208,24 +3208,24 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 129, spurious reduction of production ident -> UIDENT
-## In state 252, spurious reduction of production mty_longident -> ident
-## In state 1411, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1445, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1441, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1409, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1446, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1442, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1410, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1447, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1443, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 130, spurious reduction of production ident -> UIDENT
+## In state 253, spurious reduction of production mty_longident -> ident
+## In state 1413, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1447, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1443, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1411, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1448, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1444, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1412, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1449, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1445, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2107.
+## Ends in an error in state: 2109.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3237,7 +3237,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2106.
+## Ends in an error in state: 2108.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3249,7 +3249,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 1245.
+## Ends in an error in state: 1246.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3263,7 +3263,7 @@ interface: INCLUDE LPAREN LPAREN WITH
 
 interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2389.
+## Ends in an error in state: 2391.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF ]
@@ -3277,19 +3277,19 @@ interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1940, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2012, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2016, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2013, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1942, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2018, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2017, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN MODULE TYPE WITH
 ##
-## Ends in an error in state: 402.
+## Ends in an error in state: 403.
 ##
 ## _non_arrowed_module_type -> MODULE TYPE . module_expr [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3301,7 +3301,7 @@ interface: INCLUDE LPAREN MODULE TYPE WITH
 
 interface: INCLUDE LPAREN MODULE WITH
 ##
-## Ends in an error in state: 401.
+## Ends in an error in state: 402.
 ##
 ## _non_arrowed_module_type -> MODULE . TYPE module_expr [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3313,7 +3313,7 @@ interface: INCLUDE LPAREN MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 ##
-## Ends in an error in state: 505.
+## Ends in an error in state: 506.
 ##
 ## ident -> UIDENT . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## mod_ext2 -> mod_ext_longident DOT UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -3327,7 +3327,7 @@ interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 504.
+## Ends in an error in state: 505.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -3341,7 +3341,7 @@ interface: INCLUDE LPAREN UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 2000.
+## Ends in an error in state: 2002.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3356,7 +3356,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1999.
+## Ends in an error in state: 2001.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3368,7 +3368,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 503.
+## Ends in an error in state: 504.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -3388,7 +3388,7 @@ interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UIDENT WHILE
 ##
-## Ends in an error in state: 1244.
+## Ends in an error in state: 1245.
 ##
 ## functor_arg_name -> UIDENT . [ COLON ]
 ## ident -> UIDENT . [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3403,7 +3403,7 @@ interface: INCLUDE LPAREN UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 ##
-## Ends in an error in state: 1982.
+## Ends in an error in state: 1984.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3416,7 +3416,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1979.
+## Ends in an error in state: 1981.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ RPAREN LPAREN DOT ]
 ## mod_ext2 -> UIDENT LPAREN mod_ext_longident . RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3436,7 +3436,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UID
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1978.
+## Ends in an error in state: 1980.
 ##
 ## mod_ext2 -> UIDENT LPAREN . mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ##
@@ -3461,7 +3461,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WIT
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1976.
+## Ends in an error in state: 1978.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3473,7 +3473,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 1991.
+## Ends in an error in state: 1993.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3486,7 +3486,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 ##
-## Ends in an error in state: 1977.
+## Ends in an error in state: 1979.
 ##
 ## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ## mod_ext_longident -> UIDENT . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3499,7 +3499,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1992.
+## Ends in an error in state: 1994.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3511,7 +3511,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1975.
+## Ends in an error in state: 1977.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3524,7 +3524,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 1974.
+## Ends in an error in state: 1976.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3537,7 +3537,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 1995.
+## Ends in an error in state: 1997.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3549,7 +3549,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER A
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER EQUAL
 ##
-## Ends in an error in state: 1994.
+## Ends in an error in state: 1996.
 ##
 ## _module_type -> module_type WITH with_constraints . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## with_constraints -> with_constraints . AND with_constraint [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3561,21 +3561,21 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER E
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 331, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 690, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 684, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 686, spurious reduction of production _core_type -> core_type2
-## In state 697, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 685, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1970, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1997, spurious reduction of production with_constraints -> with_constraint
+## In state 332, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 691, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 685, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 687, spurious reduction of production _core_type -> core_type2
+## In state 698, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 686, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1972, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1999, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1969.
+## Ends in an error in state: 1971.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3587,7 +3587,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1971.
+## Ends in an error in state: 1973.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3599,7 +3599,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ##
-## Ends in an error in state: 1973.
+## Ends in an error in state: 1975.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3611,20 +3611,20 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 331, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 690, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 684, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 686, spurious reduction of production _core_type -> core_type2
-## In state 697, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 685, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1972, spurious reduction of production constraints ->
+## In state 332, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 691, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 685, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 687, spurious reduction of production _core_type -> core_type2
+## In state 698, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 686, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1974, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ##
-## Ends in an error in state: 1968.
+## Ends in an error in state: 1970.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3636,14 +3636,14 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1358, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 1360, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 1966.
+## Ends in an error in state: 1968.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3656,7 +3656,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH WITH
 ##
-## Ends in an error in state: 1965.
+## Ends in an error in state: 1967.
 ##
 ## _module_type -> module_type WITH . with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3668,7 +3668,7 @@ interface: INCLUDE LPAREN UIDENT WITH WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2120.
+## Ends in an error in state: 2122.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3682,24 +3682,24 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 129, spurious reduction of production ident -> UIDENT
-## In state 252, spurious reduction of production mty_longident -> ident
-## In state 1411, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1445, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1441, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1409, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1446, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1442, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1410, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1447, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1443, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 130, spurious reduction of production ident -> UIDENT
+## In state 253, spurious reduction of production mty_longident -> ident
+## In state 1413, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1447, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1443, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1411, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1448, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1444, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1412, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1449, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1445, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2119.
+## Ends in an error in state: 2121.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3711,7 +3711,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2118.
+## Ends in an error in state: 2120.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3723,7 +3723,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2117.
+## Ends in an error in state: 2119.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3737,24 +3737,24 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 129, spurious reduction of production ident -> UIDENT
-## In state 252, spurious reduction of production mty_longident -> ident
-## In state 1411, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1445, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1441, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1409, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1446, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1442, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1410, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1447, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1443, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 130, spurious reduction of production ident -> UIDENT
+## In state 253, spurious reduction of production mty_longident -> ident
+## In state 1413, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1447, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1443, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1411, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1448, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1444, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1412, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1449, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1445, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2116.
+## Ends in an error in state: 2118.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3766,7 +3766,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2115.
+## Ends in an error in state: 2117.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3778,7 +3778,7 @@ interface: INCLUDE LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN WITH
 ##
-## Ends in an error in state: 1243.
+## Ends in an error in state: 1244.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3792,7 +3792,7 @@ interface: INCLUDE LPAREN WITH
 
 interface: INCLUDE MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2282.
+## Ends in an error in state: 2284.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
@@ -3806,19 +3806,19 @@ interface: INCLUDE MODULE TYPE UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 775, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 779, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 776, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 755, spurious reduction of production _module_expr -> simple_module_expr
-## In state 781, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 780, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 776, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 780, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 777, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 756, spurious reduction of production _module_expr -> simple_module_expr
+## In state 782, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 781, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE MODULE TYPE WITH
 ##
-## Ends in an error in state: 450.
+## Ends in an error in state: 451.
 ##
 ## _non_arrowed_module_type -> MODULE TYPE . module_expr [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3830,7 +3830,7 @@ interface: INCLUDE MODULE TYPE WITH
 
 interface: INCLUDE MODULE WITH
 ##
-## Ends in an error in state: 449.
+## Ends in an error in state: 450.
 ##
 ## _non_arrowed_module_type -> MODULE . TYPE module_expr [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3842,7 +3842,7 @@ interface: INCLUDE MODULE WITH
 
 interface: INCLUDE UIDENT DOT UIDENT WHILE
 ##
-## Ends in an error in state: 250.
+## Ends in an error in state: 251.
 ##
 ## ident -> UIDENT . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF COLONGREATER AND ]
 ## mod_ext2 -> mod_ext_longident DOT UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -3856,7 +3856,7 @@ interface: INCLUDE UIDENT DOT UIDENT WHILE
 
 interface: INCLUDE UIDENT DOT WITH
 ##
-## Ends in an error in state: 249.
+## Ends in an error in state: 250.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -3870,7 +3870,7 @@ interface: INCLUDE UIDENT DOT WITH
 
 interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1439.
+## Ends in an error in state: 1441.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3884,24 +3884,24 @@ interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 129, spurious reduction of production ident -> UIDENT
-## In state 252, spurious reduction of production mty_longident -> ident
-## In state 1411, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1445, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1441, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1409, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1446, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1442, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1410, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1447, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1443, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 130, spurious reduction of production ident -> UIDENT
+## In state 253, spurious reduction of production mty_longident -> ident
+## In state 1413, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1447, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1443, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1411, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1448, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1444, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1412, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1449, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1445, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1438.
+## Ends in an error in state: 1440.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3913,7 +3913,7 @@ interface: INCLUDE UIDENT EQUALGREATER WITH
 
 interface: INCLUDE UIDENT LPAREN UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 248.
+## Ends in an error in state: 249.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -3933,7 +3933,7 @@ interface: INCLUDE UIDENT LPAREN UIDENT RPAREN WITH
 
 interface: INCLUDE UIDENT WHILE
 ##
-## Ends in an error in state: 129.
+## Ends in an error in state: 130.
 ##
 ## ident -> UIDENT . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF COLONGREATER AND ]
 ## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -3961,7 +3961,7 @@ interface: INCLUDE UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1426.
+## Ends in an error in state: 1428.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3973,7 +3973,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 1428.
+## Ends in an error in state: 1430.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3999,7 +3999,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1429.
+## Ends in an error in state: 1431.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4011,7 +4011,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1425.
+## Ends in an error in state: 1427.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4024,7 +4024,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 1424.
+## Ends in an error in state: 1426.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4037,7 +4037,7 @@ interface: INCLUDE UIDENT WITH MODULE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 1432.
+## Ends in an error in state: 1434.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4049,7 +4049,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ##
-## Ends in an error in state: 1431.
+## Ends in an error in state: 1433.
 ##
 ## _module_type -> module_type WITH with_constraints . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraints -> with_constraints . AND with_constraint [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4061,21 +4061,21 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1420, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1434, spurious reduction of production with_constraints -> with_constraint
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1422, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1436, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1419.
+## Ends in an error in state: 1421.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4087,7 +4087,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1421.
+## Ends in an error in state: 1423.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4099,7 +4099,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ##
-## Ends in an error in state: 1423.
+## Ends in an error in state: 1425.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4111,20 +4111,20 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1422, spurious reduction of production constraints ->
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1424, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1417.
+## Ends in an error in state: 1419.
 ##
 ## with_type_binder -> EQUAL . [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
 ## with_type_binder -> EQUAL . PRIVATE [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
@@ -4137,7 +4137,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1416.
+## Ends in an error in state: 1418.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4149,14 +4149,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1415, spurious reduction of production optional_type_parameters ->
+## In state 1417, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 1414.
+## Ends in an error in state: 1416.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4169,7 +4169,7 @@ interface: INCLUDE UIDENT WITH TYPE WITH
 
 interface: INCLUDE UIDENT WITH WITH
 ##
-## Ends in an error in state: 1413.
+## Ends in an error in state: 1415.
 ##
 ## _module_type -> module_type WITH . with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4181,7 +4181,7 @@ interface: INCLUDE UIDENT WITH WITH
 
 interface: INCLUDE WITH
 ##
-## Ends in an error in state: 2030.
+## Ends in an error in state: 2032.
 ##
 ## _signature_item -> INCLUDE . module_type post_item_attributes [ SEMI ]
 ##
@@ -4193,7 +4193,7 @@ interface: INCLUDE WITH
 
 interface: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 1465.
+## Ends in an error in state: 1467.
 ##
 ## _signature_item -> LET val_ident COLON . core_type post_item_attributes [ SEMI ]
 ##
@@ -4205,7 +4205,7 @@ interface: LET LIDENT COLON WITH
 
 interface: LET LIDENT WITH
 ##
-## Ends in an error in state: 1464.
+## Ends in an error in state: 1466.
 ##
 ## _signature_item -> LET val_ident . COLON core_type post_item_attributes [ SEMI ]
 ##
@@ -4217,7 +4217,7 @@ interface: LET LIDENT WITH
 
 interface: LET LPAREN WITH
 ##
-## Ends in an error in state: 660.
+## Ends in an error in state: 661.
 ##
 ## val_ident -> LPAREN . operator RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -4229,7 +4229,7 @@ interface: LET LPAREN WITH
 
 interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
 ##
-## Ends in an error in state: 2076.
+## Ends in an error in state: 2078.
 ##
 ## and_module_rec_declaration -> AND . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4241,7 +4241,7 @@ interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
 
 interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2075.
+## Ends in an error in state: 2077.
 ##
 ## _signature_item -> many_module_rec_declarations . [ SEMI ]
 ## many_module_rec_declarations -> many_module_rec_declarations . and_module_rec_declaration [ SEMI AND ]
@@ -4253,16 +4253,16 @@ interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1176, spurious reduction of production post_item_attributes ->
-## In state 1177, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1463, spurious reduction of production many_module_rec_declarations -> LET MODULE REC module_rec_declaration_details post_item_attributes
+## In state 1177, spurious reduction of production post_item_attributes ->
+## In state 1178, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1465, spurious reduction of production many_module_rec_declarations -> LET MODULE REC module_rec_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 1461.
+## Ends in an error in state: 1463.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -4276,24 +4276,24 @@ interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 129, spurious reduction of production ident -> UIDENT
-## In state 252, spurious reduction of production mty_longident -> ident
-## In state 1411, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1445, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1441, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1409, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1446, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1442, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1410, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1447, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1443, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 130, spurious reduction of production ident -> UIDENT
+## In state 253, spurious reduction of production mty_longident -> ident
+## In state 1413, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1447, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1443, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1411, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1448, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1444, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1412, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1449, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1445, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON WITH
 ##
-## Ends in an error in state: 1460.
+## Ends in an error in state: 1462.
 ##
 ## module_rec_declaration_details -> UIDENT COLON . module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4305,7 +4305,7 @@ interface: LET MODULE REC UIDENT COLON WITH
 
 interface: LET MODULE REC UIDENT WITH
 ##
-## Ends in an error in state: 1459.
+## Ends in an error in state: 1461.
 ##
 ## module_rec_declaration_details -> UIDENT . COLON module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4317,7 +4317,7 @@ interface: LET MODULE REC UIDENT WITH
 
 interface: LET MODULE REC WITH
 ##
-## Ends in an error in state: 1458.
+## Ends in an error in state: 1460.
 ##
 ## many_module_rec_declarations -> LET MODULE REC . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4329,7 +4329,7 @@ interface: LET MODULE REC WITH
 
 interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 1437.
+## Ends in an error in state: 1439.
 ##
 ## _module_declaration -> COLON module_type . [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -4343,24 +4343,24 @@ interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 129, spurious reduction of production ident -> UIDENT
-## In state 252, spurious reduction of production mty_longident -> ident
-## In state 1411, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1445, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1441, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1409, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1446, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1442, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1410, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1447, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1443, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 130, spurious reduction of production ident -> UIDENT
+## In state 253, spurious reduction of production mty_longident -> ident
+## In state 1413, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1447, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1443, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1411, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1448, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1444, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1412, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1449, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1445, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 1436.
+## Ends in an error in state: 1438.
 ##
 ## _module_declaration -> COLON . module_type [ SEMI LBRACKETATAT ]
 ##
@@ -4372,7 +4372,7 @@ interface: LET MODULE UIDENT COLON WITH
 
 interface: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1453.
+## Ends in an error in state: 1455.
 ##
 ## _signature_item -> LET MODULE UIDENT EQUAL . mod_longident post_item_attributes [ SEMI ]
 ##
@@ -4384,7 +4384,7 @@ interface: LET MODULE UIDENT EQUAL WITH
 
 interface: LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1451.
+## Ends in an error in state: 1453.
 ##
 ## _module_declaration -> LPAREN RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4396,7 +4396,7 @@ interface: LET MODULE UIDENT LPAREN RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1435.
+## Ends in an error in state: 1437.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4408,7 +4408,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1412.
+## Ends in an error in state: 1414.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type . RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -4422,24 +4422,24 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 129, spurious reduction of production ident -> UIDENT
-## In state 252, spurious reduction of production mty_longident -> ident
-## In state 1411, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1445, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1441, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1409, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1446, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1442, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1410, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1447, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1443, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 130, spurious reduction of production ident -> UIDENT
+## In state 253, spurious reduction of production mty_longident -> ident
+## In state 1413, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1447, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1443, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1411, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1448, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1444, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1412, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1449, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1445, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1408.
+## Ends in an error in state: 1410.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON . module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4451,7 +4451,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1407.
+## Ends in an error in state: 1409.
 ##
 ## _module_declaration -> LPAREN UIDENT . COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4463,7 +4463,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT WITH
 
 interface: LET MODULE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1406.
+## Ends in an error in state: 1408.
 ##
 ## _module_declaration -> LPAREN . UIDENT COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_declaration -> LPAREN . RPAREN module_declaration [ SEMI LBRACKETATAT ]
@@ -4476,7 +4476,7 @@ interface: LET MODULE UIDENT LPAREN WITH
 
 interface: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1405.
+## Ends in an error in state: 1407.
 ##
 ## _signature_item -> LET MODULE UIDENT . module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> LET MODULE UIDENT . EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4489,7 +4489,7 @@ interface: LET MODULE UIDENT WITH
 
 interface: LET MODULE WITH
 ##
-## Ends in an error in state: 1404.
+## Ends in an error in state: 1406.
 ##
 ## _signature_item -> LET MODULE . UIDENT module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> LET MODULE . UIDENT EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4503,7 +4503,7 @@ interface: LET MODULE WITH
 
 interface: LET WITH
 ##
-## Ends in an error in state: 1403.
+## Ends in an error in state: 1405.
 ##
 ## _signature_item -> LET . val_ident COLON core_type post_item_attributes [ SEMI ]
 ## _signature_item -> LET . MODULE UIDENT module_declaration post_item_attributes [ SEMI ]
@@ -4518,7 +4518,7 @@ interface: LET WITH
 
 interface: MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1401.
+## Ends in an error in state: 1403.
 ##
 ## _signature_item -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ SEMI ]
 ##
@@ -4530,7 +4530,7 @@ interface: MODULE TYPE UIDENT EQUAL WITH
 
 interface: MODULE TYPE WITH
 ##
-## Ends in an error in state: 1399.
+## Ends in an error in state: 1401.
 ##
 ## _signature_item -> MODULE TYPE . ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4543,7 +4543,7 @@ interface: MODULE TYPE WITH
 
 interface: MODULE WITH
 ##
-## Ends in an error in state: 1398.
+## Ends in an error in state: 1400.
 ##
 ## _signature_item -> MODULE . TYPE ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4556,7 +4556,7 @@ interface: MODULE WITH
 
 interface: OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2558.
+## Ends in an error in state: 2560.
 ##
 ## signature -> signature_item . SEMI signature [ EOF ]
 ##
@@ -4567,18 +4567,18 @@ interface: OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1396, spurious reduction of production post_item_attributes ->
-## In state 1397, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 2066, spurious reduction of production _signature_item -> open_statement
-## In state 2093, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 2067, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 1398, spurious reduction of production post_item_attributes ->
+## In state 1399, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 2068, spurious reduction of production _signature_item -> open_statement
+## In state 2095, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 2069, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 1369.
+## Ends in an error in state: 1371.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4590,7 +4590,7 @@ interface: TYPE LIDENT PLUSEQ BAR WITH
 
 interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 1368.
+## Ends in an error in state: 1370.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4602,7 +4602,7 @@ interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 
 interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 1387.
+## Ends in an error in state: 1389.
 ##
 ## sig_extension_constructors -> sig_extension_constructors BAR . extension_constructor_declaration [ SEMI LBRACKETATAT BAR ]
 ##
@@ -4614,7 +4614,7 @@ interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 interface: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 1366.
+## Ends in an error in state: 1368.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4626,7 +4626,7 @@ interface: TYPE LIDENT PLUSEQ WITH
 
 interface: TYPE LIDENT RBRACKET
 ##
-## Ends in an error in state: 1262.
+## Ends in an error in state: 1263.
 ##
 ## potentially_long_ident_and_optional_type_parameters -> LIDENT optional_type_parameters . [ PLUSEQ ]
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ SEMI LBRACKETATAT EOF AND ]
@@ -4638,14 +4638,14 @@ interface: TYPE LIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1249, spurious reduction of production optional_type_parameters ->
+## In state 1250, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2559.
+## Ends in an error in state: 2561.
 ##
 ## signature -> signature_item SEMI . signature [ EOF ]
 ##
@@ -4657,7 +4657,7 @@ interface: TYPE LIDENT SEMI WITH
 
 interface: TYPE NONREC LET
 ##
-## Ends in an error in state: 1248.
+## Ends in an error in state: 1249.
 ##
 ## many_type_declarations -> TYPE nonrec_flag . type_declaration_details post_item_attributes [ SEMI AND ]
 ## sig_type_extension -> TYPE nonrec_flag . potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
@@ -4670,7 +4670,7 @@ interface: TYPE NONREC LET
 
 interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ##
-## Ends in an error in state: 1365.
+## Ends in an error in state: 1367.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters . PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4681,15 +4681,15 @@ interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1358, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
-## In state 1362, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
+## In state 1360, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 1364, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
 ##
 
 <SYNTAX ERROR>
 
 interface: WITH
 ##
-## Ends in an error in state: 2557.
+## Ends in an error in state: 2559.
 ##
 ## interface' -> . interface [ # ]
 ##
@@ -4701,7 +4701,7 @@ interface: WITH
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1810.
+## Ends in an error in state: 1812.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4713,7 +4713,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WIT
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1808.
+## Ends in an error in state: 1810.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4725,7 +4725,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON WITH
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1801.
+## Ends in an error in state: 1803.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4737,7 +4737,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE 
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 1800.
+## Ends in an error in state: 1802.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4750,7 +4750,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE 
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1799.
+## Ends in an error in state: 1801.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4762,7 +4762,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: CLASS LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1802.
+## Ends in an error in state: 1804.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4774,18 +4774,18 @@ implementation: CLASS LIDENT COLON LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1798, spurious reduction of production type_longident -> LIDENT
-## In state 253, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
-## In state 258, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
-## In state 256, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
-## In state 260, spurious reduction of production non_arrowed_core_type -> non_arrowed_simple_core_type
+## In state 1800, spurious reduction of production type_longident -> LIDENT
+## In state 254, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
+## In state 259, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
+## In state 257, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
+## In state 261, spurious reduction of production non_arrowed_core_type -> non_arrowed_simple_core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1782.
+## Ends in an error in state: 1784.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4797,7 +4797,7 @@ implementation: CLASS LIDENT COLON NEW WITH
 
 implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1803.
+## Ends in an error in state: 1805.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4809,7 +4809,7 @@ implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT MINUS WITH
 ##
-## Ends in an error in state: 1623.
+## Ends in an error in state: 1625.
 ##
 ## signed_constant -> MINUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> MINUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -4826,7 +4826,7 @@ implementation: CLASS LIDENT MINUS WITH
 
 implementation: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1622.
+## Ends in an error in state: 1624.
 ##
 ## signed_constant -> PLUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> PLUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -4843,7 +4843,7 @@ implementation: CLASS LIDENT PLUS WITH
 
 implementation: CLASS LIDENT QUOTE WITH
 ##
-## Ends in an error in state: 1611.
+## Ends in an error in state: 1613.
 ##
 ## _type_variable -> QUOTE . ident [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLON CHAR BACKQUOTE ]
 ##
@@ -4855,7 +4855,7 @@ implementation: CLASS LIDENT QUOTE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1545.
+## Ends in an error in state: 1547.
 ##
 ## class_sig_body -> class_self_type . class_sig_fields opt_semi [ error RBRACE ]
 ##
@@ -4867,7 +4867,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 ##
-## Ends in an error in state: 1540.
+## Ends in an error in state: 1542.
 ##
 ## class_self_type -> AS core_type . SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -4878,19 +4878,19 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 ##
-## Ends in an error in state: 1539.
+## Ends in an error in state: 1541.
 ##
 ## class_self_type -> AS . core_type SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -4902,7 +4902,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1593.
+## Ends in an error in state: 1595.
 ##
 ## _class_sig_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4914,7 +4914,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1588.
+## Ends in an error in state: 1590.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT ]
 ## _class_sig_field -> INHERIT class_instance_type . [ error SEMI RBRACE ]
@@ -4927,16 +4927,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1586, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1592, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1584, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1588, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1594, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1586, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1580.
+## Ends in an error in state: 1582.
 ##
 ## _class_sig_field -> INHERIT . class_instance_type [ error SEMI RBRACE ]
 ## _class_sig_field -> INHERIT . class_instance_type item_attribute post_item_attributes [ error SEMI RBRACE ]
@@ -4949,7 +4949,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH RBRACKET WITH
 ##
-## Ends in an error in state: 1785.
+## Ends in an error in state: 1787.
 ##
 ## _class_instance_type -> LBRACE class_sig_body . RBRACE [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE class_sig_body . error [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4961,20 +4961,20 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1600, spurious reduction of production post_item_attributes ->
-## In state 1601, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
-## In state 1606, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
-## In state 1599, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
-## In state 1608, spurious reduction of production class_sig_fields -> class_sig_field
-## In state 1603, spurious reduction of production opt_semi ->
-## In state 1607, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
+## In state 1602, spurious reduction of production post_item_attributes ->
+## In state 1603, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
+## In state 1608, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
+## In state 1601, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
+## In state 1610, spurious reduction of production class_sig_fields -> class_sig_field
+## In state 1605, spurious reduction of production opt_semi ->
+## In state 1609, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 ##
-## Ends in an error in state: 1569.
+## Ends in an error in state: 1571.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label COLON . poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4986,7 +4986,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 ##
-## Ends in an error in state: 1568.
+## Ends in an error in state: 1570.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label . COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4998,7 +4998,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 ##
-## Ends in an error in state: 1565.
+## Ends in an error in state: 1567.
 ##
 ## private_virtual_flags -> PRIVATE . [ LIDENT ]
 ## private_virtual_flags -> PRIVATE . VIRTUAL [ LIDENT ]
@@ -5011,7 +5011,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1567.
+## Ends in an error in state: 1569.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags . label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5023,7 +5023,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 ##
-## Ends in an error in state: 1563.
+## Ends in an error in state: 1565.
 ##
 ## private_virtual_flags -> VIRTUAL . [ LIDENT ]
 ## private_virtual_flags -> VIRTUAL . PRIVATE [ LIDENT ]
@@ -5036,7 +5036,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 ##
-## Ends in an error in state: 1562.
+## Ends in an error in state: 1564.
 ##
 ## _class_sig_field -> METHOD . private_virtual_flags label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5048,7 +5048,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1560.
+## Ends in an error in state: 1562.
 ##
 ## value_type -> label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5060,7 +5060,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1559.
+## Ends in an error in state: 1561.
 ##
 ## value_type -> label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5072,7 +5072,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1555.
+## Ends in an error in state: 1557.
 ##
 ## value_type -> MUTABLE virtual_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5084,7 +5084,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 ##
-## Ends in an error in state: 1554.
+## Ends in an error in state: 1556.
 ##
 ## value_type -> MUTABLE virtual_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5096,7 +5096,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 ##
-## Ends in an error in state: 1553.
+## Ends in an error in state: 1555.
 ##
 ## value_type -> MUTABLE virtual_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5108,7 +5108,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1552.
+## Ends in an error in state: 1554.
 ##
 ## value_type -> MUTABLE . virtual_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5120,7 +5120,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1550.
+## Ends in an error in state: 1552.
 ##
 ## value_type -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5132,7 +5132,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1549.
+## Ends in an error in state: 1551.
 ##
 ## value_type -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5144,7 +5144,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1548.
+## Ends in an error in state: 1550.
 ##
 ## value_type -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5156,7 +5156,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1547.
+## Ends in an error in state: 1549.
 ##
 ## value_type -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5168,7 +5168,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 ##
-## Ends in an error in state: 1546.
+## Ends in an error in state: 1548.
 ##
 ## _class_sig_field -> VAL . value_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5180,7 +5180,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 ##
-## Ends in an error in state: 1784.
+## Ends in an error in state: 1786.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5193,7 +5193,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ##
-## Ends in an error in state: 1828.
+## Ends in an error in state: 1830.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## _non_arrowed_class_constructor_type -> class_instance_type . [ EQUALGREATER ]
@@ -5205,16 +5205,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1793, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1797, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1791, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1795, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1799, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1793, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1794.
+## Ends in an error in state: 1796.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
@@ -5227,7 +5227,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 ##
-## Ends in an error in state: 1793.
+## Ends in an error in state: 1795.
 ##
 ## _class_instance_type -> clty_longident . [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5240,7 +5240,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1822.
+## Ends in an error in state: 1824.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN class_constructor_type . RPAREN [ EQUALGREATER ]
 ##
@@ -5251,19 +5251,19 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1793, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1797, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1791, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1795, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1806, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1804, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1795, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1799, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1793, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1797, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1808, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1806, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 ##
-## Ends in an error in state: 1821.
+## Ends in an error in state: 1823.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN . class_constructor_type RPAREN [ EQUALGREATER ]
 ##
@@ -5275,7 +5275,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 ##
-## Ends in an error in state: 1789.
+## Ends in an error in state: 1791.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5289,7 +5289,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 ##
-## Ends in an error in state: 1788.
+## Ends in an error in state: 1790.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5309,7 +5309,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 
 implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ##
-## Ends in an error in state: 745.
+## Ends in an error in state: 746.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag simple_expr . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -5327,17 +5327,17 @@ implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 912, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 913, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FOR UNDERSCORE WHEN
 ##
-## Ends in an error in state: 739.
+## Ends in an error in state: 740.
 ##
 ## _expr -> FOR pattern . IN simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _or_pattern -> pattern . BAR pattern [ IN BAR ]
@@ -5349,14 +5349,14 @@ implementation: FOR UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 654, spurious reduction of production pattern -> pattern_without_or
+## In state 655, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2211.
+## Ends in an error in state: 2213.
 ##
 ## _simple_expr -> simple_expr . DOT label_longident [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
 ## _simple_expr -> simple_expr . DOT LPAREN expr RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
@@ -5374,17 +5374,17 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 912, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 913, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 729.
+## Ends in an error in state: 730.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern EQUAL . simple_expr [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ##
@@ -5396,7 +5396,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 727.
+## Ends in an error in state: 728.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -5410,7 +5410,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 
 implementation: FUN LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 486.
+## Ends in an error in state: 487.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -5424,7 +5424,7 @@ implementation: FUN LIDENT COLONCOLON WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2283.
+## Ends in an error in state: 2285.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -5438,24 +5438,24 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 129, spurious reduction of production ident -> UIDENT
-## In state 252, spurious reduction of production mty_longident -> ident
-## In state 1411, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1445, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1441, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1409, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1446, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1442, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1410, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1447, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1443, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 130, spurious reduction of production ident -> UIDENT
+## In state 253, spurious reduction of production mty_longident -> ident
+## In state 1413, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1447, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1443, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1411, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1448, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1444, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1412, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1449, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1445, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 448.
+## Ends in an error in state: 449.
 ##
 ## functor_arg -> LPAREN functor_arg_name COLON . module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -5467,7 +5467,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 447.
+## Ends in an error in state: 448.
 ##
 ## functor_arg -> LPAREN functor_arg_name . COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -5479,7 +5479,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 
 implementation: INCLUDE FUN LPAREN WITH
 ##
-## Ends in an error in state: 443.
+## Ends in an error in state: 444.
 ##
 ## functor_arg -> LPAREN . RPAREN [ LPAREN EQUALGREATER COLON ]
 ## functor_arg -> LPAREN . functor_arg_name COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
@@ -5492,7 +5492,7 @@ implementation: INCLUDE FUN LPAREN WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1814.
+## Ends in an error in state: 1816.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5504,16 +5504,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1641, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1647, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1639, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1643, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1649, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1641, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1813.
+## Ends in an error in state: 1815.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5525,7 +5525,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1812.
+## Ends in an error in state: 1814.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type . EQUAL class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5536,19 +5536,19 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1793, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1797, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1791, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1795, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1806, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1804, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1795, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1799, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1793, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1797, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1808, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1806, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 1781.
+## Ends in an error in state: 1783.
 ##
 ## _constrained_class_declaration -> COLON . class_constructor_type EQUAL class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5560,7 +5560,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1875.
+## Ends in an error in state: 1877.
 ##
 ## and_class_declaration -> AND . class_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5572,7 +5572,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1874.
+## Ends in an error in state: 1876.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_class_declarations -> many_class_declarations . and_class_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5584,16 +5584,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1481, spurious reduction of production post_item_attributes ->
-## In state 1482, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1837, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
+## In state 1483, spurious reduction of production post_item_attributes ->
+## In state 1484, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1839, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1780.
+## Ends in an error in state: 1782.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5605,16 +5605,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1641, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1647, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1639, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1643, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1649, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1641, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1624.
+## Ends in an error in state: 1626.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5626,7 +5626,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 1826.
+## Ends in an error in state: 1828.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5638,16 +5638,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1641, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1647, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1639, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1643, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1649, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1641, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1825.
+## Ends in an error in state: 1827.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5659,7 +5659,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1824.
+## Ends in an error in state: 1826.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type . EQUALGREATER class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5671,7 +5671,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT R
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1820.
+## Ends in an error in state: 1822.
 ##
 ## class_fun_return -> COLON . non_arrowed_class_constructor_type EQUALGREATER class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5683,7 +5683,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 1819.
+## Ends in an error in state: 1821.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> EQUALGREATER class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5695,16 +5695,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1641, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1647, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1639, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1643, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1649, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1641, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1818.
+## Ends in an error in state: 1820.
 ##
 ## class_fun_return -> EQUALGREATER . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5716,7 +5716,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1817.
+## Ends in an error in state: 1819.
 ##
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_return [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5729,7 +5729,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1621.
+## Ends in an error in state: 1623.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . constrained_class_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5744,7 +5744,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1870.
+## Ends in an error in state: 1872.
 ##
 ## and_class_type_declaration -> AND . class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5756,7 +5756,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1869.
+## Ends in an error in state: 1871.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_type_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5768,16 +5768,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND R
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1481, spurious reduction of production post_item_attributes ->
-## In state 1482, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1618, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
+## In state 1483, spurious reduction of production post_item_attributes ->
+## In state 1484, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1620, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1609.
+## Ends in an error in state: 1611.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5789,16 +5789,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1586, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1592, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1584, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1588, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1594, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1586, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1536.
+## Ends in an error in state: 1538.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5810,7 +5810,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1533.
+## Ends in an error in state: 1535.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters . EQUAL class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS EQUAL ]
@@ -5823,7 +5823,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 ##
-## Ends in an error in state: 1531.
+## Ends in an error in state: 1533.
 ##
 ## class_type_declaration_details -> virtual_flag . LIDENT class_type_parameters EQUAL class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5835,7 +5835,7 @@ implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE WITH
 ##
-## Ends in an error in state: 1530.
+## Ends in an error in state: 1532.
 ##
 ## many_class_type_declarations -> CLASS TYPE . class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5847,7 +5847,7 @@ implementation: INCLUDE LBRACE CLASS TYPE WITH
 
 implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 1619.
+## Ends in an error in state: 1621.
 ##
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters constrained_class_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5861,7 +5861,7 @@ implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 
 implementation: INCLUDE LBRACE CLASS WITH
 ##
-## Ends in an error in state: 1528.
+## Ends in an error in state: 1530.
 ##
 ## many_class_declarations -> CLASS . class_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5874,7 +5874,7 @@ implementation: INCLUDE LBRACE CLASS WITH
 
 implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 ##
-## Ends in an error in state: 1505.
+## Ends in an error in state: 1507.
 ##
 ## extension_constructor_declaration -> LPAREN . RPAREN generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## extension_constructor_rebind -> LPAREN . RPAREN EQUAL constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -5887,7 +5887,7 @@ implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1492.
+## Ends in an error in state: 1494.
 ##
 ## generalized_constructor_arguments -> COLON . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -5899,7 +5899,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 ##
-## Ends in an error in state: 1487.
+## Ends in an error in state: 1489.
 ##
 ## constr_longident -> LBRACKET . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -5911,7 +5911,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 1486.
+## Ends in an error in state: 1488.
 ##
 ## constr_longident -> LPAREN . RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -5923,7 +5923,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1485.
+## Ends in an error in state: 1487.
 ##
 ## extension_constructor_rebind -> UIDENT EQUAL . constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ##
@@ -5935,7 +5935,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1495.
+## Ends in an error in state: 1497.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list COLON . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -5947,7 +5947,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1494.
+## Ends in an error in state: 1496.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . COLON core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
@@ -5961,7 +5961,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1484.
+## Ends in an error in state: 1486.
 ##
 ## extension_constructor_declaration -> UIDENT . generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## extension_constructor_rebind -> UIDENT . EQUAL constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -5974,7 +5974,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 
 implementation: INCLUDE LBRACE EXCEPTION WITH
 ##
-## Ends in an error in state: 1483.
+## Ends in an error in state: 1485.
 ##
 ## str_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## str_exception_declaration -> EXCEPTION . extension_constructor_rebind post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
@@ -5987,7 +5987,7 @@ implementation: INCLUDE LBRACE EXCEPTION WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 ##
-## Ends in an error in state: 1477.
+## Ends in an error in state: 1479.
 ##
 ## primitive_declaration -> STRING . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ## primitive_declaration -> STRING . primitive_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
@@ -6000,7 +6000,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WIT
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1476.
+## Ends in an error in state: 1478.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6012,7 +6012,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1475.
+## Ends in an error in state: 1477.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6023,19 +6023,19 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1474.
+## Ends in an error in state: 1476.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6047,7 +6047,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 1473.
+## Ends in an error in state: 1475.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6059,7 +6059,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 
 implementation: INCLUDE LBRACE EXTERNAL WITH
 ##
-## Ends in an error in state: 1472.
+## Ends in an error in state: 1474.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6071,7 +6071,7 @@ implementation: INCLUDE LBRACE EXTERNAL WITH
 
 implementation: INCLUDE LBRACE MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 400.
+## Ends in an error in state: 401.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6083,7 +6083,7 @@ implementation: INCLUDE LBRACE MODULE TYPE UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE MODULE TYPE WITH
 ##
-## Ends in an error in state: 398.
+## Ends in an error in state: 399.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE . ident post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
@@ -6096,7 +6096,7 @@ implementation: INCLUDE LBRACE MODULE TYPE WITH
 
 implementation: INCLUDE LBRACE MODULE WITH
 ##
-## Ends in an error in state: 397.
+## Ends in an error in state: 398.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
@@ -6109,7 +6109,7 @@ implementation: INCLUDE LBRACE MODULE WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1941.
+## Ends in an error in state: 1943.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER module_expr . [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6124,7 +6124,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHIL
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1939.
+## Ends in an error in state: 1941.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER . module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6136,7 +6136,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1938.
+## Ends in an error in state: 1940.
 ##
 ## _module_expr -> FUN functor_args . EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## functor_args -> functor_args . functor_arg [ LPAREN EQUALGREATER ]
@@ -6149,7 +6149,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 
 implementation: INCLUDE LPAREN FUN WITH
 ##
-## Ends in an error in state: 1937.
+## Ends in an error in state: 1939.
 ##
 ## _module_expr -> FUN . functor_args EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6161,7 +6161,7 @@ implementation: INCLUDE LPAREN FUN WITH
 
 implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1963.
+## Ends in an error in state: 1965.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -6176,24 +6176,24 @@ implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 233, spurious reduction of production ident -> UIDENT
-## In state 507, spurious reduction of production mty_longident -> ident
-## In state 1962, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2006, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2002, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1960, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2007, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2003, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1961, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2008, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2004, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 234, spurious reduction of production ident -> UIDENT
+## In state 508, spurious reduction of production mty_longident -> ident
+## In state 1964, spurious reduction of production _simple_module_type -> mty_longident
+## In state 2008, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 2004, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1962, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 2009, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 2005, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1963, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 2010, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 2006, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1959.
+## Ends in an error in state: 1961.
 ##
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6206,7 +6206,7 @@ implementation: INCLUDE LPAREN UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2387.
+## Ends in an error in state: 2389.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -6223,19 +6223,19 @@ implementation: INCLUDE LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1940, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2012, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2016, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2013, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1942, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2018, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2017, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1953.
+## Ends in an error in state: 1955.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6246,16 +6246,16 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 129, spurious reduction of production ident -> UIDENT
-## In state 252, spurious reduction of production mty_longident -> ident
-## In state 132, spurious reduction of production package_type -> mty_longident
+## In state 130, spurious reduction of production ident -> UIDENT
+## In state 253, spurious reduction of production mty_longident -> ident
+## In state 133, spurious reduction of production package_type -> mty_longident
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1952.
+## Ends in an error in state: 1954.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6267,7 +6267,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 2385.
+## Ends in an error in state: 2387.
 ##
 ## _module_expr -> LPAREN VAL expr COLON . error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6281,7 +6281,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1947.
+## Ends in an error in state: 1949.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6292,16 +6292,16 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 129, spurious reduction of production ident -> UIDENT
-## In state 252, spurious reduction of production mty_longident -> ident
-## In state 132, spurious reduction of production package_type -> mty_longident
+## In state 130, spurious reduction of production ident -> UIDENT
+## In state 253, spurious reduction of production mty_longident -> ident
+## In state 133, spurious reduction of production package_type -> mty_longident
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 2383.
+## Ends in an error in state: 2385.
 ##
 ## _module_expr -> LPAREN VAL expr COLONGREATER . error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6314,7 +6314,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 2381.
+## Ends in an error in state: 2383.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -6354,21 +6354,21 @@ implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN VAL WITH
 ##
-## Ends in an error in state: 404.
+## Ends in an error in state: 405.
 ##
 ## _module_expr -> LPAREN VAL . expr COLON error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _module_expr -> LPAREN VAL . expr COLONGREATER error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6386,7 +6386,7 @@ implementation: INCLUDE LPAREN VAL WITH
 
 implementation: INCLUDE LPAREN WITH
 ##
-## Ends in an error in state: 403.
+## Ends in an error in state: 404.
 ##
 ## _module_expr -> LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _module_expr -> LPAREN . VAL expr COLON error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6409,7 +6409,7 @@ implementation: INCLUDE LPAREN WITH
 
 implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ##
-## Ends in an error in state: 1935.
+## Ends in an error in state: 1937.
 ##
 ## _simple_module_expr -> LBRACE structure . RBRACE [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6420,29 +6420,29 @@ implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1929, spurious reduction of production post_item_attributes ->
-## In state 1930, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1931, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1845, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1838, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1932, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1846, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1839, spurious reduction of production structure -> structure_item
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1931, spurious reduction of production post_item_attributes ->
+## In state 1932, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1933, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1847, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1840, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1934, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1848, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1841, spurious reduction of production structure -> structure_item
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 1471.
+## Ends in an error in state: 1473.
 ##
 ## _simple_module_expr -> LBRACE . structure RBRACE [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6454,7 +6454,7 @@ implementation: INCLUDE UIDENT LBRACE WITH
 
 implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1956.
+## Ends in an error in state: 1958.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -6471,19 +6471,19 @@ implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1940, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2012, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2016, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2013, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1942, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2018, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2017, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 1949.
+## Ends in an error in state: 1951.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type COLONGREATER package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6496,7 +6496,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1946.
+## Ends in an error in state: 1948.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6508,7 +6508,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 1944.
+## Ends in an error in state: 1946.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -6545,21 +6545,21 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 948, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 918, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 928, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 957, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 927, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 949, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 919, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 929, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 958, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 928, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL WITH
 ##
-## Ends in an error in state: 1943.
+## Ends in an error in state: 1945.
 ##
 ## _simple_module_expr -> LPAREN VAL . expr RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL . expr COLON package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6574,7 +6574,7 @@ implementation: INCLUDE UIDENT LPAREN VAL WITH
 
 implementation: INCLUDE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1942.
+## Ends in an error in state: 1944.
 ##
 ## _module_expr -> module_expr LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN . module_expr COLON module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6594,7 +6594,7 @@ implementation: INCLUDE UIDENT LPAREN WITH
 
 implementation: INCLUDE UIDENT WHILE
 ##
-## Ends in an error in state: 2010.
+## Ends in an error in state: 2012.
 ##
 ## _simple_module_expr -> mod_longident . [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF DOT COLON AND ]
@@ -6607,7 +6607,7 @@ implementation: INCLUDE UIDENT WHILE
 
 implementation: INCLUDE WITH
 ##
-## Ends in an error in state: 1470.
+## Ends in an error in state: 1472.
 ##
 ## _structure_item_without_item_extension_sugar -> INCLUDE . module_expr post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6619,7 +6619,7 @@ implementation: INCLUDE WITH
 
 implementation: LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1660.
+## Ends in an error in state: 1662.
 ##
 ## class_self_pattern_and_structure -> class_self_pattern . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -6631,7 +6631,7 @@ implementation: LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: LBRACE AS UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1652.
+## Ends in an error in state: 1654.
 ##
 ## _class_self_pattern -> AS pattern . SEMI [ error VAL RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ## _or_pattern -> pattern . BAR pattern [ SEMI BAR ]
@@ -6643,14 +6643,14 @@ implementation: LBRACE AS UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 654, spurious reduction of production pattern -> pattern_without_or
+## In state 655, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE AS WITH
 ##
-## Ends in an error in state: 1651.
+## Ends in an error in state: 1653.
 ##
 ## _class_self_pattern -> AS . pattern SEMI [ error VAL RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ##
@@ -6662,7 +6662,7 @@ implementation: LBRACE AS WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1595.
+## Ends in an error in state: 1597.
 ##
 ## constrain_field -> core_type EQUAL . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -6674,7 +6674,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1594.
+## Ends in an error in state: 1596.
 ##
 ## constrain_field -> core_type . EQUAL core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -6685,19 +6685,19 @@ implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1738.
+## Ends in an error in state: 1740.
 ##
 ## _class_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -6709,7 +6709,7 @@ implementation: LBRACE CONSTRAINT WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1112.
+## Ends in an error in state: 1113.
 ##
 ## record_expr -> DOTDOTDOT expr_optional_constraint COMMA . lbl_expr_list [ error RBRACE ]
 ##
@@ -6721,7 +6721,7 @@ implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ##
-## Ends in an error in state: 1111.
+## Ends in an error in state: 1112.
 ##
 ## record_expr -> DOTDOTDOT expr_optional_constraint . COMMA lbl_expr_list [ error RBRACE ]
 ##
@@ -6732,22 +6732,22 @@ implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 948, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 918, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 928, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 957, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 927, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1060, spurious reduction of production expr_optional_constraint -> expr
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 949, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 919, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 929, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 958, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 928, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1061, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE DOTDOTDOT WITH
 ##
-## Ends in an error in state: 1110.
+## Ends in an error in state: 1111.
 ##
 ## record_expr -> DOTDOTDOT . expr_optional_constraint COMMA lbl_expr_list [ error RBRACE ]
 ##
@@ -6759,7 +6759,7 @@ implementation: LBRACE DOTDOTDOT WITH
 
 implementation: LBRACE INHERIT BANG WITH
 ##
-## Ends in an error in state: 1732.
+## Ends in an error in state: 1734.
 ##
 ## _class_field -> INHERIT override_flag . class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -6771,7 +6771,7 @@ implementation: LBRACE INHERIT BANG WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1637.
+## Ends in an error in state: 1639.
 ##
 ## _class_expr -> CLASS class_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF COLON AS AND ]
@@ -6784,7 +6784,7 @@ implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1636.
+## Ends in an error in state: 1638.
 ##
 ## _class_expr -> CLASS class_longident . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> CLASS class_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6797,7 +6797,7 @@ implementation: LBRACE INHERIT CLASS LIDENT WITH
 
 implementation: LBRACE INHERIT CLASS WITH
 ##
-## Ends in an error in state: 1635.
+## Ends in an error in state: 1637.
 ##
 ## _class_expr -> CLASS . class_longident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> CLASS . class_longident non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6810,7 +6810,7 @@ implementation: LBRACE INHERIT CLASS WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1644.
+## Ends in an error in state: 1646.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER class_expr . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6823,7 +6823,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND R
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1634.
+## Ends in an error in state: 1636.
 ##
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER . class_expr [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ##
@@ -6835,7 +6835,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1633.
+## Ends in an error in state: 1635.
 ##
 ## _class_fun_def -> labeled_simple_pattern . EQUALGREATER class_expr [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern . class_fun_def [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6848,7 +6848,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 
 implementation: LBRACE INHERIT FUN WITH
 ##
-## Ends in an error in state: 1631.
+## Ends in an error in state: 1633.
 ##
 ## _class_expr -> FUN . class_fun_def [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ##
@@ -6860,7 +6860,7 @@ implementation: LBRACE INHERIT FUN WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 1657.
+## Ends in an error in state: 1659.
 ##
 ## _class_expr_lets_and_rest -> let_bindings SEMI . class_expr_lets_and_rest [ error RBRACE ]
 ##
@@ -6872,7 +6872,7 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ##
-## Ends in an error in state: 1656.
+## Ends in an error in state: 1658.
 ##
 ## _class_expr_lets_and_rest -> let_bindings . SEMI class_expr_lets_and_rest [ error RBRACE ]
 ## let_bindings -> let_bindings . and_let_binding [ SEMI AND ]
@@ -6884,22 +6884,22 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 918, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 928, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 957, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 927, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1233, spurious reduction of production let_binding_body -> pattern EQUAL expr
-## In state 1629, spurious reduction of production post_item_attributes ->
-## In state 1630, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
-## In state 1164, spurious reduction of production let_binding -> let_binding_impl
-## In state 1165, spurious reduction of production let_bindings -> let_binding
+## In state 919, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 929, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 958, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 928, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1234, spurious reduction of production let_binding_body -> pattern EQUAL expr
+## In state 1631, spurious reduction of production post_item_attributes ->
+## In state 1632, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
+## In state 1165, spurious reduction of production let_binding -> let_binding_impl
+## In state 1166, spurious reduction of production let_bindings -> let_binding
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE LET WITH
 ##
-## Ends in an error in state: 1627.
+## Ends in an error in state: 1629.
 ##
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI AND ]
 ##
@@ -6911,7 +6911,7 @@ implementation: LBRACE INHERIT LBRACE LET WITH
 
 implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ##
-## Ends in an error in state: 1751.
+## Ends in an error in state: 1753.
 ##
 ## _class_expr -> class_expr . attribute [ error RBRACE LBRACKETAT ]
 ## _class_expr_lets_and_rest -> class_expr . [ error RBRACE ]
@@ -6923,16 +6923,16 @@ implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1641, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1647, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1639, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1643, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1649, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1641, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 ##
-## Ends in an error in state: 1658.
+## Ends in an error in state: 1660.
 ##
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI AND ]
 ##
@@ -6943,15 +6943,15 @@ implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 387, spurious reduction of production attr_id -> single_attr_id
-## In state 390, spurious reduction of production item_extension_sugar -> PERCENT attr_id
+## In state 388, spurious reduction of production attr_id -> single_attr_id
+## In state 391, spurious reduction of production item_extension_sugar -> PERCENT attr_id
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE WITH
 ##
-## Ends in an error in state: 1626.
+## Ends in an error in state: 1628.
 ##
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest RBRACE [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -6964,7 +6964,7 @@ implementation: LBRACE INHERIT LBRACE WITH
 
 implementation: LBRACE INHERIT LIDENT AS WITH
 ##
-## Ends in an error in state: 1734.
+## Ends in an error in state: 1736.
 ##
 ## parent_binder -> AS . LIDENT [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -6976,7 +6976,7 @@ implementation: LBRACE INHERIT LIDENT AS WITH
 
 implementation: LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1733.
+## Ends in an error in state: 1735.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AS ]
 ## _class_field -> INHERIT override_flag class_expr . parent_binder post_item_attributes [ error SEMI RBRACE ]
@@ -6988,16 +6988,16 @@ implementation: LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1641, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1647, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1639, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1643, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1649, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1641, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT SEMI WITH
 ##
-## Ends in an error in state: 1747.
+## Ends in an error in state: 1749.
 ##
 ## semi_terminated_class_fields -> class_field SEMI . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -7009,7 +7009,7 @@ implementation: LBRACE INHERIT LIDENT SEMI WITH
 
 implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ##
-## Ends in an error in state: 1642.
+## Ends in an error in state: 1644.
 ##
 ## _class_expr -> class_simple_expr simple_labeled_expr_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## simple_labeled_expr_list -> simple_labeled_expr_list . labeled_simple_expr [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7021,20 +7021,20 @@ implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 803, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 818, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 823, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
-## In state 826, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 804, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 819, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 824, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
+## In state 827, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT WITH
 ##
-## Ends in an error in state: 1641.
+## Ends in an error in state: 1643.
 ##
 ## _class_expr -> class_simple_expr . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> class_simple_expr . simple_labeled_expr_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -7047,7 +7047,7 @@ implementation: LBRACE INHERIT LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1775.
+## Ends in an error in state: 1777.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -7059,7 +7059,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE 
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1774.
+## Ends in an error in state: 1776.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -7072,7 +7072,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE 
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1773.
+## Ends in an error in state: 1775.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -7084,7 +7084,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1766.
+## Ends in an error in state: 1768.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -7096,7 +7096,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 1765.
+## Ends in an error in state: 1767.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -7109,7 +7109,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1764.
+## Ends in an error in state: 1766.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -7121,7 +7121,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1767.
+## Ends in an error in state: 1769.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -7133,18 +7133,18 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1763, spurious reduction of production type_longident -> LIDENT
-## In state 253, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
-## In state 258, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
-## In state 256, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
-## In state 260, spurious reduction of production non_arrowed_core_type -> non_arrowed_simple_core_type
+## In state 1765, spurious reduction of production type_longident -> LIDENT
+## In state 254, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
+## In state 259, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
+## In state 257, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
+## In state 261, spurious reduction of production non_arrowed_core_type -> non_arrowed_simple_core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 ##
-## Ends in an error in state: 1538.
+## Ends in an error in state: 1540.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -7157,7 +7157,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1762.
+## Ends in an error in state: 1764.
 ##
 ## _class_constructor_type -> NEW class_instance_type . [ error RPAREN ]
 ## _class_instance_type -> class_instance_type . attribute [ error RPAREN LBRACKETAT ]
@@ -7169,16 +7169,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1586, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1592, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1584, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1588, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1594, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1586, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1587.
+## Ends in an error in state: 1589.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
@@ -7191,7 +7191,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 ##
-## Ends in an error in state: 1586.
+## Ends in an error in state: 1588.
 ##
 ## _class_instance_type -> clty_longident . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -7204,7 +7204,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 ##
-## Ends in an error in state: 1582.
+## Ends in an error in state: 1584.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -7218,7 +7218,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 ##
-## Ends in an error in state: 1581.
+## Ends in an error in state: 1583.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -7238,7 +7238,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1761.
+## Ends in an error in state: 1763.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ error RPAREN ]
 ##
@@ -7250,7 +7250,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1768.
+## Ends in an error in state: 1770.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -7262,7 +7262,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 ##
-## Ends in an error in state: 1760.
+## Ends in an error in state: 1762.
 ##
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7275,7 +7275,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ##
-## Ends in an error in state: 1757.
+## Ends in an error in state: 1759.
 ##
 ## _class_expr -> class_expr . attribute [ error RPAREN LBRACKETAT COLON ]
 ## _class_simple_expr -> LPAREN class_expr . COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7290,16 +7290,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1641, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1647, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1639, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1643, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1649, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1641, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN WITH
 ##
-## Ends in an error in state: 1625.
+## Ends in an error in state: 1627.
 ##
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7314,7 +7314,7 @@ implementation: LBRACE INHERIT LPAREN WITH
 
 implementation: LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1731.
+## Ends in an error in state: 1733.
 ##
 ## _class_field -> INHERIT . override_flag class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7326,7 +7326,7 @@ implementation: LBRACE INHERIT WITH
 
 implementation: LBRACE INITIALIZER EQUALGREATER WITH
 ##
-## Ends in an error in state: 1728.
+## Ends in an error in state: 1730.
 ##
 ## _class_field -> INITIALIZER EQUALGREATER . expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7338,7 +7338,7 @@ implementation: LBRACE INITIALIZER EQUALGREATER WITH
 
 implementation: LBRACE INITIALIZER WITH
 ##
-## Ends in an error in state: 1727.
+## Ends in an error in state: 1729.
 ##
 ## _class_field -> INITIALIZER . EQUALGREATER expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7350,7 +7350,7 @@ implementation: LBRACE INITIALIZER WITH
 
 implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 2322.
+## Ends in an error in state: 2324.
 ##
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -7362,17 +7362,17 @@ implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2247, spurious reduction of production opt_semi -> SEMI
-## In state 2258, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
-## In state 2256, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2245, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2249, spurious reduction of production opt_semi -> SEMI
+## In state 2260, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
+## In state 2258, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2247, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
 ##
 
 Expecting "}" to finish the block
 
 implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2320.
+## Ends in an error in state: 2322.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7384,7 +7384,7 @@ implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 
 implementation: LBRACE LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2317.
+## Ends in an error in state: 2319.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7396,7 +7396,7 @@ implementation: LBRACE LET MODULE UIDENT WITH
 
 implementation: LBRACE LET MODULE WITH
 ##
-## Ends in an error in state: 2316.
+## Ends in an error in state: 2318.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7408,7 +7408,7 @@ implementation: LBRACE LET MODULE WITH
 
 implementation: LBRACE LET OPEN BANG WITH
 ##
-## Ends in an error in state: 436.
+## Ends in an error in state: 437.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7420,7 +7420,7 @@ implementation: LBRACE LET OPEN BANG WITH
 
 implementation: LBRACE LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2314.
+## Ends in an error in state: 2316.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7432,7 +7432,7 @@ implementation: LBRACE LET OPEN UIDENT SEMI WITH
 
 implementation: LBRACE LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2313.
+## Ends in an error in state: 2315.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7443,14 +7443,14 @@ implementation: LBRACE LET OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 437, spurious reduction of production post_item_attributes ->
+## In state 438, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET OPEN WITH
 ##
-## Ends in an error in state: 435.
+## Ends in an error in state: 436.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7462,7 +7462,7 @@ implementation: LBRACE LET OPEN WITH
 
 implementation: LBRACE LET WITH
 ##
-## Ends in an error in state: 433.
+## Ends in an error in state: 434.
 ##
 ## _semi_terminated_seq_expr_row -> LET . MODULE UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ## _semi_terminated_seq_expr_row -> LET . OPEN override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
@@ -7476,7 +7476,7 @@ implementation: LBRACE LET WITH
 
 implementation: LBRACE LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1130.
+## Ends in an error in state: 1131.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7511,21 +7511,21 @@ implementation: LBRACE LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1129.
+## Ends in an error in state: 1130.
 ##
 ## lbl_expr -> label_longident COLON . expr [ COMMA ]
 ## non_punned_lbl_expression -> label_longident COLON . expr [ error RBRACE ]
@@ -7538,7 +7538,7 @@ implementation: LBRACE LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1119.
+## Ends in an error in state: 1120.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7572,21 +7572,21 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 ##
-## Ends in an error in state: 1118.
+## Ends in an error in state: 1119.
 ##
 ## lbl_expr -> label_longident COLON . expr [ error RBRACE COMMA ]
 ##
@@ -7598,7 +7598,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 ##
-## Ends in an error in state: 1115.
+## Ends in an error in state: 1116.
 ##
 ## lbl_expr_list -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ## lbl_expr_list -> lbl_expr COMMA . [ error RBRACE ]
@@ -7611,7 +7611,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT WITH
 ##
-## Ends in an error in state: 1117.
+## Ends in an error in state: 1118.
 ##
 ## lbl_expr -> label_longident . COLON expr [ error RBRACE COMMA ]
 ## lbl_expr -> label_longident . [ error RBRACE COMMA ]
@@ -7624,7 +7624,7 @@ implementation: LBRACE LIDENT COMMA LIDENT WITH
 
 implementation: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 1126.
+## Ends in an error in state: 1127.
 ##
 ## lbl_expr_list_that_is_not_a_single_punned_field -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ##
@@ -7636,7 +7636,7 @@ implementation: LBRACE LIDENT COMMA WITH
 
 implementation: LBRACE METHOD BANG WITH
 ##
-## Ends in an error in state: 1685.
+## Ends in an error in state: 1687.
 ##
 ## method_ -> override_flag . PRIVATE VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag . VIRTUAL private_flag label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -7653,7 +7653,7 @@ implementation: LBRACE METHOD BANG WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1720.
+## Ends in an error in state: 1722.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7687,21 +7687,21 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1719.
+## Ends in an error in state: 1721.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT core_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7713,7 +7713,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1718.
+## Ends in an error in state: 1720.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT core_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7724,19 +7724,19 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1717.
+## Ends in an error in state: 1719.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT . core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7748,7 +7748,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 1715.
+## Ends in an error in state: 1717.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE . lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7760,7 +7760,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE WITH
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1723.
+## Ends in an error in state: 1725.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7794,21 +7794,21 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1722.
+## Ends in an error in state: 1724.
 ##
 ## method_ -> override_flag private_flag label COLON poly_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7820,7 +7820,7 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1721.
+## Ends in an error in state: 1723.
 ##
 ## method_ -> override_flag private_flag label COLON poly_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7831,22 +7831,22 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1329, spurious reduction of production _poly_type -> core_type
-## In state 1330, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1328, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1331, spurious reduction of production _poly_type -> core_type
+## In state 1332, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1330, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON WITH
 ##
-## Ends in an error in state: 1714.
+## Ends in an error in state: 1716.
 ##
 ## method_ -> override_flag private_flag label COLON . poly_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag private_flag label COLON . TYPE lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -7859,7 +7859,7 @@ implementation: LBRACE METHOD LIDENT COLON WITH
 
 implementation: LBRACE METHOD LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1713.
+## Ends in an error in state: 1715.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7893,21 +7893,21 @@ implementation: LBRACE METHOD LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1712.
+## Ends in an error in state: 1714.
 ##
 ## method_ -> override_flag private_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7919,7 +7919,7 @@ implementation: LBRACE METHOD LIDENT EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1746.
+## Ends in an error in state: 1748.
 ##
 ## semi_terminated_class_fields -> class_field . [ error RBRACE ]
 ## semi_terminated_class_fields -> class_field . SEMI semi_terminated_class_fields [ error RBRACE ]
@@ -7931,27 +7931,27 @@ implementation: LBRACE METHOD LIDENT EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1703, spurious reduction of production curried_binding -> EQUALGREATER expr
-## In state 1724, spurious reduction of production method_ -> override_flag private_flag label curried_binding
-## In state 1725, spurious reduction of production post_item_attributes ->
-## In state 1726, spurious reduction of production _class_field -> METHOD method_ post_item_attributes
-## In state 1749, spurious reduction of production mark_position_cf(_class_field) -> _class_field
-## In state 1742, spurious reduction of production class_field -> mark_position_cf(_class_field)
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1705, spurious reduction of production curried_binding -> EQUALGREATER expr
+## In state 1726, spurious reduction of production method_ -> override_flag private_flag label curried_binding
+## In state 1727, spurious reduction of production post_item_attributes ->
+## In state 1728, spurious reduction of production _class_field -> METHOD method_ post_item_attributes
+## In state 1751, spurious reduction of production mark_position_cf(_class_field) -> _class_field
+## In state 1744, spurious reduction of production class_field -> mark_position_cf(_class_field)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1694.
+## Ends in an error in state: 1696.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7963,7 +7963,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1693.
+## Ends in an error in state: 1695.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7975,7 +7975,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL WITH
 ##
-## Ends in an error in state: 1692.
+## Ends in an error in state: 1694.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7987,7 +7987,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL WITH
 
 implementation: LBRACE METHOD PRIVATE WITH
 ##
-## Ends in an error in state: 1691.
+## Ends in an error in state: 1693.
 ##
 ## method_ -> override_flag PRIVATE . VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## private_flag -> PRIVATE . [ LIDENT ]
@@ -8000,7 +8000,7 @@ implementation: LBRACE METHOD PRIVATE WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1573.
+## Ends in an error in state: 1575.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8012,7 +8012,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1572.
+## Ends in an error in state: 1574.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -8025,7 +8025,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WIT
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE WITH
 ##
-## Ends in an error in state: 1570.
+## Ends in an error in state: 1572.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ error SEMI RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AS ]
 ## typevar_list -> QUOTE . ident [ QUOTE DOT ]
@@ -8038,7 +8038,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1689.
+## Ends in an error in state: 1691.
 ##
 ## method_ -> override_flag VIRTUAL private_flag label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8050,7 +8050,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1688.
+## Ends in an error in state: 1690.
 ##
 ## method_ -> override_flag VIRTUAL private_flag label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8062,7 +8062,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT WITH
 
 implementation: LBRACE METHOD VIRTUAL PRIVATE LET
 ##
-## Ends in an error in state: 1687.
+## Ends in an error in state: 1689.
 ##
 ## method_ -> override_flag VIRTUAL private_flag . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8074,7 +8074,7 @@ implementation: LBRACE METHOD VIRTUAL PRIVATE LET
 
 implementation: LBRACE METHOD VIRTUAL WITH
 ##
-## Ends in an error in state: 1686.
+## Ends in an error in state: 1688.
 ##
 ## method_ -> override_flag VIRTUAL . private_flag label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8086,7 +8086,7 @@ implementation: LBRACE METHOD VIRTUAL WITH
 
 implementation: LBRACE METHOD WITH
 ##
-## Ends in an error in state: 1684.
+## Ends in an error in state: 1686.
 ##
 ## _class_field -> METHOD . method_ post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8098,7 +8098,7 @@ implementation: LBRACE METHOD WITH
 
 implementation: LBRACE PERCENT WITH TYPE
 ##
-## Ends in an error in state: 2249.
+## Ends in an error in state: 2251.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ error RBRACE ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ error SEMI RBRACE AND ]
@@ -8110,15 +8110,15 @@ implementation: LBRACE PERCENT WITH TYPE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 387, spurious reduction of production attr_id -> single_attr_id
-## In state 390, spurious reduction of production item_extension_sugar -> PERCENT attr_id
+## In state 388, spurious reduction of production attr_id -> single_attr_id
+## In state 391, spurious reduction of production item_extension_sugar -> PERCENT attr_id
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE UIDENT DOT WITH
 ##
-## Ends in an error in state: 2242.
+## Ends in an error in state: 2244.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
@@ -8145,7 +8145,7 @@ implementation: LBRACE UIDENT DOT WITH
 
 implementation: LBRACE VAL BANG WITH
 ##
-## Ends in an error in state: 1670.
+## Ends in an error in state: 1672.
 ##
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8160,7 +8160,7 @@ implementation: LBRACE VAL BANG WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1683.
+## Ends in an error in state: 1685.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8194,21 +8194,21 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL UIDENT RP
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 ##
-## Ends in an error in state: 1682.
+## Ends in an error in state: 1684.
 ##
 ## value -> override_flag mutable_flag label type_constraint EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8220,7 +8220,7 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1681.
+## Ends in an error in state: 1683.
 ##
 ## value -> override_flag mutable_flag label type_constraint . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8231,20 +8231,20 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1062, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1063, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1680.
+## Ends in an error in state: 1682.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8278,21 +8278,21 @@ implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1679.
+## Ends in an error in state: 1681.
 ##
 ## value -> override_flag mutable_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8304,7 +8304,7 @@ implementation: LBRACE VAL LIDENT EQUAL WITH
 
 implementation: LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1678.
+## Ends in an error in state: 1680.
 ##
 ## value -> override_flag mutable_flag label . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag mutable_flag label . type_constraint EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -8317,7 +8317,7 @@ implementation: LBRACE VAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1675.
+## Ends in an error in state: 1677.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8329,19 +8329,19 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 331, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 690, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 684, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 686, spurious reduction of production _core_type -> core_type2
-## In state 697, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 685, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 332, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 691, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 685, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 687, spurious reduction of production _core_type -> core_type2
+## In state 698, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 686, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1674.
+## Ends in an error in state: 1676.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8354,7 +8354,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1673.
+## Ends in an error in state: 1675.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8367,7 +8367,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 ##
-## Ends in an error in state: 1672.
+## Ends in an error in state: 1674.
 ##
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8380,7 +8380,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 
 implementation: LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1671.
+## Ends in an error in state: 1673.
 ##
 ## mutable_flag -> MUTABLE . [ LIDENT ]
 ## value -> override_flag MUTABLE . VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -8394,7 +8394,7 @@ implementation: LBRACE VAL MUTABLE WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1666.
+## Ends in an error in state: 1668.
 ##
 ## value -> VIRTUAL mutable_flag label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8406,19 +8406,19 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 331, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 690, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 684, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 686, spurious reduction of production _core_type -> core_type2
-## In state 697, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 685, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 332, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 691, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 685, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 687, spurious reduction of production _core_type -> core_type2
+## In state 698, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 686, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1665.
+## Ends in an error in state: 1667.
 ##
 ## value -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8431,7 +8431,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1664.
+## Ends in an error in state: 1666.
 ##
 ## value -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8444,7 +8444,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1663.
+## Ends in an error in state: 1665.
 ##
 ## value -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8457,7 +8457,7 @@ implementation: LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1662.
+## Ends in an error in state: 1664.
 ##
 ## value -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL . mutable_flag label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8470,7 +8470,7 @@ implementation: LBRACE VAL VIRTUAL WITH
 
 implementation: LBRACE VAL WITH
 ##
-## Ends in an error in state: 1661.
+## Ends in an error in state: 1663.
 ##
 ## _class_field -> VAL . value post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8482,7 +8482,7 @@ implementation: LBRACE VAL WITH
 
 implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2331.
+## Ends in an error in state: 2333.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8516,21 +8516,21 @@ implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACELESS LIDENT COLON WITH
 ##
-## Ends in an error in state: 421.
+## Ends in an error in state: 422.
 ##
 ## field_expr -> LIDENT COLON . expr [ error GREATERRBRACE COMMA ]
 ##
@@ -8542,7 +8542,7 @@ implementation: LBRACELESS LIDENT COLON WITH
 
 implementation: LBRACELESS LIDENT COMMA WITH
 ##
-## Ends in an error in state: 425.
+## Ends in an error in state: 426.
 ##
 ## field_expr_list -> field_expr_list COMMA . field_expr [ error GREATERRBRACE COMMA ]
 ## opt_comma -> COMMA . [ error GREATERRBRACE ]
@@ -8555,7 +8555,7 @@ implementation: LBRACELESS LIDENT COMMA WITH
 
 implementation: LBRACELESS LIDENT WITH
 ##
-## Ends in an error in state: 420.
+## Ends in an error in state: 421.
 ##
 ## field_expr -> LIDENT . COLON expr [ error GREATERRBRACE COMMA ]
 ## field_expr -> LIDENT . [ error GREATERRBRACE COMMA ]
@@ -8568,7 +8568,7 @@ implementation: LBRACELESS LIDENT WITH
 
 implementation: LBRACKET DOTDOTDOT WITH
 ##
-## Ends in an error in state: 2182.
+## Ends in an error in state: 2184.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT . expr_optional_constraint RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -8580,7 +8580,7 @@ implementation: LBRACKET DOTDOTDOT WITH
 
 implementation: LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2185.
+## Ends in an error in state: 2187.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint . opt_comma RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## expr_comma_seq_extension -> expr_optional_constraint . COMMA expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -8592,15 +8592,15 @@ implementation: LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 948, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 918, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 928, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 957, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 927, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1060, spurious reduction of production expr_optional_constraint -> expr
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 949, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 919, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 929, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 958, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 928, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1061, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 Expecting one of the following:
@@ -8609,7 +8609,7 @@ Expecting one of the following:
 
 implementation: LBRACKET WITH
 ##
-## Ends in an error in state: 415.
+## Ends in an error in state: 416.
 ##
 ## _simple_expr -> LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## constr_longident -> LBRACKET . RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -8625,7 +8625,7 @@ Expecting one of the following:
 
 implementation: LBRACKETATATAT UNDERSCORE
 ##
-## Ends in an error in state: 454.
+## Ends in an error in state: 455.
 ##
 ## floating_attribute -> LBRACKETATATAT . attr_id payload RBRACKET [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -8637,7 +8637,7 @@ implementation: LBRACKETATATAT UNDERSCORE
 
 implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2276.
+## Ends in an error in state: 2278.
 ##
 ## floating_attribute -> LBRACKETATATAT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -8648,30 +8648,30 @@ implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1929, spurious reduction of production post_item_attributes ->
-## In state 1930, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1931, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1845, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1838, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1932, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1846, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1839, spurious reduction of production structure -> structure_item
-## In state 2023, spurious reduction of production payload -> structure
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1931, spurious reduction of production post_item_attributes ->
+## In state 1932, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1933, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1847, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1840, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1934, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1848, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1841, spurious reduction of production structure -> structure_item
+## In state 2025, spurious reduction of production payload -> structure
 ##
 
 Expecting "]" to finish current floating attribute
 
 implementation: LBRACKETBAR BANG WITH
 ##
-## Ends in an error in state: 463.
+## Ends in an error in state: 464.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -8683,7 +8683,7 @@ implementation: LBRACKETBAR BANG WITH
 
 implementation: LBRACKETBAR MINUSDOT WITH
 ##
-## Ends in an error in state: 808.
+## Ends in an error in state: 809.
 ##
 ## _expr -> subtractive . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -8695,7 +8695,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR PLUSDOT WITH
 ##
-## Ends in an error in state: 842.
+## Ends in an error in state: 843.
 ##
 ## _expr -> additive . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -8707,7 +8707,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR PREFIXOP WITH
 ##
-## Ends in an error in state: 179.
+## Ends in an error in state: 180.
 ##
 ## _simple_expr -> PREFIXOP . simple_expr [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -8719,7 +8719,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1087.
+## Ends in an error in state: 1088.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8731,7 +8731,7 @@ Expecting a type name
 
 implementation: LBRACKETBAR UIDENT COLON WITH
 ##
-## Ends in an error in state: 1084.
+## Ends in an error in state: 1085.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8743,7 +8743,7 @@ implementation: LBRACKETBAR UIDENT COLON WITH
 
 implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1082.
+## Ends in an error in state: 1083.
 ##
 ## type_constraint -> COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8755,7 +8755,7 @@ implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 
 implementation: LBRACKETBAR UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1079.
+## Ends in an error in state: 1080.
 ##
 ## expr_comma_seq -> expr_comma_seq COMMA . expr_optional_constraint [ error COMMA BARRBRACKET ]
 ## opt_comma -> COMMA . [ error BARRBRACKET ]
@@ -8768,7 +8768,7 @@ implementation: LBRACKETBAR UIDENT COMMA WITH
 
 implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 ##
-## Ends in an error in state: 452.
+## Ends in an error in state: 453.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT . attr_id payload RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -8780,7 +8780,7 @@ implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH COLON WITH
 ##
-## Ends in an error in state: 2021.
+## Ends in an error in state: 2023.
 ##
 ## payload -> COLON . core_type [ RBRACKET ]
 ##
@@ -8804,7 +8804,7 @@ implementation: LBRACKETPERCENTPERCENT WITH DOT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ##
-## Ends in an error in state: 2415.
+## Ends in an error in state: 2417.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN RBRACKET BAR ]
 ## payload -> QUESTION pattern . [ RBRACKET ]
@@ -8817,14 +8817,14 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 654, spurious reduction of production pattern -> pattern_without_or
+## In state 655, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2417.
+## Ends in an error in state: 2419.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8858,21 +8858,21 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 948, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 918, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 928, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 957, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 927, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 949, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 919, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 929, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 958, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 928, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2416.
+## Ends in an error in state: 2418.
 ##
 ## payload -> QUESTION pattern WHEN . expr [ RBRACKET ]
 ##
@@ -8884,7 +8884,7 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN WITH
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION WITH
 ##
-## Ends in an error in state: 190.
+## Ends in an error in state: 191.
 ##
 ## payload -> QUESTION . pattern [ RBRACKET ]
 ## payload -> QUESTION . pattern WHEN expr [ RBRACKET ]
@@ -8897,7 +8897,7 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION WITH
 
 implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2278.
+## Ends in an error in state: 2280.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -8908,23 +8908,23 @@ implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1929, spurious reduction of production post_item_attributes ->
-## In state 1930, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1931, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1845, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1838, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1932, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1846, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1839, spurious reduction of production structure -> structure_item
-## In state 2023, spurious reduction of production payload -> structure
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1931, spurious reduction of production post_item_attributes ->
+## In state 1932, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1933, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1847, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1840, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1934, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1848, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1841, spurious reduction of production structure -> structure_item
+## In state 2025, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
@@ -8944,7 +8944,7 @@ implementation: LBRACKETPERCENTPERCENT WITH WITH
 
 implementation: LET CHAR EQUAL CHAR AND WITH
 ##
-## Ends in an error in state: 1880.
+## Ends in an error in state: 1882.
 ##
 ## and_let_binding -> AND . let_binding_body post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -8956,7 +8956,7 @@ implementation: LET CHAR EQUAL CHAR AND WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1896.
+## Ends in an error in state: 1898.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -8990,21 +8990,21 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1900.
+## Ends in an error in state: 1902.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9016,7 +9016,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1899.
+## Ends in an error in state: 1901.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9027,19 +9027,19 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1898.
+## Ends in an error in state: 1900.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9051,7 +9051,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1897.
+## Ends in an error in state: 1899.
 ##
 ## let_binding_body -> val_ident COLON typevar_list . DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -9064,7 +9064,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1894.
+## Ends in an error in state: 1896.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9076,7 +9076,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1893.
+## Ends in an error in state: 1895.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9087,19 +9087,19 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1892.
+## Ends in an error in state: 1894.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9111,7 +9111,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1203.
+## Ends in an error in state: 1204.
 ##
 ## lident_list -> LIDENT . [ DOT ]
 ## lident_list -> LIDENT . lident_list [ DOT ]
@@ -9124,7 +9124,7 @@ implementation: LET LIDENT COLON TYPE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 1890.
+## Ends in an error in state: 1892.
 ##
 ## let_binding_body -> val_ident COLON TYPE . lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9136,7 +9136,7 @@ implementation: LET LIDENT COLON TYPE WITH
 
 implementation: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 1889.
+## Ends in an error in state: 1891.
 ##
 ## let_binding_body -> val_ident COLON . typevar_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## let_binding_body -> val_ident COLON . TYPE lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9150,7 +9150,7 @@ implementation: LET LIDENT COLON WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1903.
+## Ends in an error in state: 1905.
 ##
 ## let_binding_body -> val_ident type_constraint EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9162,7 +9162,7 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 1902.
+## Ends in an error in state: 1904.
 ##
 ## let_binding_body -> val_ident type_constraint . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9173,20 +9173,20 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1062, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1063, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1887.
+## Ends in an error in state: 1889.
 ##
 ## _curried_binding_return_typed -> EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9198,7 +9198,7 @@ implementation: LET LIDENT EQUALGREATER WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1885.
+## Ends in an error in state: 1887.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9210,7 +9210,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1884.
+## Ends in an error in state: 1886.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9222,7 +9222,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1883.
+## Ends in an error in state: 1885.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9234,7 +9234,7 @@ implementation: LET LIDENT LPAREN TYPE WITH
 
 implementation: LET LIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1882.
+## Ends in an error in state: 1884.
 ##
 ## _curried_binding_return_typed -> LPAREN . TYPE LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -9257,7 +9257,7 @@ implementation: LET LIDENT LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1707.
+## Ends in an error in state: 1709.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -9291,21 +9291,21 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1706.
+## Ends in an error in state: 1708.
 ##
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9317,7 +9317,7 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1705.
+## Ends in an error in state: 1707.
 ##
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type . EQUALGREATER expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9331,7 +9331,7 @@ Expecting "=>" to start the function body
 
 implementation: LET LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1704.
+## Ends in an error in state: 1706.
 ##
 ## curried_binding_return_typed_ -> COLON . non_arrowed_core_type EQUALGREATER expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9343,7 +9343,7 @@ implementation: LET LIDENT UNDERSCORE COLON WITH
 
 implementation: LET LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1702.
+## Ends in an error in state: 1704.
 ##
 ## curried_binding -> EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9355,7 +9355,7 @@ Expecting an expression as function body
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1701.
+## Ends in an error in state: 1703.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9367,7 +9367,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1700.
+## Ends in an error in state: 1702.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9379,7 +9379,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1699.
+## Ends in an error in state: 1701.
 ##
 ## curried_binding -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9391,7 +9391,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 1698.
+## Ends in an error in state: 1700.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -9414,7 +9414,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 1708.
+## Ends in an error in state: 1710.
 ##
 ## curried_binding -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9426,7 +9426,7 @@ implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 
 implementation: LET LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1906.
+## Ends in an error in state: 1908.
 ##
 ## _curried_binding_return_typed -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9442,7 +9442,7 @@ Expecting one of the following:
 
 implementation: LET LIDENT WITH
 ##
-## Ends in an error in state: 1881.
+## Ends in an error in state: 1883.
 ##
 ## _simple_pattern -> val_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> val_ident . type_constraint EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9458,7 +9458,7 @@ implementation: LET LIDENT WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 ##
-## Ends in an error in state: 1865.
+## Ends in an error in state: 1867.
 ##
 ## and_nonlocal_module_bindings -> AND . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9470,7 +9470,7 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1864.
+## Ends in an error in state: 1866.
 ##
 ## _structure_item_without_item_extension_sugar -> many_nonlocal_module_bindings . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> many_nonlocal_module_bindings . and_nonlocal_module_bindings [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -9482,16 +9482,16 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WIT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1481, spurious reduction of production post_item_attributes ->
-## In state 1482, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2305, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
+## In state 1483, spurious reduction of production post_item_attributes ->
+## In state 1484, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2307, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE REC WITH
 ##
-## Ends in an error in state: 2303.
+## Ends in an error in state: 2305.
 ##
 ## many_nonlocal_module_bindings -> LET MODULE REC . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9503,7 +9503,7 @@ implementation: LET MODULE REC WITH
 
 implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2290.
+## Ends in an error in state: 2292.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9517,19 +9517,19 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1940, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2012, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2016, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2013, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1942, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2018, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2017, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2289.
+## Ends in an error in state: 2291.
 ##
 ## module_binding_body_expr -> COLON module_type EQUAL . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9541,7 +9541,7 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
 
 implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2288.
+## Ends in an error in state: 2290.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER EQUAL ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER EQUAL ]
@@ -9555,24 +9555,24 @@ implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 129, spurious reduction of production ident -> UIDENT
-## In state 252, spurious reduction of production mty_longident -> ident
-## In state 1411, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1445, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1441, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1409, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1446, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1442, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1410, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1447, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1443, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 130, spurious reduction of production ident -> UIDENT
+## In state 253, spurious reduction of production mty_longident -> ident
+## In state 1413, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1447, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1443, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1411, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1448, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1444, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1412, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1449, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1445, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2287.
+## Ends in an error in state: 2289.
 ##
 ## module_binding_body_expr -> COLON . module_type EQUAL module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9584,7 +9584,7 @@ implementation: LET MODULE UIDENT COLON WITH
 
 implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2286.
+## Ends in an error in state: 2288.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9598,19 +9598,19 @@ implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1940, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2012, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2016, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2013, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1942, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2018, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2017, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2285.
+## Ends in an error in state: 2287.
 ##
 ## module_binding_body_expr -> EQUAL . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9622,7 +9622,7 @@ implementation: LET MODULE UIDENT EQUAL WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2301.
+## Ends in an error in state: 2303.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER module_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9636,19 +9636,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1940, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2012, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2016, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2013, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1942, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2018, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2017, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2300.
+## Ends in an error in state: 2302.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9660,7 +9660,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2299.
+## Ends in an error in state: 2301.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type . EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_type -> non_arrowed_module_type . [ WITH LBRACKETAT EQUALGREATER ]
@@ -9672,21 +9672,21 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 129, spurious reduction of production ident -> UIDENT
-## In state 252, spurious reduction of production mty_longident -> ident
-## In state 1411, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1445, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1441, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1409, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1446, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1442, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 130, spurious reduction of production ident -> UIDENT
+## In state 253, spurious reduction of production mty_longident -> ident
+## In state 1413, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1447, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1443, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1411, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1448, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1444, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER SEMI
 ##
-## Ends in an error in state: 2138.
+## Ends in an error in state: 2140.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER ]
@@ -9699,24 +9699,24 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT CO
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1420, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1434, spurious reduction of production with_constraints -> with_constraint
-## In state 1431, spurious reduction of production _module_type -> module_type WITH with_constraints
-## In state 1447, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1443, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1422, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1436, spurious reduction of production with_constraints -> with_constraint
+## In state 1433, spurious reduction of production _module_type -> module_type WITH with_constraints
+## In state 1449, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1445, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
 ##
-## Ends in an error in state: 2298.
+## Ends in an error in state: 2300.
 ##
 ## _module_binding_body_functor -> functor_args COLON . non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9728,7 +9728,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2297.
+## Ends in an error in state: 2299.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER module_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9742,19 +9742,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2010, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2014, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2011, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1940, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2016, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2015, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2012, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2016, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2013, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1942, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2018, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2017, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2296.
+## Ends in an error in state: 2298.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9766,7 +9766,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2295.
+## Ends in an error in state: 2297.
 ##
 ## _module_binding_body_functor -> functor_args . EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_binding_body_functor -> functor_args . COLON non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9780,7 +9780,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 
 implementation: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 442.
+## Ends in an error in state: 443.
 ##
 ## nonlocal_module_binding_details -> UIDENT . module_binding_body [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9792,7 +9792,7 @@ implementation: LET MODULE UIDENT WITH
 
 implementation: LET MODULE WITH
 ##
-## Ends in an error in state: 441.
+## Ends in an error in state: 442.
 ##
 ## _structure_item_without_item_extension_sugar -> LET MODULE . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> LET MODULE . REC nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -9805,7 +9805,7 @@ implementation: LET MODULE WITH
 
 implementation: LET REC ASSERT
 ##
-## Ends in an error in state: 2308.
+## Ends in an error in state: 2310.
 ##
 ## let_binding_impl -> LET rec_flag . let_binding_body post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9817,7 +9817,7 @@ implementation: LET REC ASSERT
 
 implementation: LET UIDENT UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1915.
+## Ends in an error in state: 1917.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EQUAL BAR ]
 ## let_binding_body -> pattern . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9829,17 +9829,17 @@ implementation: LET UIDENT UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 650, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
-## In state 653, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
-## In state 648, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
-## In state 654, spurious reduction of production pattern -> pattern_without_or
+## In state 651, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
+## In state 654, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
+## In state 649, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
+## In state 655, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1913.
+## Ends in an error in state: 1915.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9851,7 +9851,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1912.
+## Ends in an error in state: 1914.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9862,19 +9862,19 @@ implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1911.
+## Ends in an error in state: 1913.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON . core_type EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9886,7 +9886,7 @@ implementation: LET UNDERSCORE COLON WITH
 
 implementation: LET UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1916.
+## Ends in an error in state: 1918.
 ##
 ## let_binding_body -> pattern EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9898,7 +9898,7 @@ implementation: LET UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE WITH
 ##
-## Ends in an error in state: 1910.
+## Ends in an error in state: 1912.
 ##
 ## _simple_pattern -> simple_pattern_not_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> simple_pattern_not_ident . COLON core_type EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9911,7 +9911,7 @@ implementation: LET UNDERSCORE WITH
 
 implementation: LET WITH
 ##
-## Ends in an error in state: 440.
+## Ends in an error in state: 441.
 ##
 ## _structure_item_without_item_extension_sugar -> LET . MODULE nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -9925,7 +9925,7 @@ Incomplete let binding
 
 implementation: LPAREN ASSERT WITH
 ##
-## Ends in an error in state: 806.
+## Ends in an error in state: 807.
 ##
 ## _expr -> ASSERT . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -9937,7 +9937,7 @@ implementation: LPAREN ASSERT WITH
 
 implementation: LPAREN BACKQUOTE WITH
 ##
-## Ends in an error in state: 464.
+## Ends in an error in state: 465.
 ##
 ## name_tag -> BACKQUOTE . ident [ error UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -9949,7 +9949,7 @@ implementation: LPAREN BACKQUOTE WITH
 
 implementation: LPAREN BANG WITH
 ##
-## Ends in an error in state: 800.
+## Ends in an error in state: 801.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SHARP RPAREN QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## operator -> BANG . [ RPAREN ]
@@ -9962,7 +9962,7 @@ implementation: LPAREN BANG WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 ##
-## Ends in an error in state: 744.
+## Ends in an error in state: 745.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag . simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -9974,7 +9974,7 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ##
-## Ends in an error in state: 741.
+## Ends in an error in state: 742.
 ##
 ## _expr -> FOR pattern IN simple_expr . direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ TO SHARP DOWNTO DOT ]
@@ -9992,17 +9992,17 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 912, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 913, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FOR UNDERSCORE IN WITH
 ##
-## Ends in an error in state: 740.
+## Ends in an error in state: 741.
 ##
 ## _expr -> FOR pattern IN . simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10014,7 +10014,7 @@ implementation: LPAREN FOR UNDERSCORE IN WITH
 
 implementation: LPAREN FOR WITH
 ##
-## Ends in an error in state: 738.
+## Ends in an error in state: 739.
 ##
 ## _expr -> FOR . pattern IN simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10026,7 +10026,7 @@ implementation: LPAREN FOR WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2228.
+## Ends in an error in state: 2230.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10060,17 +10060,17 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2227.
+## Ends in an error in state: 2229.
 ##
 ## leading_bar_match_case -> pattern_with_bar EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10082,7 +10082,7 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2226.
+## Ends in an error in state: 2228.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10116,17 +10116,17 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2225.
+## Ends in an error in state: 2227.
 ##
 ## leading_bar_match_case -> pattern_with_bar WHEN expr EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10138,7 +10138,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2224.
+## Ends in an error in state: 2226.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10172,21 +10172,21 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 948, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 918, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 928, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 957, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 927, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 949, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 919, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 929, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 958, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 928, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2223.
+## Ends in an error in state: 2225.
 ##
 ## leading_bar_match_case -> pattern_with_bar WHEN . expr EQUALGREATER expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10198,7 +10198,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 480.
+## Ends in an error in state: 481.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10210,7 +10210,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 479.
+## Ends in an error in state: 480.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10222,7 +10222,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN LPAREN TYPE WITH
 ##
-## Ends in an error in state: 478.
+## Ends in an error in state: 479.
 ##
 ## _expr -> FUN LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10234,7 +10234,7 @@ implementation: LPAREN FUN LPAREN TYPE WITH
 
 implementation: LPAREN FUN LPAREN WITH
 ##
-## Ends in an error in state: 477.
+## Ends in an error in state: 478.
 ##
 ## _expr -> FUN LPAREN . TYPE LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -10257,7 +10257,7 @@ implementation: LPAREN FUN LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2213.
+## Ends in an error in state: 2215.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10291,17 +10291,17 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2212.
+## Ends in an error in state: 2214.
 ##
 ## fun_def -> EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10313,7 +10313,7 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 484.
+## Ends in an error in state: 485.
 ##
 ## fun_def -> LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10325,7 +10325,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 483.
+## Ends in an error in state: 484.
 ##
 ## fun_def -> LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10337,7 +10337,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 482.
+## Ends in an error in state: 483.
 ##
 ## fun_def -> LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10349,7 +10349,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 481.
+## Ends in an error in state: 482.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -10372,7 +10372,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 2218.
+## Ends in an error in state: 2220.
 ##
 ## fun_def -> labeled_simple_pattern . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10384,7 +10384,7 @@ implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 
 implementation: LPAREN FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2232.
+## Ends in an error in state: 2234.
 ##
 ## _expr -> FUN labeled_simple_pattern . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10396,7 +10396,7 @@ implementation: LPAREN FUN UNDERSCORE WITH
 
 implementation: LPAREN FUN WITH
 ##
-## Ends in an error in state: 476.
+## Ends in an error in state: 477.
 ##
 ## _expr -> FUN . labeled_simple_pattern fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> FUN . LPAREN TYPE LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10410,7 +10410,7 @@ implementation: LPAREN FUN WITH
 
 implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 ##
-## Ends in an error in state: 2264.
+## Ends in an error in state: 2266.
 ##
 ## _expr -> IF simple_expr simple_expr ELSE . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10422,7 +10422,7 @@ implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 
 implementation: LPAREN IF UIDENT WITH
 ##
-## Ends in an error in state: 2262.
+## Ends in an error in state: 2264.
 ##
 ## _expr -> IF simple_expr . simple_expr ELSE expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF simple_expr . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10441,17 +10441,17 @@ implementation: LPAREN IF UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 912, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 913, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN IF WITH
 ##
-## Ends in an error in state: 474.
+## Ends in an error in state: 475.
 ##
 ## _expr -> IF . simple_expr simple_expr ELSE expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF . simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10464,7 +10464,7 @@ implementation: LPAREN IF WITH
 
 implementation: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 456.
+## Ends in an error in state: 457.
 ##
 ## _expr -> LAZY . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10476,7 +10476,7 @@ implementation: LPAREN LAZY WITH
 
 implementation: LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 431.
+## Ends in an error in state: 432.
 ##
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10493,7 +10493,7 @@ implementation: LPAREN LBRACE WITH
 
 implementation: LPAREN LBRACELESS WITH
 ##
-## Ends in an error in state: 422.
+## Ends in an error in state: 423.
 ##
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10507,7 +10507,7 @@ implementation: LPAREN LBRACELESS WITH
 
 implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ##
-## Ends in an error in state: 2183.
+## Ends in an error in state: 2185.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT expr_optional_constraint . RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10518,22 +10518,22 @@ implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 948, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 918, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 928, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 957, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 927, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1060, spurious reduction of production expr_optional_constraint -> expr
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 949, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 919, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 929, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 958, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 928, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1061, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKET UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2186.
+## Ends in an error in state: 2188.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint COMMA . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## opt_comma -> COMMA . [ RBRACKET ]
@@ -10546,7 +10546,7 @@ implementation: LPAREN LBRACKET UIDENT COMMA WITH
 
 implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2348.
+## Ends in an error in state: 2350.
 ##
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10559,23 +10559,23 @@ implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1081, spurious reduction of production expr_optional_constraint -> expr
-## In state 1077, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1082, spurious reduction of production expr_optional_constraint -> expr
+## In state 1078, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKETBAR WITH
 ##
-## Ends in an error in state: 414.
+## Ends in an error in state: 415.
 ##
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10589,7 +10589,7 @@ implementation: LPAREN LBRACKETBAR WITH
 
 implementation: LPAREN LBRACKETPERCENT UNDERSCORE
 ##
-## Ends in an error in state: 188.
+## Ends in an error in state: 189.
 ##
 ## extension -> LBRACKETPERCENT . attr_id payload RBRACKET [ error WITH UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10601,7 +10601,7 @@ implementation: LPAREN LBRACKETPERCENT UNDERSCORE
 
 implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2418.
+## Ends in an error in state: 2420.
 ##
 ## extension -> LBRACKETPERCENT attr_id payload . RBRACKET [ error WITH UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10612,30 +10612,30 @@ implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1929, spurious reduction of production post_item_attributes ->
-## In state 1930, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1931, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1845, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1838, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1932, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1846, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1839, spurious reduction of production structure -> structure_item
-## In state 2023, spurious reduction of production payload -> structure
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1931, spurious reduction of production post_item_attributes ->
+## In state 1932, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1933, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1847, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1840, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1934, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1848, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1841, spurious reduction of production structure -> structure_item
+## In state 2025, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 828.
+## Ends in an error in state: 829.
 ##
 ## _expr -> label EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10647,7 +10647,7 @@ implementation: LPAREN LIDENT EQUAL WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ##
-## Ends in an error in state: 2371.
+## Ends in an error in state: 2373.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr . RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10681,21 +10681,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 948, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 918, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 928, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 957, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 927, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 949, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 919, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 929, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 958, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 928, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2370.
+## Ends in an error in state: 2372.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA . expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10707,7 +10707,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2369.
+## Ends in an error in state: 2371.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr . COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10741,21 +10741,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 948, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 918, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 928, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 957, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 927, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 949, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 919, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 929, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 958, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 928, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2368.
+## Ends in an error in state: 2370.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN . expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10767,7 +10767,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2367.
+## Ends in an error in state: 2369.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN . LPAREN expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10779,7 +10779,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2366.
+## Ends in an error in state: 2368.
 ##
 ## _expr -> LPAREN COLONCOLON . RPAREN LPAREN expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10791,7 +10791,7 @@ implementation: LPAREN LPAREN COLONCOLON WITH
 
 implementation: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2360.
+## Ends in an error in state: 2362.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -10807,19 +10807,19 @@ implementation: LPAREN LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 775, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 779, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 776, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 755, spurious reduction of production _module_expr -> simple_module_expr
-## In state 781, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 780, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 776, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 780, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 777, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 756, spurious reduction of production _module_expr -> simple_module_expr
+## In state 782, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 781, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN MODULE WITH
 ##
-## Ends in an error in state: 410.
+## Ends in an error in state: 411.
 ##
 ## _simple_expr -> LPAREN MODULE . module_expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE . module_expr COLON package_type RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10833,7 +10833,7 @@ Expecting a module expression
 
 implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ##
-## Ends in an error in state: 2373.
+## Ends in an error in state: 2375.
 ##
 ## _simple_expr -> LPAREN expr_comma_list . RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN expr_comma_list . error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10846,19 +10846,19 @@ implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1081, spurious reduction of production expr_optional_constraint -> expr
-## In state 1138, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1082, spurious reduction of production expr_optional_constraint -> expr
+## In state 1139, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 407.
+## Ends in an error in state: 408.
 ##
 ## _expr -> LPAREN . COLONCOLON RPAREN LPAREN expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -10885,7 +10885,7 @@ Expecting one of the following:
 
 implementation: LPAREN MINUS WITH
 ##
-## Ends in an error in state: 783.
+## Ends in an error in state: 784.
 ##
 ## operator -> MINUS . [ RPAREN ]
 ## subtractive -> MINUS . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
@@ -10898,7 +10898,7 @@ implementation: LPAREN MINUS WITH
 
 implementation: LPAREN MINUSDOT WITH
 ##
-## Ends in an error in state: 782.
+## Ends in an error in state: 783.
 ##
 ## operator -> MINUSDOT . [ RPAREN ]
 ## subtractive -> MINUSDOT . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
@@ -10911,7 +10911,7 @@ implementation: LPAREN MINUSDOT WITH
 
 implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2364.
+## Ends in an error in state: 2366.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10922,16 +10922,16 @@ implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 129, spurious reduction of production ident -> UIDENT
-## In state 252, spurious reduction of production mty_longident -> ident
-## In state 132, spurious reduction of production package_type -> mty_longident
+## In state 130, spurious reduction of production ident -> UIDENT
+## In state 253, spurious reduction of production mty_longident -> ident
+## In state 133, spurious reduction of production package_type -> mty_longident
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2362.
+## Ends in an error in state: 2364.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10970,7 +10970,7 @@ implementation: LPAREN NEW UIDENT WITH
 
 implementation: LPAREN NEW WITH
 ##
-## Ends in an error in state: 180.
+## Ends in an error in state: 181.
 ##
 ## _simple_expr -> NEW . class_longident [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10982,7 +10982,7 @@ implementation: LPAREN NEW WITH
 
 implementation: LPAREN PLUS WITH
 ##
-## Ends in an error in state: 409.
+## Ends in an error in state: 410.
 ##
 ## additive -> PLUS . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
 ## operator -> PLUS . [ RPAREN ]
@@ -10995,7 +10995,7 @@ implementation: LPAREN PLUS WITH
 
 implementation: LPAREN PLUSDOT WITH
 ##
-## Ends in an error in state: 408.
+## Ends in an error in state: 409.
 ##
 ## additive -> PLUSDOT . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
 ## operator -> PLUSDOT . [ RPAREN ]
@@ -11008,7 +11008,7 @@ implementation: LPAREN PLUSDOT WITH
 
 implementation: LPAREN PREFIXOP WITH
 ##
-## Ends in an error in state: 186.
+## Ends in an error in state: 187.
 ##
 ## _simple_expr -> PREFIXOP . simple_expr [ error UIDENT TRUE STRING STAR SHARP RPAREN QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## operator -> PREFIXOP . [ RPAREN ]
@@ -11021,7 +11021,7 @@ implementation: LPAREN PREFIXOP WITH
 
 implementation: LPAREN STAR WITH
 ##
-## Ends in an error in state: 582.
+## Ends in an error in state: 583.
 ##
 ## val_ident -> LPAREN operator . RPAREN [ error UNDERSCORE UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11033,7 +11033,7 @@ implementation: LPAREN STAR WITH
 
 implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1066.
+## Ends in an error in state: 1067.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ RPAREN RBRACKET EQUAL COMMA ]
 ##
@@ -11045,7 +11045,7 @@ implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 
 implementation: LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1063.
+## Ends in an error in state: 1064.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ RPAREN RBRACKET EQUAL COMMA ]
 ##
@@ -11057,7 +11057,7 @@ implementation: LPAREN UIDENT COLON WITH
 
 implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1136.
+## Ends in an error in state: 1137.
 ##
 ## expr_comma_list -> expr_optional_constraint . COMMA expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -11068,21 +11068,21 @@ implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1062, spurious reduction of production type_constraint -> COLONGREATER core_type
-## In state 2379, spurious reduction of production expr_optional_constraint -> expr type_constraint
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1063, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 2381, spurious reduction of production expr_optional_constraint -> expr type_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1061.
+## Ends in an error in state: 1062.
 ##
 ## type_constraint -> COLONGREATER . core_type [ RPAREN RBRACKET EQUAL COMMA ]
 ##
@@ -11094,7 +11094,7 @@ implementation: LPAREN UIDENT COLONGREATER WITH
 
 implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 1142.
+## Ends in an error in state: 1143.
 ##
 ## expr_comma_list -> expr_comma_list COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -11106,7 +11106,7 @@ implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 
 implementation: LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1137.
+## Ends in an error in state: 1138.
 ##
 ## expr_comma_list -> expr_optional_constraint COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -11118,7 +11118,7 @@ implementation: LPAREN UIDENT COMMA WITH
 
 implementation: OPEN BANG WITH
 ##
-## Ends in an error in state: 393.
+## Ends in an error in state: 394.
 ##
 ## open_statement -> OPEN override_flag . mod_longident post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -11130,7 +11130,7 @@ implementation: OPEN BANG WITH
 
 implementation: OPEN WITH
 ##
-## Ends in an error in state: 391.
+## Ends in an error in state: 392.
 ##
 ## open_statement -> OPEN . override_flag mod_longident post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -11142,7 +11142,7 @@ implementation: OPEN WITH
 
 implementation: PERCENT UNDERSCORE
 ##
-## Ends in an error in state: 336.
+## Ends in an error in state: 337.
 ##
 ## item_extension_sugar -> PERCENT . attr_id [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW NATIVEINT MODULE MINUSDOT MINUS LPAREN LIDENT LET LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION CLASS CHAR BANG BACKQUOTE ASSERT ]
 ##
@@ -11154,7 +11154,7 @@ implementation: PERCENT UNDERSCORE
 
 implementation: PERCENT WITH DOT UNDERSCORE
 ##
-## Ends in an error in state: 388.
+## Ends in an error in state: 389.
 ##
 ## attr_id -> single_attr_id DOT . attr_id [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW NATIVEINT MODULE MINUSDOT MINUS LPAREN LIDENT LET LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION CLASS CHAR BANG BACKQUOTE ASSERT ]
 ##
@@ -11166,7 +11166,7 @@ implementation: PERCENT WITH DOT UNDERSCORE
 
 implementation: PERCENT WITH WITH
 ##
-## Ends in an error in state: 387.
+## Ends in an error in state: 388.
 ##
 ## attr_id -> single_attr_id . [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW NATIVEINT MODULE MINUSDOT MINUS LPAREN LIDENT LET LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION CLASS CHAR BANG BACKQUOTE ASSERT ]
 ## attr_id -> single_attr_id . DOT attr_id [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW NATIVEINT MODULE MINUSDOT MINUS LPAREN LIDENT LET LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION CLASS CHAR BANG BACKQUOTE ASSERT ]
@@ -11179,7 +11179,7 @@ implementation: PERCENT WITH WITH
 
 implementation: STRING LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 820.
+## Ends in an error in state: 821.
 ##
 ## label_expr -> LIDENT COLONCOLON . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11191,7 +11191,7 @@ implementation: STRING LIDENT COLONCOLON WITH
 
 implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 817.
+## Ends in an error in state: 818.
 ##
 ## label_expr -> LIDENT EXPLICITLY_PASSED_OPTIONAL . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11203,7 +11203,7 @@ implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: STRING WITH
 ##
-## Ends in an error in state: 1839.
+## Ends in an error in state: 1841.
 ##
 ## structure -> structure_item . [ RBRACKET RBRACE EOF ]
 ## structure -> structure_item . error structure [ RBRACKET RBRACE EOF ]
@@ -11216,24 +11216,24 @@ implementation: STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1929, spurious reduction of production post_item_attributes ->
-## In state 1930, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1931, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1845, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1838, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1932, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1846, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1931, spurious reduction of production post_item_attributes ->
+## In state 1932, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1933, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1847, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1840, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1934, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1848, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 Incomplete statement. Did you forget a ";"?
 
 implementation: SWITCH UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2427.
+## Ends in an error in state: 2429.
 ##
 ## _expr -> SWITCH simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11245,7 +11245,7 @@ implementation: SWITCH UIDENT LBRACE WITH
 
 implementation: SWITCH UIDENT WITH
 ##
-## Ends in an error in state: 2426.
+## Ends in an error in state: 2428.
 ##
 ## _expr -> SWITCH simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ SHARP LBRACE DOT ]
@@ -11263,17 +11263,17 @@ implementation: SWITCH UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 912, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 913, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: SWITCH WITH
 ##
-## Ends in an error in state: 176.
+## Ends in an error in state: 177.
 ##
 ## _expr -> SWITCH . simple_expr LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11285,7 +11285,7 @@ implementation: SWITCH WITH
 
 implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 ##
-## Ends in an error in state: 1051.
+## Ends in an error in state: 1052.
 ##
 ## _expr -> simple_expr DOT LBRACE expr RBRACE EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11297,7 +11297,7 @@ implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 
 implementation: TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 1049.
+## Ends in an error in state: 1050.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11332,21 +11332,21 @@ implementation: TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 948, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 918, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 928, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 957, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 927, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 949, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 919, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 929, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 958, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 928, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 1048.
+## Ends in an error in state: 1049.
 ##
 ## _expr -> simple_expr DOT LBRACE . expr RBRACE EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11359,7 +11359,7 @@ implementation: TRUE DOT LBRACE WITH
 
 implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 ##
-## Ends in an error in state: 1046.
+## Ends in an error in state: 1047.
 ##
 ## _expr -> simple_expr DOT LBRACKET expr RBRACKET EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11371,7 +11371,7 @@ implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 
 implementation: TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 1043.
+## Ends in an error in state: 1044.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11407,21 +11407,21 @@ implementation: TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1042.
+## Ends in an error in state: 1043.
 ##
 ## _expr -> simple_expr DOT LBRACKET . expr RBRACKET EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11435,7 +11435,7 @@ implementation: TRUE DOT LBRACKET WITH
 
 implementation: TRUE DOT LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1054.
+## Ends in an error in state: 1055.
 ##
 ## _expr -> simple_expr DOT label_longident EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11447,7 +11447,7 @@ implementation: TRUE DOT LIDENT EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 ##
-## Ends in an error in state: 886.
+## Ends in an error in state: 887.
 ##
 ## _expr -> simple_expr DOT LPAREN expr RPAREN EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11459,7 +11459,7 @@ implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 883.
+## Ends in an error in state: 884.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11495,21 +11495,21 @@ implementation: TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 811.
+## Ends in an error in state: 812.
 ##
 ## _expr -> simple_expr DOT LPAREN . expr RPAREN EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11523,7 +11523,7 @@ implementation: TRUE DOT LPAREN WITH
 
 implementation: TRUE DOT UIDENT DOT WITH
 ##
-## Ends in an error in state: 519.
+## Ends in an error in state: 520.
 ##
 ## label_longident -> mod_longident DOT . LIDENT [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident DOT . UIDENT [ DOT ]
@@ -11536,7 +11536,7 @@ implementation: TRUE DOT UIDENT DOT WITH
 
 implementation: TRUE DOT UIDENT WITH
 ##
-## Ends in an error in state: 518.
+## Ends in an error in state: 519.
 ##
 ## label_longident -> mod_longident . DOT LIDENT [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident . DOT UIDENT [ DOT ]
@@ -11549,7 +11549,7 @@ implementation: TRUE DOT UIDENT WITH
 
 implementation: TRUE DOT WITH
 ##
-## Ends in an error in state: 810.
+## Ends in an error in state: 811.
 ##
 ## _expr -> simple_expr DOT . label_longident EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> simple_expr DOT . LPAREN expr RPAREN EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -11570,7 +11570,7 @@ implementation: TRUE DOT WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER CHAR BAR WITH
 ##
-## Ends in an error in state: 762.
+## Ends in an error in state: 763.
 ##
 ## pattern_with_bar -> BAR . pattern [ WHEN EQUALGREATER ]
 ##
@@ -11582,7 +11582,7 @@ Expecting a match case
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT RBRACKET
 ##
-## Ends in an error in state: 775.
+## Ends in an error in state: 776.
 ##
 ## _simple_module_expr -> mod_longident . [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF DOT COLON AND ]
@@ -11595,7 +11595,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2128.
+## Ends in an error in state: 2130.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11607,7 +11607,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1239.
+## Ends in an error in state: 1240.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11619,7 +11619,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 ##
-## Ends in an error in state: 1238.
+## Ends in an error in state: 1239.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11631,7 +11631,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 ##
-## Ends in an error in state: 1153.
+## Ends in an error in state: 1154.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11643,7 +11643,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 1156.
+## Ends in an error in state: 1157.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11655,7 +11655,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 1155.
+## Ends in an error in state: 1156.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11666,14 +11666,14 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1154, spurious reduction of production post_item_attributes ->
+## In state 1155, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 ##
-## Ends in an error in state: 1152.
+## Ends in an error in state: 1153.
 ##
 ## _semi_terminated_seq_expr_row -> LET OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11685,7 +11685,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 ##
-## Ends in an error in state: 1151.
+## Ends in an error in state: 1152.
 ##
 ## _semi_terminated_seq_expr_row -> LET . MODULE UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ## _semi_terminated_seq_expr_row -> LET . OPEN override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
@@ -11699,7 +11699,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 ##
-## Ends in an error in state: 1166.
+## Ends in an error in state: 1167.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ RBRACE BAR ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI RBRACE BAR AND ]
@@ -11711,15 +11711,15 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 387, spurious reduction of production attr_id -> single_attr_id
-## In state 390, spurious reduction of production item_extension_sugar -> PERCENT attr_id
+## In state 388, spurious reduction of production attr_id -> single_attr_id
+## In state 391, spurious reduction of production item_extension_sugar -> PERCENT attr_id
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 2546.
+## Ends in an error in state: 2548.
 ##
 ## _expr -> TRY simple_expr LBRACE leading_bar_match_cases_to_sequence_body . RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## leading_bar_match_cases_to_sequence_body -> leading_bar_match_cases_to_sequence_body . leading_bar_match_case_to_sequence_body [ RBRACE BAR ]
@@ -11731,24 +11731,24 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 948, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 918, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 928, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 957, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 927, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1169, spurious reduction of production post_item_attributes ->
-## In state 1170, spurious reduction of production opt_semi ->
-## In state 1175, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
-## In state 1173, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
-## In state 1159, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
-## In state 1157, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
-## In state 1174, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 1160, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
-## In state 2142, spurious reduction of production leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER semi_terminated_seq_expr
-## In state 2146, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 949, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 919, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 929, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 958, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 928, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1170, spurious reduction of production post_item_attributes ->
+## In state 1171, spurious reduction of production opt_semi ->
+## In state 1176, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
+## In state 1174, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
+## In state 1160, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
+## In state 1158, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
+## In state 1175, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 1161, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2144, spurious reduction of production leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER semi_terminated_seq_expr
+## In state 2148, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
 ##
 
 Expecting one of the following:
@@ -11757,7 +11757,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2141.
+## Ends in an error in state: 2143.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11769,7 +11769,7 @@ Expecting the body of the matched pattern
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ##
-## Ends in an error in state: 763.
+## Ends in an error in state: 764.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN EQUALGREATER BAR ]
 ## pattern_with_bar -> BAR pattern . [ WHEN EQUALGREATER ]
@@ -11781,7 +11781,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 654, spurious reduction of production pattern -> pattern_without_or
+## In state 655, spurious reduction of production pattern -> pattern_without_or
 ##
 
 Expecting one of the following:
@@ -11791,7 +11791,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1150.
+## Ends in an error in state: 1151.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar WHEN expr EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11803,7 +11803,7 @@ Expecting a sequence item
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 1149.
+## Ends in an error in state: 1150.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11837,21 +11837,21 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 948, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 918, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 928, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 957, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 927, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 949, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 919, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 929, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 958, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 928, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 765.
+## Ends in an error in state: 766.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar WHEN . expr EQUALGREATER semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11863,7 +11863,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 
 implementation: TRY UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2545.
+## Ends in an error in state: 2547.
 ##
 ## _expr -> TRY simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11875,7 +11875,7 @@ implementation: TRY UIDENT LBRACE WITH
 
 implementation: TRY UIDENT UNDERSCORE
 ##
-## Ends in an error in state: 2542.
+## Ends in an error in state: 2544.
 ##
 ## _expr -> TRY simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> TRY simple_expr . WITH error [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -11894,17 +11894,17 @@ implementation: TRY UIDENT UNDERSCORE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 912, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 913, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT WITH WITH
 ##
-## Ends in an error in state: 2543.
+## Ends in an error in state: 2545.
 ##
 ## _expr -> TRY simple_expr WITH . error [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11929,7 +11929,7 @@ implementation: TRY WITH
 
 implementation: TYPE LIDENT AND LIDENT WITH
 ##
-## Ends in an error in state: 1850.
+## Ends in an error in state: 1852.
 ##
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -11940,14 +11940,14 @@ implementation: TYPE LIDENT AND LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1849, spurious reduction of production optional_type_parameters ->
+## In state 1851, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT AND WITH
 ##
-## Ends in an error in state: 1848.
+## Ends in an error in state: 1850.
 ##
 ## and_type_declaration -> AND . type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -11959,7 +11959,7 @@ implementation: TYPE LIDENT AND WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1855.
+## Ends in an error in state: 1857.
 ##
 ## constrain -> core_type EQUAL . core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -11971,7 +11971,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1854.
+## Ends in an error in state: 1856.
 ##
 ## constrain -> core_type . EQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -11982,19 +11982,19 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT CONSTRAINT WITH
 ##
-## Ends in an error in state: 1853.
+## Ends in an error in state: 1855.
 ##
 ## constraints -> constraints CONSTRAINT . constrain [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -12006,7 +12006,7 @@ implementation: TYPE LIDENT CONSTRAINT WITH
 
 implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2501.
+## Ends in an error in state: 2503.
 ##
 ## constructor_declarations -> constructor_declarations_leading_bar . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations_leading_bar -> constructor_declarations_leading_bar . constructor_declaration_leading_bar [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
@@ -12018,17 +12018,17 @@ implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1490, spurious reduction of production attributes ->
-## In state 1491, spurious reduction of production attributes -> attribute attributes
-## In state 2486, spurious reduction of production constructor_declaration_leading_bar -> BAR UIDENT generalized_constructor_arguments attributes
-## In state 2506, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
+## In state 1492, spurious reduction of production attributes ->
+## In state 1493, spurious reduction of production attributes -> attribute attributes
+## In state 2488, spurious reduction of production constructor_declaration_leading_bar -> BAR UIDENT generalized_constructor_arguments attributes
+## In state 2508, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 ##
-## Ends in an error in state: 1852.
+## Ends in an error in state: 1854.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_declaration_details -> LIDENT optional_type_parameters type_kind constraints . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -12041,7 +12041,7 @@ implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 ##
-## Ends in an error in state: 1332.
+## Ends in an error in state: 1334.
 ##
 ## label_declarations -> label_declarations COMMA . label_declaration [ RBRACE COMMA ]
 ## opt_comma -> COMMA . [ RBRACE ]
@@ -12056,7 +12056,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2510.
+## Ends in an error in state: 2512.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12068,18 +12068,18 @@ implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 262, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 274, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 265, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 270, spurious reduction of production _core_type -> core_type2
-## In state 279, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 266, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1329, spurious reduction of production _poly_type -> core_type
-## In state 1330, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1328, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 1326, spurious reduction of production attributes ->
-## In state 1327, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 1336, spurious reduction of production label_declarations -> label_declaration
+## In state 263, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 275, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 266, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 271, spurious reduction of production _core_type -> core_type2
+## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1331, spurious reduction of production _poly_type -> core_type
+## In state 1332, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1330, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 1328, spurious reduction of production attributes ->
+## In state 1329, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 1338, spurious reduction of production label_declarations -> label_declaration
 ##
 
 Expecting one of the following:
@@ -12088,7 +12088,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1322.
+## Ends in an error in state: 1324.
 ##
 ## label_declaration -> mutable_flag LIDENT COLON . poly_type attributes [ RBRACE COMMA ]
 ##
@@ -12100,7 +12100,7 @@ Expecting a type name describing this field
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 1321.
+## Ends in an error in state: 1323.
 ##
 ## label_declaration -> mutable_flag LIDENT . COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -12113,7 +12113,7 @@ Expecting ":"
 
 implementation: TYPE LIDENT EQUAL LBRACE MUTABLE LET
 ##
-## Ends in an error in state: 1320.
+## Ends in an error in state: 1322.
 ##
 ## label_declaration -> mutable_flag . LIDENT COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -12126,7 +12126,7 @@ Expecting a type field definition in the form of:
 
 implementation: TYPE LIDENT EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2509.
+## Ends in an error in state: 2511.
 ##
 ## type_kind -> EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -12139,7 +12139,7 @@ Expecting at least one type field definition in the form of:
 
     implementation: TYPE LIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 2473.
+## Ends in an error in state: 2475.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
 ## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
@@ -12153,7 +12153,7 @@ Expecting at least one type field definition in the form of:
 
 implementation: TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 2472.
+## Ends in an error in state: 2474.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL PRIVATE . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12181,7 +12181,7 @@ implementation: TYPE LIDENT EQUAL UIDENT WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 ##
-## Ends in an error in state: 2483.
+## Ends in an error in state: 2485.
 ##
 ## constructor_declaration_leading_bar -> BAR . UIDENT generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
 ## constructor_declaration_leading_bar -> BAR . LPAREN RPAREN generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
@@ -12197,7 +12197,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 2522.
+## Ends in an error in state: 2524.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12209,17 +12209,17 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDO
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1276, spurious reduction of production attributes ->
-## In state 1277, spurious reduction of production attributes -> attribute attributes
-## In state 1327, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 1336, spurious reduction of production label_declarations -> label_declaration
+## In state 1278, spurious reduction of production attributes ->
+## In state 1279, spurious reduction of production attributes -> attribute attributes
+## In state 1329, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 1338, spurious reduction of production label_declarations -> label_declaration
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2521.
+## Ends in an error in state: 2523.
 ##
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -12231,7 +12231,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 ##
-## Ends in an error in state: 2516.
+## Ends in an error in state: 2518.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL core_type EQUAL PRIVATE . constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12244,7 +12244,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2504.
+## Ends in an error in state: 2506.
 ##
 ## constructor_declarations -> constructor_declaration_no_leading_bar . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations -> constructor_declaration_no_leading_bar . constructor_declarations_leading_bar [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12256,16 +12256,16 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1490, spurious reduction of production attributes ->
-## In state 1491, spurious reduction of production attributes -> attribute attributes
-## In state 2468, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
+## In state 1492, spurious reduction of production attributes ->
+## In state 1493, spurious reduction of production attributes -> attribute attributes
+## In state 2470, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2514.
+## Ends in an error in state: 2516.
 ##
 ## type_kind -> EQUAL core_type EQUAL . constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type EQUAL . PRIVATE constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12280,7 +12280,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 2513.
+## Ends in an error in state: 2515.
 ##
 ## type_kind -> EQUAL core_type . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type . EQUAL constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12295,12 +12295,12 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 331, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 690, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 684, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 686, spurious reduction of production _core_type -> core_type2
-## In state 697, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 685, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 332, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 691, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 685, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 687, spurious reduction of production _core_type -> core_type2
+## In state 698, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 686, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
@@ -12328,7 +12328,7 @@ implementation: TYPE LIDENT EQUAL WITH
 
 implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1847.
+## Ends in an error in state: 1849.
 ##
 ## _structure_item_without_item_extension_sugar -> many_type_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -12340,9 +12340,9 @@ implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1481, spurious reduction of production post_item_attributes ->
-## In state 1482, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2528, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 1483, spurious reduction of production post_item_attributes ->
+## In state 1484, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2530, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
@@ -12399,7 +12399,7 @@ implementation: TYPE LIDENT PLUS WITH
 
 implementation: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 2532.
+## Ends in an error in state: 2534.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12411,7 +12411,7 @@ implementation: TYPE LIDENT PLUSEQ BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 2531.
+## Ends in an error in state: 2533.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12423,7 +12423,7 @@ implementation: TYPE LIDENT PLUSEQ PRIVATE BANG
 
 implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 2534.
+## Ends in an error in state: 2536.
 ##
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_rebind [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -12436,7 +12436,7 @@ implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 2530.
+## Ends in an error in state: 2532.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12484,7 +12484,7 @@ Expecting one of the following:
 
 implementation: TYPE UIDENT DOT WITH
 ##
-## Ends in an error in state: 1392.
+## Ends in an error in state: 1394.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -12498,7 +12498,7 @@ implementation: TYPE UIDENT DOT WITH
 
 implementation: TYPE UIDENT WITH
 ##
-## Ends in an error in state: 1391.
+## Ends in an error in state: 1393.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -12537,7 +12537,7 @@ implementation: TYPE WITH
 
 implementation: UIDENT AMPERAMPER WITH
 ##
-## Ends in an error in state: 879.
+## Ends in an error in state: 880.
 ##
 ## _expr -> expr AMPERAMPER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12549,7 +12549,7 @@ implementation: UIDENT AMPERAMPER WITH
 
 implementation: UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 877.
+## Ends in an error in state: 878.
 ##
 ## _expr -> expr AMPERSAND . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12561,7 +12561,7 @@ implementation: UIDENT AMPERSAND WITH
 
 implementation: UIDENT BARBAR WITH
 ##
-## Ends in an error in state: 875.
+## Ends in an error in state: 876.
 ##
 ## _expr -> expr BARBAR . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12573,7 +12573,7 @@ implementation: UIDENT BARBAR WITH
 
 implementation: UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 881.
+## Ends in an error in state: 882.
 ##
 ## _expr -> expr COLONEQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12585,7 +12585,7 @@ implementation: UIDENT COLONEQUAL WITH
 
 implementation: UIDENT DOT LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 1128.
+## Ends in an error in state: 1129.
 ##
 ## lbl_expr -> label_longident . COLON expr [ COMMA ]
 ## lbl_expr -> label_longident . [ COMMA ]
@@ -12599,7 +12599,7 @@ implementation: UIDENT DOT LBRACE LIDENT WITH
 
 implementation: UIDENT DOT LBRACE WITH
 ##
-## Ends in an error in state: 2196.
+## Ends in an error in state: 2198.
 ##
 ## _simple_expr -> mod_longident DOT LBRACE . RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12613,7 +12613,7 @@ implementation: UIDENT DOT LBRACE WITH
 
 implementation: UIDENT DOT LBRACELESS WITH
 ##
-## Ends in an error in state: 2191.
+## Ends in an error in state: 2193.
 ##
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12626,7 +12626,7 @@ implementation: UIDENT DOT LBRACELESS WITH
 
 implementation: UIDENT DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2181.
+## Ends in an error in state: 2183.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12638,7 +12638,7 @@ implementation: UIDENT DOT LBRACKET WITH
 
 implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2177.
+## Ends in an error in state: 2179.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12651,23 +12651,23 @@ implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1081, spurious reduction of production expr_optional_constraint -> expr
-## In state 1077, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1082, spurious reduction of production expr_optional_constraint -> expr
+## In state 1078, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LBRACKETBAR WITH
 ##
-## Ends in an error in state: 2176.
+## Ends in an error in state: 2178.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12680,7 +12680,7 @@ implementation: UIDENT DOT LBRACKETBAR WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2169.
+## Ends in an error in state: 2171.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12691,16 +12691,16 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 129, spurious reduction of production ident -> UIDENT
-## In state 252, spurious reduction of production mty_longident -> ident
-## In state 132, spurious reduction of production package_type -> mty_longident
+## In state 130, spurious reduction of production ident -> UIDENT
+## In state 253, spurious reduction of production mty_longident -> ident
+## In state 133, spurious reduction of production package_type -> mty_longident
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2167.
+## Ends in an error in state: 2169.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12713,7 +12713,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2166.
+## Ends in an error in state: 2168.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -12728,19 +12728,19 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 775, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 779, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 776, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 755, spurious reduction of production _module_expr -> simple_module_expr
-## In state 781, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 780, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 776, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 780, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 777, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 756, spurious reduction of production _module_expr -> simple_module_expr
+## In state 782, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 781, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN MODULE WITH
 ##
-## Ends in an error in state: 751.
+## Ends in an error in state: 752.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON package_type RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12753,7 +12753,7 @@ implementation: UIDENT DOT LPAREN MODULE WITH
 
 implementation: UIDENT DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1057.
+## Ends in an error in state: 1058.
 ##
 ## expr_comma_list -> expr_optional_constraint . COMMA expr_optional_constraint [ RPAREN COMMA ]
 ##
@@ -12764,22 +12764,22 @@ implementation: UIDENT DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2173, spurious reduction of production expr_optional_constraint -> expr
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2175, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN WITH
 ##
-## Ends in an error in state: 750.
+## Ends in an error in state: 751.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN . expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12796,7 +12796,7 @@ implementation: UIDENT DOT LPAREN WITH
 
 implementation: UIDENT DOT WITH
 ##
-## Ends in an error in state: 749.
+## Ends in an error in state: 750.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12822,7 +12822,7 @@ implementation: UIDENT DOT WITH
 
 implementation: UIDENT GREATER WITH
 ##
-## Ends in an error in state: 873.
+## Ends in an error in state: 874.
 ##
 ## _expr -> expr GREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12834,7 +12834,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP0 WITH
 ##
-## Ends in an error in state: 871.
+## Ends in an error in state: 872.
 ##
 ## _expr -> expr INFIXOP0 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12846,7 +12846,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP1 WITH
 ##
-## Ends in an error in state: 865.
+## Ends in an error in state: 866.
 ##
 ## _expr -> expr INFIXOP1 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12858,7 +12858,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP2 WITH
 ##
-## Ends in an error in state: 863.
+## Ends in an error in state: 864.
 ##
 ## _expr -> expr INFIXOP2 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12870,7 +12870,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP3 WITH
 ##
-## Ends in an error in state: 849.
+## Ends in an error in state: 850.
 ##
 ## _expr -> expr INFIXOP3 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12882,7 +12882,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP4 WITH
 ##
-## Ends in an error in state: 832.
+## Ends in an error in state: 833.
 ##
 ## _expr -> expr INFIXOP4 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12894,7 +12894,7 @@ Expecting an expression
 
 implementation: UIDENT LBRACKETAT UNDERSCORE
 ##
-## Ends in an error in state: 332.
+## Ends in an error in state: 333.
 ##
 ## attribute -> LBRACKETAT . attr_id payload RBRACKET [ error WITH UIDENT STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARRBRACKET BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12906,7 +12906,7 @@ Expecting an attribute id
 
 implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2396.
+## Ends in an error in state: 2398.
 ##
 ## attribute -> LBRACKETAT attr_id payload . RBRACKET [ error WITH UIDENT STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARRBRACKET BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12917,30 +12917,30 @@ implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1929, spurious reduction of production post_item_attributes ->
-## In state 1930, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1931, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1845, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1838, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1932, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1846, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1839, spurious reduction of production structure -> structure_item
-## In state 2023, spurious reduction of production payload -> structure
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1931, spurious reduction of production post_item_attributes ->
+## In state 1932, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1933, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1847, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1840, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1934, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1848, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1841, spurious reduction of production structure -> structure_item
+## In state 2025, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
 
 implementation: UIDENT LBRACKETATAT UNDERSCORE
 ##
-## Ends in an error in state: 395.
+## Ends in an error in state: 396.
 ##
 ## item_attribute -> LBRACKETATAT . attr_id payload RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -12952,7 +12952,7 @@ Expecting an attributed id
 
 implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2393.
+## Ends in an error in state: 2395.
 ##
 ## item_attribute -> LBRACKETATAT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -12963,30 +12963,30 @@ implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1929, spurious reduction of production post_item_attributes ->
-## In state 1930, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1931, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1845, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1838, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1932, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1846, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1839, spurious reduction of production structure -> structure_item
-## In state 2023, spurious reduction of production payload -> structure
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1931, spurious reduction of production post_item_attributes ->
+## In state 1932, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1933, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1847, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1840, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1934, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1848, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1841, spurious reduction of production structure -> structure_item
+## In state 2025, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
 
 implementation: UIDENT LESS WITH
 ##
-## Ends in an error in state: 869.
+## Ends in an error in state: 870.
 ##
 ## _expr -> expr LESS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12998,7 +12998,7 @@ Expecting an expression
 
 implementation: UIDENT LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 867.
+## Ends in an error in state: 868.
 ##
 ## _expr -> expr LESSDOTDOTGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13010,7 +13010,7 @@ Expecting an expression
 
 implementation: UIDENT LESSGREATER WITH
 ##
-## Ends in an error in state: 861.
+## Ends in an error in state: 862.
 ##
 ## _expr -> expr LESSGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13022,7 +13022,7 @@ Expecting an expression
 
 implementation: UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 183.
+## Ends in an error in state: 184.
 ##
 ## _simple_expr -> LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -13047,7 +13047,7 @@ Expecting one of the following:
 
 implementation: UIDENT MINUS WITH
 ##
-## Ends in an error in state: 859.
+## Ends in an error in state: 860.
 ##
 ## _expr -> expr MINUS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13059,7 +13059,7 @@ Expecting an expression
 
 implementation: UIDENT MINUSDOT WITH
 ##
-## Ends in an error in state: 857.
+## Ends in an error in state: 858.
 ##
 ## _expr -> expr MINUSDOT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13071,7 +13071,7 @@ Expecting an expression
 
 implementation: UIDENT OR WITH
 ##
-## Ends in an error in state: 855.
+## Ends in an error in state: 856.
 ##
 ## _expr -> expr OR . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13083,7 +13083,7 @@ Expecting an expression
 
 implementation: UIDENT PERCENT WITH
 ##
-## Ends in an error in state: 847.
+## Ends in an error in state: 848.
 ##
 ## _expr -> expr PERCENT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13095,7 +13095,7 @@ Expecting an expression
 
 implementation: UIDENT PLUS WITH
 ##
-## Ends in an error in state: 853.
+## Ends in an error in state: 854.
 ##
 ## _expr -> expr PLUS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13107,7 +13107,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSDOT WITH
 ##
-## Ends in an error in state: 851.
+## Ends in an error in state: 852.
 ##
 ## _expr -> expr PLUSDOT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13119,7 +13119,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 845.
+## Ends in an error in state: 846.
 ##
 ## _expr -> expr PLUSEQ . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13131,7 +13131,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1040.
+## Ends in an error in state: 1041.
 ##
 ## _expr -> expr QUESTION expr COLON . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13143,7 +13143,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT SEMI
 ##
-## Ends in an error in state: 1039.
+## Ends in an error in state: 1040.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -13177,14 +13177,14 @@ implementation: UIDENT QUESTION UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 948, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 918, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 928, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 957, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 927, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 949, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 919, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 929, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 958, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 928, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13193,7 +13193,7 @@ Expecting one of the following:
 
 implementation: UIDENT QUESTION WITH
 ##
-## Ends in an error in state: 888.
+## Ends in an error in state: 889.
 ##
 ## _expr -> expr QUESTION . expr COLON expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13205,7 +13205,7 @@ Expecting an expression
 
 implementation: UIDENT RBRACKET
 ##
-## Ends in an error in state: 2554.
+## Ends in an error in state: 2556.
 ##
 ## implementation -> structure . EOF [ # ]
 ##
@@ -13216,29 +13216,29 @@ implementation: UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1929, spurious reduction of production post_item_attributes ->
-## In state 1930, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1931, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1845, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1838, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1932, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1846, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1839, spurious reduction of production structure -> structure_item
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1931, spurious reduction of production post_item_attributes ->
+## In state 1932, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1933, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1847, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1840, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1934, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1848, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1841, spurious reduction of production structure -> structure_item
 ##
 
 Invalid token
 
 implementation: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 1933.
+## Ends in an error in state: 1935.
 ##
 ## structure -> structure_item SEMI . structure [ RBRACKET RBRACE EOF ]
 ##
@@ -13250,7 +13250,7 @@ Expecting a structure item
 
 implementation: UIDENT SHARP WITH
 ##
-## Ends in an error in state: 469.
+## Ends in an error in state: 470.
 ##
 ## _simple_expr -> simple_expr SHARP . label [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -13262,7 +13262,7 @@ Expecting an identifier
 
 implementation: UIDENT STAR WITH
 ##
-## Ends in an error in state: 830.
+## Ends in an error in state: 831.
 ##
 ## _expr -> expr STAR . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13274,7 +13274,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 2272.
+## Ends in an error in state: 2274.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13308,14 +13308,14 @@ implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 791, spurious reduction of production constr_longident -> mod_longident
-## In state 948, spurious reduction of production _simple_expr -> constr_longident
-## In state 914, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 910, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 918, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 928, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 957, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 927, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 949, spurious reduction of production _simple_expr -> constr_longident
+## In state 915, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 911, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 919, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 929, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 958, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 928, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13324,7 +13324,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 2271.
+## Ends in an error in state: 2273.
 ##
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -13336,7 +13336,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2269.
+## Ends in an error in state: 2271.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13371,14 +13371,14 @@ implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13387,7 +13387,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2268.
+## Ends in an error in state: 2270.
 ##
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -13400,7 +13400,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2266.
+## Ends in an error in state: 2268.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13435,14 +13435,14 @@ implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 748, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 805, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 801, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 809, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 815, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 844, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 814, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 749, spurious reduction of production constr_longident -> mod_longident
+## In state 836, spurious reduction of production _simple_expr -> constr_longident
+## In state 806, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 802, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 810, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 816, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 845, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 815, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13451,7 +13451,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 473.
+## Ends in an error in state: 474.
 ##
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr error [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -13464,7 +13464,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT WITH
 ##
-## Ends in an error in state: 472.
+## Ends in an error in state: 473.
 ##
 ## _simple_expr -> simple_expr DOT . label_longident [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -865,6 +865,7 @@ let built_in_explicit_arity_constructors = ["Some"; "Assert_failure"; "Match_fai
 %token LBRACKETAT
 %token LBRACKETATAT
 %token LBRACKETATATAT
+%token OF
 %token SWITCH
 %token MATCH
 %token METHOD
@@ -3598,6 +3599,8 @@ sig_exception_declaration:
 ;
 generalized_constructor_arguments:
     /*empty*/                                   { ([],None) }
+  | as_loc(OF)
+      { Location.raise_errorf ~loc:$1.loc "The of keyword is not used in Reason" }
   | non_arrowed_simple_core_type_list                    { (List.rev $1, None) }
   | non_arrowed_simple_core_type_list COLON core_type
                                                 { (List.rev $1,Some $3) }


### PR DESCRIPTION
Fixes #690.