### PR TITLE
Fix disappearing item attributes with Bucklescript's FFI

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -315,6 +315,9 @@ let myFun
 
 let myFun
     (X (hello [@onHello]) | Y (hello [@onHello])) => hello;
+
 /* Another bug: Cannot have an attribute on or pattern
    let myFun = fun ((X hello | Y hello) [@onOrPattern]) => hello;
    */
+/* Bucklescript FFI item attributes */
+external imul : int => int => int = "Math.imul" [@@bs.val];

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -245,3 +245,7 @@ let myFun = fun (X (hello [@onHello]) | Y (hello [@onHello])) => hello;
 /* Another bug: Cannot have an attribute on or pattern
 let myFun = fun ((X hello | Y hello) [@onOrPattern]) => hello;
 */
+
+/* Bucklescript FFI item attributes */
+
+external imul : int => int => int = "Math.imul" [@@bs.val];

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -5460,12 +5460,14 @@ class printer  ()= object(self:'self)
         | Pstr_class l -> self#class_declaration_list l
         | Pstr_class_type (l) -> self#class_type_declaration_list l
         | Pstr_primitive vd ->
-            makeList ~postSpace:true [
+            let attrs =  List.map (fun x -> self#item_attribute x) vd.pval_attributes in 
+            let lst = List.append [
               atom ("external");
               protectIdentifier vd.pval_name.txt;
               atom (":");
               self#value_description vd;
-            ]
+            ] attrs in
+            makeList ~postSpace:true lst
         | Pstr_include incl ->
             (* Kind of a hack *)
             let moduleExpr = incl.pincl_mod in


### PR DESCRIPTION
Fix for https://github.com/facebook/reason/issues/521

Item attributes are now preserved after a refmt format.