### PR TITLE
Fix pretty printing #=

### DIFF
--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -4,24 +4,19 @@ bla#=(Some 10);
 
 bla#=(someFunc (Some 10));
 
-bla#=((someFunc someFunc2) 10);
-
 test##var#=(Some (-10));
 
 obj##.prop;
 
 obj##.prod := exp;
 
-preview##style##border#=Js.string "1px black dashed";
+preview##style##border#=(Js.string "1px black dashed");
+
+preview##(style##border)#=args somenum;
 
 x##y##z#=(xxxx##yyyy##zzzz);
 
-let result =
-  js_method_run1 (!react)#createElement foo;
-
-let foo a => a;
-
-id#=(foo 2);
+let result = js_method_run1 (!react)#createElement foo;
 
 add zz##yy xx##ww;
 
@@ -65,6 +60,6 @@ res#=?!!z##q;
 
 res#=?!!z##(q##a);
 
-let result = myFunction (x y#=z) (a b#=c);
+let result = myFunction (x y##z) (a b#=c);
 
 (!x)##y##(b##c);

--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -66,3 +66,5 @@ res#=?!!z##q;
 res#=?!!z##(q##a);
 
 let result = myFunction (x y#=z) (a b#=c);
+
+(!x)##y##(b##c);

--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -1,0 +1,68 @@
+bla#=10;
+
+bla#=(Some 10);
+
+bla#=(someFunc (Some 10));
+
+bla#=((someFunc someFunc2) 10);
+
+test##var#=(Some (-10));
+
+obj##.prop;
+
+obj##.prod := exp;
+
+preview##style##border#=Js.string "1px black dashed";
+
+x##y##z#=(xxxx##yyyy##zzzz);
+
+let result =
+  js_method_run1 (!react)#createElement foo;
+
+let foo a => a;
+
+id#=(foo 2);
+
+add zz##yy xx##ww;
+
+/* These should print the same */
+let res = x##y + z##q; /* AST */
+
+let res = x##y + z##q; /* Minimum parens */
+
+/* These should print the same */
+let res = y + z##q##a; /* AST */
+
+let res = y + z##q##a; /* Min parens */
+
+/* Make sure it's actually parsed as left precedence
+ * and that is maintained when printed */
+let res = z##(q##a); /* AST */
+
+let res = z##(q##a); /* Min parens */
+
+/* These should print the same */
+let res = !x##y; /* AST */
+
+let res = !x##y; /* Minimum parens */
+
+/* These should print the same */
+let res = !z##q##a; /* AST */
+
+let res = !z##q##a; /* Min parens */
+
+/* These should print the same */
+let res = ?!!x##y; /* AST */
+
+let res = ?!!x##y; /* Minimum parens */
+
+/* These should print the same */
+let res = ?!!z##(q##a); /* AST */
+
+let res = ?!!z##(q##a); /* Min parens */
+
+res#=?!!z##q;
+
+res#=?!!z##(q##a);
+
+let result = myFunction (x y#=z) (a b#=c);

--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -10,13 +10,16 @@ obj##.prop;
 
 obj##.prod := exp;
 
-preview##style##border#=(Js.string "1px black dashed");
+preview##style##border#=(
+                          Js.string "1px black dashed"
+                        );
 
 preview##(style##border)#=args somenum;
 
 x##y##z#=(xxxx##yyyy##zzzz);
 
-let result = js_method_run1 (!react)#createElement foo;
+let result =
+  js_method_run1 (!react)#createElement foo;
 
 add zz##yy xx##ww;
 

--- a/formatTest/unit_tests/input/bucklescript.re
+++ b/formatTest/unit_tests/input/bucklescript.re
@@ -1,26 +1,22 @@
-bla #= 10;
+bla#=10;
 
-bla #= (Some 10);
+bla#=(Some 10);
 
-bla #= (someFunc (Some 10));
+bla#=(someFunc (Some 10));
 
-bla #= ((someFunc someFunc2) 10);
-
-test##var #= (Some (-10));
+test##var#=(Some (-10));
 
 obj##.prop;
 
 obj##.prod := exp;
 
-preview##style##border #= Js.string "1px black dashed";
+preview##style##border#=(Js.string "1px black dashed");
 
-(x##y)##z #= ((xxxx##yyyy)##zzzz);
+(preview##(style##border)#=args) somenum;
+
+(x##y)##z#=((xxxx##yyyy)##zzzz);
 
 let result = js_method_run1 (!react)#createElement foo;
-
-let foo a => a;
-
-id #= (foo 2);
 
 add zz##yy xx##ww;
 
@@ -56,6 +52,6 @@ let res = ?!!z##(q##a);   /* Min parens */
 res #= ?!!z ## q;
 res #= ?!!z##(q##a);
 
-let result = myFunction (x y #= z) (a b #= c);
+let result = myFunction (x y ## z) (a b #= c);
 
 (!x)##y##(b##c);

--- a/formatTest/unit_tests/input/bucklescript.re
+++ b/formatTest/unit_tests/input/bucklescript.re
@@ -56,4 +56,6 @@ let res = ?!!z##(q##a);   /* Min parens */
 res #= ?!!z ## q;
 res #= ?!!z##(q##a);
 
-let result = myFunction (x y #= z) (a b #= c)
+let result = myFunction (x y #= z) (a b #= c);
+
+(!x)##y##(b##c);

--- a/formatTest/unit_tests/input/bucklescript.re
+++ b/formatTest/unit_tests/input/bucklescript.re
@@ -1,0 +1,59 @@
+bla #= 10;
+
+bla #= (Some 10);
+
+bla #= (someFunc (Some 10));
+
+bla #= ((someFunc someFunc2) 10);
+
+test##var #= (Some (-10));
+
+obj##.prop;
+
+obj##.prod := exp;
+
+preview##style##border #= Js.string "1px black dashed";
+
+(x##y)##z #= ((xxxx##yyyy)##zzzz);
+
+let result = js_method_run1 (!react)#createElement foo;
+
+let foo a => a;
+
+id #= (foo 2);
+
+add zz##yy xx##ww;
+
+/* These should print the same */
+let res = ((x##y) + (z##q));   /* AST */
+let res = x##y + z##q; /* Minimum parens */
+
+/* These should print the same */
+let res = (y + (z##q)##a);   /* AST */
+let res = y + z##q##a;   /* Min parens */
+
+/* Make sure it's actually parsed as left precedence
+ * and that is maintained when printed */
+let res = (z##(q##a));   /* AST */
+let res = z##(q##a);   /* Min parens */
+
+/* These should print the same */
+let res = (! (x##y));   /* AST */
+let res = !x##y;        /* Minimum parens */
+
+/* These should print the same */
+let res = (!(z##q)##a);   /* AST */
+let res = !z##q##a;   /* Min parens */
+
+/* These should print the same */
+let res = (?!! (x##y));   /* AST */
+let res = ?!!x##y;        /* Minimum parens */
+
+/* These should print the same */
+let res = (?!!z##(q##a));   /* AST */
+let res = ?!!z##(q##a);   /* Min parens */
+
+res #= ?!!z ## q;
+res #= ?!!z##(q##a);
+
+let result = myFunction (x y #= z) (a b #= c)


### PR DESCRIPTION
Fixes #736.
Special casing `#` followed by any of `['!' '$' '%' '&' '+' '-' '.' ':' '<' '=' '>' '?' '@' '^' '|' '~']` or
`('\\' '*') | ('\\' '/')` to be printed properly with the right
precedence and associativity.

I added tests in a new file that I called "bucklescript", I'm not sure that's the best name for it.