### PR TITLE
Make rebuild support ocamlc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ setup_convenient_bin_links:
 	ln -fs $(shell pwd)/_build/src/refmt_impl.native $(shell pwd)/_build/bin/refmt
 	ln -fs $(shell pwd)/_build/src/refmt_merlin_impl.sh $(shell pwd)/_build/bin/refmt_merlin
 	ln -fs $(shell pwd)/_build/src/reopt.sh $(shell pwd)/_build/bin/reopt
+	ln -fs $(shell pwd)/_build/src/rec.sh $(shell pwd)/_build/bin/rec
+	ln -fs $(shell pwd)/_build/src/share.sh $(shell pwd)/_build/bin/share
 	ln -fs $(shell pwd)/_build/src/reup.sh $(shell pwd)/_build/bin/reup
 
 build_without_utop: compile_error setup_convenient_bin_links

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -5,15 +5,18 @@ let () = dispatch (
   | Before_rules ->
     rule "myocamlbuild"
       ~prod:"_reasonbuild/_build/myocamlbuild"
-      ~deps:["src/reasonbuild.cmx"; "src/reopt.sh"]
+      ~deps:["src/reasonbuild.cmx"; "src/reopt.sh"; "src/rec.sh"; "src/share.sh"]
       begin fun env build ->
         Cmd(S[Sh"mkdir -p _reasonbuild;";
               Sh"cd _reasonbuild;";
               Sh"pwd;";
               Sh"touch myocamlbuild.ml;";
               Sh"chmod +x ../src/reopt.sh;";
+              Sh"chmod +x ../src/rec.sh;";
               A"ocamlbuild"; A"-just-plugin"; A"-ocamlopt";
-              A"env REASON_BUILD_DIR=../../src ../../src/reopt.sh"])
+              A"env REASON_BUILD_DIR=../../src ../../src/reopt.sh";
+              A"-ocamlc";
+              A"env REASON_BUILD_DIR=../../src ../../src/rec.sh" ])
       end;
   | After_rules ->
     flag ["ocaml"; "pp"; "pp_byte"; "reason"] &

--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -39,6 +39,8 @@ let () =
     Pkg.bin ~auto:true "src/ocamlmerlin_reason" ~dst:"ocamlmerlin-reason";
     Pkg.bin  "src/refmt_merlin_impl.sh" ~dst:"refmt_merlin";
     Pkg.bin  "src/reopt.sh" ~dst:"reopt";
+    Pkg.bin  "src/rec.sh" ~dst:"rec";
+    Pkg.bin  "src/share.sh" ~dst:"share";
     Pkg.bin  "src/rebuild.sh" ~dst:"rebuild";
     Pkg.bin  "src/rtop.sh" ~dst:"rtop";
     Pkg.bin  "src/redoc.sh" ~dst:"redoc";

--- a/src/rebuild.sh
+++ b/src/rebuild.sh
@@ -3,13 +3,15 @@
 
 # rebuild is a reasonbuild wrapper that builds reason files
 # it calls into ocamlbuild, telling it to call a special
-# command 'reopt' which links custom reasson build
+# command 'reopt' and 'rec' which links custom reasson build
 # rules.
 
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 REOPT=""
+
+REC=""
 
 if [[ -f $DIR/reopt.sh ]];
 then
@@ -27,10 +29,27 @@ then
     exit 1
 fi
 
-# Since we need to override -ocamlopt, we parse the user passed-in -ocamlopt
-# here and rebuild it in reopt
+if [[ -f $DIR/rec.sh ]];
+then
+    REC="$DIR/rec.sh"
+fi
+
+if [[ -f $DIR/rec ]];
+then
+    REC="$DIR/rec"
+fi
+
+if [ -z "$REC" ];
+then
+    echo "Couldn't find rec"
+    exit 1
+fi
+
+# Since we need to override -ocamlopt and -ocaml, we parse the user passed-in
+#  -ocamlopt and -ocamlc here and rebuild it in reopt and rec
 
 OCAMLOPTIDX=-1
+OCAMLCIDX=-1
 USEOCAMLFIND=-1
 
 # find ocamlopt in argument list
@@ -41,6 +60,12 @@ do
     then
         OCAMLOPTIDX=$i
     fi
+
+    if [[ $var = "-ocamlc" ]];
+    then
+        OCAMLCIDX=$i
+    fi
+
     if [[ $var = "-use-ocamlfind" ]];
     then
         USEOCAMLFIND=1
@@ -59,10 +84,21 @@ then
     set -- "${@:1:OCAMLOPTIDX-1}" "${@: VALUEIDX+1}"
 fi
 
+# found ocamlc, parsing
+OCAMLC="ocamlc"
+if [[ $OCAMLCIDX -ne -1 ]];
+then
+    # The argument after "-ocamlc" will be parsed into rec as ocamlc to be used
+    VALUEIDX=$((OCAMLCIDX+1))
+    OCAMLC=${!VALUEIDX}
+    # Remove the parsed argument out of argument list
+    set -- "${@:1:OCAMLCIDX-1}" "${@: VALUEIDX+1}"
+fi
+
 if [[ $USEOCAMLFIND -ne -1 ]];
 then
-    env OCAMLFIND_COMMANDS="ocamlc=$REOPT" reasonbuild "$@"
+    env OCAMLFIND_COMMANDS="ocamlopt=$REOPT ocamlc=$REC" reasonbuild "$@"
 else
    # pass OCAMLOPT as an environment variable
-   reasonbuild -ocamlopt "env OCAMLOPT=\"$OCAMLOPT\" $REOPT" "$@"
+   reasonbuild -ocamlopt "env OCAMLOPT=\"$OCAMLOPT\" $REOPT" -ocamlc "env OCAMLC=\"$OCAMLC\" $REC" "$@"
 fi

--- a/src/rec.sh
+++ b/src/rec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
 
-# reopt is a decorator for ocamlopt that passes arguments through to ocamlopt directly
+# rec is a decorator for ocamlc that passes arguments through to ocamlc directly
 # If it detects the invocation is to build myocamlbuild, it modifies the commandline arguments
 # by adding reasonbuild.cmx
 
@@ -17,10 +17,10 @@ then
     . "$DIR/share"
 fi
 
-if [ -z "$OCAMLOPT" ];
+if [ -z "$OCAMLC" ];
 then
-    OCAMLOPT="ocamlopt.opt"
+    OCAMLC="ocamlc"
 fi
 
-# use OCAMLOPT that's passed in by rebuild
-$OCAMLOPT "$@"
+# use OCAMLC that's passed in by rebuild
+$OCAMLC "$@"

--- a/src/share.sh
+++ b/src/share.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# share logic between rec and reopt to set up rebuild configs
+
+MY_OCAML_BUILD="-o myocamlbuild"
+
+if [ -z "$REASON_BUILD_DIR" ];
+then
+    REASON_BUILD_DIR=$(ocamlfind query reason)
+fi
+
+if [ -z "$REASON_BUILD_DIR" ];
+then
+    echo "Couldn't find Reason"
+    exit 1
+fi
+
+# Expand special subtitions like '~'
+eval REASON_BUILD_DIR=$REASON_BUILD_DIR
+
+if [[ "${@: -2}" = "${MY_OCAML_BUILD}" ]];
+then
+    #
+    # Remove "unix.cmxa" as myocamlbuild is already linked
+    # with the library
+    #
+    # See https://github.com/facebook/Reason/issues/133
+    #
+    UNIXIDX=-1
+    i=1
+    for var in "$@"
+    do
+        if [[ $var =~ "unix.cmxa" ]];
+        then
+            #
+            # If there is already an unix.cmxa linked, remove the second one
+            #
+            if [[ $UNIXIDX -ne -1 ]];
+            then
+                set -- "${@:1:i-1}" "${@: i+1}"
+            fi
+            UNIXIDX=$i
+        fi
+        i=$i+1
+    done
+    # Link reason build rules
+    set -- "${@:1:$#-3}" "$REASON_BUILD_DIR/reasonbuild.cmx" "${@: -3}"
+fi


### PR DESCRIPTION
Add a new command "rec" to be used in rebuild as a replacement for ocamlc. This is needed to
support ocamlc specific functionalities, such as compiling cmo files.

#725