### PR TITLE
Fix #688

### DIFF
--- a/formatTest/unit_tests/expected_output/polymorphism.re
+++ b/formatTest/unit_tests/expected_output/polymorphism.re
@@ -9,6 +9,9 @@ type myTupleType = (int, int);
 
 type myPolymorphicTupleType 'a = ('a, 'a);
 
+type extensible 'a = 'a
+constraint 'a = [ | `Base int];
+
 type intListTranformer = list int => list int;
 
 type x = list (int, string);

--- a/formatTest/unit_tests/input/polymorphism.re
+++ b/formatTest/unit_tests/input/polymorphism.re
@@ -10,6 +10,9 @@ type myTwoParamType 'a 'b = ('a, 'b);
 type myTupleType = (int, int);
 type myPolymorphicTupleType 'a = ('a, 'a);
 
+type extensible 'a = 'a
+constraint 'a = [ | `Base int];
+
 type intListTranformer = list int => list int;
 
 type x = list (int, string);


### PR DESCRIPTION
[Menhir doc](http://gallium.inria.fr/~fpottier/menhir/manual.pdf) says that `Parsing.ml` is deprecated whereas `symbol_rloc()` calls `Parsing.symbol_start_pos`.

But! ``type  extensible 'a = 'a constraint 'a = [`Base int];`` DOES work in refmt, and I have no idea why. RTop fails as expected.

There are other usages of deprecated ocamlyacc functions. I can remove them in this PR later today or tomorrow.