### PR TITLE
[npm] use utop-bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
         "substs": "https://github.com/yunxing/substs.git",
         "easy-format": "https://github.com/npm-opam/easy-format",
         "merlin-extend": "https://github.com/npm-opam/merlin-extend",
-        "opam-installer-bin": "https://github.com/yunxing/opam-installer-bin.git",        
+        "opam-installer-bin": "https://github.com/yunxing/opam-installer-bin.git",
         "nopam": "https://github.com/yunxing/nopam.git",
-        "utop": "https://github.com/npm-opam/utop",
+        "utop-bin": "https://github.com/reasonml/utop-bin",
         "menhir": "https://github.com/npm-opam/menhir"
     },
     "scripts": {


### PR DESCRIPTION
utop-bin is a manually generated package that prebuilts utop on linux and darwin systems. 

Using it as a dependency reduces half of the Reason installation time [down to 3.5 minutes on a 2014 Mac] through npm. 