### PR TITLE
[Reason] Add pretty_print to ocamlmerlin_reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,28 +33,6 @@ opam pin add -y reason 'https://github.com/facebook/reason.git#0.0.6'
 
 ```
 
-Install master (For contributors)
-----------
-```
-# On OSX, install opam via Homebrew:
-brew update
-brew install opam
-# On Linux, see here (you will need opam >= 1.2.2): http://opam.ocaml.org/doc/Install.html
-
-opam init
-# Add this to your ~/.bashrc (or ~/.zshrc):
-#   eval $(opam config env)
-
-opam update
-opam switch 4.02.3
-eval $(opam config env)
-opam pin add -y merlin 'https://github.com/the-lambda-church/merlin.git#reason-0.0.1'
-opam pin add -y merlin_extend 'https://github.com/let-def/merlin-extend.git#reason-0.0.1'
-git clone git@github.com:facebook/reason.git
-cd reason
-opam pin add -y reason .
-```
-
 Test Installation
 ----------
 
@@ -80,6 +58,34 @@ Contribute back to that documentation in the [documentation branch](https://gith
 Community
 ---------------
 Get in touch! We're on IRC freenode #reasonml, and [Gitter](https://gitter.im/facebook/reason).
+
+Contributing To Development
+----------
+```
+# On OSX, install opam via Homebrew:
+brew update
+brew install opam
+# On Linux, see here (you will need opam >= 1.2.2): http://opam.ocaml.org/doc/Install.html
+
+opam init
+# Add this to your ~/.bashrc (or ~/.zshrc):
+#   eval $(opam config env)
+
+opam update
+opam switch 4.02.3
+eval $(opam config env)
+opam pin add -y merlin 'https://github.com/the-lambda-church/merlin.git'
+opam pin add -y merlin_extend 'https://github.com/let-def/merlin-extend.git'
+git clone git@github.com:facebook/reason.git
+cd reason
+opam pin add -y reason .
+```
+
+If the compilation of `Reason` does not succeed *after* pinning
+`merlin/merlin-extend` as described above, then a change to `merlin` or
+`merlin-extend` may have broken `Reason` (please file a Github Issue).  We
+should try to keep all three projects' master branches compatible with each
+other.
 
 
 License

--- a/src/ocamlmerlin_reason.ml
+++ b/src/ocamlmerlin_reason.ml
@@ -26,6 +26,20 @@ module Reason_reader = struct
 
   let ident_at t _ = []
 
+  let formatter =
+     let fmt = lazy (Reason_pprint_ast.createFormatter ()) in
+     fun () -> Lazy.force fmt
+
+  let pretty_print ppf =
+    let open Reason_pprint_ast in function
+    | Pretty_core_type       x -> (formatter ())#core_type       ppf x
+    | Pretty_case_list       x -> (formatter ())#case_list       ppf x
+    | Pretty_expression      x -> (formatter ())#expression      ppf x
+    | Pretty_pattern         x -> (formatter ())#pattern         ppf x
+    | Pretty_signature       x -> (formatter ())#signature    [] ppf x
+    | Pretty_structure       x -> (formatter ())#structure    [] ppf x
+    | Pretty_toplevel_phrase x -> (formatter ())#toplevel_phrase ppf x
+
   let print_outcome ppf =
     let open Reason_oprint in function
     | Out_value          x -> print_out_value          ppf x
@@ -37,6 +51,8 @@ module Reason_reader = struct
     | Out_type_extension x -> print_out_type_extension ppf x
     | Out_phrase         x -> print_out_phrase         ppf x
 end
+
+
 
 let () =
   let open Extend_main in

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -5666,7 +5666,7 @@ let toplevel_phrase f x =
 
 let case_list f x =
   let l = easy#case_list x in
-  (List.map (fun x -> easyFormatToFormatter f (layoutToEasyFormatNoComments x)) l)
+  (List.iter (fun x -> easyFormatToFormatter f (layoutToEasyFormatNoComments x)) l)
 
 let top_phrase f x =
   pp_print_newline f () ;
@@ -5777,6 +5777,9 @@ let signature (comments : commentWithCategory) f x =
   easyFormatToFormatter f (layoutToEasyFormat (easy#signature (apply_mapper_chain_to_signature x preprocessing_chain)) comments)
 let structure (comments : commentWithCategory) f x =
   easyFormatToFormatter f (layoutToEasyFormat (easy#structure (apply_mapper_chain_to_structure x preprocessing_chain)) comments)
+let expression f x =
+  easyFormatToFormatter f (layoutToEasyFormatNoComments (easy#unparseExpr (apply_mapper_chain_to_expr x preprocessing_chain)))
+let case_list = case_list
 end
 in
 object
@@ -5784,6 +5787,10 @@ object
   method pattern = Formatter.pattern
   method signature = Formatter.signature
   method structure = Formatter.structure
+  (* For merlin-destruct *)
+  method toplevel_phrase = Formatter.toplevel_phrase
+  method expression = Formatter.expression
+  method case_list = Formatter.case_list
 end
 
 let defaultSettings = defaultSettings


### PR DESCRIPTION
Summary: This adds the hook needed to bump merlin/merlin-extend to master.

IMPORTANT
=========
The main docs still point to old tags, and that's fine - those are stable.
But for developing, we now need to pin merlin/merlin-extend from master, and I've updated the README to reflect this.

Test Plan:

Reviewers:let-def, yunxing, sanderspies

CC: