### PR TITLE
[parser] Nit: better error for `of`

### DIFF
--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -3600,7 +3600,7 @@ sig_exception_declaration:
 generalized_constructor_arguments:
     /*empty*/                                   { ([],None) }
   | as_loc(OF)
-      { Location.raise_errorf ~loc:$1.loc "The of keyword is not used in Reason" }
+      { Location.raise_errorf ~loc:$1.loc "The `of` keyword after an OCaml variant constructor is not needed in the Reason syntax." }
   | non_arrowed_simple_core_type_list                    { (List.rev $1, None) }
   | non_arrowed_simple_core_type_list COLON core_type
                                                 { (List.rev $1,Some $3) }


### PR DESCRIPTION
See https://github.com/facebook/reason/commit/e2fb37146d738afce3fac55715d3c35875d2282c#diff-93c201b41bf10dfca8380188d820970aR3603

Also, utop uses the outcome printer and sucks at printing this:
<img width="572" alt="screenshot 2016-08-17 17 44 03" src="https://cloud.githubusercontent.com/assets/1909539/17758190/3486e098-64a2-11e6-99d5-1970321b4291.png">
