### PR TITLE
[atom-reason] Add more operators so that ligatures render correctly

### DIFF
--- a/editorSupport/language-reason/grammars/reason.cson
+++ b/editorSupport/language-reason/grammars/reason.cson
@@ -253,7 +253,7 @@
   {
     'comment': 'Operator'
     'name': 'keyword.operator.reason'
-    'match': '(\\+|-|/|\\*|=|<=|>=|\\^|&|\\||!|%|<<|>>|>|<)'
+    'match': '(\\+|-|\\|>|>>=|!==|!=|/|\\*|=|<=|>=|\\^|&|\\||!|%|<<|>>|>|<)'
   }
   # Standard types and traits
   { 'include': '#core_types' }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/3112509/18407864/caeb6a18-773a-11e6-822c-8a3f6c1e7e81.png)

Both `|>` and `>>=` both render correctly. Are there any more common operators that we need to add?

cc @jordwalke 