### PR TITLE
[Reason] Fix Many Parsing Bugs (including incorrect ternary) by Refac…

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -68,7 +68,7 @@ let x = "hello" [@onHello] ^ "goodbye";
 
 let x = "hello" ^ "goodbye" [@onGoodbye];
 
-let x = (^) "hello" "goodbye" [@onEverything];
+let x = ("hello" ^ "goodbye") [@onEverything];
 
 let x = 10 + 20 [@on20];
 
@@ -78,7 +78,7 @@ let x = 10 [@on10] + 20;
 
 let x = 10 [@on10] + 20;
 
-let x = (+) 10 20 [@attrEverything];
+let x = (10 + 20) [@attrEverything];
 
 let x = 10 - 20 [@on20];
 
@@ -88,7 +88,7 @@ let x = 10 [@on10] - 20;
 
 let x = 10 [@on10] - 20;
 
-let x = (-) 10 20 [@attrEntireEverything];
+let x = (10 - 20) [@attrEntireEverything];
 
 let x = true && false [@onFalse];
 
@@ -98,7 +98,7 @@ let x = true [@onTrue] && false;
 
 let x = true [@onTrue] && false;
 
-let x = (&&) true false [@attrEverything];
+let x = (true && false) [@attrEverything];
 
 /* now make sure to try with variants (tagged and `) */
 
@@ -117,21 +117,20 @@ let res =
 let res =
   (if true {false} else {false}) [@onEntireIf];
 
-let add a b => (+) (a [@onA]) b [@onEverything];
+let add a b => (a [@onA] + b) [@onEverything];
 
 let add a b =>
-  (+) (a [@onA]) (b [@onB]) [@onEverything];
+  (a [@onA] + b [@onB]) [@onEverything];
 
 let add a b => a + b [@onB];
 
 let both = (fun a => a) [@onEntireFunction];
 
-let both a b =>
-  (&&) (a [@onA]) b [@onEverything];
+let both a b => (a [@onA] && b) [@onEverything];
 
 let both a b => a [@onA] && b [@onB] [@onB];
 
-let both a b => (&&) a b [@onEverything];
+let both a b => (a && b) [@onEverything];
 
 let thisVal = 10;
 
@@ -139,19 +138,17 @@ let x =
   20 + (- add thisVal thisVal [@onFunctionCall]);
 
 let x =
-  (+) 20 (- add thisVal thisVal) [@onEverything];
+  (20 + (- add thisVal thisVal)) [@onEverything];
 
 let x = - add thisVal thisVal [@onFunctionCall];
 
-let x =
-  (~-) (add thisVal thisVal) [@onEverything];
+let x = (- add thisVal thisVal) [@onEverything];
 
 let bothTrue x y => {contents: x && y};
 
 let something =
-  (!)
-    (bothTrue true true)
-    [@onEverythingToRightOfEquals];
+  !(bothTrue true true)
+  [@onEverythingToRightOfEquals];
 
 let res =
   add 2 4 [@appliesToEntireFunctionApplication];
@@ -162,7 +159,8 @@ let myObj = {method p () => {method z () => 10}};
 
 let result =
   (myObj#p () [@attOnFirstSend])#z
-    () [@onSecondSend];
+  ()
+  [@onSecondSend];
 
 type recordFunctions = {
   p: unit => recordFunctions [@onUnit],
@@ -179,7 +177,8 @@ and unused = ();
 
 let result =
   (myRecord.p () [@attOnFirstSend]).q
-    () [@onSecondSend];
+  ()
+  [@onSecondSend];
 
 type variantType =
   | Foo int [@onInt] | Bar (int [@onInt]) | Baz

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -150,6 +150,9 @@ let something =
   !(bothTrue true true)
   [@onEverythingToRightOfEquals];
 
+let something =
+  !(bothTrue true true [@onlyOnArgumentToBang]);
+
 let res =
   add 2 4 [@appliesToEntireFunctionApplication];
 

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -60,45 +60,45 @@ let x = "hello" [@onHello];
 
 let x = "hello" [@onHello];
 
-let x = "hello" ^ ("goodbye" [@onGoodbye]);
+let x = "hello" ^ "goodbye" [@onGoodbye];
 
-let x = ("hello" [@onHello]) ^ "goodbye";
+let x = "hello" [@onHello] ^ "goodbye";
 
-let x = ("hello" [@onHello]) ^ "goodbye";
+let x = "hello" [@onHello] ^ "goodbye";
 
-let x = "hello" ^ ("goodbye" [@onGoodbye]);
+let x = "hello" ^ "goodbye" [@onGoodbye];
 
-let x = ("hello" ^ "goodbye") [@onEverything];
+let x = (^) "hello" "goodbye" [@onEverything];
 
-let x = 10 + (20 [@on20]);
+let x = 10 + 20 [@on20];
 
-let x = 10 + (20 [@on20]);
+let x = 10 + 20 [@on20];
 
-let x = (10 [@on10]) + 20;
+let x = 10 [@on10] + 20;
 
-let x = (10 [@on10]) + 20;
+let x = 10 [@on10] + 20;
 
-let x = (10 + 20) [@attrEverything];
+let x = (+) 10 20 [@attrEverything];
 
-let x = 10 - (20 [@on20]);
+let x = 10 - 20 [@on20];
 
-let x = 10 - (20 [@on20]);
+let x = 10 - 20 [@on20];
 
-let x = (10 [@on10]) - 20;
+let x = 10 [@on10] - 20;
 
-let x = (10 [@on10]) - 20;
+let x = 10 [@on10] - 20;
 
-let x = (10 - 20) [@attrEntireEverything];
+let x = (-) 10 20 [@attrEntireEverything];
 
-let x = true && (false [@onFalse]);
+let x = true && false [@onFalse];
 
-let x = true && (false [@onFalse]);
+let x = true && false [@onFalse];
 
-let x = (true [@onTrue]) && false;
+let x = true [@onTrue] && false;
 
-let x = (true [@onTrue]) && false;
+let x = true [@onTrue] && false;
 
-let x = (true && false) [@attrEverything];
+let x = (&&) true false [@attrEverything];
 
 /* now make sure to try with variants (tagged and `) */
 
@@ -117,44 +117,40 @@ let res =
 let res =
   (if true {false} else {false}) [@onEntireIf];
 
-let add a b => ((a [@onA]) + b) [@onEverything];
+let add a b => (+) (a [@onA]) b [@onEverything];
 
 let add a b =>
-  ((a [@onA]) + (b [@onB])) [@onEverything];
+  (+) (a [@onA]) (b [@onB]) [@onEverything];
 
-let add a b => a + (b [@onB]);
+let add a b => a + b [@onB];
 
 let both = (fun a => a) [@onEntireFunction];
 
 let both a b =>
-  ((a [@onA]) && b) [@onEverything];
+  (&&) (a [@onA]) b [@onEverything];
 
-let both a b => (a [@onA]) && (b [@onB] [@onB]);
+let both a b => a [@onA] && b [@onB] [@onB];
 
-let both a b => (a && b) [@onEverything];
+let both a b => (&&) a b [@onEverything];
 
 let thisVal = 10;
 
-let x = 20 + (
-  - (add thisVal thisVal [@onFunctionCall])
-);
+let x =
+  20 + (- add thisVal thisVal [@onFunctionCall]);
 
 let x =
-  (20 + (- (add thisVal thisVal)))
-    [@onEverything];
+  (+) 20 (- add thisVal thisVal) [@onEverything];
+
+let x = - add thisVal thisVal [@onFunctionCall];
 
 let x =
-  -
-  (add thisVal thisVal [@onFunctionCall]);
-
-
-let x =
-  (- (add thisVal thisVal)) [@onEverything];
+  (~-) (add thisVal thisVal) [@onEverything];
 
 let bothTrue x y => {contents: x && y};
 
 let something =
-  !(bothTrue true true)
+  (!)
+    (bothTrue true true)
     [@onEverythingToRightOfEquals];
 
 let res =

--- a/formatTest/typeCheckedTests/expected_output/imperative.re
+++ b/formatTest/typeCheckedTests/expected_output/imperative.re
@@ -55,9 +55,11 @@ try (
 };
 
 let result =
-  while false {
-    ()
-  } ==
+  (
+    while false {
+      ()
+    }
+  ) ==
   () ?
     false : true;
 

--- a/formatTest/typeCheckedTests/expected_output/imperative.re
+++ b/formatTest/typeCheckedTests/expected_output/imperative.re
@@ -55,12 +55,10 @@ try (
 };
 
 let result =
-  (
-    while false {
-      ()
-    }
-  ) ==
-    () ?
+  while false {
+    ()
+  } ==
+  () ?
     false : true;
 
 switch (

--- a/formatTest/typeCheckedTests/expected_output/mlSyntax.re
+++ b/formatTest/typeCheckedTests/expected_output/mlSyntax.re
@@ -77,7 +77,8 @@ let equalityInIf =
     false
   };
 
-let equalityWithIdentifiers = physicalEquality == referentialEquality;
+let equalityWithIdentifiers =
+  physicalEquality == referentialEquality;
 
 let nestedSome = Some (1, 2, Some (1, 2, 3));
 

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -150,10 +150,12 @@ let coercedReturn = {
 };
 
 let acceptsOpenAnonObjAsArg
-    (o: <x : int, y : int, ..>) => o#x + o#y;
+    (o: <x : int, y : int, ..>) =>
+  o#x + o#y;
 
 let acceptsClosedAnonObjAsArg
-    (o: <x : int, y : int>) => o#x + o#y;
+    (o: <x : int, y : int>) =>
+  o#x + o#y;
 
 let res = acceptsOpenAnonObjAsArg {
   method x = 0;

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -110,7 +110,8 @@ let myFunction
     /* First arg */
     withFirstArg
     /* Second Arg */
-    andSecondArg => withFirstArg + andSecondArg; /* After Semi */
+    andSecondArg =>
+  withFirstArg + andSecondArg; /* After Semi */
 
 type point = {
   x: string, /* x field */
@@ -357,7 +358,7 @@ let name_equal x y => x == y;
 
 let equal i1 i2 =>
   i1.contents === i2.contents &&
-    true; /* most unlikely first */
+  true; /* most unlikely first */
 
 let equal i1 i2 =>
   compare

--- a/formatTest/typeCheckedTests/expected_output/sequences.re
+++ b/formatTest/typeCheckedTests/expected_output/sequences.re
@@ -65,7 +65,8 @@ let cannotPunASingleFieldRecord = {
   number: number
 };
 
-let fourty = 20 + cannotPunASingleFieldRecord.number;
+let fourty =
+  20 + cannotPunASingleFieldRecord.number;
 
 let thisIsASequenceNotPunedRecord = number;
 

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -107,6 +107,7 @@ let x = (- add thisVal thisVal) [@onEverything];
 
 let bothTrue x y => {contents: x && y};
 let something = !(bothTrue true true) [@onEverythingToRightOfEquals];
+let something = !(bothTrue true true [@onlyOnArgumentToBang]);
 
 let res = add 2 4 [@appliesToEntireFunctionApplication];
 add 2 4 [@appliesToEntireFunctionApplication];

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -28,6 +28,8 @@ for i in
   }
 };
 
+let x = !(! !foo).bar;
+
 let x = !foo.bar;
 
 let x = !foo#bar;
@@ -36,7 +38,23 @@ let x = !(!foo).bar;
 
 let x = !(!foo)#bar;
 
-/* Prefix operator */
+/* Prefix operators:
+ * ! followed by zero or more appropriate_operator_suffix_chars (see the
+ * lexer).
+ * ? or ~ followed by at least one appropriate_operator_suffix_chars.
+ */
+let x = ! !foo.bar;
+
+let x = ?! !foo.bar;
+
+let x = ! ?!foo.bar;
+
+let x = ~! !foo.bar;
+
+let x = ! ~!foo.bar;
+
+let x = ~! ~!foo.bar;
+
 let x = !!foo.bar;
 
 let x = !!foo#bar;
@@ -57,12 +75,21 @@ let parensNeededAroundFirst = (!blah)#foo#bar;
 
 let parensNeededAroundSecond = (!blah#foo)#bar;
 
-/* The following two have an error in formatting! We must check for
- * *consecutive* prefix operators and either space separate or guard in
- * parens. */
-let x = !!foo.bar;
+let parensWithSpaceNeededAroundFirst =
+  (! !blah)#foo#bar;
 
-let x = !!foo#bar;
+let parensWithSpaceNeededAroundSecond =
+  (! !blah#foo)#bar;
+
+let parensWithSpaceNeededAroundFirst =
+  (?!(+ blah))#foo#bar;
+
+let parensWithSpaceNeededAroundSecond =
+  (?!(+ blah#foo))#bar;
+
+let x = ! !foo.bar;
+
+let x = ! !foo#bar;
 
 /* Comments */
 /*Below is an empty comment*/

--- a/formatTest/unit_tests/expected_output/fixme.re
+++ b/formatTest/unit_tests/expected_output/fixme.re
@@ -4,6 +4,6 @@
 let store_attributes proc_attributes => {
   let should_write =
     /* only overwrite defined procedures */ proc_attributes.ProcAttributes.is_defined ||
-      not (DB.file_exists attributes_file);
+    not (DB.file_exists attributes_file);
   should_write
 };

--- a/formatTest/unit_tests/expected_output/functionInfix.re
+++ b/formatTest/unit_tests/expected_output/functionInfix.re
@@ -1,0 +1,65 @@
+let entries = ref [];
+
+let all = ref 0;
+
+/*
+ * >>= is left associative, and higher precedence than =>
+ */
+let (>>=) a b => b a;
+
+let fff = ();
+
+
+/** Parse tree */
+fff >>= (xx yy >>= aa bb);
+
+/* Minimum parenthesis */
+fff >>= (xx yy >>= aa bb);
+
+/* Actually printed parenthesis */
+fff >>= (xx yy >>= aa bb);
+
+
+/** Parse tree */
+fff >>= ((fun xx => 0) >>= (fun aa => 10));
+
+/* Minimum parenthesis */
+fff >>= ((fun xx => 0) >>= (fun aa => 10));
+
+/* Actually printed parenthesis */
+fff >>= ((fun xx => 0) >>= (fun aa => 10));
+
+
+/** Parse tree */
+fff >>= (fun xx => 0) >>= (fun aa => 10);
+
+/* Minimum parenthesis */
+/* It is very difficult to actually achieve this. */
+fff >>= (fun xx => 0) >>= (fun aa => 10);
+
+/* Actually printed. */
+fff >>= (fun xx => 0) >>= (fun aa => 10);
+
+
+/** Parse tree */
+fff >>= (fun xx => 0 >>= (fun aa cc => 10));
+
+/* Minimum parens - grouping the zero */
+/* Difficult to achieve. */
+fff >>= (fun xx => 0 >>= (fun aa cc => 10));
+
+/* Actually printed parenthesis. */
+fff >>= (fun xx => 0) >>= (fun aa cc => 10);
+
+/* Another way you could also write it it */
+fff >>= (fun xx => 0) >>= (fun aa cc => 10);
+
+
+/** Parse tree */
+fff >>= (fun xx => 0);
+
+/* Minimum parens - grouping the zero */
+fff >>= (fun xx => 0);
+
+/* Printed parens - see how more are printed than necessary. */
+fff >>= (fun xx => 0);

--- a/formatTest/unit_tests/expected_output/if.re
+++ b/formatTest/unit_tests/expected_output/if.re
@@ -83,13 +83,13 @@ let ternaryResult =
   something ?
     callThisFunction withThisArg : thatResult;
 
-let annotatedTernary = true && (
-  something ? true : false: bool
-);
+let annotatedTernary =
+  true && (something ? true : false: bool);
 
-let annotatedBranch = true && (
-  something ? (true: bool) : false: bool
-);
+let annotatedBranch =
+  true && (
+    something ? (true: bool) : false: bool
+  );
 
 /* The following should be... */
 let whatShouldThisBeParsedAs =

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -9,21 +9,18 @@
    infix applications ungrouped in parenthesis (which is what the above test
    verifies), but the additional parenthesis is nice.  */
 /* < > = all have same precedence level/direction(left) */
-let parseTree = ((x > y > z) < a < b) == c == d;
+let parseTree = x > y > z < a < b == c == d;
 
-let minParens = ((x > y > z) < a < b) == c == d;
+let minParens = x > y > z < a < b == c == d;
 
-let formatted = ((x > y > z) < a < b) == c == d;
+let formatted = x > y > z < a < b == c == d;
 
 /* Case with === */
-let parseTree =
-  ((x > y > z) < a < b) === c === d;
+let parseTree = x > y > z < a < b === c === d;
 
-let minParens =
-  ((x > y > z) < a < b) === c === d;
+let minParens = x > y > z < a < b === c === d;
 
-let formatted =
-  ((x > y > z) < a < b) === c === d;
+let formatted = x > y > z < a < b === c === d;
 
 /* < > = all have same precedence level and direction (left) */
 let parseTree =
@@ -67,33 +64,48 @@ let formatted =
 
 /* !=...(left) same level =(left) is higher than :=(right) */
 let parseTree =
-  a1 := a2 := b1 == ((b2 == y) != x != z);
+  a1 := a2 := b1 == (b2 == y != x != z);
 
 let minParens =
-  a1 := a2 := b1 == ((b2 == y) != x != z);
+  a1 := a2 := b1 == (b2 == y != x != z);
 
 let formatted =
-  a1 := a2 := b1 == ((b2 == y) != x != z);
+  a1 := a2 := b1 == (b2 == y != x != z);
 
 /* Case with === */
 let parseTree =
-  a1 := a2 := b1 === ((b2 === y) !== x !== z);
+  a1 := a2 := b1 === (b2 === y !== x !== z);
 
 let minParens =
-  a1 := a2 := b1 === ((b2 === y) !== x !== z);
+  a1 := a2 := b1 === (b2 === y !== x !== z);
 
 let formatted =
-  a1 := a2 := b1 === ((b2 === y) !== x !== z);
+  a1 := a2 := b1 === (b2 === y !== x !== z);
 
 /* &...(left) is higher than &(right). &(right) is equal to &&(right) */
 let parseTree =
-  a1 && a2 && (b1 & b2 & y &|| x &|| z);
+  a1 && a2 && b1 & b2 & y &|| x &|| z;
 
 let minParens =
-  a1 && a2 && (b1 & b2 & y &|| x &|| z);
+  a1 && a2 && b1 & b2 & y &|| x &|| z;
 
 let formatted =
-  a1 && a2 && (b1 & b2 & y &|| x &|| z);
+  a1 && a2 && b1 & b2 & y &|| x &|| z;
+
+
+/**
+ * Now, let's try an example that resembles the above, yet would require
+ * parenthesis everywhere.
+ */
+/* &...(left) is higher than &(right). &(right) is equal to &&(right) */
+let parseTree =
+  ((((a1 && a2) && b1) & b2) & y) &|| (x &|| z);
+
+let minParens =
+  ((((a1 && a2) && b1) & b2) & y) &|| (x &|| z);
+
+let formatted =
+  ((((a1 && a2) && b1) & b2) & y) &|| (x &|| z);
 
 /* **...(right) is higher than *...(left) */
 let parseTree = b1 *| b2 *| y *\*| x *\*| z;
@@ -142,9 +154,8 @@ first || second || third;
 (first || second) || third;
 
 /* No parens should be added/removed from the following when formatting */
-let seeWhichCharacterHasHigherPrecedence = (
-  first |> second |> third
-) ^> fourth;
+let seeWhichCharacterHasHigherPrecedence =
+  (first |> second |> third) ^> fourth;
 
 let seeWhichCharacterHasHigherPrecedence =
   first |> second |> third;
@@ -157,12 +168,11 @@ let comparison = (==);
 /* Why would the following two cases have different grouping? */
 let res =
   blah ||
-    DataConstructor 10 ||
-    DataConstructor 10 && 10;
+  DataConstructor 10 || DataConstructor 10 && 10;
 
 let res =
   blah &&
-    DataConstructor 10 && DataConstructor 10 + 10;
+  DataConstructor 10 && DataConstructor 10 + 10;
 
 /* This demonstrates how broken infix pretty printing is:
  */
@@ -199,7 +209,8 @@ let res = first |> second;
 let res = (|>) first;
 
 /* Custom infix with labeled args */
-let (|>) first::first second::second => first + second;
+let (|>) first::first second::second =>
+  first + second;
 
 /* Should NOT reformat named args to actually be placed infix */
 let res = (|>) first::first second::second;
@@ -252,16 +263,18 @@ let seeWhichCharacterHasHigherPrecedence =
 
 let res =
   blah &&
-    DataConstructor 10 && DataConstructor 10 + 10;
+  DataConstructor 10 && DataConstructor 10 + 10;
 
 /* Should be parsed as */
 let res =
   blah &&
-    DataConstructor 10 && DataConstructor 10 + 10;
+  DataConstructor 10 && DataConstructor 10 + 10;
 
-let (++) label::label label2::label2 => label + label2;
+let (++) label::label label2::label2 =>
+  label + label2;
 
-let (++) label::label label2::label2 => label + label2;
+let (++) label::label label2::label2 =>
+  label + label2;
 
 let (++) = (++);
 
@@ -294,12 +307,9 @@ let includesACommentCloseInIdentifier = ( *\*\/ );
 
 let shouldSimplifyAnythingExceptApplicationAndConstruction =
   call "hi" ^
-    (
-      switch x {
-      | _ => "hi"
-      }
-    ) ^
-    "yo";
+  switch x {
+  | _ => "hi"
+  } ^ "yo";
 
 /* Add tests with IF/then mixed with infix/constructor application on left and right sides */
 
@@ -348,3 +358,568 @@ let myFunc
     aaaa bbbb cccc dddd aaaa bbbb cccc dddd aaaa,
   ...someType
 ];
+
+
+/**
+ * Testing various fixity.
+ */
+
+/**
+ * For each of these test cases for imperative updates, we'll test both record
+ * update, object member update and array update.
+ */
+let containingObject = {
+  val mutable y = 0;
+  val arr = [|true, false, false|];
+  val bigArr = "goodThingThisIsntTypeChecked";
+  val str = "string";
+  method testCases () => {
+
+    /**
+     * The lowest precedence token is =, followed by :=, and then ?, then :.
+     *
+     * The following text
+     *
+     *     x.contents = tenaryTest ? ifTrue : ifFalse
+     *
+     * Generates the following parse tree:
+     *
+     *                =
+     *              /   \
+     *             /     \
+     *         record   ternary
+     *
+     * Because when encountering the ? the parser will shift on the ? instead of
+     * reducing  expr = expr
+     */
+
+    /**
+     * Without a + 1
+     */
+    x.contents = something ? hello : goodbye;
+    y = something ? hello : goodbye;
+    arr.(0) = something ? hello : goodbye;
+    bigArr.{0} = something ? hello : goodbye;
+    str.[0] = something ? hello : goodbye;
+    (x.contents = something) ? hello : goodbye;
+    (y = something) ? hello : goodbye;
+    (arr.(0) = something) ? hello : goodbye;
+    (bigArr.{0} = something) ? hello : goodbye;
+    (str.[0] = something) ? hello : goodbye;
+    x.contents = something ? hello : goodbye;
+    y = something ? hello : goodbye;
+    arr.(0) = something ? hello : goodbye;
+    bigArr.{0} = something ? hello : goodbye;
+    str.[0] = something ? hello : goodbye;
+
+    /**
+     * With a + 1
+     */
+    x.contents = something + 1 ? hello : goodbye;
+    x := something + 1 ? hello : goodbye;
+    y = something + 1 ? hello : goodbye;
+    arr.(0) = something + 1 ? hello : goodbye;
+    bigArr.{0} = something + 1 ? hello : goodbye;
+    str.[0] = something + 1 ? hello : goodbye;
+    (x.contents = something + 1) ?
+      hello : goodbye;
+    (x := something + 1) ? hello : goodbye;
+    (y = something + 1) ? hello : goodbye;
+    (arr.(0) = something + 1) ? hello : goodbye;
+    (bigArr.{0} = something + 1) ?
+      hello : goodbye;
+    (str.[0] = something + 1) ? hello : goodbye;
+    x.contents = something + 1 ? hello : goodbye;
+    x := something + 1 ? hello : goodbye;
+    y = something + 1 ? hello : goodbye;
+    arr.(0) = something + 1 ? hello : goodbye;
+    bigArr.{0} = something + 1 ? hello : goodbye;
+    str.[0] = something + 1 ? hello : goodbye;
+
+    /**
+     * #NotActuallyAConflict
+     * Note that there's a difference with how = and := behave.
+     * We only *simulate* = being an infix identifier for the sake of printing,
+     * but for parsing it's a little more nuanced. There *isn't* technically
+     * a conflict in:
+     *
+     *     a + b.c = d
+     *
+     * Between reducing a + b.c, and shifting =, like there would be if it was
+     * := instead of =. That's because the rule for = isn't the infix rule with
+     * an arbitrary expression on its left - it's something much more specific.
+     *
+     * (simple_expr) DOT LIDENT EQUAL expression.
+     *
+     * So with the way yacc/menhir works, when it sees an equal sign, it knows
+     * that there is no valid parse where a + b.c is reduced to an expression
+     * with an = immediately appearing after, so it shifts the equals.
+     *
+     * If you replace = with :=, you'd see different behavior.
+     *
+     *     a + b.c := d
+     *
+     *  Since := has lower precedence than +, it would be parsed as:
+     *
+     *     (a + b.c) := d
+     *
+     * However, our printing logic will print = assignment with parenthesis:
+     *
+     *     a + (b.c = d)
+     *
+     * Even though they're not needed, because it doesn't know details about
+     * which rules are valid, we just told it to print = as if it were a valid
+     * infix identifier.
+     *
+     */
+    /* The following */
+    x + (something.contents = y);
+    x + (something = y);
+    x + something.contents := y;
+    x + something := y;
+    /* Should be parsed as: */
+    x + (
+      something.contents = y
+    ); /* Because of the #NotActuallyAConflict above */
+    x + (something = y); /* Same */
+    x + something.contents := y;
+    x + something := y;
+    /* To make the := parse differently, we must use parens */
+    x + (something.contents := y);
+    x + (something := y);
+
+    /**
+     * Try with ||
+     */
+    x.contents || something + 1 ?
+      hello : goodbye;
+    y || something + 1 ? hello : goodbye;
+    arr.(0) || something + 1 ? hello : goodbye;
+    bigArr.{0} || something + 1 ?
+      hello : goodbye;
+    str.[0] || something + 1 ? hello : goodbye;
+    x.contents || something + 1 ?
+      hello : goodbye;
+    y || something + 1 ? hello : goodbye;
+    arr.(0) || something + 1 ? hello : goodbye;
+    bigArr.{0} || something + 1 ?
+      hello : goodbye;
+    str.[0] || something + 1 ? hello : goodbye;
+    x.contents || (
+      something + 1 ? hello : goodbye
+    );
+    y || (something + 1 ? hello : goodbye);
+    arr.(0) || (something + 1 ? hello : goodbye);
+    bigArr.{0} || (
+      something + 1 ? hello : goodbye
+    );
+    str.[0] || (something + 1 ? hello : goodbye);
+
+    /**
+     * Try with &&
+     */
+    x.contents && something + 1 ?
+      hello : goodbye;
+    y && something + 1 ? hello : goodbye;
+    arr.(0) && something + 1 ? hello : goodbye;
+    bigArr.{0} && something + 1 ?
+      hello : goodbye;
+    str.[0] && something + 1 ? hello : goodbye;
+    x.contents && something + 1 ?
+      hello : goodbye;
+    y && something + 1 ? hello : goodbye;
+    arr.(0) && something + 1 ? hello : goodbye;
+    bigArr.{0} && something + 1 ?
+      hello : goodbye;
+    str.[0] && something + 1 ? hello : goodbye;
+    x.contents && (
+      something + 1 ? hello : goodbye
+    );
+    y && (something + 1 ? hello : goodbye);
+    arr.(0) && (something + 1 ? hello : goodbye);
+    bigArr.{0} && (
+      something + 1 ? hello : goodbye
+    );
+    str.[0] && (something + 1 ? hello : goodbye);
+
+    /**
+     * See how regular infix operators work correctly.
+     */
+    x.contents = 2 + 4;
+    y = 2 + 4;
+    arr.(0) = 2 + 4;
+    bigArr.{0} = 2 + 4;
+    str.[0] = 2 + 4;
+    (x.contents = 2) + 4;
+    (y = 2) + 4;
+    (arr.(0) = 2) + 4;
+    (bigArr.{0} = 2) + 4;
+    (str.[0] = 2) + 4;
+
+    /**
+     * Ensures that record update, object field update, and := are all right
+     * associative.
+     */
+    x.contents = y.contents = 10;
+    y = x.contents = 10;
+    arr.(0) = x.contents = 10;
+    bigArr.{0} = x.contents = 10;
+    str.[0] = x.contents = 10;
+    /* Should be the same as */
+    x.contents = x.contents = 10;
+    y = x.contents = 10;
+    arr.(0) = x.contents = 10;
+    bigArr.{0} = x.contents = 10;
+    str.[0] = x.contents = 10;
+
+    /**
+     * Ensures that record update, object field update, and := are all right
+     * associative.
+     */
+    x := x := 10;
+    /* Should be the same as */
+    x := x := 10;
+    /* By default, without parens*/
+    x ? y : z ? a : b;
+    /* It is parsed as the following: */
+    x ? y : z ? a : b;
+    /* Not this: */
+    (x ? y : z) ? a : b;
+
+    /**
+     *          ^
+     * When rendering the content to the left of the ? we know that we want the
+     * parser to reduce the thing to the left of the ? when the ? is seen.  So we
+     * look at the expression to the left of ? and discover what precedence level
+     * it is (token of its rightmost terminal). We then compare it with ? to see
+     * who would win a shift reduce conflict. We want the term to the left of the ?
+     * to be reduced. So if it's rightmost terminal isn't higher precedence than ?,
+     * we wrap it in parens.
+     */
+
+    /***
+     * The following
+     */
+    x.contents =
+      something ?
+        x.contents = somethingElse : goodbye;
+    y = something ? y = somethingElse : goodbye;
+    arr.(0) =
+      something ?
+        arr.(0) = somethingElse : goodbye;
+    bigArr.{0} =
+      something ?
+        bigArr.{0} = somethingElse : goodbye;
+    str.[0] =
+      something ?
+        str.[0] = somethingElse : goodbye;
+    /*
+     * Should be parsed as
+     */
+    x.contents =
+      something ?
+        x.contents = somethingElse : goodbye;
+    y = something ? y = somethingElse : goodbye;
+    arr.(0) =
+      something ?
+        arr.(0) = somethingElse : goodbye;
+    bigArr.{0} =
+      something ?
+        bigArr.{0} = somethingElse : goodbye;
+    str.[0] =
+      something ?
+        str.[0] = somethingElse : goodbye;
+
+    /** And this */
+    y :=
+      something ? y := somethingElse : goodbye;
+    arr.(0) :=
+      something ?
+        arr.(0) := somethingElse : goodbye;
+    bigArr.{0} :=
+      something ?
+        bigArr.{0} := somethingElse : goodbye;
+    str.[0] :=
+      something ?
+        str.[0] := somethingElse : goodbye;
+    /* Should be parsed as */
+    y :=
+      something ? y := somethingElse : goodbye;
+    arr.(0) :=
+      something ?
+        arr.(0) := somethingElse : goodbye;
+    bigArr.{0} :=
+      something ?
+        bigArr.{0} := somethingElse : goodbye;
+    str.[0] :=
+      something ?
+        str.[0] := somethingElse : goodbye;
+    /* The following */
+    x :=
+      something ?
+        x.contents =
+          somethingElse ? goodbye : goodbye :
+        goodbye;
+    x :=
+      something ?
+        arr.(0) =
+          somethingElse ? goodbye : goodbye :
+        goodbye;
+    x :=
+      something ?
+        bigArr.{0} =
+          somethingElse ? goodbye : goodbye :
+        goodbye;
+    x :=
+      something ?
+        str.[0] =
+          somethingElse ? goodbye : goodbye :
+        goodbye;
+    /* Is parsed as */
+    x :=
+      something ?
+        x.contents =
+          somethingElse ? goodbye : goodbye :
+        goodbye;
+    x :=
+      something ?
+        arr.(0) =
+          somethingElse ? goodbye : goodbye :
+        goodbye;
+    x :=
+      something ?
+        bigArr.{0} =
+          somethingElse ? goodbye : goodbye :
+        goodbye;
+    x :=
+      something ?
+        str.[0] =
+          somethingElse ? goodbye : goodbye :
+        goodbye;
+    /* is not the same as */
+    x :=
+      something ?
+        (x.contents = somethingElse) ?
+          goodbye : goodbye :
+        goodbye;
+    x :=
+      something ?
+        (arr.(0) = somethingElse) ?
+          goodbye : goodbye :
+        goodbye;
+    x :=
+      something ?
+        (bigArr.{0} = somethingElse) ?
+          goodbye : goodbye :
+        goodbye;
+    x :=
+      something ?
+        (str.[0] = somethingElse) ?
+          goodbye : goodbye :
+        goodbye;
+
+    /**
+     * And
+     */
+
+    /** These should be parsed the same */
+    something ?
+      somethingElse :
+      x.contents = somethingElse ? x : z;
+    something ?
+      somethingElse :
+      x.contents = somethingElse ? x : z;
+    /* Not: */
+    something ?
+      somethingElse :
+      (x.contents = somethingElse) ? x : z;
+    (
+      something ?
+        somethingElse :
+        x.contents = somethingElse
+    ) ?
+      x : z;
+    /* These should be parsed the same */
+    something ?
+      somethingElse : x := somethingElse ? x : z;
+    something ?
+      somethingElse : x := somethingElse ? x : z;
+    /* Not: */
+    something ?
+      somethingElse :
+      (x := somethingElse) ? x : z;
+    (
+      something ?
+        somethingElse : x := somethingElse
+    ) ?
+      x : z;
+
+    /** These should be parsed the same */
+    something ?
+      somethingElse : y = somethingElse ? x : z;
+    something ?
+      somethingElse : y = somethingElse ? x : z;
+    /* Not: */
+    something ?
+      somethingElse : (y = somethingElse) ? x : z;
+    (
+      something ?
+        somethingElse : y = somethingElse
+    ) ?
+      x : z;
+
+    /** These should be parsed the same */
+    something ?
+      somethingElse :
+      arr.(0) = somethingElse ? x : arr.(0);
+    something ?
+      somethingElse :
+      arr.(0) = somethingElse ? x : arr.(0);
+    /* Not: */
+    something ?
+      somethingElse :
+      (arr.(0) = somethingElse) ? x : z;
+    (
+      something ?
+        somethingElse : arr.(0) = somethingElse
+    ) ?
+      x : z;
+
+    /** These should be parsed the same */
+    something ?
+      somethingElse :
+      bigArr.{0} = somethingElse ? x : bigArr.{0};
+    something ?
+      somethingElse :
+      bigArr.{0} = somethingElse ? x : bigArr.{0};
+    /* Not: */
+    something ?
+      somethingElse :
+      (bigArr.{0} = somethingElse) ? x : z;
+    (
+      something ?
+        somethingElse :
+        bigArr.{0} = somethingElse
+    ) ?
+      x : z;
+
+    /** These should be parsed the same */
+    something ?
+      somethingElse :
+      arr.[0] = somethingElse ? x : arr.[0];
+    something ?
+      somethingElse :
+      arr.[0] = somethingElse ? x : arr.[0];
+    /* Not: */
+    something ?
+      somethingElse :
+      (str.[0] = somethingElse) ? x : z;
+    (
+      something ?
+        somethingElse : str.[0] = somethingElse
+    ) ?
+      x : z;
+
+    /**
+     * It creates a totally different meaning when parens group the :
+     */
+    x.contents =
+      something ?
+        (x.contents = somethingElse: x) : z;
+    y = something ? (y = somethingElse: x) : z;
+    arr.(0) =
+      something ?
+        (arr.(0) = somethingElse: x) : z;
+    bigArr.{0} =
+      something ?
+        (bigArr.{0} = somethingElse: x) : z;
+    str.[0] =
+      something ?
+        (str.[0] = somethingElse: x) : z;
+
+    /**
+     * Various precedence groupings.
+     */
+    true ? true ? false : false : false;
+    /* Is the same as */
+    true ? true ? false : false : false;
+    /*
+     * Just some examples of how prefix will be printed.
+     */
+    - x + (something.contents = y);
+    - x + (something = y);
+    - x + something.contents := y;
+    - x + something := y;
+    x + (- (something.contents = y));
+    x + (- (something = y));
+    x + (- something.contents) := y;
+    x + (- something) := y;
+    x.contents || something + 1 ?
+      - hello : goodbye;
+    bigArr.{0} || - something + 1 ?
+      hello : goodbye;
+    let result = - x + (something.contents = y);
+    /* Prefix minus is actually sugar for regular function identifier ~-*/
+    let result = 2 + (- add 4 0);
+    /* Same as */
+    let result = 2 + (- add) 4 0;
+    /* Same as */
+    let result = 2 + (- add 4 0);
+    /* That same example but with ppx attributes on the add application */
+    let result = 2 + (- add 4 0 [@ppx]);
+    /* Same as */
+    let result = 2 + (- add) 4 0 [@ppx];
+    /* Same as */
+    let result = 2 + (- add 4 0 [@ppx]);
+    /* Multiple nested prefixes */
+    let result = 2 + (- (- (- add 4 0)));
+    /* And with attributes */
+    let result =
+      2 + (
+        - (- (- add 4 0 [@onAddApplication]))
+      );
+
+    /**
+     * TODO: Move all of these test cases to attributes.re.
+     */
+    /* Attribute on the prefix application */
+    let res = (~-) (something blah blah) [@attr];
+    /* Attribute on the regular function application, not prefix */
+    let res = - something blah blah [@attr];
+    let attrOnPrefix = (-1) [@ppxOnPrefixApp];
+    let attrOnPrefix = 5 + (-1);
+    let result =
+      String.get
+        arr 0 [@ppxAttributeOnSugarGetter];
+
+    /**
+     * Unary plus/minus has lower precedence than prefix operators:
+     * And unary plus has same precedence as unary minus.
+     */
+    let res = - !record;
+    /* Should be parsed as: */
+    let res = - !record;
+    /* Although that precedence ranking doesn't likely have any effect in that
+     * case. */
+
+    /**
+     * And this
+     */
+    let res = - (+ callThisFunc ());
+    /* should be parsed as: */
+    let res = - (+ callThisFunc ());
+
+    /**
+     * And this
+     */
+    let res = !(- callThisFunc ());
+    /* Should be parsed (and should remain printed as: */
+    let res = !(- callThisFunc ());
+    let res = (!) x [@onApplication];
+    let res = !(x [@onX]);
+    let res = !(x [@onX]);
+    something.contents = "newvalue";
+    something.contents =
+      "newvalue" [@shouldBeRenderedOnString]
+  }
+};

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -345,6 +345,14 @@ let res = - (- x);
 
 let res = f (- x);
 
+
+/**
+ * Test using almost simple prefix as regular function.
+ */
+let (!!) a b => a + b;
+
+let res = (!!) 20 40;
+
 /* The semicolon should be attached to someType */
 let myFunc
     aaaa

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -496,10 +496,12 @@ let myFirstClassWillBeFormattedAs: (module HasInt) =
   (module MyModule);
 
 let acceptsAndUnpacksFirstClass
-    ((module M): (module HasInt)) => M.x + M.x;
+    ((module M): (module HasInt)) =>
+  M.x + M.x;
 
 let acceptsAndUnpacksFirstClass
-    ((module M): (module HasInt)) => M.x + M.x;
+    ((module M): (module HasInt)) =>
+  M.x + M.x;
 
 let module SecondClass = (val myFirstClass);
 

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -546,7 +546,8 @@ dummy res2;
 dummy res3;
 
 /* Some edge cases */
-let myFun firstArg (Red x | Black x | Green x) => firstArg + x;
+let myFun firstArg (Red x | Black x | Green x) =>
+  firstArg + x;
 
 let matchesWithWhen a =>
   switch a {
@@ -586,7 +587,8 @@ let myRecordWithFunctions = {
 let result =
   myRecordWithFunctions.addThreeNumbers 10 20 30;
 
-let result = myRecordWithFunctions.addThreeNumbersTupled (
+let result =
+  myRecordWithFunctions.addThreeNumbersTupled (
   10,
   20,
   30
@@ -978,3 +980,7 @@ let A | B | C = X;
  *
  */
 external f : int => int = "foo";
+
+let x = {contents: 0};
+
+let unitVal = x.contents = 210;

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -26,7 +26,8 @@ let notTupled: notTupleVariant =
 /* Doesn't work because we've correctly annotated parse tree nodes with explicit_arity! */
 /* let notTupled: notTupleVariant = NotActuallyATuple (10, 10); */
 let funcOnNotActuallyATuple
-    (NotActuallyATuple x y) => x + y;
+    (NotActuallyATuple x y) =>
+  x + y;
 
 /* let funcOnNotActuallyATuple (NotActuallyATuple (x, y)) => x + y; */
 /* let notTupled: notTupleVariant = NotActuallyATuple intTuple; /*Doesn't work! */ */
@@ -173,14 +174,16 @@ type combination 'a =
 /** But then how do we parse matches in function arguments? */
 /* We must require parenthesis around construction matching in function args only*/
 let howWouldWeMatchFunctionArgs
-    (HeresTwoConstructorArguments x y) => x + y;
+    (HeresTwoConstructorArguments x y) =>
+  x + y;
 
 /* How would we annotate said arg? */
 let howWouldWeMatchFunctionArgs
     (
       HeresTwoConstructorArguments x y:
         combination 'wat
-    ) => x + y;
+    ) =>
+  x + y;
 
 let matchingTwoCurriedConstructorsInTuple x =>
   switch x {
@@ -403,7 +406,7 @@ let rec atLeastOneFlushableChildAndNoWipNoPending
     | SuperLongNameThatWontBreakByItselfSoWhenWillHaveToBreak
         when
           priority ==
-            AtPrasldkfjalsdfjasdlfalsdkf =>
+          AtPrasldkfjalsdfjasdlfalsdkf =>
       noWipNoPending tl atPriority
     | _ => false
     }

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -8,17 +8,15 @@ let reallyLongIdent = 100;
 let andYetAnotherReallyLongIdent = 30;
 
 let something =
-  reallyLongIdent +
-    andYetAnotherReallyLongIdent +
-    reallyLongIdent;
+  reallyLongIdent + andYetAnotherReallyLongIdent + reallyLongIdent;
 
 let something =
   /* Hopefully */
   reallyLongIdent +
-    /* It will indent like this */
-    andYetAnotherReallyLongIdent +
-    /* And no further */
-    reallyLongIdent;
+  /* It will indent like this */
+  andYetAnotherReallyLongIdent +
+  /* And no further */
+  reallyLongIdent;
 
 /* Comments can be written like this.
    No leading star is required on each line.
@@ -52,44 +50,40 @@ let test = 10;
  */
 let testPrintingPrecedence =
   reallyLongIdent +
-    reallyLongIdent * andYetAnotherReallyLongIdent +
-    reallyLongIdent;
+  reallyLongIdent * andYetAnotherReallyLongIdent + reallyLongIdent;
 
 let testPrintingPrecedence =
   reallyLongIdent +
-    /*
-     * In this case, grouping of the right expression is needed because the
-     * right side of the infix operator is of *lower* precedence than STAR.
-     */
-    reallyLongIdent * (
-      reallyLongIdent + andYetAnotherReallyLongIdent
-    ) +
-    reallyLongIdent * 10;
+  /*
+   * In this case, grouping of the right expression is needed because the
+   * right side of the infix operator is of *lower* precedence than STAR.
+   */
+  reallyLongIdent * (
+    reallyLongIdent + andYetAnotherReallyLongIdent
+  ) +
+  reallyLongIdent * 10;
 
 let testPrintingPrecedence =
   reallyLongIdent +
-    /*
-     * In this case, grouping of the right expression is needed because the
-     * right side of the infix operator is of *lower* precedence than STAR.
-     */
-    reallyLongIdent * (
-      reallyLongIdent + andYetAnotherReallyLongIdent
-    ) +
-    reallyLongIdent;
+  /*
+   * In this case, grouping of the right expression is needed because the
+   * right side of the infix operator is of *lower* precedence than STAR.
+   */
+  reallyLongIdent * (
+    reallyLongIdent + andYetAnotherReallyLongIdent
+  ) + reallyLongIdent;
 
 let add x y => x + y;
 
 let testPrintingPrecedence =
   reallyLongIdent +
-    /*
-     * In this case, grouping of the right expression is needed because the
-     * right side isn't even infix at all.
-     */
-    reallyLongIdent *
-      add
-        reallyLongIdent
-        andYetAnotherReallyLongIdent +
-    reallyLongIdent;
+  /*
+   * In this case, grouping of the right expression is needed because the
+   * right side isn't even infix at all.
+   */
+  reallyLongIdent *
+  add
+    reallyLongIdent andYetAnotherReallyLongIdent + reallyLongIdent;
 
 /*
  * Test wrapping every form of named arguments where various parts are
@@ -447,7 +441,8 @@ let myFunctionsInARecordThatMustWrap = {
         anotherReallyLongArgument => reallyLongArgument,
   minuser:
     fun reallyLongArgument
-        anotherReallyLongArgument => reallyLongArgument + anotherReallyLongArgument
+        anotherReallyLongArgument =>
+    reallyLongArgument + anotherReallyLongArgument
 };
 
 type threeArgFunctionsInARecord = {
@@ -466,7 +461,8 @@ let myFunctionsInARecordThatMustWrap = {
   minuser:
     fun reallyLongArgument
         anotherReallyLongArgument
-        anotherReallyLongArgument => reallyLongArgument + anotherReallyLongArgument
+        anotherReallyLongArgument =>
+    reallyLongArgument + anotherReallyLongArgument
 };
 
 let oneArgShouldWrapToAlignWith
@@ -531,7 +527,8 @@ let howDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark
 
 let howDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark
     x
-    y => x + y;
+    y =>
+  x + y;
 
 let reallyHowDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark
     x
@@ -541,7 +538,8 @@ let reallyHowDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark
 
 let reallyHowDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark
     x
-    y => x + y;
+    y =>
+  x + y;
 
 let reallyLongFunctionNameThatJustConcats a =>
   String.concat "-" a;
@@ -2081,19 +2079,23 @@ type someRecord = {
    pattern).
  */
 let funcOnSomeConstructorHi
-    (SomeConstructorHi x y) => x + y;
+    (SomeConstructorHi x y) =>
+  x + y;
 
 let funcOnSomeConstructorHi
     (SomeConstructorHi x y)
-    secondArg => x + y;
+    secondArg =>
+  x + y;
 
 /* With two args */
 let funcOnSomeRecord
-    {firstFieldInRecord, secondField} => firstFieldInRecord + secondField;
+    {firstFieldInRecord, secondField} =>
+  firstFieldInRecord + secondField;
 
 let funcOnSomeRecord
     {firstFieldInRecord, secondField}
-    secondArg => firstFieldInRecord + secondField;
+    secondArg =>
+  firstFieldInRecord + secondField;
 
 /*
    With settings.functionBindingStyle = DontAttachFirstTermToLabel,
@@ -2102,19 +2104,23 @@ let funcOnSomeRecord
    pattern).
  */
 let funcOnSomeConstructorHi
-    (SomeConstructorHi x y) => x + y;
+    (SomeConstructorHi x y) =>
+  x + y;
 
 let funcOnSomeRecord
-    {firstFieldInRecord, secondField} => firstFieldInRecord + secondField;
+    {firstFieldInRecord, secondField} =>
+  firstFieldInRecord + secondField;
 
 /* With two args */
 let funcOnSomeConstructorHi
     (SomeConstructorHi x y)
-    secondArg => x + y;
+    secondArg =>
+  x + y;
 
 let funcOnSomeRecord
     {firstFieldInRecord, secondField}
-    secondArg => firstFieldInRecord + secondField;
+    secondArg =>
+  firstFieldInRecord + secondField;
 
 type simpleTupleVariant =
   | SimpleActuallyATuple (int, int);

--- a/formatTest/unit_tests/input/basicStructures.re
+++ b/formatTest/unit_tests/input/basicStructures.re
@@ -25,6 +25,8 @@ for i in 0 to (endOfRangeMustBeSimple expr soWrap) {
   };
 };
 
+let x = !(! !foo).bar;
+
 let x = !foo.bar;
 
 let x = !foo#bar;
@@ -33,7 +35,23 @@ let x = !(!foo).bar;
 
 let x = !(!foo)#bar;
 
-/* Prefix operator */
+/* Prefix operators:
+ * ! followed by zero or more appropriate_operator_suffix_chars (see the
+ * lexer).
+ * ? or ~ followed by at least one appropriate_operator_suffix_chars.
+ */
+let x = ! !foo.bar;
+
+let x = ?! !foo.bar;
+
+let x = ! ?!foo.bar;
+
+let x = ~! !foo.bar;
+
+let x = ! ~!foo.bar;
+
+let x = ~! ~!foo.bar;
+
 let x = !!foo.bar;
 
 let x = !!foo#bar;
@@ -54,9 +72,15 @@ let parensNeededAroundFirst = (!blah)#foo#bar;
 
 let parensNeededAroundSecond = (!blah#foo)#bar;
 
-/* The following two have an error in formatting! We must check for
- * *consecutive* prefix operators and either space separate or guard in
- * parens. */
+
+let parensWithSpaceNeededAroundFirst = (! !blah)#foo#bar;
+
+let parensWithSpaceNeededAroundSecond = (! !blah#foo)#bar;
+
+let parensWithSpaceNeededAroundFirst = (?! ~+blah)#foo#bar;
+
+let parensWithSpaceNeededAroundSecond = (?! ~+blah#foo)#bar;
+
 let x = !(!foo.bar);
 
 let x = !(!foo#bar);

--- a/formatTest/unit_tests/input/functionInfix.re
+++ b/formatTest/unit_tests/input/functionInfix.re
@@ -1,0 +1,65 @@
+let entries = ref [];
+
+let all = ref 0;
+
+/*
+ * >>= is left associative, and higher precedence than =>
+ */
+let (>>=) a b => b a;
+
+let fff = ();
+
+
+/** Parse tree */
+(fff >>= ((xx yy) >>= (aa bb)));
+
+/* Minimum parenthesis */
+fff >>= (xx yy >>= aa bb);
+
+/* Actually printed parenthesis */
+fff >>= (xx yy >>= aa bb);
+
+
+/** Parse tree */
+fff >>= ((fun xx => 0) >>= (fun aa => 10));
+
+/* Minimum parenthesis */
+fff >>= ((fun xx => 0) >>= (fun aa => 10));
+
+/* Actually printed parenthesis */
+fff >>= ((fun xx => 0) >>= (fun aa => 10));
+
+
+/** Parse tree */
+((fff >>= (fun xx => 0)) >>= (fun aa => 10));
+
+/* Minimum parenthesis */
+/* It is very difficult to actually achieve this. */
+fff >>= (fun xx => 0) >>= fun aa => 10;
+
+/* Actually printed. */
+fff >>= (fun xx => 0) >>= (fun aa => 10);
+
+
+/** Parse tree */
+(fff >>= (fun xx => (0 >>= (fun aa cc => 10))));
+
+/* Minimum parens - grouping the zero */
+/* Difficult to achieve. */
+fff >>= fun xx => 0 >>= (fun aa cc => 10);
+
+/* Actually printed parenthesis. */
+fff >>= (fun xx => 0) >>= (fun aa cc => 10);
+
+/* Another way you could also write it it */
+(fff >>= fun xx => 0) >>= (fun aa cc => 10);
+
+
+/** Parse tree */
+(fff >>= (fun xx => 0));
+
+/* Minimum parens - grouping the zero */
+fff >>= fun xx => 0;
+
+/* Printed parens - see how more are printed than necessary. */
+fff >>= (fun xx => 0);

--- a/formatTest/unit_tests/input/infix.re
+++ b/formatTest/unit_tests/input/infix.re
@@ -386,14 +386,16 @@ let containingObject = {
      * #NotActuallyAConflict
      * Note that there's a difference with how = and := behave.
      * We only *simulate* = being an infix identifier for the sake of printing,
-     * but for parsing it's a little more nuanced. There *isn't* technically
-     * a conflict in:
+     * but for parsing it's a little more nuanced. There *isn't* technically a
+     * shift/reduce conflict in the following that must be resolved via
+     * precedence ranking:
      *
      *     a + b.c = d
      *
-     * Between reducing a + b.c, and shifting =, like there would be if it was
-     * := instead of =. That's because the rule for = isn't the infix rule with
-     * an arbitrary expression on its left - it's something much more specific.
+     * No conflict between reducing a + b.c, and shifting =, like there would
+     * be if it was := instead of =. That's because the rule for = isn't the
+     * infix rule with an arbitrary expression on its left - it's something
+     * much more specific.
      *
      * (simple_expr) DOT LIDENT EQUAL expression.
      *
@@ -416,6 +418,22 @@ let containingObject = {
      * Even though they're not needed, because it doesn't know details about
      * which rules are valid, we just told it to print = as if it were a valid
      * infix identifier.
+     *
+     * Another case:
+     *
+     *    something >>= fun x => x + 1;
+     *
+     * Will be printed as:
+     *
+     *    something >>= (fun x => x + 1);
+     *
+     * Because the arrow has lower precedence than >>=, but it wasn't needed because
+     *
+     *    (something >>= fun x) => x + 1;
+     *
+     * Is not a valid parse. Parens around the `=>` weren't needed to prevent
+     * reducing instead of shifting. To optimize this part, we need a much
+     * deeper encoding of the parse rules to print parens only when needed.
      *
      */
 

--- a/formatTest/unit_tests/input/infix.re
+++ b/formatTest/unit_tests/input/infix.re
@@ -298,6 +298,12 @@ let res = - (- x);
 
 let res = f (- x);
 
+/**
+ * Test using almost simple prefix as regular function.
+ */
+let (!!) a b => a + b;
+
+let res = (!!) 20 40;
 
 /* The semicolon should be attached to someType */
 let myFunc aaaa bbbb cccc dddd aaaa bbbb cccc dddd aaaa =>

--- a/formatTest/unit_tests/input/infix.re
+++ b/formatTest/unit_tests/input/infix.re
@@ -70,11 +70,22 @@ let minParens = a1 := a2 := b1 === ((b2 === y) !== x !== z);
 let formatted = a1 := a2 := b1 === ((b2 === y) !== x !== z);
 
 /* &...(left) is higher than &(right). &(right) is equal to &&(right) */
-let parseTree = a1 && a2 && (b1 & b2 & y &|| x &|| z);
+let parseTree = a1 && (a2 && (b1 & b2 & y &|| x &|| z));
 
 let minParens = a1 && a2 && (b1 & b2 & y &|| x &|| z);
 
 let formatted = a1 && a2 && (b1 & b2 & y &|| x &|| z);
+
+/**
+ * Now, let's try an example that resembles the above, yet would require
+ * parenthesis everywhere.
+ */
+/* &...(left) is higher than &(right). &(right) is equal to &&(right) */
+let parseTree = ((((a1 && a2) && b1) & b2) & y) &|| (x &|| z);
+
+let minParens = ((((a1 && a2) && b1) & b2) & y) &|| (x &|| z);
+
+let formatted = ((((a1 && a2) && b1) & b2) & y) &|| (x &|| z);
 
 /* **...(right) is higher than *...(left) */
 let parseTree = ((b1 *| b2) *| (y *\*| (x *\*| z)));
@@ -291,3 +302,432 @@ let res = f (- x);
 /* The semicolon should be attached to someType */
 let myFunc aaaa bbbb cccc dddd aaaa bbbb cccc dddd aaaa =>
   [blah aaaa bbbb cccc dddd aaaa bbbb cccc dddd aaaa, ...someType];
+
+/**
+ * Testing various fixity.
+ */
+
+/**
+ * For each of these test cases for imperative updates, we'll test both record
+ * update, object member update and array update.
+ */
+let containingObject = {
+  val mutable y = 0;
+  val arr = [|true, false, false|];
+  val bigArr = "goodThingThisIsntTypeChecked";
+  val str = "string";
+  method testCases () => {
+    /**
+     * The lowest precedence token is =, followed by :=, and then ?, then :.
+     *
+     * The following text
+     *
+     *     x.contents = tenaryTest ? ifTrue : ifFalse
+     *
+     * Generates the following parse tree:
+     *
+     *                =
+     *              /   \
+     *             /     \
+     *         record   ternary
+     *
+     * Because when encountering the ? the parser will shift on the ? instead of
+     * reducing  expr = expr
+     */
+
+    /**
+     * Without a + 1
+     */
+    x.contents = something ? hello : goodbye;
+    y = something ? hello : goodbye;
+    arr.(0) = something ? hello : goodbye;
+    bigArr.{0} = something ? hello : goodbye;
+    str.[0] = something ? hello : goodbye;
+
+    (x.contents = something) ? hello : goodbye;
+    (y = something) ? hello : goodbye;
+    (arr.(0) = something) ? hello : goodbye;
+    (bigArr.{0} = something) ? hello : goodbye;
+    (str.[0] = something) ? hello : goodbye;
+
+    x.contents = (something ? hello : goodbye);
+    y = (something ? hello : goodbye);
+    arr.(0) = (something ? hello : goodbye);
+    bigArr.{0} = (something ? hello : goodbye);
+    str.[0] = (something ? hello : goodbye);
+
+
+    /**
+     * With a + 1
+     */
+    x.contents = something + 1 ? hello : goodbye;
+    x := something + 1 ? hello : goodbye;
+    y = something + 1 ? hello : goodbye;
+    arr.(0) = something + 1 ? hello : goodbye;
+    bigArr.{0} = something + 1 ? hello : goodbye;
+    str.[0] = something + 1 ? hello : goodbye;
+
+    (x.contents = something + 1) ? hello : goodbye;
+    (x := something + 1) ? hello : goodbye;
+    (y = something + 1) ? hello : goodbye;
+    (arr.(0) = something + 1) ? hello : goodbye;
+    (bigArr.{0} = something + 1) ? hello : goodbye;
+    (str.[0] = something + 1) ? hello : goodbye;
+
+    x.contents = (something + 1 ? hello : goodbye);
+    x := (something + 1 ? hello : goodbye);
+    y = (something + 1 ? hello : goodbye);
+    arr.(0) = (something + 1 ? hello : goodbye);
+    bigArr.{0} = (something + 1 ? hello : goodbye);
+    str.[0] = (something + 1 ? hello : goodbye);
+
+
+    /**
+     * #NotActuallyAConflict
+     * Note that there's a difference with how = and := behave.
+     * We only *simulate* = being an infix identifier for the sake of printing,
+     * but for parsing it's a little more nuanced. There *isn't* technically
+     * a conflict in:
+     *
+     *     a + b.c = d
+     *
+     * Between reducing a + b.c, and shifting =, like there would be if it was
+     * := instead of =. That's because the rule for = isn't the infix rule with
+     * an arbitrary expression on its left - it's something much more specific.
+     *
+     * (simple_expr) DOT LIDENT EQUAL expression.
+     *
+     * So with the way yacc/menhir works, when it sees an equal sign, it knows
+     * that there is no valid parse where a + b.c is reduced to an expression
+     * with an = immediately appearing after, so it shifts the equals.
+     *
+     * If you replace = with :=, you'd see different behavior.
+     *
+     *     a + b.c := d
+     *
+     *  Since := has lower precedence than +, it would be parsed as:
+     *
+     *     (a + b.c) := d
+     *
+     * However, our printing logic will print = assignment with parenthesis:
+     *
+     *     a + (b.c = d)
+     *
+     * Even though they're not needed, because it doesn't know details about
+     * which rules are valid, we just told it to print = as if it were a valid
+     * infix identifier.
+     *
+     */
+
+    /* The following */
+    x + something.contents = y;
+    x + something = y;
+    x + something.contents := y;
+    x + something := y;
+
+    /* Should be parsed as: */
+    x + (something.contents = y); /* Because of the #NotActuallyAConflict above */
+    x + (something = y); /* Same */
+    (x + something.contents) := y;
+    (x + something) := y;
+
+    /* To make the := parse differently, we must use parens */
+    x + (something.contents := y);
+    x + (something := y);
+
+
+    /**
+     * Try with ||
+     */
+    x.contents || something + 1 ? hello : goodbye;
+    y || something + 1 ? hello : goodbye;
+    arr.(0) || something + 1 ? hello : goodbye;
+    bigArr.{0} || something + 1 ? hello : goodbye;
+    str.[0] || something + 1 ? hello : goodbye;
+
+    (x.contents || something + 1) ? hello : goodbye;
+    (y || something + 1) ? hello : goodbye;
+    (arr.(0) || something + 1) ? hello : goodbye;
+    (bigArr.{0} || something + 1) ? hello : goodbye;
+    (str.[0] || something + 1) ? hello : goodbye;
+
+    x.contents || (something + 1 ? hello : goodbye);
+    y || (something + 1 ? hello : goodbye);
+    arr.(0) || (something + 1 ? hello : goodbye);
+    bigArr.{0} || (something + 1 ? hello : goodbye);
+    str.[0] || (something + 1 ? hello : goodbye);
+
+
+    /**
+     * Try with &&
+     */
+    x.contents && something + 1 ? hello : goodbye;
+    y && something + 1 ? hello : goodbye;
+    arr.(0) && something + 1 ? hello : goodbye;
+    bigArr.{0} && something + 1 ? hello : goodbye;
+    str.[0] && something + 1 ? hello : goodbye;
+
+    (x.contents && something + 1) ? hello : goodbye;
+    (y && something + 1) ? hello : goodbye;
+    (arr.(0) && something + 1) ? hello : goodbye;
+    (bigArr.{0} && something + 1) ? hello : goodbye;
+    (str.[0] && something + 1) ? hello : goodbye;
+
+    x.contents && (something + 1 ? hello : goodbye);
+    y && (something + 1 ? hello : goodbye);
+    arr.(0) && (something + 1 ? hello : goodbye);
+    bigArr.{0} && (something + 1 ? hello : goodbye);
+    str.[0] && (something + 1 ? hello : goodbye);
+
+
+
+    /**
+     * See how regular infix operators work correctly.
+     */
+    x.contents = (2 + 4);
+    y = (2 + 4);
+    arr.(0) = (2 + 4);
+    bigArr.{0} = (2 + 4);
+    str.[0] = (2 + 4);
+
+    (x.contents = 2) + 4;
+    (y = 2) + 4;
+    (arr.(0) = 2) + 4;
+    (bigArr.{0} = 2) + 4;
+    (str.[0] = 2) + 4;
+
+
+    /**
+     * Ensures that record update, object field update, and := are all right
+     * associative.
+     */
+    x.contents = y.contents = 10;
+    y = x.contents = 10;
+    arr.(0) = x.contents = 10;
+    bigArr.{0} = x.contents = 10;
+    str.[0] = x.contents = 10;
+    /* Should be the same as */
+    x.contents = (x.contents = 10);
+    y = (x.contents = 10);
+    arr.(0) = (x.contents = 10);
+    bigArr.{0} = (x.contents = 10);
+    str.[0] = (x.contents = 10);
+
+
+    /**
+     * Ensures that record update, object field update, and := are all right
+     * associative.
+     */
+    x := x := 10;
+    /* Should be the same as */
+    x := (x := 10);
+
+    /* By default, without parens*/
+    x ? y : z ? a : b;
+
+    /* It is parsed as the following: */
+    x ? y : (z ? a : b);
+
+    /* Not this: */
+    (x ? y : z) ? a : b;
+
+    /**
+     *          ^
+     * When rendering the content to the left of the ? we know that we want the
+     * parser to reduce the thing to the left of the ? when the ? is seen.  So we
+     * look at the expression to the left of ? and discover what precedence level
+     * it is (token of its rightmost terminal). We then compare it with ? to see
+     * who would win a shift reduce conflict. We want the term to the left of the ?
+     * to be reduced. So if it's rightmost terminal isn't higher precedence than ?,
+     * we wrap it in parens.
+     */
+
+
+    /***
+     * The following
+     */
+    x.contents = something ? x.contents = somethingElse : goodbye;
+    y = something ? y = somethingElse : goodbye;
+    arr.(0) = something ? arr.(0) = somethingElse : goodbye;
+    bigArr.{0} = something ? bigArr.{0} = somethingElse : goodbye;
+    str.[0] = something ? str.[0] = somethingElse : goodbye;
+    /*
+     * Should be parsed as
+     */
+    x.contents = (something ? x.contents = somethingElse : goodbye);
+    y = (something ? y = somethingElse : goodbye);
+    arr.(0) = (something ? arr.(0) = somethingElse : goodbye);
+    bigArr.{0} = (something ? bigArr.{0} = somethingElse : goodbye);
+    str.[0] = (something ? str.[0] = somethingElse : goodbye);
+
+    /** And this */
+    y := something ? y := somethingElse : goodbye;
+    arr.(0) := something ? arr.(0) := somethingElse : goodbye;
+    bigArr.{0} := something ? bigArr.{0} := somethingElse : goodbye;
+    str.[0] := something ? str.[0] := somethingElse : goodbye;
+
+    /* Should be parsed as */
+    y := (something ? (y := somethingElse) : goodbye);
+    arr.(0) := (something ? (arr.(0) := somethingElse) : goodbye);
+    bigArr.{0} := (something ? (bigArr.{0} := somethingElse) : goodbye);
+    str.[0] := (something ? (str.[0] := somethingElse) : goodbye);
+
+
+    /* The following */
+    x := something ? x.contents = somethingElse ? goodbye : goodbye : goodbye;
+    x := something ? arr.(0) = somethingElse ? goodbye : goodbye : goodbye;
+    x := something ? bigArr.{0} = somethingElse ? goodbye : goodbye : goodbye;
+    x := something ? str.[0] = somethingElse ? goodbye : goodbye : goodbye;
+    /* Is parsed as */
+    x := (something ? x.contents = (somethingElse ? goodbye : goodbye) : goodbye);
+    x := (something ? arr.(0) = (somethingElse ? goodbye : goodbye) : goodbye);
+    x := (something ? bigArr.{0} = (somethingElse ? goodbye : goodbye) : goodbye);
+    x := (something ? str.[0] = (somethingElse ? goodbye : goodbye) : goodbye);
+    /* is not the same as */
+    x := something ? (x.contents = somethingElse) ? goodbye : goodbye : goodbye;
+    x := something ? (arr.(0) = somethingElse) ? goodbye : goodbye : goodbye;
+    x := something ? (bigArr.{0} = somethingElse) ? goodbye : goodbye : goodbye;
+    x := something ? (str.[0] = somethingElse) ? goodbye : goodbye : goodbye;
+
+    /**
+     * And
+     */
+
+    /** These should be parsed the same */
+    something ? somethingElse : x.contents = somethingElse ? x : z;
+    something ? somethingElse : (x.contents = (somethingElse ? x : z));
+    /* Not: */
+    something ? somethingElse : (x.contents = somethingElse) ? x : z;
+    (something ? somethingElse : (x.contents = somethingElse)) ? x : z;
+
+    /* These should be parsed the same */
+    something ? somethingElse : x := somethingElse ? x : z;
+    something ? somethingElse : (x := (somethingElse ? x : z));
+    /* Not: */
+    something ? somethingElse : (x := somethingElse) ? x : z;
+    (something ? somethingElse : (x := somethingElse)) ? x : z;
+
+    /** These should be parsed the same */
+    something ? somethingElse : y = somethingElse ? x : z;
+    something ? somethingElse : (y = (somethingElse ? x : z));
+    /* Not: */
+    something ? somethingElse : (y = somethingElse) ? x : z;
+    (something ? somethingElse : (y = somethingElse)) ? x : z;
+
+    /** These should be parsed the same */
+    something ? somethingElse : arr.(0) = somethingElse ? x : arr.(0);
+    something ? somethingElse : (arr.(0) = (somethingElse ? x : arr.(0)));
+    /* Not: */
+    something ? somethingElse : (arr.(0) = somethingElse) ? x : z;
+    (something ? somethingElse : (arr.(0) = somethingElse)) ? x : z;
+
+    /** These should be parsed the same */
+    something ? somethingElse : bigArr.{0} = somethingElse ? x : bigArr.{0};
+    something ? somethingElse : (bigArr.{0} = (somethingElse ? x : bigArr.{0}));
+    /* Not: */
+    something ? somethingElse : (bigArr.{0} = somethingElse) ? x : z;
+    (something ? somethingElse : (bigArr.{0} = somethingElse)) ? x : z;
+
+    /** These should be parsed the same */
+    something ? somethingElse : arr.[0] = somethingElse ? x : arr.[0];
+    something ? somethingElse : (arr.[0] = (somethingElse ? x : arr.[0]));
+    /* Not: */
+    something ? somethingElse : (str.[0] = somethingElse) ? x : z;
+    (something ? somethingElse : (str.[0] = somethingElse)) ? x : z;
+
+    /**
+     * It creates a totally different meaning when parens group the :
+     */
+    x.contents = something ? (x.contents = somethingElse : x) : z;
+    y = something ? (y = somethingElse : x) : z;
+    arr.(0) = something ? (arr.(0) = somethingElse : x) : z;
+    bigArr.{0} = something ? (bigArr.{0} = somethingElse : x) : z;
+    str.[0] = something ? (str.[0] = somethingElse : x) : z;
+
+    /**
+     * Various precedence groupings.
+     */
+    true ? true ? false : false : false;
+    /* Is the same as */
+    true ? (true ? false : false) : false;
+    /*
+     * Just some examples of how prefix will be printed.
+     */
+    - x + something.contents = y;
+    - x + something = y;
+    - x + something.contents := y;
+    - x + something := y;
+    x + - something.contents = y;
+    x + - something = y;
+    x + - something.contents := y;
+    x + - something := y;
+    x.contents || something + 1 ? - hello : goodbye;
+    bigArr.{0} || - something + 1 ? hello : goodbye;
+    let result = - x + something.contents = y;
+
+    /* Prefix minus is actually sugar for regular function identifier ~-*/
+    let result = 2 + (~-) (add 4 0);
+    /* Same as */
+    let result = 2 + ~- add 4 0;
+    /* Same as */
+    let result = 2 + - add 4 0;
+
+    /* That same example but with ppx attributes on the add application */
+    let result = 2 + (~-) (add 4 0 [@ppx]);
+    /* Same as */
+    let result = 2 + ~- add 4 0 [@ppx];
+    /* Same as */
+    let result = 2 + - add 4 0 [@ppx];
+
+
+    /* Multiple nested prefixes */
+    let result = 2 + - - - add 4 0;
+
+    /* And with attributes */
+    let result = 2 + - - - add 4 0 [@onAddApplication];
+
+
+    /**
+     * TODO: Move all of these test cases to attributes.re.
+     */
+    /* Attribute on the prefix application */
+    let res = (- something blah blah) [@attr];
+    /* Attribute on the regular function application, not prefix */
+    let res = - something blah blah [@attr];
+    let attrOnPrefix = (- 1) [@ppxOnPrefixApp];
+    let attrOnPrefix = 5 + - 1 [@ppxOnPrefixApp];
+    let result = arr.[0] [@ppxAttributeOnSugarGetter];
+
+
+    /**
+     * Unary plus/minus has lower precedence than prefix operators:
+     * And unary plus has same precedence as unary minus.
+     */
+    let res = - !record;
+    /* Should be parsed as: */
+    let res = - (! record);
+    /* Although that precedence ranking doesn't likely have any effect in that
+     * case. */
+    /**
+     * And this
+     */
+    let res = - + callThisFunc ();
+    /* should be parsed as: */
+    let res = - + callThisFunc ();
+
+    /**
+     * And this
+     */
+    let res = ! (- callThisFunc ());
+    /* Should be parsed (and should remain printed as: */
+    let res = ! (- callThisFunc ());
+
+
+    let res = !x [@onApplication];
+    let res = !(x [@onX]);
+
+    let res = !(x [@onX]);
+    (something.contents = "newvalue") [@shouldBeRenderedOnEntireSetField];
+    something.contents = "newvalue" [@shouldBeRenderedOnString];
+  };
+};

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -863,3 +863,7 @@ let A | B | C = X;
  *
  */
 external f : int => int = "foo";
+
+let x = {contents: 0};
+
+let unitVal = x.contents = 210;

--- a/src/reason_parser.messages
+++ b/src/reason_parser.messages
@@ -38,13 +38,13 @@ use_file: UIDENT RPAREN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 956, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 926, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 936, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 965, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 935, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 911, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 881, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 891, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 920, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 890, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 2753, spurious reduction of production post_item_attributes ->
 ## In state 2754, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 2755, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
@@ -175,13 +175,13 @@ toplevel_phrase: UIDENT RPAREN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 956, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 926, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 936, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 965, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 935, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 911, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 881, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 891, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 920, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 890, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 2753, spurious reduction of production post_item_attributes ->
 ## In state 2754, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 2755, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
@@ -1990,13 +1990,13 @@ parse_expression: UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 956, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 926, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 936, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 965, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 935, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 911, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 881, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 891, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 920, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 890, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -5330,9 +5330,9 @@ implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 920, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 875, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -5378,9 +5378,9 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 920, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 875, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -6551,13 +6551,13 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 956, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 926, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 936, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 965, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 935, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 911, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 881, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 891, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 920, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 890, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -6891,10 +6891,10 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 926, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 936, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 965, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 935, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 881, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 891, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 920, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 890, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1243, spurious reduction of production let_binding_body -> pattern EQUAL expr
 ## In state 1640, spurious reduction of production post_item_attributes ->
 ## In state 1641, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
@@ -8608,13 +8608,13 @@ implementation: LBRACKET UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 956, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 926, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 936, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 965, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 935, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 911, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 881, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 891, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 920, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 890, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1070, spurious reduction of production expr_optional_constraint -> expr
 ##
 
@@ -8875,13 +8875,13 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 956, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 926, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 936, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 965, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 935, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 911, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 881, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 891, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 920, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 890, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -10012,9 +10012,9 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 920, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 875, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -10195,13 +10195,13 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 956, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 926, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 936, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 965, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 935, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 911, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 881, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 891, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 920, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 890, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -10466,9 +10466,9 @@ implementation: LPAREN IF UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 920, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 875, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -10543,13 +10543,13 @@ implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 956, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 926, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 936, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 965, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 935, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 911, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 881, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 891, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 920, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 890, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1070, spurious reduction of production expr_optional_constraint -> expr
 ##
 
@@ -10707,13 +10707,13 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 956, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 926, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 936, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 965, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 935, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 911, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 881, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 891, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 920, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 890, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -10768,13 +10768,13 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 956, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 926, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 936, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 965, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 935, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 911, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 881, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 891, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 920, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 890, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -11291,9 +11291,9 @@ implementation: SWITCH UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 920, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 875, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -11361,13 +11361,13 @@ implementation: TRUE DOT LBRACE UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 956, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 926, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 936, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 965, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 935, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 911, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 881, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 891, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 920, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 890, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -11476,7 +11476,7 @@ implementation: TRUE DOT LIDENT EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 ##
-## Ends in an error in state: 894.
+## Ends in an error in state: 1050.
 ##
 ## _expr -> simple_expr DOT LPAREN expr RPAREN EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11488,7 +11488,7 @@ implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 891.
+## Ends in an error in state: 1047.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11762,13 +11762,13 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 956, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 926, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 936, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 965, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 935, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 911, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 881, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 891, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 920, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 890, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1179, spurious reduction of production post_item_attributes ->
 ## In state 1180, spurious reduction of production opt_semi ->
 ## In state 1185, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
@@ -11869,13 +11869,13 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 956, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 926, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 936, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 965, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 935, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 911, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 881, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 891, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 920, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 890, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -11927,9 +11927,9 @@ implementation: TRY UIDENT UNDERSCORE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 920, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 875, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -12569,7 +12569,7 @@ implementation: TYPE WITH
 
 implementation: UIDENT AMPERAMPER WITH
 ##
-## Ends in an error in state: 887.
+## Ends in an error in state: 1002.
 ##
 ## _expr -> expr AMPERAMPER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12581,7 +12581,7 @@ implementation: UIDENT AMPERAMPER WITH
 
 implementation: UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 885.
+## Ends in an error in state: 1000.
 ##
 ## _expr -> expr AMPERSAND . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12593,7 +12593,7 @@ implementation: UIDENT AMPERSAND WITH
 
 implementation: UIDENT BARBAR WITH
 ##
-## Ends in an error in state: 883.
+## Ends in an error in state: 998.
 ##
 ## _expr -> expr BARBAR . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12605,7 +12605,7 @@ implementation: UIDENT BARBAR WITH
 
 implementation: UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 889.
+## Ends in an error in state: 1004.
 ##
 ## _expr -> expr COLONEQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12854,7 +12854,7 @@ implementation: UIDENT DOT WITH
 
 implementation: UIDENT GREATER WITH
 ##
-## Ends in an error in state: 879.
+## Ends in an error in state: 994.
 ##
 ## _expr -> expr GREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr GREATER . GREATER expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -12867,7 +12867,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP0 WITH
 ##
-## Ends in an error in state: 877.
+## Ends in an error in state: 992.
 ##
 ## _expr -> expr INFIXOP0 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12879,7 +12879,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP1 WITH
 ##
-## Ends in an error in state: 871.
+## Ends in an error in state: 986.
 ##
 ## _expr -> expr INFIXOP1 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12891,7 +12891,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP2 WITH
 ##
-## Ends in an error in state: 869.
+## Ends in an error in state: 984.
 ##
 ## _expr -> expr INFIXOP2 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12903,7 +12903,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP3 WITH
 ##
-## Ends in an error in state: 855.
+## Ends in an error in state: 970.
 ##
 ## _expr -> expr INFIXOP3 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13019,7 +13019,7 @@ Expecting "]"
 
 implementation: UIDENT LESS WITH
 ##
-## Ends in an error in state: 875.
+## Ends in an error in state: 990.
 ##
 ## _expr -> expr LESS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13031,7 +13031,7 @@ Expecting an expression
 
 implementation: UIDENT LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 873.
+## Ends in an error in state: 988.
 ##
 ## _expr -> expr LESSDOTDOTGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13043,7 +13043,7 @@ Expecting an expression
 
 implementation: UIDENT LESSGREATER WITH
 ##
-## Ends in an error in state: 867.
+## Ends in an error in state: 982.
 ##
 ## _expr -> expr LESSGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13080,7 +13080,7 @@ Expecting one of the following:
 
 implementation: UIDENT MINUS WITH
 ##
-## Ends in an error in state: 865.
+## Ends in an error in state: 980.
 ##
 ## _expr -> expr MINUS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13092,7 +13092,7 @@ Expecting an expression
 
 implementation: UIDENT MINUSDOT WITH
 ##
-## Ends in an error in state: 863.
+## Ends in an error in state: 978.
 ##
 ## _expr -> expr MINUSDOT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13104,7 +13104,7 @@ Expecting an expression
 
 implementation: UIDENT OR WITH
 ##
-## Ends in an error in state: 861.
+## Ends in an error in state: 976.
 ##
 ## _expr -> expr OR . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13116,7 +13116,7 @@ Expecting an expression
 
 implementation: UIDENT PERCENT WITH
 ##
-## Ends in an error in state: 853.
+## Ends in an error in state: 968.
 ##
 ## _expr -> expr PERCENT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13128,7 +13128,7 @@ Expecting an expression
 
 implementation: UIDENT PLUS WITH
 ##
-## Ends in an error in state: 859.
+## Ends in an error in state: 974.
 ##
 ## _expr -> expr PLUS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13140,7 +13140,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSDOT WITH
 ##
-## Ends in an error in state: 857.
+## Ends in an error in state: 972.
 ##
 ## _expr -> expr PLUSDOT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13152,7 +13152,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 851.
+## Ends in an error in state: 966.
 ##
 ## _expr -> expr PLUSEQ . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13164,7 +13164,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1050.
+## Ends in an error in state: 1045.
 ##
 ## _expr -> expr QUESTION expr COLON . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13176,7 +13176,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT SEMI
 ##
-## Ends in an error in state: 1049.
+## Ends in an error in state: 1044.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -13212,13 +13212,13 @@ implementation: UIDENT QUESTION UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 956, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 926, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 936, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 965, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 935, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 911, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 881, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 891, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 920, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 890, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13227,7 +13227,7 @@ Expecting one of the following:
 
 implementation: UIDENT QUESTION WITH
 ##
-## Ends in an error in state: 896.
+## Ends in an error in state: 851.
 ##
 ## _expr -> expr QUESTION . expr COLON expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13344,13 +13344,13 @@ implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 797, spurious reduction of production constr_longident -> mod_longident
-## In state 956, spurious reduction of production _simple_expr -> constr_longident
-## In state 922, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 918, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 926, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 936, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 965, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 935, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 911, spurious reduction of production _simple_expr -> constr_longident
+## In state 877, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 873, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 881, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 891, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 920, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 890, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -920,34 +920,10 @@ let built_in_explicit_arity_constructors = ["Some"; "Assert_failure"; "Match_fai
 Tokens and rules have precedences and those precedences are used to
 resolve what would otherwise be a conflict in the grammar.
 
-Precedence and associativity:
+Precedence and associativity/Resolving conflicts:
 ----------------------------
-- The list that follows this docblock determines precedence in order
-  form low to high along with an optional associativity.
-- Within each row in the list, the precedences are equivalent.
-- Each entry's position in the list either determines the relative precedence of the
-  mentioned token, or it creates a new "name" for a reusable precednece/associativity
-  (such as below_SEMI).
-  - By default, a rule has the precedence of its rightmost terminal (if any).
-  - But a rule can use one of the reusable "names" for precedence/associativity
-    from the list below.
-
-Resolving conflicts in grammar:
--------------------------------
-Different types of conflicts are resolved in different ways.
-- Reduce/reduce conflict:
-  - (Are not resolved using precedence?)
-  - (Instead?) Resolved in favor of the first rule (in source file order).
-- Shift/reduce conflict between rule and token being shifted:
-  - Resolved by comparing the "precedence" and "associativity" of the
-    token to be shifted with those of the rule to be reduced.
-  - When the rule and the token have the same precedence, it is resolved
-    using the associativity:
-    - If the token is left-associative, the parser will reduce.
-    - If the token is right-associative, the parser will shift.
-    - If non-associative, the parser will declare a syntax error.
-  - Question: What about when the rule to reduce has no precedence because it
-  has no rightmost terminal?
+See [http://caml.inria.fr/pub/docs/manual-ocaml-4.00/manual026.html] section
+about conflicts.
 
 We will only use associativities with operators of the kind  x * x -> x
 for example, in the rules of the form    expr: expr BINOP expr
@@ -955,16 +931,17 @@ in all other cases, we define two precedences if needed to resolve
 conflicts.
 
 */
+/* Question: Where is the SEMI explicit precedence? */
 %nonassoc below_SEMI
 %nonassoc below_EQUALGREATER
 %right    EQUALGREATER                  /* core_type2 (t => t => t) */
-%nonassoc below_QUESTION
+%right COLON
+%right    EQUAL                         /* below COLONEQUAL (lbl = x := e) */
+%right    COLONEQUAL                    /* expr (e := e := e) */
 %nonassoc QUESTION
 %nonassoc WITH             /* below BAR  (match ... with ...) */
 %nonassoc AND             /* above WITH (module rec A: SIG with ... and ...) */
 %nonassoc ELSE                          /* (if ... then ... else ...) */
-%nonassoc EQUAL                         /* below COLONEQUAL (lbl = x := e) */
-%right    COLONEQUAL                    /* expr (e := e := e) */
 %nonassoc AS
 %nonassoc below_BAR                     /* Allows "building up" of many bars */
 %left     BAR                           /* pattern (p|p|p) */
@@ -1017,8 +994,8 @@ conflicts.
  * attributes. In expressions, they have the same precedence as function
  * arguments, as if they are additional arguments to a function application.
  *
- * Note that prefix unary subtractive/plus parses with lower precedence than
- * function application (and attributes) This means that:
+ * Note that unary subtractive/plus parses with lower precedence than function
+ * application (and attributes) This means that:
  *
  *   let = - something blah blah [@attr];
  *
@@ -1026,12 +1003,32 @@ conflicts.
  * unary minus, as if the attribute was merely another argument to the function
  * application.
  *
+ *
+ * To make the attribute apply to the unary -, wrap in parens.
+ *
+ *   let = (- something blah blah) [@attr];
+ *
  * Where arrows occur, it will (as always) obey the rules of function/type
  * application.
  *
  *   type x = int => int [@onlyAppliedToTheInt];
  *   type x = (int => int) [@appliedToTheArrow];
  *
+ * However, unary subtractive/plus parses with *higher* precedence than infix
+ * application, so that
+ *
+ *   3 + - funcCall arg arg + 3;
+ *
+ * Is parsed as:
+ *
+ *   3 + (- (funcCall arg arg)) + 3;
+ *
+ * TODO:
+ *
+ * We would also like to bring this behavior to `!` as well, when ! becomes
+ * "not". This is so that you may do !someFunction(arg, arg) and have the
+ * entire function application negated. In fact, we may as well just have all
+ * of PREFIXOP have the unary precedence parsing behavior for consistency.
  */
 
 %nonassoc prec_unary_minus prec_unary_plus /* unary - */
@@ -1039,6 +1036,8 @@ conflicts.
 /* Now that commas require wrapping parens (for tuples), prec_constr_appl no
 * longer needs to be above COMMA, but it doesn't hurt */
 %nonassoc prec_constr_appl              /* above AS BAR COLONCOLON COMMA */
+
+/* PREFIXOP and BANG precedence */
 %nonassoc below_DOT_AND_SHARP           /* practically same as below_SHARP but we convey purpose */
 %nonassoc SHARP                         /* simple_expr/toplevel_directive */
 %left     SHARPOP
@@ -2597,7 +2596,7 @@ _expr:
    *
    *     switch expression { | true => expr1 | false => expr2 }
    *
-   * The prec below_QUESTION is so that the following parses:
+   * The COLON token priority is below QUESTION so that the following parses:
    *
    *    x ? y :
    *    z ? q : r
@@ -2616,7 +2615,7 @@ _expr:
    * that we, instead, shift the qusetion mark so that the *latter* ternary is
    * recognized first on the top of the stack. (z ? q : r).
    */
-  | expr QUESTION expr COLON expr %prec below_QUESTION {
+  | expr QUESTION expr COLON expr {
       (* Should use ghost expressions, but not sure how that would work with source maps *)
       (* So ? will become true and : becomes false for now*)
       let loc_question = mklocation $startpos($2) $endpos($2) in
@@ -2813,7 +2812,9 @@ _simple_expr:
 
 /**
  * Nice reusable version of simple_expr that waits to be reduced until enough
- * of the input has been observed, in order to consider Module.X.Y a single simple_expr
+ * of the input has been observed, in order to consider Module.X.Y a single
+ * simple_expr. It's terribly nuanced that this would make a difference. (No
+ * longer necessary)?
  */
 less_aggressive_simple_expression:
   simple_expr {$1}


### PR DESCRIPTION
When converting the css-layout library to Reason, I found the following "bug".

```rust
x.contents = e1 ? e2 : e3;
```

Most people (and JS) would expect that to be parsed as:
```rust
x.contents = (e1 ? e2 : e3);
```

But Reason was parsing/printing it as:

```rust
(x.contents = e1) ? e2 : e3;
```

It was very difficult to fix this without a major refactor, because there's many combination of infix operators, update token `=` and ternary `?` that didn't fit into the existing "framework" of printing. So I implemented light version of "unparsing", which resembles a more general unparsing strategy. It uses rules tables that rank token precedences (and also custom `%prec` rules that we've used) in order to determine when to add precedence `()` wrappers on various parts of the printing. Now, this is not generalized, so we cannot automatically generate a printing algorithm from new parsing rules we add, but it's an exploration in that direction.

In the process, it helped me fix a few bugs that were outstanding, eliminate a few unnecessary parens, and generally consolidate all the crazy logic about "fixity" (`Infix/`Prefix/`Normal) into one place.