### PR TITLE
Better help message for refmt

### DIFF
--- a/src/refmt_impl.ml
+++ b/src/refmt_impl.ml
@@ -35,21 +35,21 @@ let reasonBinaryParser use_stdin filename =
   let (magic_number, filename, ast, comments, parsedAsML, parsedAsInterface) = input_value chan in
   ((ast, comments), parsedAsML, parsedAsInterface)
 
-let usage =
-"Reason: Meta Language Utility\n\
-\n\
-[Usage]: refmt [options] some-file.[re|ml]\
-\n\
-\n   // translate ocaml to reason on stdin\
-\n   echo 'let _ = ()' | refmt -print re -parse ml -use-stdin true -is-interface-pp false\
-\n\
-\n   // print the AST of a file\
-\n   refmt -parse re -print ast some-file.re\
-\n\
-\n   // reformat a file\
-\n   refmt -parse re -print re some-file.re\
-\n\
-\n[Options]:\n"
+let usage = {|Reason: Meta Language Utility
+
+[Usage]: refmt [options] some-file.[re|ml]
+
+   // translate ocaml to reason on stdin
+   echo 'let _ = ()' | refmt -print re -parse ml -use-stdin true -is-interface-pp false
+
+   // print the AST of a file
+   refmt -parse re -print ast some-file.re
+
+   // reformat a file
+   refmt -parse re -print re some-file.re
+
+[Options]:
+|}
 
 (*
  * As soon as m17n vends comments, this should be replaced with what is

--- a/src/refmt_impl.ml
+++ b/src/refmt_impl.ml
@@ -84,12 +84,12 @@ let () =
   let () = Arg.parse options (fun arg -> filename := arg) usage in
   let print_help = !print_help in
   let filename = !filename in
+  let use_stdin = !use_stdin in
   let _ =
-    if filename = "" || print_help then
+    if (filename = "" && not use_stdin) || print_help then
       let () = Arg.usage options usage in
         exit 1;
   in
-  let use_stdin = !use_stdin in
   let print_width = match !print_width with
     | None -> default_print_width
     | Some x -> x


### PR DESCRIPTION
- added example usages
- show help if no filename given
- show help if `-h` given

Test Plan:
`make build && ./_build/bin/refmt -h`

```
:~/clone/rsn/Reason$ ./_build/bin/refmt -h hi
Reason: Meta Language Utility

[Usage]: refmt [options] some-file.[re|ml]

   // translate ocaml to reason on stdin
   echo 'let _ = ()' | refmt -print re -parse ml -use-stdin true -is-interface-pp false

   // print the AST of a file
   refmt -parse re -print ast some-file.re

   // reformat a file
   refmt -parse re -print re some-file.re

[Options]:

  -ignore ignored
  -is-interface-pp <interface>, parse AST as <interface> (either true or false)
  -use-stdin <use_stdin>, parse AST from <use_stdin> (either true, false). You still must provide a file name even if using stdin for errors to be reported
  -recoverable Enable recoverable parser
  -assume-explicit-arity If a constructor's argument is a tuple, always interpret it as multiple arguments
  -parse <parse>, parse AST as <parse> (either 'ml', 're', 'binary_reason(for interchange between Reason versions')
  -print <print>, print AST in <print> (either 'ml', 're', 'binary(default - for compiler input)', 'binary_reason(for interchange between Reason versions)', 'ast (print human readable directly)', 'none')
  -print-width <print-width>, wrapping width for printing the AST
  -heuristics-file <path>, load path as a heuristics file to specify which constructors are defined with multi-arguments. Mostly used in removing [@implicit_arity] introduced from OCaml conversion.
                example.txt:
                Constructor1
                Constructor2
  -h  Display this list of options
  -help  Display this list of options
  --help  Display this list of options
:~/clone/rsn/Reason$
```