### PR TITLE
[atom-reason] Bump versions

### DIFF
--- a/editorSupport/atom-reason/package.json
+++ b/editorSupport/atom-reason/package.json
@@ -2,7 +2,7 @@
   "name": "atom-reason",
   "repository": "https://github.com/facebook/Reason/tree/master/editorSupport/atom-reason",
   "main": "./lib/main",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Reason IDE implementation - installed by atom-reason",
   "keywords": [
     "Reason"

--- a/editorSupport/language-reason/package.json
+++ b/editorSupport/language-reason/package.json
@@ -1,7 +1,7 @@
 {
   "name": "language-reason",
   "main": "./lib/language-reason",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Reason syntax for Atom",
   "keywords": [
   ],


### PR DESCRIPTION
We now support linux through #699, so why not.

@jordwalke 