### PR TITLE
[atom-reason] Linux support, attempt 2

### DIFF
--- a/editorSupport/atom-reason/lib/environment-helpers.js
+++ b/editorSupport/atom-reason/lib/environment-helpers.js
@@ -32,7 +32,13 @@ function getRawShellEnv () {
   // The `-ilc` set of options was tested to work with the OS X v10.11
   // default-installed versions of bash, zsh, sh, and ksh. It *does not*
   // work with csh or tcsh.
-  let results = spawnSync(shell, ['-ilc', 'env'], {encoding: 'utf8'});
+
+  let results = spawnSync(shell, ['-ilc', 'env'], {
+    encoding: 'utf8',
+    // github.com/ioquatix/script-runner/blob/6eb2d23af099a6daeacc7361248c43bce233dff1/lib/script-runner.coffee#L49
+    detached: true,
+    stdio: ['ignore', 'pipe', process.stderr],
+  });
   if (results.error || !results.stdout || results.stdout.length <= 0) {
     return;
   }


### PR DESCRIPTION
https://github.com/facebook/reason/pull/695#issuecomment-240762630

@vramana could you please check that this patch works for linux (and the newest atom-reason-loader)?