### PR TITLE
BuckleScript bs.obj support

### DIFF
--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -66,3 +66,23 @@ res#=?!!z##(q##a);
 let result = myFunction (x y##z) (a b#=c);
 
 (!x)##y##(b##c);
+
+let a = {"key": 10};
+
+let b = {
+  "nested": {"objs": {"are": {"nice": "<3"}}}
+};
+
+let c = {
+  "a": a,
+  "b": b,
+  "func": fun a => a##c#=(func 10)
+};
+
+let d = {
+  "a": a2,
+  "b": b,
+  "func": fun a => {
+    "a": fun arg1 arg2 => arg1 + arg2
+  }
+};

--- a/formatTest/unit_tests/input/bucklescript.re
+++ b/formatTest/unit_tests/input/bucklescript.re
@@ -55,3 +55,11 @@ res #= ?!!z##(q##a);
 let result = myFunction (x y ## z) (a b #= c);
 
 (!x)##y##(b##c);
+
+let a = {"key": 10};
+
+let b = {"nested": {"objs": {"are": {"nice": "<3"}}}};
+
+let c = {"a": a, "b": b, "func": fun a => a##c#=(func 10)};
+
+let d = {"a": a2, "b": b , "func": fun a => {"a": (fun arg1 arg2 => arg1 + arg2)}};

--- a/src/reason_parser.messages
+++ b/src/reason_parser.messages
@@ -42,7 +42,7 @@
 
 use_file: SHARP LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2773.
+## Ends in an error in state: 2794.
 ##
 ## _use_file -> toplevel_directive SEMI . use_file [ # ]
 ##
@@ -54,7 +54,7 @@ use_file: SHARP LIDENT SEMI WITH
 
 use_file: SHARP LIDENT TRUE WITH
 ##
-## Ends in an error in state: 2772.
+## Ends in an error in state: 2793.
 ##
 ## _use_file -> toplevel_directive . SEMI use_file [ # ]
 ## _use_file -> toplevel_directive . EOF [ # ]
@@ -67,7 +67,7 @@ use_file: SHARP LIDENT TRUE WITH
 
 use_file: UIDENT RPAREN
 ##
-## Ends in an error in state: 2775.
+## Ends in an error in state: 2796.
 ##
 ## _use_file -> structure_item . SEMI use_file [ # ]
 ## _use_file -> structure_item . EOF [ # ]
@@ -79,28 +79,28 @@ use_file: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 910, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 880, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 890, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 919, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 889, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2764, spurious reduction of production post_item_attributes ->
-## In state 2765, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 2766, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 2744, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 2738, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 2768, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 2745, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 912, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 882, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 921, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 891, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2785, spurious reduction of production post_item_attributes ->
+## In state 2786, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 2787, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 2765, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 2759, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 2789, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 2766, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 use_file: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2776.
+## Ends in an error in state: 2797.
 ##
 ## _use_file -> structure_item SEMI . use_file [ # ]
 ##
@@ -112,7 +112,7 @@ use_file: UIDENT SEMI WITH
 
 use_file: WITH
 ##
-## Ends in an error in state: 2769.
+## Ends in an error in state: 2790.
 ##
 ## use_file' -> . use_file [ # ]
 ##
@@ -124,7 +124,7 @@ use_file: WITH
 
 toplevel_phrase: SHARP UIDENT EOF
 ##
-## Ends in an error in state: 2736.
+## Ends in an error in state: 2757.
 ##
 ## _toplevel_phrase -> toplevel_directive . SEMI [ # ]
 ##
@@ -135,14 +135,14 @@ toplevel_phrase: SHARP UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2636, spurious reduction of production toplevel_directive -> SHARP ident
+## In state 2657, spurious reduction of production toplevel_directive -> SHARP ident
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 ##
-## Ends in an error in state: 2643.
+## Ends in an error in state: 2664.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ SEMI EOF DOT ]
 ## val_longident -> mod_longident DOT . val_ident [ SEMI EOF ]
@@ -155,7 +155,7 @@ toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 
 toplevel_phrase: SHARP UIDENT UIDENT WITH
 ##
-## Ends in an error in state: 2642.
+## Ends in an error in state: 2663.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ SEMI EOF DOT ]
 ## toplevel_directive -> SHARP ident mod_longident . [ SEMI EOF ]
@@ -169,7 +169,7 @@ toplevel_phrase: SHARP UIDENT UIDENT WITH
 
 toplevel_phrase: SHARP UIDENT WITH
 ##
-## Ends in an error in state: 2636.
+## Ends in an error in state: 2657.
 ##
 ## toplevel_directive -> SHARP ident . [ SEMI EOF ]
 ## toplevel_directive -> SHARP ident . STRING [ SEMI EOF ]
@@ -187,7 +187,7 @@ toplevel_phrase: SHARP UIDENT WITH
 
 toplevel_phrase: SHARP WITH
 ##
-## Ends in an error in state: 2635.
+## Ends in an error in state: 2656.
 ##
 ## toplevel_directive -> SHARP . ident [ SEMI EOF ]
 ## toplevel_directive -> SHARP . ident STRING [ SEMI EOF ]
@@ -205,7 +205,7 @@ toplevel_phrase: SHARP WITH
 
 toplevel_phrase: UIDENT RPAREN
 ##
-## Ends in an error in state: 2739.
+## Ends in an error in state: 2760.
 ##
 ## _toplevel_phrase -> structure_item . SEMI [ # ]
 ##
@@ -216,28 +216,28 @@ toplevel_phrase: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 910, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 880, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 890, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 919, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 889, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2764, spurious reduction of production post_item_attributes ->
-## In state 2765, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 2766, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 2744, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 2738, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 2768, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 2745, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 912, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 882, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 921, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 891, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2785, spurious reduction of production post_item_attributes ->
+## In state 2786, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 2787, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 2765, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 2759, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 2789, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 2766, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: WITH
 ##
-## Ends in an error in state: 2598.
+## Ends in an error in state: 2619.
 ##
 ## toplevel_phrase' -> . toplevel_phrase [ # ]
 ##
@@ -249,7 +249,7 @@ toplevel_phrase: WITH
 
 parse_pattern: EXCEPTION WITH
 ##
-## Ends in an error in state: 642.
+## Ends in an error in state: 661.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -261,7 +261,7 @@ parse_pattern: EXCEPTION WITH
 
 parse_pattern: LAZY WITH
 ##
-## Ends in an error in state: 619.
+## Ends in an error in state: 644.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -273,7 +273,7 @@ parse_pattern: LAZY WITH
 
 parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ##
-## Ends in an error in state: 699.
+## Ends in an error in state: 718.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error RBRACE COMMA BAR ]
 ## lbl_pattern -> label_longident COLON pattern . [ error RBRACE COMMA ]
@@ -285,14 +285,14 @@ parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 573, spurious reduction of production pattern -> pattern_without_or
+## In state 598, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 530.
+## Ends in an error in state: 555.
 ##
 ## lbl_pattern -> label_longident COLON . pattern [ error RBRACE COMMA ]
 ##
@@ -304,7 +304,7 @@ parse_pattern: LBRACE LIDENT COLON WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 616.
+## Ends in an error in state: 641.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -317,7 +317,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 525.
+## Ends in an error in state: 550.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA UNDERSCORE . opt_comma [ error RBRACE ]
 ##
@@ -329,7 +329,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 
 parse_pattern: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 524.
+## Ends in an error in state: 549.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA . [ error RBRACE ]
 ## lbl_pattern_list -> lbl_pattern COMMA . UNDERSCORE opt_comma [ error RBRACE ]
@@ -343,7 +343,7 @@ parse_pattern: LBRACE LIDENT COMMA WITH
 
 parse_pattern: LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 529.
+## Ends in an error in state: 554.
 ##
 ## lbl_pattern -> label_longident . COLON pattern [ error RBRACE COMMA ]
 ## lbl_pattern -> label_longident . [ error RBRACE COMMA ]
@@ -356,7 +356,7 @@ parse_pattern: LBRACE LIDENT WITH
 
 parse_pattern: LBRACE WITH
 ##
-## Ends in an error in state: 615.
+## Ends in an error in state: 640.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -369,7 +369,7 @@ parse_pattern: LBRACE WITH
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 612.
+## Ends in an error in state: 637.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET BAR ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT pattern . [ error SEMI RBRACKET ]
@@ -381,14 +381,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 573, spurious reduction of production pattern -> pattern_without_or
+## In state 598, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT WITH
 ##
-## Ends in an error in state: 611.
+## Ends in an error in state: 636.
 ##
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT . pattern [ error SEMI RBRACKET ]
 ##
@@ -400,7 +400,7 @@ Expecting a valid list identifier
 
 parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 613.
+## Ends in an error in state: 638.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ COMMA ]
@@ -413,14 +413,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 573, spurious reduction of production pattern -> pattern_without_or
+## In state 598, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 610.
+## Ends in an error in state: 635.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ COMMA ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA . DOTDOTDOT pattern [ error SEMI RBRACKET ]
@@ -434,7 +434,7 @@ parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKET UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 614.
+## Ends in an error in state: 639.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern . [ COMMA ]
@@ -447,14 +447,14 @@ parse_pattern: LBRACKET UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 573, spurious reduction of production pattern -> pattern_without_or
+## In state 598, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 606.
+## Ends in an error in state: 631.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -467,7 +467,7 @@ parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LBRACKET WITH
 ##
-## Ends in an error in state: 603.
+## Ends in an error in state: 628.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -481,7 +481,7 @@ parse_pattern: LBRACKET WITH
 
 parse_pattern: LBRACKETBAR MINUS WITH
 ##
-## Ends in an error in state: 512.
+## Ends in an error in state: 537.
 ##
 ## signed_constant -> MINUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> MINUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -497,7 +497,7 @@ parse_pattern: LBRACKETBAR MINUS WITH
 
 parse_pattern: LBRACKETBAR PLUS WITH
 ##
-## Ends in an error in state: 511.
+## Ends in an error in state: 536.
 ##
 ## signed_constant -> PLUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> PLUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -513,7 +513,7 @@ parse_pattern: LBRACKETBAR PLUS WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 593.
+## Ends in an error in state: 618.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -525,14 +525,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 573, spurious reduction of production pattern -> pattern_without_or
+## In state 598, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 592.
+## Ends in an error in state: 617.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ error SEMI COMMA BARRBRACKET ]
 ##
@@ -544,7 +544,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 602.
+## Ends in an error in state: 627.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -556,14 +556,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 573, spurious reduction of production pattern -> pattern_without_or
+## In state 598, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 599.
+## Ends in an error in state: 624.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -576,7 +576,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LBRACKETBAR WITH
 ##
-## Ends in an error in state: 588.
+## Ends in an error in state: 613.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -590,7 +590,7 @@ parse_pattern: LBRACKETBAR WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 2434.
+## Ends in an error in state: 2455.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -608,7 +608,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 2433.
+## Ends in an error in state: 2454.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -621,7 +621,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2432.
+## Ends in an error in state: 2453.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -639,7 +639,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2431.
+## Ends in an error in state: 2452.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -652,7 +652,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2430.
+## Ends in an error in state: 2451.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -665,7 +665,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2429.
+## Ends in an error in state: 2450.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -678,7 +678,7 @@ parse_pattern: LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN EXCEPTION WITH
 ##
-## Ends in an error in state: 540.
+## Ends in an error in state: 565.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -690,7 +690,7 @@ parse_pattern: LPAREN EXCEPTION WITH
 
 parse_pattern: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 531.
+## Ends in an error in state: 556.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -702,7 +702,7 @@ parse_pattern: LPAREN LAZY WITH
 
 parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 520.
+## Ends in an error in state: 545.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -715,7 +715,7 @@ parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 515.
+## Ends in an error in state: 540.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -728,7 +728,7 @@ parse_pattern: LPAREN LBRACE WITH
 
 parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 701.
+## Ends in an error in state: 720.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -741,7 +741,7 @@ parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LPAREN LBRACKET WITH
 ##
-## Ends in an error in state: 513.
+## Ends in an error in state: 538.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -755,7 +755,7 @@ parse_pattern: LPAREN LBRACKET WITH
 
 parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 706.
+## Ends in an error in state: 725.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -768,7 +768,7 @@ parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LPAREN LBRACKETBAR WITH
 ##
-## Ends in an error in state: 510.
+## Ends in an error in state: 535.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -782,7 +782,7 @@ parse_pattern: LPAREN LBRACKETBAR WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 714.
+## Ends in an error in state: 733.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -800,7 +800,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCOR
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 713.
+## Ends in an error in state: 732.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -813,7 +813,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 712.
+## Ends in an error in state: 731.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -831,7 +831,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 711.
+## Ends in an error in state: 730.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -844,7 +844,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 710.
+## Ends in an error in state: 729.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -857,7 +857,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 709.
+## Ends in an error in state: 728.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -870,7 +870,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 498.
+## Ends in an error in state: 523.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -883,7 +883,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 496.
+## Ends in an error in state: 521.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -897,7 +897,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 
 parse_pattern: LPAREN LPAREN MODULE WITH
 ##
-## Ends in an error in state: 495.
+## Ends in an error in state: 520.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -911,7 +911,7 @@ parse_pattern: LPAREN LPAREN MODULE WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 681.
+## Ends in an error in state: 700.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -926,7 +926,7 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 585.
+## Ends in an error in state: 610.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -944,17 +944,17 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER
 ## In state 271, spurious reduction of production _core_type -> core_type2
 ## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 667, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
-## In state 674, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 673, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 677, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 686, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
+## In state 693, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 692, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 696, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 494.
+## Ends in an error in state: 519.
 ##
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -978,7 +978,7 @@ parse_pattern: LPAREN LPAREN WITH
 
 parse_pattern: LPAREN MINUS WITH
 ##
-## Ends in an error in state: 488.
+## Ends in an error in state: 513.
 ##
 ## operator -> MINUS . [ RPAREN ]
 ## signed_constant -> MINUS . INT [ error RPAREN LBRACKETAT DOTDOT COMMA COLONCOLON COLON BAR AS ]
@@ -1008,7 +1008,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 234, spurious reduction of production ident -> UIDENT
-## In state 506, spurious reduction of production mty_longident -> ident
+## In state 531, spurious reduction of production mty_longident -> ident
 ##
 
 <SYNTAX ERROR>
@@ -1029,7 +1029,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WHILE
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2427.
+## Ends in an error in state: 2448.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ error RPAREN ]
 ##
@@ -1041,7 +1041,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2426.
+## Ends in an error in state: 2447.
 ##
 ## package_type_cstrs -> package_type_cstr . [ error RPAREN ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ error RPAREN ]
@@ -1054,12 +1054,12 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 332, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 690, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 684, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 686, spurious reduction of production _core_type -> core_type2
-## In state 697, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 685, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2424, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 709, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 703, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 705, spurious reduction of production _core_type -> core_type2
+## In state 716, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 704, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 2445, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
@@ -1218,7 +1218,7 @@ parse_pattern: LPAREN SHARP WITH
 
 parse_pattern: LPAREN STRING DOTDOT WITH
 ##
-## Ends in an error in state: 545.
+## Ends in an error in state: 570.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ##
@@ -1230,7 +1230,7 @@ parse_pattern: LPAREN STRING DOTDOT WITH
 
 parse_pattern: LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 554.
+## Ends in an error in state: 579.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ error WITH UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS AND ]
 ##
@@ -1242,7 +1242,7 @@ parse_pattern: LPAREN UIDENT DOT WITH
 
 parse_pattern: LPAREN UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 532.
+## Ends in an error in state: 557.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1264,7 +1264,7 @@ parse_pattern: LPAREN UIDENT LPAREN WITH
 
 parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 564.
+## Ends in an error in state: 589.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1277,7 +1277,7 @@ parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 594.
+## Ends in an error in state: 619.
 ##
 ## _or_pattern -> pattern BAR . pattern [ error SEMI RPAREN RBRACKET RBRACE COMMA COLON BARRBRACKET BAR ]
 ##
@@ -1302,7 +1302,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BACKQUOTE LIDENT GREATER
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 173, spurious reduction of production attributes ->
-## In state 2461, spurious reduction of production tag_field -> name_tag attributes
+## In state 2482, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
@@ -1512,7 +1512,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LESS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2422.
+## Ends in an error in state: 2443.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1695,7 +1695,7 @@ parse_pattern: LPAREN UNDERSCORE COLON SHARP WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS QUOTE WITH
 ##
-## Ends in an error in state: 692.
+## Ends in an error in state: 711.
 ##
 ## _core_type -> core_type2 AS QUOTE . ident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AND ]
 ##
@@ -1707,7 +1707,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS QUOTE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS WITH
 ##
-## Ends in an error in state: 691.
+## Ends in an error in state: 710.
 ##
 ## _core_type -> core_type2 AS . QUOTE ident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AND ]
 ##
@@ -1719,7 +1719,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 687.
+## Ends in an error in state: 706.
 ##
 ## _core_type2 -> core_type2 EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1731,7 +1731,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 722.
+## Ends in an error in state: 741.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1746,7 +1746,7 @@ parse_pattern: LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 587.
+## Ends in an error in state: 612.
 ##
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1758,7 +1758,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 666.
+## Ends in an error in state: 685.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ RPAREN COMMA ]
 ##
@@ -1770,7 +1770,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ##
-## Ends in an error in state: 717.
+## Ends in an error in state: 736.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -1782,18 +1782,18 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 654, spurious reduction of production pattern -> pattern_without_or
-## In state 665, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 674, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 673, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 677, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 673, spurious reduction of production pattern -> pattern_without_or
+## In state 684, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 693, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 692, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 696, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 676.
+## Ends in an error in state: 695.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1805,7 +1805,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 675.
+## Ends in an error in state: 694.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint . COMMA pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1816,10 +1816,10 @@ parse_pattern: LPAREN UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 573, spurious reduction of production pattern -> pattern_without_or
-## In state 719, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 674, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 673, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 598, spurious reduction of production pattern -> pattern_without_or
+## In state 738, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 693, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 692, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
 ##
 
 <SYNTAX ERROR>
@@ -1894,7 +1894,7 @@ parse_pattern: SHARP WITH
 
 parse_pattern: STRING DOTDOT WITH
 ##
-## Ends in an error in state: 630.
+## Ends in an error in state: 649.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ##
@@ -1906,7 +1906,7 @@ parse_pattern: STRING DOTDOT WITH
 
 parse_pattern: UIDENT DOT WITH
 ##
-## Ends in an error in state: 635.
+## Ends in an error in state: 654.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ WITH WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS AND ]
 ##
@@ -1918,7 +1918,7 @@ parse_pattern: UIDENT DOT WITH
 
 parse_pattern: UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 486.
+## Ends in an error in state: 511.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1940,7 +1940,7 @@ parse_pattern: UIDENT LPAREN WITH
 
 parse_pattern: UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 650.
+## Ends in an error in state: 669.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1953,7 +1953,7 @@ parse_pattern: UIDENT UNDERSCORE WITH
 
 parse_pattern: UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 668.
+## Ends in an error in state: 687.
 ##
 ## _or_pattern -> pattern BAR . pattern [ WHEN SEMI RPAREN RBRACKET IN EQUALGREATER EQUAL EOF COMMA COLON BAR ]
 ##
@@ -1965,7 +1965,7 @@ parse_pattern: UNDERSCORE BAR WITH
 
 parse_pattern: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2595.
+## Ends in an error in state: 2616.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EOF BAR ]
 ## parse_pattern -> pattern . EOF [ # ]
@@ -1977,14 +1977,14 @@ parse_pattern: UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 654, spurious reduction of production pattern -> pattern_without_or
+## In state 673, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: WITH
 ##
-## Ends in an error in state: 2594.
+## Ends in an error in state: 2615.
 ##
 ## parse_pattern' -> . parse_pattern [ # ]
 ##
@@ -1996,7 +1996,7 @@ parse_pattern: WITH
 
 parse_expression: UIDENT SEMI
 ##
-## Ends in an error in state: 2592.
+## Ends in an error in state: 2613.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -2031,21 +2031,21 @@ parse_expression: UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 910, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 880, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 890, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 919, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 889, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 912, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 882, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 921, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 891, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 parse_expression: WITH
 ##
-## Ends in an error in state: 2590.
+## Ends in an error in state: 2611.
 ##
 ## parse_expression' -> . parse_expression [ # ]
 ##
@@ -2057,7 +2057,7 @@ parse_expression: WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 2455.
+## Ends in an error in state: 2476.
 ##
 ## tag_field -> name_tag opt_ampersand . amper_type_list attributes [ RBRACKET GREATER BAR ]
 ##
@@ -2069,7 +2069,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 ##
-## Ends in an error in state: 2458.
+## Ends in an error in state: 2479.
 ##
 ## amper_type_list -> amper_type_list AMPERSAND . core_type [ RBRACKET LBRACKETAT GREATER BAR AMPERSAND ]
 ##
@@ -2081,7 +2081,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ##
-## Ends in an error in state: 2462.
+## Ends in an error in state: 2483.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET tag_field . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field -> tag_field . [ BAR ]
@@ -2094,7 +2094,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 173, spurious reduction of production attributes ->
-## In state 2461, spurious reduction of production tag_field -> name_tag attributes
+## In state 2482, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
@@ -2126,7 +2126,7 @@ parse_core_type: LBRACKET BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 2466.
+## Ends in an error in state: 2487.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2139,7 +2139,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 2465.
+## Ends in an error in state: 2486.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2151,7 +2151,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE WITH
 ##
-## Ends in an error in state: 2464.
+## Ends in an error in state: 2485.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field . BAR row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2189,7 +2189,7 @@ parse_core_type: LBRACKETGREATER BAR ASSERT
 
 parse_core_type: LBRACKETGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 2468.
+## Ends in an error in state: 2489.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2240,7 +2240,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2473.
+## Ends in an error in state: 2494.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER name_tag_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## name_tag_list -> name_tag_list . name_tag [ RBRACKET BACKQUOTE ]
@@ -2253,7 +2253,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 ##
-## Ends in an error in state: 2472.
+## Ends in an error in state: 2493.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER . name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2265,7 +2265,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE WITH
 ##
-## Ends in an error in state: 2470.
+## Ends in an error in state: 2491.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . GREATER name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2317,7 +2317,7 @@ parse_core_type: LESS LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 ##
-## Ends in an error in state: 1250.
+## Ends in an error in state: 1264.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ##
@@ -2329,7 +2329,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1247.
+## Ends in an error in state: 1261.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -2342,7 +2342,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE WITH
 ##
-## Ends in an error in state: 1248.
+## Ends in an error in state: 1262.
 ##
 ## typevar_list -> typevar_list QUOTE . ident [ QUOTE DOT ]
 ##
@@ -2385,11 +2385,11 @@ parse_core_type: LESS LIDENT COLON UNDERSCORE WITH
 ## In state 271, spurious reduction of production _core_type -> core_type2
 ## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1255, spurious reduction of production _poly_type -> core_type
-## In state 1256, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1254, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 2475, spurious reduction of production attributes ->
-## In state 2476, spurious reduction of production field -> label COLON poly_type attributes
+## In state 1269, spurious reduction of production _poly_type -> core_type
+## In state 1270, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1268, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 2496, spurious reduction of production attributes ->
+## In state 2497, spurious reduction of production field -> label COLON poly_type attributes
 ##
 
 <SYNTAX ERROR>
@@ -2432,7 +2432,7 @@ parse_core_type: LESS WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2481.
+## Ends in an error in state: 2502.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2444,7 +2444,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 ##
-## Ends in an error in state: 2479.
+## Ends in an error in state: 2500.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2456,7 +2456,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 ##
-## Ends in an error in state: 2478.
+## Ends in an error in state: 2499.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION . EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2468,7 +2468,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2477.
+## Ends in an error in state: 2498.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . QUESTION EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2560,7 +2560,7 @@ parse_core_type: LPAREN MODULE UIDENT SEMI
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2486.
+## Ends in an error in state: 2507.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ RPAREN COLONGREATER ]
 ##
@@ -2572,7 +2572,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER A
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2485.
+## Ends in an error in state: 2506.
 ##
 ## package_type_cstrs -> package_type_cstr . [ RPAREN COLONGREATER ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ RPAREN COLONGREATER ]
@@ -2590,7 +2590,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER W
 ## In state 271, spurious reduction of production _core_type -> core_type2
 ## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2483, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 2504, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
@@ -2669,7 +2669,7 @@ parse_core_type: LPAREN UNDERSCORE COMMA WITH
 
 parse_core_type: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1191.
+## Ends in an error in state: 1205.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN core_type_comma_list . RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## core_type_comma_list -> core_type_comma_list . COMMA core_type [ RPAREN COMMA ]
@@ -2708,7 +2708,7 @@ parse_core_type: QUOTE WITH
 
 parse_core_type: SHARP LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 2488.
+## Ends in an error in state: 2509.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP class_longident non_arrowed_simple_core_type_list . [ WITH SEMI RPAREN RBRACKET RBRACE QUESTION LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2875,7 +2875,7 @@ parse_core_type: UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2588.
+## Ends in an error in state: 2609.
 ##
 ## parse_core_type -> core_type . EOF [ # ]
 ##
@@ -2898,7 +2898,7 @@ parse_core_type: UNDERSCORE WITH
 
 parse_core_type: WITH
 ##
-## Ends in an error in state: 2586.
+## Ends in an error in state: 2607.
 ##
 ## parse_core_type' -> . parse_core_type [ # ]
 ##
@@ -2910,7 +2910,7 @@ parse_core_type: WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 ##
-## Ends in an error in state: 2075.
+## Ends in an error in state: 2056.
 ##
 ## and_class_description -> AND . class_description_details post_item_attributes [ SEMI AND ]
 ##
@@ -2922,7 +2922,7 @@ interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ##
-## Ends in an error in state: 2074.
+## Ends in an error in state: 2055.
 ##
 ## _signature_item -> many_class_descriptions . [ SEMI ]
 ## many_class_descriptions -> many_class_descriptions . and_class_description [ SEMI AND ]
@@ -2934,22 +2934,22 @@ interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1770, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1774, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1768, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1772, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1783, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1781, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
-## In state 2047, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
-## In state 2048, spurious reduction of production post_item_attributes ->
-## In state 2049, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
+## In state 1692, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1696, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1690, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1694, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1705, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1703, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 2028, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
+## In state 2029, spurious reduction of production post_item_attributes ->
+## In state 2030, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 2046.
+## Ends in an error in state: 2027.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters COLON . class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -2961,7 +2961,7 @@ interface: CLASS LIDENT COLON WITH
 
 interface: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1524.
+## Ends in an error in state: 1446.
 ##
 ## type_parameter -> type_variance . type_variable [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLON CHAR BACKQUOTE ]
 ##
@@ -2973,7 +2973,7 @@ interface: CLASS LIDENT PLUS WITH
 
 interface: CLASS LIDENT WITH
 ##
-## Ends in an error in state: 2045.
+## Ends in an error in state: 2026.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters . COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS COLON ]
@@ -2986,7 +2986,7 @@ interface: CLASS LIDENT WITH
 
 interface: CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 2043.
+## Ends in an error in state: 2024.
 ##
 ## class_description_details -> virtual_flag . LIDENT class_type_parameters COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -2998,7 +2998,7 @@ interface: CLASS VIRTUAL LET
 
 interface: CLASS WITH
 ##
-## Ends in an error in state: 2034.
+## Ends in an error in state: 2015.
 ##
 ## many_class_descriptions -> CLASS . class_description_details post_item_attributes [ SEMI AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ SEMI AND ]
@@ -3011,7 +3011,7 @@ interface: CLASS WITH
 
 interface: EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1915.
+## Ends in an error in state: 1842.
 ##
 ## extension_constructor_declaration -> UIDENT . generalized_constructor_arguments attributes [ SEMI LBRACKETATAT BAR ]
 ##
@@ -3023,7 +3023,7 @@ interface: EXCEPTION UIDENT WITH
 
 interface: EXCEPTION WITH
 ##
-## Ends in an error in state: 2031.
+## Ends in an error in state: 2012.
 ##
 ## sig_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ SEMI ]
 ##
@@ -3035,7 +3035,7 @@ interface: EXCEPTION WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2026.
+## Ends in an error in state: 2007.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3047,7 +3047,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2025.
+## Ends in an error in state: 2006.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3070,7 +3070,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 interface: EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 2024.
+## Ends in an error in state: 2005.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3082,7 +3082,7 @@ interface: EXTERNAL LIDENT COLON WITH
 
 interface: EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 2023.
+## Ends in an error in state: 2004.
 ##
 ## _signature_item -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3094,7 +3094,7 @@ interface: EXTERNAL LIDENT WITH
 
 interface: EXTERNAL WITH
 ##
-## Ends in an error in state: 2022.
+## Ends in an error in state: 2003.
 ##
 ## _signature_item -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3106,7 +3106,7 @@ interface: EXTERNAL WITH
 
 interface: INCLUDE LBRACE OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2050.
+## Ends in an error in state: 2031.
 ##
 ## signature -> signature_item . SEMI signature [ error RBRACE ]
 ##
@@ -3117,18 +3117,18 @@ interface: INCLUDE LBRACE OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1941, spurious reduction of production post_item_attributes ->
-## In state 1942, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 2055, spurious reduction of production _signature_item -> open_statement
-## In state 2082, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 2056, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 1868, spurious reduction of production post_item_attributes ->
+## In state 1869, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 2036, spurious reduction of production _signature_item -> open_statement
+## In state 2063, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 2037, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2051.
+## Ends in an error in state: 2032.
 ##
 ## signature -> signature_item SEMI . signature [ error RBRACE ]
 ##
@@ -3140,7 +3140,7 @@ interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 
 interface: INCLUDE LBRACE WITH
 ##
-## Ends in an error in state: 1947.
+## Ends in an error in state: 1928.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LBRACE . signature error [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3153,7 +3153,7 @@ interface: INCLUDE LBRACE WITH
 
 interface: INCLUDE LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 1169.
+## Ends in an error in state: 1183.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _simple_module_type -> LBRACE . signature error [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3166,7 +3166,7 @@ interface: INCLUDE LPAREN LBRACE WITH
 
 interface: INCLUDE LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 2101.
+## Ends in an error in state: 1878.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3182,7 +3182,7 @@ interface: INCLUDE LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 2092.
+## Ends in an error in state: 2077.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3198,7 +3198,7 @@ interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 2100.
+## Ends in an error in state: 2085.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3213,7 +3213,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LID
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2099.
+## Ends in an error in state: 2084.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3225,7 +3225,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WIT
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2098.
+## Ends in an error in state: 2083.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3237,7 +3237,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2097.
+## Ends in an error in state: 2082.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3253,22 +3253,22 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 130, spurious reduction of production ident -> UIDENT
 ## In state 253, spurious reduction of production mty_longident -> ident
-## In state 1956, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1988, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1984, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1954, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1989, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1985, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1955, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1990, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1986, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1937, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1969, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1965, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1935, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1970, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1966, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1936, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1971, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1967, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2096.
+## Ends in an error in state: 2081.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3280,7 +3280,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2095.
+## Ends in an error in state: 2080.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3292,7 +3292,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 1168.
+## Ends in an error in state: 1181.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3306,7 +3306,7 @@ interface: INCLUDE LPAREN LPAREN WITH
 
 interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2411.
+## Ends in an error in state: 2432.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF ]
@@ -3320,12 +3320,12 @@ interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1373, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1377, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1374, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1296, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1379, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1378, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2090, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2094, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2091, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 481, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2096, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2095, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
@@ -3356,7 +3356,7 @@ interface: INCLUDE LPAREN MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 ##
-## Ends in an error in state: 504.
+## Ends in an error in state: 529.
 ##
 ## ident -> UIDENT . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## mod_ext2 -> mod_ext_longident DOT UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -3370,7 +3370,7 @@ interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 503.
+## Ends in an error in state: 528.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -3384,7 +3384,7 @@ interface: INCLUDE LPAREN UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 1363.
+## Ends in an error in state: 1917.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3399,7 +3399,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1362.
+## Ends in an error in state: 1916.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3411,7 +3411,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 502.
+## Ends in an error in state: 527.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -3431,7 +3431,7 @@ interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UIDENT WHILE
 ##
-## Ends in an error in state: 1167.
+## Ends in an error in state: 1182.
 ##
 ## functor_arg_name -> UIDENT . [ COLON ]
 ## ident -> UIDENT . [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3446,7 +3446,7 @@ interface: INCLUDE LPAREN UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 ##
-## Ends in an error in state: 1345.
+## Ends in an error in state: 1899.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3459,7 +3459,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1342.
+## Ends in an error in state: 1896.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ RPAREN LPAREN DOT ]
 ## mod_ext2 -> UIDENT LPAREN mod_ext_longident . RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3479,7 +3479,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UID
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1341.
+## Ends in an error in state: 1895.
 ##
 ## mod_ext2 -> UIDENT LPAREN . mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ##
@@ -3504,7 +3504,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WIT
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1339.
+## Ends in an error in state: 1893.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3516,7 +3516,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 1354.
+## Ends in an error in state: 1908.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3529,7 +3529,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 ##
-## Ends in an error in state: 1340.
+## Ends in an error in state: 1894.
 ##
 ## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ## mod_ext_longident -> UIDENT . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3542,7 +3542,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1355.
+## Ends in an error in state: 1909.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3554,7 +3554,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1338.
+## Ends in an error in state: 1892.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3567,7 +3567,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 1337.
+## Ends in an error in state: 1891.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3580,7 +3580,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 1358.
+## Ends in an error in state: 1912.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3592,7 +3592,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER A
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER EQUAL
 ##
-## Ends in an error in state: 1357.
+## Ends in an error in state: 1911.
 ##
 ## _module_type -> module_type WITH with_constraints . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## with_constraints -> with_constraints . AND with_constraint [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3605,20 +3605,20 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER E
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 332, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 690, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 684, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 686, spurious reduction of production _core_type -> core_type2
-## In state 697, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 685, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1328, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1360, spurious reduction of production with_constraints -> with_constraint
+## In state 709, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 703, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 705, spurious reduction of production _core_type -> core_type2
+## In state 716, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 704, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1887, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1914, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1327.
+## Ends in an error in state: 1886.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3630,7 +3630,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1329.
+## Ends in an error in state: 1888.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3642,7 +3642,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ##
-## Ends in an error in state: 1331.
+## Ends in an error in state: 1890.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3655,19 +3655,19 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 332, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 690, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 684, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 686, spurious reduction of production _core_type -> core_type2
-## In state 697, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 685, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1330, spurious reduction of production constraints ->
+## In state 709, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 703, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 705, spurious reduction of production _core_type -> core_type2
+## In state 716, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 704, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1889, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ##
-## Ends in an error in state: 1324.
+## Ends in an error in state: 1883.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3679,14 +3679,14 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1284, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 1298, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 1322.
+## Ends in an error in state: 1881.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3699,7 +3699,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH WITH
 ##
-## Ends in an error in state: 1321.
+## Ends in an error in state: 1880.
 ##
 ## _module_type -> module_type WITH . with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3711,7 +3711,7 @@ interface: INCLUDE LPAREN UIDENT WITH WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2109.
+## Ends in an error in state: 2070.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3727,22 +3727,22 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COL
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 130, spurious reduction of production ident -> UIDENT
 ## In state 253, spurious reduction of production mty_longident -> ident
-## In state 1956, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1988, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1984, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1954, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1989, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1985, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1955, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1990, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1986, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1937, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1969, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1965, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1935, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1970, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1966, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1936, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1971, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1967, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2108.
+## Ends in an error in state: 2069.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3754,7 +3754,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2107.
+## Ends in an error in state: 2068.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3766,7 +3766,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2106.
+## Ends in an error in state: 2067.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3782,22 +3782,22 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 130, spurious reduction of production ident -> UIDENT
 ## In state 253, spurious reduction of production mty_longident -> ident
-## In state 1956, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1988, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1984, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1954, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1989, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1985, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1955, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1990, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1986, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1937, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1969, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1965, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1935, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1970, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1966, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1936, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1971, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1967, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2105.
+## Ends in an error in state: 1927.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3809,7 +3809,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2104.
+## Ends in an error in state: 1926.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3821,7 +3821,7 @@ interface: INCLUDE LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN WITH
 ##
-## Ends in an error in state: 1166.
+## Ends in an error in state: 1874.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3835,7 +3835,7 @@ interface: INCLUDE LPAREN WITH
 
 interface: INCLUDE MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2333.
+## Ends in an error in state: 2281.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
@@ -3849,19 +3849,19 @@ interface: INCLUDE MODULE TYPE UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 780, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 784, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 781, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 773, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 777, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 774, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
 ## In state 760, spurious reduction of production _module_expr -> simple_module_expr
-## In state 786, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 785, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 779, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 778, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE MODULE TYPE WITH
 ##
-## Ends in an error in state: 445.
+## Ends in an error in state: 466.
 ##
 ## _non_arrowed_module_type -> MODULE TYPE . module_expr [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3873,7 +3873,7 @@ interface: INCLUDE MODULE TYPE WITH
 
 interface: INCLUDE MODULE WITH
 ##
-## Ends in an error in state: 444.
+## Ends in an error in state: 465.
 ##
 ## _non_arrowed_module_type -> MODULE . TYPE module_expr [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3913,7 +3913,7 @@ interface: INCLUDE UIDENT DOT WITH
 
 interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1982.
+## Ends in an error in state: 1963.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3929,22 +3929,22 @@ interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 130, spurious reduction of production ident -> UIDENT
 ## In state 253, spurious reduction of production mty_longident -> ident
-## In state 1956, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1988, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1984, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1954, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1989, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1985, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1955, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1990, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1986, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1937, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1969, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1965, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1935, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1970, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1966, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1936, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1971, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1967, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1981.
+## Ends in an error in state: 1962.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4004,7 +4004,7 @@ interface: INCLUDE UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1969.
+## Ends in an error in state: 1950.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4016,7 +4016,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 1971.
+## Ends in an error in state: 1952.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4042,7 +4042,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1972.
+## Ends in an error in state: 1953.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4054,7 +4054,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1968.
+## Ends in an error in state: 1949.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4067,7 +4067,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 1967.
+## Ends in an error in state: 1948.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4080,7 +4080,7 @@ interface: INCLUDE UIDENT WITH MODULE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 1975.
+## Ends in an error in state: 1956.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4092,7 +4092,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ##
-## Ends in an error in state: 1974.
+## Ends in an error in state: 1955.
 ##
 ## _module_type -> module_type WITH with_constraints . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraints -> with_constraints . AND with_constraint [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4110,15 +4110,15 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ## In state 271, spurious reduction of production _core_type -> core_type2
 ## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1963, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1977, spurious reduction of production with_constraints -> with_constraint
+## In state 1944, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1958, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1962.
+## Ends in an error in state: 1943.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4130,7 +4130,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1964.
+## Ends in an error in state: 1945.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4142,7 +4142,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ##
-## Ends in an error in state: 1966.
+## Ends in an error in state: 1947.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4160,14 +4160,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ## In state 271, spurious reduction of production _core_type -> core_type2
 ## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1965, spurious reduction of production constraints ->
+## In state 1946, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1325.
+## Ends in an error in state: 1884.
 ##
 ## with_type_binder -> EQUAL . [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
 ## with_type_binder -> EQUAL . PRIVATE [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
@@ -4180,7 +4180,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1961.
+## Ends in an error in state: 1942.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4192,14 +4192,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1960, spurious reduction of production optional_type_parameters ->
+## In state 1941, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 1959.
+## Ends in an error in state: 1940.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4212,7 +4212,7 @@ interface: INCLUDE UIDENT WITH TYPE WITH
 
 interface: INCLUDE UIDENT WITH WITH
 ##
-## Ends in an error in state: 1958.
+## Ends in an error in state: 1939.
 ##
 ## _module_type -> module_type WITH . with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4224,7 +4224,7 @@ interface: INCLUDE UIDENT WITH WITH
 
 interface: INCLUDE WITH
 ##
-## Ends in an error in state: 2019.
+## Ends in an error in state: 2000.
 ##
 ## _signature_item -> INCLUDE . module_type post_item_attributes [ SEMI ]
 ##
@@ -4236,7 +4236,7 @@ interface: INCLUDE WITH
 
 interface: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 2008.
+## Ends in an error in state: 1989.
 ##
 ## _signature_item -> LET val_ident COLON . core_type post_item_attributes [ SEMI ]
 ##
@@ -4248,7 +4248,7 @@ interface: LET LIDENT COLON WITH
 
 interface: LET LIDENT WITH
 ##
-## Ends in an error in state: 2007.
+## Ends in an error in state: 1988.
 ##
 ## _signature_item -> LET val_ident . COLON core_type post_item_attributes [ SEMI ]
 ##
@@ -4260,7 +4260,7 @@ interface: LET LIDENT WITH
 
 interface: LET LPAREN WITH
 ##
-## Ends in an error in state: 660.
+## Ends in an error in state: 679.
 ##
 ## val_ident -> LPAREN . operator RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -4272,7 +4272,7 @@ interface: LET LPAREN WITH
 
 interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
 ##
-## Ends in an error in state: 2065.
+## Ends in an error in state: 2046.
 ##
 ## and_module_rec_declaration -> AND . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4284,7 +4284,7 @@ interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
 
 interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2064.
+## Ends in an error in state: 2045.
 ##
 ## _signature_item -> many_module_rec_declarations . [ SEMI ]
 ## many_module_rec_declarations -> many_module_rec_declarations . and_module_rec_declaration [ SEMI AND ]
@@ -4296,16 +4296,16 @@ interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1598, spurious reduction of production post_item_attributes ->
-## In state 1599, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2006, spurious reduction of production many_module_rec_declarations -> LET MODULE REC module_rec_declaration_details post_item_attributes
+## In state 1520, spurious reduction of production post_item_attributes ->
+## In state 1521, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1987, spurious reduction of production many_module_rec_declarations -> LET MODULE REC module_rec_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 2004.
+## Ends in an error in state: 1985.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -4321,22 +4321,22 @@ interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 130, spurious reduction of production ident -> UIDENT
 ## In state 253, spurious reduction of production mty_longident -> ident
-## In state 1956, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1988, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1984, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1954, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1989, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1985, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1955, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1990, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1986, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1937, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1969, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1965, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1935, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1970, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1966, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1936, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1971, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1967, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON WITH
 ##
-## Ends in an error in state: 2003.
+## Ends in an error in state: 1984.
 ##
 ## module_rec_declaration_details -> UIDENT COLON . module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4348,7 +4348,7 @@ interface: LET MODULE REC UIDENT COLON WITH
 
 interface: LET MODULE REC UIDENT WITH
 ##
-## Ends in an error in state: 2002.
+## Ends in an error in state: 1983.
 ##
 ## module_rec_declaration_details -> UIDENT . COLON module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4360,7 +4360,7 @@ interface: LET MODULE REC UIDENT WITH
 
 interface: LET MODULE REC WITH
 ##
-## Ends in an error in state: 2001.
+## Ends in an error in state: 1982.
 ##
 ## many_module_rec_declarations -> LET MODULE REC . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4372,7 +4372,7 @@ interface: LET MODULE REC WITH
 
 interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 1980.
+## Ends in an error in state: 1961.
 ##
 ## _module_declaration -> COLON module_type . [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -4388,22 +4388,22 @@ interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 130, spurious reduction of production ident -> UIDENT
 ## In state 253, spurious reduction of production mty_longident -> ident
-## In state 1956, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1988, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1984, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1954, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1989, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1985, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1955, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1990, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1986, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1937, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1969, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1965, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1935, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1970, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1966, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1936, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1971, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1967, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 1979.
+## Ends in an error in state: 1960.
 ##
 ## _module_declaration -> COLON . module_type [ SEMI LBRACKETATAT ]
 ##
@@ -4415,7 +4415,7 @@ interface: LET MODULE UIDENT COLON WITH
 
 interface: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1996.
+## Ends in an error in state: 1977.
 ##
 ## _signature_item -> LET MODULE UIDENT EQUAL . mod_longident post_item_attributes [ SEMI ]
 ##
@@ -4427,7 +4427,7 @@ interface: LET MODULE UIDENT EQUAL WITH
 
 interface: LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1994.
+## Ends in an error in state: 1975.
 ##
 ## _module_declaration -> LPAREN RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4439,7 +4439,7 @@ interface: LET MODULE UIDENT LPAREN RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1978.
+## Ends in an error in state: 1959.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4451,7 +4451,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1957.
+## Ends in an error in state: 1938.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type . RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -4467,22 +4467,22 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 130, spurious reduction of production ident -> UIDENT
 ## In state 253, spurious reduction of production mty_longident -> ident
-## In state 1956, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1988, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1984, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1954, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1989, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1985, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1955, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1990, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1986, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1937, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1969, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1965, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1935, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1970, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1966, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1936, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1971, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1967, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1953.
+## Ends in an error in state: 1934.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON . module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4494,7 +4494,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1952.
+## Ends in an error in state: 1933.
 ##
 ## _module_declaration -> LPAREN UIDENT . COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4506,7 +4506,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT WITH
 
 interface: LET MODULE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1951.
+## Ends in an error in state: 1932.
 ##
 ## _module_declaration -> LPAREN . UIDENT COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_declaration -> LPAREN . RPAREN module_declaration [ SEMI LBRACKETATAT ]
@@ -4519,7 +4519,7 @@ interface: LET MODULE UIDENT LPAREN WITH
 
 interface: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1950.
+## Ends in an error in state: 1931.
 ##
 ## _signature_item -> LET MODULE UIDENT . module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> LET MODULE UIDENT . EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4532,7 +4532,7 @@ interface: LET MODULE UIDENT WITH
 
 interface: LET MODULE WITH
 ##
-## Ends in an error in state: 1949.
+## Ends in an error in state: 1930.
 ##
 ## _signature_item -> LET MODULE . UIDENT module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> LET MODULE . UIDENT EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4546,7 +4546,7 @@ interface: LET MODULE WITH
 
 interface: LET WITH
 ##
-## Ends in an error in state: 1948.
+## Ends in an error in state: 1929.
 ##
 ## _signature_item -> LET . val_ident COLON core_type post_item_attributes [ SEMI ]
 ## _signature_item -> LET . MODULE UIDENT module_declaration post_item_attributes [ SEMI ]
@@ -4561,7 +4561,7 @@ interface: LET WITH
 
 interface: MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1946.
+## Ends in an error in state: 1873.
 ##
 ## _signature_item -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ SEMI ]
 ##
@@ -4573,7 +4573,7 @@ interface: MODULE TYPE UIDENT EQUAL WITH
 
 interface: MODULE TYPE WITH
 ##
-## Ends in an error in state: 1944.
+## Ends in an error in state: 1871.
 ##
 ## _signature_item -> MODULE TYPE . ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4586,7 +4586,7 @@ interface: MODULE TYPE WITH
 
 interface: MODULE WITH
 ##
-## Ends in an error in state: 1943.
+## Ends in an error in state: 1870.
 ##
 ## _signature_item -> MODULE . TYPE ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4599,7 +4599,7 @@ interface: MODULE WITH
 
 interface: OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2580.
+## Ends in an error in state: 2601.
 ##
 ## signature -> signature_item . SEMI signature [ EOF ]
 ##
@@ -4610,18 +4610,18 @@ interface: OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1941, spurious reduction of production post_item_attributes ->
-## In state 1942, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 2055, spurious reduction of production _signature_item -> open_statement
-## In state 2082, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 2056, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 1868, spurious reduction of production post_item_attributes ->
+## In state 1869, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 2036, spurious reduction of production _signature_item -> open_statement
+## In state 2063, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 2037, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 1914.
+## Ends in an error in state: 1841.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4633,7 +4633,7 @@ interface: TYPE LIDENT PLUSEQ BAR WITH
 
 interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 1913.
+## Ends in an error in state: 1840.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4645,7 +4645,7 @@ interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 
 interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 1932.
+## Ends in an error in state: 1859.
 ##
 ## sig_extension_constructors -> sig_extension_constructors BAR . extension_constructor_declaration [ SEMI LBRACKETATAT BAR ]
 ##
@@ -4657,7 +4657,7 @@ interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 interface: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 1912.
+## Ends in an error in state: 1839.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4669,7 +4669,7 @@ interface: TYPE LIDENT PLUSEQ WITH
 
 interface: TYPE LIDENT RBRACKET
 ##
-## Ends in an error in state: 1185.
+## Ends in an error in state: 1199.
 ##
 ## potentially_long_ident_and_optional_type_parameters -> LIDENT optional_type_parameters . [ PLUSEQ ]
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ SEMI LBRACKETATAT EOF AND ]
@@ -4681,14 +4681,14 @@ interface: TYPE LIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1172, spurious reduction of production optional_type_parameters ->
+## In state 1186, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2581.
+## Ends in an error in state: 2602.
 ##
 ## signature -> signature_item SEMI . signature [ EOF ]
 ##
@@ -4700,7 +4700,7 @@ interface: TYPE LIDENT SEMI WITH
 
 interface: TYPE NONREC LET
 ##
-## Ends in an error in state: 1171.
+## Ends in an error in state: 1185.
 ##
 ## many_type_declarations -> TYPE nonrec_flag . type_declaration_details post_item_attributes [ SEMI AND ]
 ## sig_type_extension -> TYPE nonrec_flag . potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
@@ -4713,7 +4713,7 @@ interface: TYPE NONREC LET
 
 interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ##
-## Ends in an error in state: 1911.
+## Ends in an error in state: 1838.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters . PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4724,15 +4724,15 @@ interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1284, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
-## In state 1288, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
+## In state 1298, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 1302, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
 ##
 
 <SYNTAX ERROR>
 
 interface: WITH
 ##
-## Ends in an error in state: 2579.
+## Ends in an error in state: 2600.
 ##
 ## interface' -> . interface [ # ]
 ##
@@ -4744,7 +4744,7 @@ interface: WITH
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1787.
+## Ends in an error in state: 1709.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4756,7 +4756,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WIT
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1785.
+## Ends in an error in state: 1707.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4768,7 +4768,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON WITH
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1778.
+## Ends in an error in state: 1700.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4780,7 +4780,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE 
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 1777.
+## Ends in an error in state: 1699.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4793,7 +4793,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE 
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1776.
+## Ends in an error in state: 1698.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4805,7 +4805,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: CLASS LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1779.
+## Ends in an error in state: 1701.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4817,7 +4817,7 @@ implementation: CLASS LIDENT COLON LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1775, spurious reduction of production type_longident -> LIDENT
+## In state 1697, spurious reduction of production type_longident -> LIDENT
 ## In state 254, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
 ## In state 259, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
 ## In state 257, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
@@ -4828,7 +4828,7 @@ implementation: CLASS LIDENT COLON LIDENT WITH
 
 implementation: CLASS LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1759.
+## Ends in an error in state: 1681.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4840,7 +4840,7 @@ implementation: CLASS LIDENT COLON NEW WITH
 
 implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1780.
+## Ends in an error in state: 1702.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4852,7 +4852,7 @@ implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT MINUS WITH
 ##
-## Ends in an error in state: 1537.
+## Ends in an error in state: 1459.
 ##
 ## signed_constant -> MINUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> MINUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -4869,7 +4869,7 @@ implementation: CLASS LIDENT MINUS WITH
 
 implementation: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1536.
+## Ends in an error in state: 1458.
 ##
 ## signed_constant -> PLUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> PLUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -4886,7 +4886,7 @@ implementation: CLASS LIDENT PLUS WITH
 
 implementation: CLASS LIDENT QUOTE WITH
 ##
-## Ends in an error in state: 1525.
+## Ends in an error in state: 1447.
 ##
 ## _type_variable -> QUOTE . ident [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLON CHAR BACKQUOTE ]
 ##
@@ -4898,7 +4898,7 @@ implementation: CLASS LIDENT QUOTE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1459.
+## Ends in an error in state: 1381.
 ##
 ## class_sig_body -> class_self_type . class_sig_fields opt_semi [ error RBRACE ]
 ##
@@ -4910,7 +4910,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 ##
-## Ends in an error in state: 1454.
+## Ends in an error in state: 1376.
 ##
 ## class_self_type -> AS core_type . SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -4933,7 +4933,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 ##
-## Ends in an error in state: 1453.
+## Ends in an error in state: 1375.
 ##
 ## class_self_type -> AS . core_type SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -4945,7 +4945,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1507.
+## Ends in an error in state: 1429.
 ##
 ## _class_sig_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4957,7 +4957,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1502.
+## Ends in an error in state: 1424.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT ]
 ## _class_sig_field -> INHERIT class_instance_type . [ error SEMI RBRACE ]
@@ -4970,16 +4970,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1500, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1506, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1498, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1422, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1428, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1420, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1494.
+## Ends in an error in state: 1416.
 ##
 ## _class_sig_field -> INHERIT . class_instance_type [ error SEMI RBRACE ]
 ## _class_sig_field -> INHERIT . class_instance_type item_attribute post_item_attributes [ error SEMI RBRACE ]
@@ -4992,7 +4992,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH RBRACKET WITH
 ##
-## Ends in an error in state: 1762.
+## Ends in an error in state: 1684.
 ##
 ## _class_instance_type -> LBRACE class_sig_body . RBRACE [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE class_sig_body . error [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5004,20 +5004,20 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1514, spurious reduction of production post_item_attributes ->
-## In state 1515, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
-## In state 1520, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
-## In state 1513, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
-## In state 1522, spurious reduction of production class_sig_fields -> class_sig_field
-## In state 1517, spurious reduction of production opt_semi ->
-## In state 1521, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
+## In state 1436, spurious reduction of production post_item_attributes ->
+## In state 1437, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
+## In state 1442, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
+## In state 1435, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
+## In state 1444, spurious reduction of production class_sig_fields -> class_sig_field
+## In state 1439, spurious reduction of production opt_semi ->
+## In state 1443, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 ##
-## Ends in an error in state: 1483.
+## Ends in an error in state: 1405.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label COLON . poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5029,7 +5029,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 ##
-## Ends in an error in state: 1482.
+## Ends in an error in state: 1404.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label . COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5041,7 +5041,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 ##
-## Ends in an error in state: 1479.
+## Ends in an error in state: 1401.
 ##
 ## private_virtual_flags -> PRIVATE . [ LIDENT ]
 ## private_virtual_flags -> PRIVATE . VIRTUAL [ LIDENT ]
@@ -5054,7 +5054,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1481.
+## Ends in an error in state: 1403.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags . label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5066,7 +5066,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 ##
-## Ends in an error in state: 1477.
+## Ends in an error in state: 1399.
 ##
 ## private_virtual_flags -> VIRTUAL . [ LIDENT ]
 ## private_virtual_flags -> VIRTUAL . PRIVATE [ LIDENT ]
@@ -5079,7 +5079,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 ##
-## Ends in an error in state: 1476.
+## Ends in an error in state: 1398.
 ##
 ## _class_sig_field -> METHOD . private_virtual_flags label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5091,7 +5091,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1474.
+## Ends in an error in state: 1396.
 ##
 ## value_type -> label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5103,7 +5103,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1473.
+## Ends in an error in state: 1395.
 ##
 ## value_type -> label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5115,7 +5115,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1469.
+## Ends in an error in state: 1391.
 ##
 ## value_type -> MUTABLE virtual_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5127,7 +5127,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 ##
-## Ends in an error in state: 1468.
+## Ends in an error in state: 1390.
 ##
 ## value_type -> MUTABLE virtual_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5139,7 +5139,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 ##
-## Ends in an error in state: 1467.
+## Ends in an error in state: 1389.
 ##
 ## value_type -> MUTABLE virtual_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5151,7 +5151,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1466.
+## Ends in an error in state: 1388.
 ##
 ## value_type -> MUTABLE . virtual_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5163,7 +5163,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1464.
+## Ends in an error in state: 1386.
 ##
 ## value_type -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5175,7 +5175,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1463.
+## Ends in an error in state: 1385.
 ##
 ## value_type -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5187,7 +5187,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1462.
+## Ends in an error in state: 1384.
 ##
 ## value_type -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5199,7 +5199,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1461.
+## Ends in an error in state: 1383.
 ##
 ## value_type -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5211,7 +5211,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 ##
-## Ends in an error in state: 1460.
+## Ends in an error in state: 1382.
 ##
 ## _class_sig_field -> VAL . value_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5223,7 +5223,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 ##
-## Ends in an error in state: 1761.
+## Ends in an error in state: 1683.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5236,7 +5236,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ##
-## Ends in an error in state: 1805.
+## Ends in an error in state: 1727.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## _non_arrowed_class_constructor_type -> class_instance_type . [ EQUALGREATER ]
@@ -5248,16 +5248,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1770, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1774, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1768, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1692, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1696, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1690, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1771.
+## Ends in an error in state: 1693.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
@@ -5270,7 +5270,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 ##
-## Ends in an error in state: 1770.
+## Ends in an error in state: 1692.
 ##
 ## _class_instance_type -> clty_longident . [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5283,7 +5283,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1799.
+## Ends in an error in state: 1721.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN class_constructor_type . RPAREN [ EQUALGREATER ]
 ##
@@ -5294,19 +5294,19 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1770, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1774, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1768, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1772, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1783, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1781, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1692, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1696, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1690, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1694, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1705, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1703, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 ##
-## Ends in an error in state: 1798.
+## Ends in an error in state: 1720.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN . class_constructor_type RPAREN [ EQUALGREATER ]
 ##
@@ -5318,7 +5318,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 ##
-## Ends in an error in state: 1766.
+## Ends in an error in state: 1688.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5332,7 +5332,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 ##
-## Ends in an error in state: 1765.
+## Ends in an error in state: 1687.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5352,7 +5352,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 
 implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ##
-## Ends in an error in state: 747.
+## Ends in an error in state: 789.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag simple_expr . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARPOP SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -5371,17 +5371,17 @@ implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 874, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 855, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FOR UNDERSCORE WHEN
 ##
-## Ends in an error in state: 739.
+## Ends in an error in state: 783.
 ##
 ## _expr -> FOR pattern . IN simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _or_pattern -> pattern . BAR pattern [ IN BAR ]
@@ -5393,14 +5393,14 @@ implementation: FOR UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 654, spurious reduction of production pattern -> pattern_without_or
+## In state 673, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2223.
+## Ends in an error in state: 749.
 ##
 ## _simple_expr -> simple_expr . DOT label_longident [ UNDERSCORE UIDENT TRUE STRING SHARPOP SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
 ## _simple_expr -> simple_expr . DOT LPAREN expr RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARPOP SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
@@ -5419,17 +5419,17 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 874, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 855, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 729.
+## Ends in an error in state: 748.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern EQUAL . simple_expr [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ##
@@ -5441,7 +5441,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 727.
+## Ends in an error in state: 746.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -5455,7 +5455,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 
 implementation: FUN LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 485.
+## Ends in an error in state: 510.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -5469,7 +5469,7 @@ implementation: FUN LIDENT COLONCOLON WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2334.
+## Ends in an error in state: 2282.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -5485,22 +5485,22 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 130, spurious reduction of production ident -> UIDENT
 ## In state 253, spurious reduction of production mty_longident -> ident
-## In state 1956, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1988, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1984, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1954, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1989, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1985, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1955, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1990, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1986, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1937, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1969, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1965, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1935, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1970, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1966, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1936, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1971, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1967, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 443.
+## Ends in an error in state: 464.
 ##
 ## functor_arg -> LPAREN functor_arg_name COLON . module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -5512,7 +5512,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 442.
+## Ends in an error in state: 463.
 ##
 ## functor_arg -> LPAREN functor_arg_name . COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -5524,7 +5524,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 
 implementation: INCLUDE FUN LPAREN WITH
 ##
-## Ends in an error in state: 438.
+## Ends in an error in state: 459.
 ##
 ## functor_arg -> LPAREN . RPAREN [ LPAREN EQUALGREATER COLON ]
 ## functor_arg -> LPAREN . functor_arg_name COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
@@ -5537,7 +5537,7 @@ implementation: INCLUDE FUN LPAREN WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1791.
+## Ends in an error in state: 1713.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5549,16 +5549,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1610, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1616, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1608, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1532, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1538, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1530, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1790.
+## Ends in an error in state: 1712.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5570,7 +5570,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1789.
+## Ends in an error in state: 1711.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type . EQUAL class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5581,19 +5581,19 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1770, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1774, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1768, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1772, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1783, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1781, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1692, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1696, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1690, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1694, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1705, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1703, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 1758.
+## Ends in an error in state: 1680.
 ##
 ## _constrained_class_declaration -> COLON . class_constructor_type EQUAL class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5605,7 +5605,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1847.
+## Ends in an error in state: 1774.
 ##
 ## and_class_declaration -> AND . class_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5617,7 +5617,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1846.
+## Ends in an error in state: 1773.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_class_declarations -> many_class_declarations . and_class_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5629,16 +5629,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1384, spurious reduction of production post_item_attributes ->
-## In state 1385, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1814, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
+## In state 1315, spurious reduction of production post_item_attributes ->
+## In state 1316, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1736, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1757.
+## Ends in an error in state: 1679.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5650,16 +5650,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1610, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1616, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1608, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1532, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1538, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1530, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1538.
+## Ends in an error in state: 1460.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5671,7 +5671,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 1803.
+## Ends in an error in state: 1725.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5683,16 +5683,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1610, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1616, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1608, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1532, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1538, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1530, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1802.
+## Ends in an error in state: 1724.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5704,7 +5704,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1801.
+## Ends in an error in state: 1723.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type . EQUALGREATER class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5716,7 +5716,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT R
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1797.
+## Ends in an error in state: 1719.
 ##
 ## class_fun_return -> COLON . non_arrowed_class_constructor_type EQUALGREATER class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5728,7 +5728,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 1796.
+## Ends in an error in state: 1718.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> EQUALGREATER class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5740,16 +5740,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1610, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1616, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1608, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1532, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1538, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1530, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1795.
+## Ends in an error in state: 1717.
 ##
 ## class_fun_return -> EQUALGREATER . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5761,7 +5761,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1794.
+## Ends in an error in state: 1716.
 ##
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_return [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5774,7 +5774,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1535.
+## Ends in an error in state: 1457.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . constrained_class_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5789,7 +5789,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1842.
+## Ends in an error in state: 1769.
 ##
 ## and_class_type_declaration -> AND . class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5801,7 +5801,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1841.
+## Ends in an error in state: 1768.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_type_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5813,16 +5813,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND R
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1384, spurious reduction of production post_item_attributes ->
-## In state 1385, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1532, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
+## In state 1315, spurious reduction of production post_item_attributes ->
+## In state 1316, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1454, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1523.
+## Ends in an error in state: 1445.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5834,16 +5834,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1500, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1506, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1498, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1422, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1428, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1420, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1450.
+## Ends in an error in state: 1372.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5855,7 +5855,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1447.
+## Ends in an error in state: 1369.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters . EQUAL class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS EQUAL ]
@@ -5868,7 +5868,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 ##
-## Ends in an error in state: 1445.
+## Ends in an error in state: 1367.
 ##
 ## class_type_declaration_details -> virtual_flag . LIDENT class_type_parameters EQUAL class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5880,7 +5880,7 @@ implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE WITH
 ##
-## Ends in an error in state: 1444.
+## Ends in an error in state: 1366.
 ##
 ## many_class_type_declarations -> CLASS TYPE . class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5892,7 +5892,7 @@ implementation: INCLUDE LBRACE CLASS TYPE WITH
 
 implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 1533.
+## Ends in an error in state: 1455.
 ##
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters constrained_class_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5906,7 +5906,7 @@ implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 
 implementation: INCLUDE LBRACE CLASS WITH
 ##
-## Ends in an error in state: 1442.
+## Ends in an error in state: 1364.
 ##
 ## many_class_declarations -> CLASS . class_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5919,7 +5919,7 @@ implementation: INCLUDE LBRACE CLASS WITH
 
 implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 ##
-## Ends in an error in state: 1417.
+## Ends in an error in state: 1339.
 ##
 ## extension_constructor_declaration -> LPAREN . RPAREN generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## extension_constructor_rebind -> LPAREN . RPAREN EQUAL constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -5932,7 +5932,7 @@ implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1404.
+## Ends in an error in state: 1326.
 ##
 ## generalized_constructor_arguments -> COLON . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -5944,7 +5944,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 ##
-## Ends in an error in state: 1399.
+## Ends in an error in state: 1321.
 ##
 ## constr_longident -> LBRACKET . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -5956,7 +5956,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 1398.
+## Ends in an error in state: 1320.
 ##
 ## constr_longident -> LPAREN . RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -5968,7 +5968,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1397.
+## Ends in an error in state: 1319.
 ##
 ## extension_constructor_rebind -> UIDENT EQUAL . constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ##
@@ -5980,7 +5980,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1407.
+## Ends in an error in state: 1329.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list COLON . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -5992,7 +5992,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1406.
+## Ends in an error in state: 1328.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . COLON core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
@@ -6006,7 +6006,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1396.
+## Ends in an error in state: 1318.
 ##
 ## extension_constructor_declaration -> UIDENT . generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## extension_constructor_rebind -> UIDENT . EQUAL constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -6019,7 +6019,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 
 implementation: INCLUDE LBRACE EXCEPTION WITH
 ##
-## Ends in an error in state: 1395.
+## Ends in an error in state: 1317.
 ##
 ## str_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## str_exception_declaration -> EXCEPTION . extension_constructor_rebind post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
@@ -6032,7 +6032,7 @@ implementation: INCLUDE LBRACE EXCEPTION WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 ##
-## Ends in an error in state: 1391.
+## Ends in an error in state: 1311.
 ##
 ## primitive_declaration -> STRING . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ## primitive_declaration -> STRING . primitive_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
@@ -6045,7 +6045,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WIT
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1390.
+## Ends in an error in state: 1310.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6057,7 +6057,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1389.
+## Ends in an error in state: 1309.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6080,7 +6080,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1388.
+## Ends in an error in state: 1308.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6092,7 +6092,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 1387.
+## Ends in an error in state: 1307.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6104,7 +6104,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 
 implementation: INCLUDE LBRACE EXTERNAL WITH
 ##
-## Ends in an error in state: 1386.
+## Ends in an error in state: 1306.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6154,7 +6154,7 @@ implementation: INCLUDE LBRACE MODULE WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1297.
+## Ends in an error in state: 482.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER module_expr . [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6169,7 +6169,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHIL
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1295.
+## Ends in an error in state: 480.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER . module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6181,7 +6181,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1294.
+## Ends in an error in state: 479.
 ##
 ## _module_expr -> FUN functor_args . EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## functor_args -> functor_args . functor_arg [ LPAREN EQUALGREATER ]
@@ -6194,7 +6194,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 
 implementation: INCLUDE LPAREN FUN WITH
 ##
-## Ends in an error in state: 1293.
+## Ends in an error in state: 478.
 ##
 ## _module_expr -> FUN . functor_args EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6206,7 +6206,7 @@ implementation: INCLUDE LPAREN FUN WITH
 
 implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1319.
+## Ends in an error in state: 2243.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -6222,23 +6222,23 @@ implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 234, spurious reduction of production ident -> UIDENT
-## In state 506, spurious reduction of production mty_longident -> ident
-## In state 1318, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1369, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1365, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1316, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1370, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1366, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1317, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1371, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1367, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 531, spurious reduction of production mty_longident -> ident
+## In state 1877, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1923, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1919, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1875, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1924, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1920, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1876, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1925, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1921, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1315.
+## Ends in an error in state: 2242.
 ##
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6251,7 +6251,7 @@ implementation: INCLUDE LPAREN UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2409.
+## Ends in an error in state: 2430.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -6268,19 +6268,19 @@ implementation: INCLUDE LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1373, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1377, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1374, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1296, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1379, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1378, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2090, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2094, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2091, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 481, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2096, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2095, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1309.
+## Ends in an error in state: 2236.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6300,7 +6300,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLON
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1308.
+## Ends in an error in state: 2235.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6312,7 +6312,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 2407.
+## Ends in an error in state: 2428.
 ##
 ## _module_expr -> LPAREN VAL expr COLON . error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6326,7 +6326,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1303.
+## Ends in an error in state: 2230.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6346,7 +6346,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 2405.
+## Ends in an error in state: 2426.
 ##
 ## _module_expr -> LPAREN VAL expr COLONGREATER . error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6359,7 +6359,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 2403.
+## Ends in an error in state: 2424.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -6400,14 +6400,14 @@ implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -6455,7 +6455,7 @@ implementation: INCLUDE LPAREN WITH
 
 implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ##
-## Ends in an error in state: 2304.
+## Ends in an error in state: 2252.
 ##
 ## _simple_module_expr -> LBRACE structure . RBRACE [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6466,29 +6466,29 @@ implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1901, spurious reduction of production post_item_attributes ->
-## In state 1902, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1903, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1815, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1904, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1816, spurious reduction of production structure -> structure_item
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1828, spurious reduction of production post_item_attributes ->
+## In state 1829, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1830, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1744, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1737, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1831, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1745, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1738, spurious reduction of production structure -> structure_item
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 451.
+## Ends in an error in state: 472.
 ##
 ## _simple_module_expr -> LBRACE . structure RBRACE [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6500,7 +6500,7 @@ implementation: INCLUDE UIDENT LBRACE WITH
 
 implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1312.
+## Ends in an error in state: 2239.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -6517,19 +6517,19 @@ implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1373, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1377, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1374, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1296, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1379, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1378, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2090, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2094, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2091, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 481, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2096, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2095, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 1305.
+## Ends in an error in state: 2232.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type COLONGREATER package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6542,7 +6542,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1302.
+## Ends in an error in state: 2229.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6554,7 +6554,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 1300.
+## Ends in an error in state: 2227.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -6592,21 +6592,21 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 910, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 880, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 890, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 919, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 889, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 912, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 882, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 921, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 891, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL WITH
 ##
-## Ends in an error in state: 1299.
+## Ends in an error in state: 484.
 ##
 ## _simple_module_expr -> LPAREN VAL . expr RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL . expr COLON package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6621,7 +6621,7 @@ implementation: INCLUDE UIDENT LPAREN VAL WITH
 
 implementation: INCLUDE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1298.
+## Ends in an error in state: 483.
 ##
 ## _module_expr -> module_expr LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN . module_expr COLON module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6641,7 +6641,7 @@ implementation: INCLUDE UIDENT LPAREN WITH
 
 implementation: INCLUDE UIDENT WHILE
 ##
-## Ends in an error in state: 1373.
+## Ends in an error in state: 2090.
 ##
 ## _simple_module_expr -> mod_longident . [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF DOT COLON AND ]
@@ -6654,7 +6654,7 @@ implementation: INCLUDE UIDENT WHILE
 
 implementation: INCLUDE WITH
 ##
-## Ends in an error in state: 1292.
+## Ends in an error in state: 477.
 ##
 ## _structure_item_without_item_extension_sugar -> INCLUDE . module_expr post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6666,7 +6666,7 @@ implementation: INCLUDE WITH
 
 implementation: LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1632.
+## Ends in an error in state: 1554.
 ##
 ## class_self_pattern_and_structure -> class_self_pattern . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -6678,7 +6678,7 @@ implementation: LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: LBRACE AS UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1621.
+## Ends in an error in state: 1543.
 ##
 ## _class_self_pattern -> AS pattern . SEMI [ error VAL RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ## _or_pattern -> pattern . BAR pattern [ SEMI BAR ]
@@ -6690,14 +6690,14 @@ implementation: LBRACE AS UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 654, spurious reduction of production pattern -> pattern_without_or
+## In state 673, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE AS WITH
 ##
-## Ends in an error in state: 1620.
+## Ends in an error in state: 1542.
 ##
 ## _class_self_pattern -> AS . pattern SEMI [ error VAL RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ##
@@ -6709,7 +6709,7 @@ implementation: LBRACE AS WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1509.
+## Ends in an error in state: 1431.
 ##
 ## constrain_field -> core_type EQUAL . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -6721,7 +6721,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1508.
+## Ends in an error in state: 1430.
 ##
 ## constrain_field -> core_type . EQUAL core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -6744,7 +6744,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 
 implementation: LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1711.
+## Ends in an error in state: 1633.
 ##
 ## _class_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -6756,10 +6756,11 @@ implementation: LBRACE CONSTRAINT WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2248.
+## Ends in an error in state: 2313.
 ##
 ## opt_comma -> COMMA . [ RBRACE ]
 ## record_expr -> DOTDOTDOT expr_optional_constraint COMMA . lbl_expr_list [ error RBRACE ]
+## record_expr_with_string_keys -> DOTDOTDOT expr_optional_constraint COMMA . string_literal_expr_list [ error RBRACE ]
 ##
 ## The known suffix of the stack is as follows:
 ## DOTDOTDOT expr_optional_constraint COMMA
@@ -6769,10 +6770,11 @@ implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ##
-## Ends in an error in state: 2341.
+## Ends in an error in state: 2359.
 ##
 ## _simple_expr -> LBRACE DOTDOTDOT expr_optional_constraint . opt_comma RBRACE [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## record_expr -> DOTDOTDOT expr_optional_constraint . COMMA lbl_expr_list [ error RBRACE ]
+## record_expr_with_string_keys -> DOTDOTDOT expr_optional_constraint . COMMA string_literal_expr_list [ error RBRACE ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE DOTDOTDOT expr_optional_constraint
@@ -6781,25 +6783,26 @@ implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 910, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 880, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 890, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 919, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 889, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1069, spurious reduction of production expr_optional_constraint -> expr
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 912, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 882, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 921, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 891, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1073, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE DOTDOTDOT WITH
 ##
-## Ends in an error in state: 2340.
+## Ends in an error in state: 2358.
 ##
 ## _simple_expr -> LBRACE DOTDOTDOT . expr_optional_constraint opt_comma RBRACE [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## record_expr -> DOTDOTDOT . expr_optional_constraint COMMA lbl_expr_list [ error RBRACE ]
+## record_expr_with_string_keys -> DOTDOTDOT . expr_optional_constraint COMMA string_literal_expr_list [ error RBRACE ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE DOTDOTDOT
@@ -6809,7 +6812,7 @@ implementation: LBRACE DOTDOTDOT WITH
 
 implementation: LBRACE INHERIT BANG WITH
 ##
-## Ends in an error in state: 1705.
+## Ends in an error in state: 1627.
 ##
 ## _class_field -> INHERIT override_flag . class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -6821,7 +6824,7 @@ implementation: LBRACE INHERIT BANG WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1606.
+## Ends in an error in state: 1528.
 ##
 ## _class_expr -> CLASS class_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF COLON AS AND ]
@@ -6834,7 +6837,7 @@ implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1605.
+## Ends in an error in state: 1527.
 ##
 ## _class_expr -> CLASS class_longident . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> CLASS class_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6847,7 +6850,7 @@ implementation: LBRACE INHERIT CLASS LIDENT WITH
 
 implementation: LBRACE INHERIT CLASS WITH
 ##
-## Ends in an error in state: 1604.
+## Ends in an error in state: 1526.
 ##
 ## _class_expr -> CLASS . class_longident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> CLASS . class_longident non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6860,7 +6863,7 @@ implementation: LBRACE INHERIT CLASS WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1613.
+## Ends in an error in state: 1535.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER class_expr . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6873,7 +6876,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND R
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1603.
+## Ends in an error in state: 1525.
 ##
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER . class_expr [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ##
@@ -6885,7 +6888,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1602.
+## Ends in an error in state: 1524.
 ##
 ## _class_fun_def -> labeled_simple_pattern . EQUALGREATER class_expr [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern . class_fun_def [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6898,7 +6901,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 
 implementation: LBRACE INHERIT FUN WITH
 ##
-## Ends in an error in state: 1600.
+## Ends in an error in state: 1522.
 ##
 ## _class_expr -> FUN . class_fun_def [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ##
@@ -6910,7 +6913,7 @@ implementation: LBRACE INHERIT FUN WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 1626.
+## Ends in an error in state: 1548.
 ##
 ## _class_expr_lets_and_rest -> let_bindings SEMI . class_expr_lets_and_rest [ error RBRACE ]
 ##
@@ -6922,7 +6925,7 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ##
-## Ends in an error in state: 1625.
+## Ends in an error in state: 1547.
 ##
 ## _class_expr_lets_and_rest -> let_bindings . SEMI class_expr_lets_and_rest [ error RBRACE ]
 ## let_bindings -> let_bindings . and_let_binding [ SEMI AND ]
@@ -6934,22 +6937,22 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 880, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 890, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 919, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 889, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1595, spurious reduction of production let_binding_body -> pattern EQUAL expr
-## In state 1596, spurious reduction of production post_item_attributes ->
-## In state 1597, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
-## In state 1627, spurious reduction of production let_binding -> let_binding_impl
-## In state 1628, spurious reduction of production let_bindings -> let_binding
+## In state 882, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 921, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 891, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1517, spurious reduction of production let_binding_body -> pattern EQUAL expr
+## In state 1518, spurious reduction of production post_item_attributes ->
+## In state 1519, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
+## In state 1549, spurious reduction of production let_binding -> let_binding_impl
+## In state 1550, spurious reduction of production let_bindings -> let_binding
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE LET WITH
 ##
-## Ends in an error in state: 1541.
+## Ends in an error in state: 1463.
 ##
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI AND ]
 ##
@@ -6961,7 +6964,7 @@ implementation: LBRACE INHERIT LBRACE LET WITH
 
 implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ##
-## Ends in an error in state: 1724.
+## Ends in an error in state: 1646.
 ##
 ## _class_expr -> class_expr . attribute [ error RBRACE LBRACKETAT ]
 ## _class_expr_lets_and_rest -> class_expr . [ error RBRACE ]
@@ -6973,16 +6976,16 @@ implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1610, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1616, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1608, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1532, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1538, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1530, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 ##
-## Ends in an error in state: 1629.
+## Ends in an error in state: 1551.
 ##
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI AND ]
 ##
@@ -7001,7 +7004,7 @@ implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 
 implementation: LBRACE INHERIT LBRACE WITH
 ##
-## Ends in an error in state: 1540.
+## Ends in an error in state: 1462.
 ##
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest RBRACE [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7014,7 +7017,7 @@ implementation: LBRACE INHERIT LBRACE WITH
 
 implementation: LBRACE INHERIT LIDENT AS WITH
 ##
-## Ends in an error in state: 1707.
+## Ends in an error in state: 1629.
 ##
 ## parent_binder -> AS . LIDENT [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7026,7 +7029,7 @@ implementation: LBRACE INHERIT LIDENT AS WITH
 
 implementation: LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1706.
+## Ends in an error in state: 1628.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AS ]
 ## _class_field -> INHERIT override_flag class_expr . parent_binder post_item_attributes [ error SEMI RBRACE ]
@@ -7038,16 +7041,16 @@ implementation: LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1610, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1616, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1608, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1532, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1538, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1530, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT SEMI WITH
 ##
-## Ends in an error in state: 1720.
+## Ends in an error in state: 1642.
 ##
 ## semi_terminated_class_fields -> class_field SEMI . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -7059,7 +7062,7 @@ implementation: LBRACE INHERIT LIDENT SEMI WITH
 
 implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ##
-## Ends in an error in state: 1611.
+## Ends in an error in state: 1533.
 ##
 ## _class_expr -> class_simple_expr simple_labeled_expr_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## simple_labeled_expr_list -> simple_labeled_expr_list . labeled_simple_expr [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7071,20 +7074,20 @@ implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 808, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 823, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 828, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
-## In state 831, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 807, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 822, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 827, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
+## In state 830, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT WITH
 ##
-## Ends in an error in state: 1610.
+## Ends in an error in state: 1532.
 ##
 ## _class_expr -> class_simple_expr . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> class_simple_expr . simple_labeled_expr_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -7097,7 +7100,7 @@ implementation: LBRACE INHERIT LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1752.
+## Ends in an error in state: 1674.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -7109,7 +7112,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE 
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1751.
+## Ends in an error in state: 1673.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -7122,7 +7125,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE 
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1750.
+## Ends in an error in state: 1672.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -7134,7 +7137,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1743.
+## Ends in an error in state: 1665.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -7146,7 +7149,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 1742.
+## Ends in an error in state: 1664.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -7159,7 +7162,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1741.
+## Ends in an error in state: 1663.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -7171,7 +7174,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1744.
+## Ends in an error in state: 1666.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -7183,7 +7186,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1740, spurious reduction of production type_longident -> LIDENT
+## In state 1662, spurious reduction of production type_longident -> LIDENT
 ## In state 254, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
 ## In state 259, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
 ## In state 257, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
@@ -7194,7 +7197,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 ##
-## Ends in an error in state: 1452.
+## Ends in an error in state: 1374.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -7207,7 +7210,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1739.
+## Ends in an error in state: 1661.
 ##
 ## _class_constructor_type -> NEW class_instance_type . [ error RPAREN ]
 ## _class_instance_type -> class_instance_type . attribute [ error RPAREN LBRACKETAT ]
@@ -7219,16 +7222,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1500, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1506, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1498, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1422, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1428, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1420, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1501.
+## Ends in an error in state: 1423.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
@@ -7241,7 +7244,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 ##
-## Ends in an error in state: 1500.
+## Ends in an error in state: 1422.
 ##
 ## _class_instance_type -> clty_longident . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -7254,7 +7257,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 ##
-## Ends in an error in state: 1496.
+## Ends in an error in state: 1418.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -7268,7 +7271,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 ##
-## Ends in an error in state: 1495.
+## Ends in an error in state: 1417.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -7288,7 +7291,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1738.
+## Ends in an error in state: 1660.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ error RPAREN ]
 ##
@@ -7300,7 +7303,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1745.
+## Ends in an error in state: 1667.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -7312,7 +7315,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 ##
-## Ends in an error in state: 1737.
+## Ends in an error in state: 1659.
 ##
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7325,7 +7328,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ##
-## Ends in an error in state: 1734.
+## Ends in an error in state: 1656.
 ##
 ## _class_expr -> class_expr . attribute [ error RPAREN LBRACKETAT COLON ]
 ## _class_simple_expr -> LPAREN class_expr . COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7340,16 +7343,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1610, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1616, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1608, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1532, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1538, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1530, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN WITH
 ##
-## Ends in an error in state: 1539.
+## Ends in an error in state: 1461.
 ##
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7364,7 +7367,7 @@ implementation: LBRACE INHERIT LPAREN WITH
 
 implementation: LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1704.
+## Ends in an error in state: 1626.
 ##
 ## _class_field -> INHERIT . override_flag class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7376,7 +7379,7 @@ implementation: LBRACE INHERIT WITH
 
 implementation: LBRACE INITIALIZER EQUALGREATER WITH
 ##
-## Ends in an error in state: 1701.
+## Ends in an error in state: 1623.
 ##
 ## _class_field -> INITIALIZER EQUALGREATER . expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7388,7 +7391,7 @@ implementation: LBRACE INITIALIZER EQUALGREATER WITH
 
 implementation: LBRACE INITIALIZER WITH
 ##
-## Ends in an error in state: 1700.
+## Ends in an error in state: 1622.
 ##
 ## _class_field -> INITIALIZER . EQUALGREATER expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7400,7 +7403,7 @@ implementation: LBRACE INITIALIZER WITH
 
 implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 2344.
+## Ends in an error in state: 2362.
 ##
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . RBRACE [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . error [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -7412,17 +7415,17 @@ implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2268, spurious reduction of production opt_semi -> SEMI
-## In state 2279, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
-## In state 2277, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2266, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2299, spurious reduction of production opt_semi -> SEMI
+## In state 2310, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
+## In state 2308, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2297, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
 ##
 
 Expecting "}" to finish the block
 
 implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2338.
+## Ends in an error in state: 2286.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7434,7 +7437,7 @@ implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 
 implementation: LBRACE LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 437.
+## Ends in an error in state: 458.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7446,7 +7449,7 @@ implementation: LBRACE LET MODULE UIDENT WITH
 
 implementation: LBRACE LET MODULE WITH
 ##
-## Ends in an error in state: 436.
+## Ends in an error in state: 457.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7458,7 +7461,7 @@ implementation: LBRACE LET MODULE WITH
 
 implementation: LBRACE LET OPEN BANG WITH
 ##
-## Ends in an error in state: 2260.
+## Ends in an error in state: 2291.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7470,7 +7473,7 @@ implementation: LBRACE LET OPEN BANG WITH
 
 implementation: LBRACE LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2263.
+## Ends in an error in state: 2294.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7482,7 +7485,7 @@ implementation: LBRACE LET OPEN UIDENT SEMI WITH
 
 implementation: LBRACE LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2262.
+## Ends in an error in state: 2293.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7493,14 +7496,14 @@ implementation: LBRACE LET OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2261, spurious reduction of production post_item_attributes ->
+## In state 2292, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET OPEN WITH
 ##
-## Ends in an error in state: 2259.
+## Ends in an error in state: 2290.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7512,7 +7515,7 @@ implementation: LBRACE LET OPEN WITH
 
 implementation: LBRACE LET WITH
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 455.
 ##
 ## _semi_terminated_seq_expr_row -> LET . MODULE UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ error SEMI RBRACE AND ]
@@ -7526,7 +7529,7 @@ implementation: LBRACE LET WITH
 
 implementation: LBRACE LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1139.
+## Ends in an error in state: 1143.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7562,21 +7565,21 @@ implementation: LBRACE LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1138.
+## Ends in an error in state: 1142.
 ##
 ## lbl_expr -> label_longident COLON . expr [ COMMA ]
 ## non_punned_lbl_expression -> label_longident COLON . expr [ error RBRACE ]
@@ -7589,7 +7592,7 @@ implementation: LBRACE LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1128.
+## Ends in an error in state: 1132.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7624,21 +7627,21 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 ##
-## Ends in an error in state: 1127.
+## Ends in an error in state: 1131.
 ##
 ## lbl_expr -> label_longident COLON . expr [ error RBRACE COMMA ]
 ##
@@ -7650,7 +7653,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 ##
-## Ends in an error in state: 1124.
+## Ends in an error in state: 1128.
 ##
 ## lbl_expr_list -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ## lbl_expr_list -> lbl_expr COMMA . [ error RBRACE ]
@@ -7663,7 +7666,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT WITH
 ##
-## Ends in an error in state: 1126.
+## Ends in an error in state: 1130.
 ##
 ## lbl_expr -> label_longident . COLON expr [ error RBRACE COMMA ]
 ## lbl_expr -> label_longident . [ error RBRACE COMMA ]
@@ -7676,7 +7679,7 @@ implementation: LBRACE LIDENT COMMA LIDENT WITH
 
 implementation: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 1135.
+## Ends in an error in state: 1139.
 ##
 ## lbl_expr_list_that_is_not_a_single_punned_field -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ##
@@ -7688,7 +7691,7 @@ implementation: LBRACE LIDENT COMMA WITH
 
 implementation: LBRACE METHOD BANG WITH
 ##
-## Ends in an error in state: 1657.
+## Ends in an error in state: 1579.
 ##
 ## method_ -> override_flag . PRIVATE VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag . VIRTUAL private_flag label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -7705,7 +7708,7 @@ implementation: LBRACE METHOD BANG WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1693.
+## Ends in an error in state: 1615.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7740,21 +7743,21 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1692.
+## Ends in an error in state: 1614.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT core_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7766,7 +7769,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1691.
+## Ends in an error in state: 1613.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT core_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7789,7 +7792,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1690.
+## Ends in an error in state: 1612.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT . core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7801,7 +7804,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 1688.
+## Ends in an error in state: 1610.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE . lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7813,7 +7816,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE WITH
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1696.
+## Ends in an error in state: 1618.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7848,21 +7851,21 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1695.
+## Ends in an error in state: 1617.
 ##
 ## method_ -> override_flag private_flag label COLON poly_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7874,7 +7877,7 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1694.
+## Ends in an error in state: 1616.
 ##
 ## method_ -> override_flag private_flag label COLON poly_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7891,16 +7894,16 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE WITH
 ## In state 271, spurious reduction of production _core_type -> core_type2
 ## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1255, spurious reduction of production _poly_type -> core_type
-## In state 1256, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1254, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 1269, spurious reduction of production _poly_type -> core_type
+## In state 1270, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1268, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON WITH
 ##
-## Ends in an error in state: 1687.
+## Ends in an error in state: 1609.
 ##
 ## method_ -> override_flag private_flag label COLON . poly_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag private_flag label COLON . TYPE lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -7913,7 +7916,7 @@ implementation: LBRACE METHOD LIDENT COLON WITH
 
 implementation: LBRACE METHOD LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1686.
+## Ends in an error in state: 1608.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7948,21 +7951,21 @@ implementation: LBRACE METHOD LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1685.
+## Ends in an error in state: 1607.
 ##
 ## method_ -> override_flag private_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7974,7 +7977,7 @@ implementation: LBRACE METHOD LIDENT EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1719.
+## Ends in an error in state: 1641.
 ##
 ## semi_terminated_class_fields -> class_field . [ error RBRACE ]
 ## semi_terminated_class_fields -> class_field . SEMI semi_terminated_class_fields [ error RBRACE ]
@@ -7986,27 +7989,27 @@ implementation: LBRACE METHOD LIDENT EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1676, spurious reduction of production curried_binding -> EQUALGREATER expr
-## In state 1697, spurious reduction of production method_ -> override_flag private_flag label curried_binding
-## In state 1698, spurious reduction of production post_item_attributes ->
-## In state 1699, spurious reduction of production _class_field -> METHOD method_ post_item_attributes
-## In state 1722, spurious reduction of production mark_position_cf(_class_field) -> _class_field
-## In state 1715, spurious reduction of production class_field -> mark_position_cf(_class_field)
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1598, spurious reduction of production curried_binding -> EQUALGREATER expr
+## In state 1619, spurious reduction of production method_ -> override_flag private_flag label curried_binding
+## In state 1620, spurious reduction of production post_item_attributes ->
+## In state 1621, spurious reduction of production _class_field -> METHOD method_ post_item_attributes
+## In state 1644, spurious reduction of production mark_position_cf(_class_field) -> _class_field
+## In state 1637, spurious reduction of production class_field -> mark_position_cf(_class_field)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1667.
+## Ends in an error in state: 1589.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8018,7 +8021,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1666.
+## Ends in an error in state: 1588.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8030,7 +8033,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL WITH
 ##
-## Ends in an error in state: 1665.
+## Ends in an error in state: 1587.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8042,7 +8045,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL WITH
 
 implementation: LBRACE METHOD PRIVATE WITH
 ##
-## Ends in an error in state: 1664.
+## Ends in an error in state: 1586.
 ##
 ## method_ -> override_flag PRIVATE . VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## private_flag -> PRIVATE . [ LIDENT ]
@@ -8055,7 +8058,7 @@ implementation: LBRACE METHOD PRIVATE WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1487.
+## Ends in an error in state: 1409.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8067,7 +8070,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1486.
+## Ends in an error in state: 1408.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -8080,7 +8083,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WIT
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE WITH
 ##
-## Ends in an error in state: 1484.
+## Ends in an error in state: 1406.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ error SEMI RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AS ]
 ## typevar_list -> QUOTE . ident [ QUOTE DOT ]
@@ -8093,7 +8096,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1662.
+## Ends in an error in state: 1584.
 ##
 ## method_ -> override_flag VIRTUAL private_flag label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8105,7 +8108,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1661.
+## Ends in an error in state: 1583.
 ##
 ## method_ -> override_flag VIRTUAL private_flag label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8117,7 +8120,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT WITH
 
 implementation: LBRACE METHOD VIRTUAL PRIVATE LET
 ##
-## Ends in an error in state: 1660.
+## Ends in an error in state: 1582.
 ##
 ## method_ -> override_flag VIRTUAL private_flag . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8129,7 +8132,7 @@ implementation: LBRACE METHOD VIRTUAL PRIVATE LET
 
 implementation: LBRACE METHOD VIRTUAL WITH
 ##
-## Ends in an error in state: 1658.
+## Ends in an error in state: 1580.
 ##
 ## method_ -> override_flag VIRTUAL . private_flag label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8141,7 +8144,7 @@ implementation: LBRACE METHOD VIRTUAL WITH
 
 implementation: LBRACE METHOD WITH
 ##
-## Ends in an error in state: 1656.
+## Ends in an error in state: 1578.
 ##
 ## _class_field -> METHOD . method_ post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8153,7 +8156,7 @@ implementation: LBRACE METHOD WITH
 
 implementation: LBRACE PERCENT WITH TYPE
 ##
-## Ends in an error in state: 2270.
+## Ends in an error in state: 2301.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ error RBRACE ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ error SEMI RBRACE AND ]
@@ -8173,7 +8176,7 @@ implementation: LBRACE PERCENT WITH TYPE
 
 implementation: LBRACE UIDENT DOT WITH
 ##
-## Ends in an error in state: 2281.
+## Ends in an error in state: 2338.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
@@ -8200,7 +8203,7 @@ implementation: LBRACE UIDENT DOT WITH
 
 implementation: LBRACE VAL BANG WITH
 ##
-## Ends in an error in state: 1642.
+## Ends in an error in state: 1564.
 ##
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8215,7 +8218,7 @@ implementation: LBRACE VAL BANG WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1655.
+## Ends in an error in state: 1577.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8250,21 +8253,21 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL UIDENT RP
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 ##
-## Ends in an error in state: 1654.
+## Ends in an error in state: 1576.
 ##
 ## value -> override_flag mutable_flag label type_constraint EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8276,7 +8279,7 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1653.
+## Ends in an error in state: 1575.
 ##
 ## value -> override_flag mutable_flag label type_constraint . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8293,14 +8296,14 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 271, spurious reduction of production _core_type -> core_type2
 ## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1071, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1075, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1652.
+## Ends in an error in state: 1574.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8335,21 +8338,21 @@ implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1651.
+## Ends in an error in state: 1573.
 ##
 ## value -> override_flag mutable_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8361,7 +8364,7 @@ implementation: LBRACE VAL LIDENT EQUAL WITH
 
 implementation: LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1650.
+## Ends in an error in state: 1572.
 ##
 ## value -> override_flag mutable_flag label . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag mutable_flag label . type_constraint EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -8374,7 +8377,7 @@ implementation: LBRACE VAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1647.
+## Ends in an error in state: 1569.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8387,18 +8390,18 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 332, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 690, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 684, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 686, spurious reduction of production _core_type -> core_type2
-## In state 697, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 685, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 709, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 703, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 705, spurious reduction of production _core_type -> core_type2
+## In state 716, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 704, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1646.
+## Ends in an error in state: 1568.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8411,7 +8414,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1645.
+## Ends in an error in state: 1567.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8424,7 +8427,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 ##
-## Ends in an error in state: 1644.
+## Ends in an error in state: 1566.
 ##
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8437,7 +8440,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 
 implementation: LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1643.
+## Ends in an error in state: 1565.
 ##
 ## mutable_flag -> MUTABLE . [ LIDENT ]
 ## value -> override_flag MUTABLE . VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -8451,7 +8454,7 @@ implementation: LBRACE VAL MUTABLE WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1638.
+## Ends in an error in state: 1560.
 ##
 ## value -> VIRTUAL mutable_flag label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8464,18 +8467,18 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 332, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 690, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 684, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 686, spurious reduction of production _core_type -> core_type2
-## In state 697, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 685, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 709, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 703, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 705, spurious reduction of production _core_type -> core_type2
+## In state 716, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 704, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1637.
+## Ends in an error in state: 1559.
 ##
 ## value -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8488,7 +8491,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1636.
+## Ends in an error in state: 1558.
 ##
 ## value -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8501,7 +8504,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1635.
+## Ends in an error in state: 1557.
 ##
 ## value -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8514,7 +8517,7 @@ implementation: LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1634.
+## Ends in an error in state: 1556.
 ##
 ## value -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL . mutable_flag label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8527,7 +8530,7 @@ implementation: LBRACE VAL VIRTUAL WITH
 
 implementation: LBRACE VAL WITH
 ##
-## Ends in an error in state: 1633.
+## Ends in an error in state: 1555.
 ##
 ## _class_field -> VAL . value post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8539,7 +8542,7 @@ implementation: LBRACE VAL WITH
 
 implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2353.
+## Ends in an error in state: 2374.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8574,14 +8577,14 @@ implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -8626,7 +8629,7 @@ implementation: LBRACELESS LIDENT WITH
 
 implementation: LBRACKET DOTDOTDOT WITH
 ##
-## Ends in an error in state: 2194.
+## Ends in an error in state: 1107.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT . expr_optional_constraint RBRACKET [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -8638,7 +8641,7 @@ implementation: LBRACKET DOTDOTDOT WITH
 
 implementation: LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2197.
+## Ends in an error in state: 1110.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint . opt_comma RBRACKET [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## expr_comma_seq_extension -> expr_optional_constraint . COMMA expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -8650,15 +8653,15 @@ implementation: LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 910, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 880, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 890, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 919, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 889, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1069, spurious reduction of production expr_optional_constraint -> expr
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 912, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 882, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 921, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 891, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1073, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 Expecting one of the following:
@@ -8683,7 +8686,7 @@ Expecting one of the following:
 
 implementation: LBRACKETATATAT UNDERSCORE
 ##
-## Ends in an error in state: 454.
+## Ends in an error in state: 475.
 ##
 ## floating_attribute -> LBRACKETATATAT . attr_id payload RBRACKET [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -8695,7 +8698,7 @@ implementation: LBRACKETATATAT UNDERSCORE
 
 implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2300.
+## Ends in an error in state: 2248.
 ##
 ## floating_attribute -> LBRACKETATATAT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -8706,30 +8709,30 @@ implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1901, spurious reduction of production post_item_attributes ->
-## In state 1902, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1903, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1815, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1904, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1816, spurious reduction of production structure -> structure_item
-## In state 1907, spurious reduction of production payload -> structure
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1828, spurious reduction of production post_item_attributes ->
+## In state 1829, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1830, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1744, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1737, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1831, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1745, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1738, spurious reduction of production structure -> structure_item
+## In state 1834, spurious reduction of production payload -> structure
 ##
 
 Expecting "]" to finish current floating attribute
 
 implementation: LBRACKETBAR BANG WITH
 ##
-## Ends in an error in state: 463.
+## Ends in an error in state: 442.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -8741,7 +8744,7 @@ implementation: LBRACKETBAR BANG WITH
 
 implementation: LBRACKETBAR MINUSDOT WITH
 ##
-## Ends in an error in state: 813.
+## Ends in an error in state: 812.
 ##
 ## _expr -> subtractive . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -8753,7 +8756,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR PLUSDOT WITH
 ##
-## Ends in an error in state: 847.
+## Ends in an error in state: 846.
 ##
 ## _expr -> additive . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -8777,7 +8780,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1096.
+## Ends in an error in state: 1100.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8789,7 +8792,7 @@ Expecting a type name
 
 implementation: LBRACKETBAR UIDENT COLON WITH
 ##
-## Ends in an error in state: 1093.
+## Ends in an error in state: 1097.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8801,7 +8804,7 @@ implementation: LBRACKETBAR UIDENT COLON WITH
 
 implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1091.
+## Ends in an error in state: 1095.
 ##
 ## type_constraint -> COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8813,7 +8816,7 @@ implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 
 implementation: LBRACKETBAR UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1088.
+## Ends in an error in state: 1092.
 ##
 ## expr_comma_seq -> expr_comma_seq COMMA . expr_optional_constraint [ error COMMA BARRBRACKET ]
 ## opt_comma -> COMMA . [ error BARRBRACKET ]
@@ -8826,7 +8829,7 @@ implementation: LBRACKETBAR UIDENT COMMA WITH
 
 implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 ##
-## Ends in an error in state: 452.
+## Ends in an error in state: 473.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT . attr_id payload RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -8838,7 +8841,7 @@ implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH COLON WITH
 ##
-## Ends in an error in state: 1440.
+## Ends in an error in state: 1362.
 ##
 ## payload -> COLON . core_type [ RBRACKET ]
 ##
@@ -8862,7 +8865,7 @@ implementation: LBRACKETPERCENTPERCENT WITH DOT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ##
-## Ends in an error in state: 2437.
+## Ends in an error in state: 2458.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN RBRACKET BAR ]
 ## payload -> QUESTION pattern . [ RBRACKET ]
@@ -8875,14 +8878,14 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 654, spurious reduction of production pattern -> pattern_without_or
+## In state 673, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2439.
+## Ends in an error in state: 2460.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8917,21 +8920,21 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 910, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 880, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 890, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 919, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 889, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 912, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 882, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 921, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 891, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2438.
+## Ends in an error in state: 2459.
 ##
 ## payload -> QUESTION pattern WHEN . expr [ RBRACKET ]
 ##
@@ -8956,7 +8959,7 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION WITH
 
 implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2302.
+## Ends in an error in state: 2250.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -8967,23 +8970,23 @@ implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1901, spurious reduction of production post_item_attributes ->
-## In state 1902, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1903, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1815, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1904, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1816, spurious reduction of production structure -> structure_item
-## In state 1907, spurious reduction of production payload -> structure
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1828, spurious reduction of production post_item_attributes ->
+## In state 1829, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1830, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1744, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1737, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1831, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1745, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1738, spurious reduction of production structure -> structure_item
+## In state 1834, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
@@ -9003,7 +9006,7 @@ implementation: LBRACKETPERCENTPERCENT WITH WITH
 
 implementation: LET CHAR EQUAL CHAR AND WITH
 ##
-## Ends in an error in state: 1852.
+## Ends in an error in state: 1779.
 ##
 ## and_let_binding -> AND . let_binding_body post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9015,7 +9018,7 @@ implementation: LET CHAR EQUAL CHAR AND WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1868.
+## Ends in an error in state: 1795.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -9050,21 +9053,21 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1872.
+## Ends in an error in state: 1799.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9076,7 +9079,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1871.
+## Ends in an error in state: 1798.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9099,7 +9102,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1870.
+## Ends in an error in state: 1797.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9111,7 +9114,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1869.
+## Ends in an error in state: 1796.
 ##
 ## let_binding_body -> val_ident COLON typevar_list . DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -9124,7 +9127,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1866.
+## Ends in an error in state: 1793.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9136,7 +9139,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1865.
+## Ends in an error in state: 1792.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9159,7 +9162,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1864.
+## Ends in an error in state: 1791.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9171,7 +9174,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1567.
+## Ends in an error in state: 1489.
 ##
 ## lident_list -> LIDENT . [ DOT ]
 ## lident_list -> LIDENT . lident_list [ DOT ]
@@ -9184,7 +9187,7 @@ implementation: LET LIDENT COLON TYPE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 1862.
+## Ends in an error in state: 1789.
 ##
 ## let_binding_body -> val_ident COLON TYPE . lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9196,7 +9199,7 @@ implementation: LET LIDENT COLON TYPE WITH
 
 implementation: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 1861.
+## Ends in an error in state: 1788.
 ##
 ## let_binding_body -> val_ident COLON . typevar_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## let_binding_body -> val_ident COLON . TYPE lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9210,7 +9213,7 @@ implementation: LET LIDENT COLON WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1875.
+## Ends in an error in state: 1802.
 ##
 ## let_binding_body -> val_ident type_constraint EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9222,7 +9225,7 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 1874.
+## Ends in an error in state: 1801.
 ##
 ## let_binding_body -> val_ident type_constraint . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9239,14 +9242,14 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ## In state 271, spurious reduction of production _core_type -> core_type2
 ## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1071, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1075, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1859.
+## Ends in an error in state: 1786.
 ##
 ## _curried_binding_return_typed -> EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9258,7 +9261,7 @@ implementation: LET LIDENT EQUALGREATER WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1857.
+## Ends in an error in state: 1784.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9270,7 +9273,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1856.
+## Ends in an error in state: 1783.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9282,7 +9285,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1855.
+## Ends in an error in state: 1782.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9294,7 +9297,7 @@ implementation: LET LIDENT LPAREN TYPE WITH
 
 implementation: LET LIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1854.
+## Ends in an error in state: 1781.
 ##
 ## _curried_binding_return_typed -> LPAREN . TYPE LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -9317,7 +9320,7 @@ implementation: LET LIDENT LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1680.
+## Ends in an error in state: 1602.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -9352,21 +9355,21 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1679.
+## Ends in an error in state: 1601.
 ##
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9378,7 +9381,7 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1678.
+## Ends in an error in state: 1600.
 ##
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type . EQUALGREATER expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9392,7 +9395,7 @@ Expecting "=>" to start the function body
 
 implementation: LET LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1677.
+## Ends in an error in state: 1599.
 ##
 ## curried_binding_return_typed_ -> COLON . non_arrowed_core_type EQUALGREATER expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9404,7 +9407,7 @@ implementation: LET LIDENT UNDERSCORE COLON WITH
 
 implementation: LET LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1675.
+## Ends in an error in state: 1597.
 ##
 ## curried_binding -> EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9416,7 +9419,7 @@ Expecting an expression as function body
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1674.
+## Ends in an error in state: 1596.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9428,7 +9431,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1673.
+## Ends in an error in state: 1595.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9440,7 +9443,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1672.
+## Ends in an error in state: 1594.
 ##
 ## curried_binding -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9452,7 +9455,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 1671.
+## Ends in an error in state: 1593.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -9475,7 +9478,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 1681.
+## Ends in an error in state: 1603.
 ##
 ## curried_binding -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9487,7 +9490,7 @@ implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 
 implementation: LET LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1878.
+## Ends in an error in state: 1805.
 ##
 ## _curried_binding_return_typed -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9503,7 +9506,7 @@ Expecting one of the following:
 
 implementation: LET LIDENT WITH
 ##
-## Ends in an error in state: 1853.
+## Ends in an error in state: 1780.
 ##
 ## _simple_pattern -> val_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> val_ident . type_constraint EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9519,7 +9522,7 @@ implementation: LET LIDENT WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 ##
-## Ends in an error in state: 1837.
+## Ends in an error in state: 1764.
 ##
 ## and_nonlocal_module_bindings -> AND . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9531,7 +9534,7 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1836.
+## Ends in an error in state: 1763.
 ##
 ## _structure_item_without_item_extension_sugar -> many_nonlocal_module_bindings . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> many_nonlocal_module_bindings . and_nonlocal_module_bindings [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -9543,16 +9546,16 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WIT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1384, spurious reduction of production post_item_attributes ->
-## In state 1385, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2325, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
+## In state 1315, spurious reduction of production post_item_attributes ->
+## In state 1316, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2273, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE REC WITH
 ##
-## Ends in an error in state: 2323.
+## Ends in an error in state: 2271.
 ##
 ## many_nonlocal_module_bindings -> LET MODULE REC . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9564,7 +9567,7 @@ implementation: LET MODULE REC WITH
 
 implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2310.
+## Ends in an error in state: 2258.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9578,19 +9581,19 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1373, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1377, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1374, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1296, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1379, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1378, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2090, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2094, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2091, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 481, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2096, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2095, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2309.
+## Ends in an error in state: 2257.
 ##
 ## module_binding_body_expr -> COLON module_type EQUAL . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9602,7 +9605,7 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
 
 implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2308.
+## Ends in an error in state: 2256.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER EQUAL ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER EQUAL ]
@@ -9618,22 +9621,22 @@ implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 130, spurious reduction of production ident -> UIDENT
 ## In state 253, spurious reduction of production mty_longident -> ident
-## In state 1956, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1988, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1984, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1954, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1989, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1985, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1955, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1990, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1986, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1937, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1969, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1965, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1935, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1970, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1966, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1936, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1971, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1967, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2307.
+## Ends in an error in state: 2255.
 ##
 ## module_binding_body_expr -> COLON . module_type EQUAL module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9645,7 +9648,7 @@ implementation: LET MODULE UIDENT COLON WITH
 
 implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2306.
+## Ends in an error in state: 2254.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9659,19 +9662,19 @@ implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1373, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1377, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1374, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1296, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1379, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1378, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2090, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2094, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2091, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 481, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2096, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2095, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 450.
+## Ends in an error in state: 471.
 ##
 ## module_binding_body_expr -> EQUAL . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9683,7 +9686,7 @@ implementation: LET MODULE UIDENT EQUAL WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2321.
+## Ends in an error in state: 2269.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER module_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9697,19 +9700,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1373, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1377, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1374, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1296, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1379, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1378, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2090, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2094, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2091, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 481, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2096, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2095, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2320.
+## Ends in an error in state: 2268.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9721,7 +9724,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2319.
+## Ends in an error in state: 2267.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type . EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_type -> non_arrowed_module_type . [ WITH LBRACKETAT EQUALGREATER ]
@@ -9735,19 +9738,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 130, spurious reduction of production ident -> UIDENT
 ## In state 253, spurious reduction of production mty_longident -> ident
-## In state 1956, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1988, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1984, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1954, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1989, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1985, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1937, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1969, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1965, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1935, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1970, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1966, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER SEMI
 ##
-## Ends in an error in state: 2150.
+## Ends in an error in state: 2218.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER ]
@@ -9766,18 +9769,18 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT CO
 ## In state 271, spurious reduction of production _core_type -> core_type2
 ## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1963, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1977, spurious reduction of production with_constraints -> with_constraint
-## In state 1974, spurious reduction of production _module_type -> module_type WITH with_constraints
-## In state 1990, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1986, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1944, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1958, spurious reduction of production with_constraints -> with_constraint
+## In state 1955, spurious reduction of production _module_type -> module_type WITH with_constraints
+## In state 1971, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1967, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
 ##
-## Ends in an error in state: 2318.
+## Ends in an error in state: 2266.
 ##
 ## _module_binding_body_functor -> functor_args COLON . non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9789,7 +9792,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2317.
+## Ends in an error in state: 2265.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER module_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9803,19 +9806,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1373, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1377, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1374, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1296, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1379, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1378, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2090, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2094, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2091, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 481, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2096, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2095, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2316.
+## Ends in an error in state: 2264.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9827,7 +9830,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2315.
+## Ends in an error in state: 2263.
 ##
 ## _module_binding_body_functor -> functor_args . EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_binding_body_functor -> functor_args . COLON non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9841,7 +9844,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 
 implementation: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 449.
+## Ends in an error in state: 470.
 ##
 ## nonlocal_module_binding_details -> UIDENT . module_binding_body [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9853,7 +9856,7 @@ implementation: LET MODULE UIDENT WITH
 
 implementation: LET MODULE WITH
 ##
-## Ends in an error in state: 448.
+## Ends in an error in state: 469.
 ##
 ## _structure_item_without_item_extension_sugar -> LET MODULE . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> LET MODULE . REC nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -9866,7 +9869,7 @@ implementation: LET MODULE WITH
 
 implementation: LET REC ASSERT
 ##
-## Ends in an error in state: 2328.
+## Ends in an error in state: 2276.
 ##
 ## let_binding_impl -> LET rec_flag . let_binding_body post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9878,7 +9881,7 @@ implementation: LET REC ASSERT
 
 implementation: LET UIDENT UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1887.
+## Ends in an error in state: 1814.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EQUAL BAR ]
 ## let_binding_body -> pattern . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9890,17 +9893,17 @@ implementation: LET UIDENT UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 650, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
-## In state 653, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
-## In state 648, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
-## In state 654, spurious reduction of production pattern -> pattern_without_or
+## In state 669, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
+## In state 672, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
+## In state 667, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
+## In state 673, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1885.
+## Ends in an error in state: 1812.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9912,7 +9915,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1884.
+## Ends in an error in state: 1811.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9935,7 +9938,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 
 implementation: LET UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1883.
+## Ends in an error in state: 1810.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON . core_type EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9947,7 +9950,7 @@ implementation: LET UNDERSCORE COLON WITH
 
 implementation: LET UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1888.
+## Ends in an error in state: 1815.
 ##
 ## let_binding_body -> pattern EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9959,7 +9962,7 @@ implementation: LET UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE WITH
 ##
-## Ends in an error in state: 1882.
+## Ends in an error in state: 1809.
 ##
 ## _simple_pattern -> simple_pattern_not_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> simple_pattern_not_ident . COLON core_type EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9972,7 +9975,7 @@ implementation: LET UNDERSCORE WITH
 
 implementation: LET WITH
 ##
-## Ends in an error in state: 447.
+## Ends in an error in state: 468.
 ##
 ## _structure_item_without_item_extension_sugar -> LET . MODULE nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -9986,7 +9989,7 @@ Incomplete let binding
 
 implementation: LPAREN ASSERT WITH
 ##
-## Ends in an error in state: 811.
+## Ends in an error in state: 810.
 ##
 ## _expr -> ASSERT . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -9998,7 +10001,7 @@ implementation: LPAREN ASSERT WITH
 
 implementation: LPAREN BACKQUOTE WITH
 ##
-## Ends in an error in state: 464.
+## Ends in an error in state: 443.
 ##
 ## name_tag -> BACKQUOTE . ident [ error UNDERSCORE UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10010,7 +10013,7 @@ implementation: LPAREN BACKQUOTE WITH
 
 implementation: LPAREN BANG WITH
 ##
-## Ends in an error in state: 805.
+## Ends in an error in state: 804.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SHARPOP SHARP RPAREN QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## operator -> BANG . [ RPAREN ]
@@ -10023,7 +10026,7 @@ implementation: LPAREN BANG WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 ##
-## Ends in an error in state: 746.
+## Ends in an error in state: 788.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag . simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10035,7 +10038,7 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ##
-## Ends in an error in state: 741.
+## Ends in an error in state: 785.
 ##
 ## _expr -> FOR pattern IN simple_expr . direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ TO SHARPOP SHARP DOWNTO DOT ]
@@ -10054,17 +10057,17 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 874, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 855, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FOR UNDERSCORE IN WITH
 ##
-## Ends in an error in state: 740.
+## Ends in an error in state: 784.
 ##
 ## _expr -> FOR pattern IN . simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10076,7 +10079,7 @@ implementation: LPAREN FOR UNDERSCORE IN WITH
 
 implementation: LPAREN FOR WITH
 ##
-## Ends in an error in state: 738.
+## Ends in an error in state: 782.
 ##
 ## _expr -> FOR . pattern IN simple_expr direction_flag simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10088,7 +10091,7 @@ implementation: LPAREN FOR WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2240.
+## Ends in an error in state: 2151.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10123,17 +10126,17 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2239.
+## Ends in an error in state: 2150.
 ##
 ## leading_bar_match_case -> pattern_with_bar EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10145,7 +10148,7 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2238.
+## Ends in an error in state: 2149.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10180,17 +10183,17 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2237.
+## Ends in an error in state: 2148.
 ##
 ## leading_bar_match_case -> pattern_with_bar WHEN expr EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10202,7 +10205,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2236.
+## Ends in an error in state: 2147.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10237,21 +10240,21 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 910, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 880, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 890, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 919, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 889, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 912, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 882, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 921, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 891, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2235.
+## Ends in an error in state: 2146.
 ##
 ## leading_bar_match_case -> pattern_with_bar WHEN . expr EQUALGREATER expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10263,7 +10266,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 479.
+## Ends in an error in state: 504.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10275,7 +10278,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 478.
+## Ends in an error in state: 503.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10287,7 +10290,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN LPAREN TYPE WITH
 ##
-## Ends in an error in state: 477.
+## Ends in an error in state: 502.
 ##
 ## _expr -> FUN LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10299,7 +10302,7 @@ implementation: LPAREN FUN LPAREN TYPE WITH
 
 implementation: LPAREN FUN LPAREN WITH
 ##
-## Ends in an error in state: 476.
+## Ends in an error in state: 501.
 ##
 ## _expr -> FUN LPAREN . TYPE LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -10322,7 +10325,7 @@ implementation: LPAREN FUN LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2225.
+## Ends in an error in state: 2136.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10357,17 +10360,17 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2224.
+## Ends in an error in state: 2135.
 ##
 ## fun_def -> EQUALGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10379,7 +10382,7 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 483.
+## Ends in an error in state: 508.
 ##
 ## fun_def -> LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10391,7 +10394,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 482.
+## Ends in an error in state: 507.
 ##
 ## fun_def -> LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10403,7 +10406,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 481.
+## Ends in an error in state: 506.
 ##
 ## fun_def -> LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10415,7 +10418,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 480.
+## Ends in an error in state: 505.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -10438,7 +10441,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 2230.
+## Ends in an error in state: 2141.
 ##
 ## fun_def -> labeled_simple_pattern . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10450,7 +10453,7 @@ implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 
 implementation: LPAREN FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2244.
+## Ends in an error in state: 2155.
 ##
 ## _expr -> FUN labeled_simple_pattern . fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10462,7 +10465,7 @@ implementation: LPAREN FUN UNDERSCORE WITH
 
 implementation: LPAREN FUN WITH
 ##
-## Ends in an error in state: 475.
+## Ends in an error in state: 500.
 ##
 ## _expr -> FUN . labeled_simple_pattern fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> FUN . LPAREN TYPE LIDENT RPAREN fun_def [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10476,7 +10479,7 @@ implementation: LPAREN FUN WITH
 
 implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 ##
-## Ends in an error in state: 2288.
+## Ends in an error in state: 2345.
 ##
 ## _expr -> IF simple_expr simple_expr ELSE . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10488,7 +10491,7 @@ implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 
 implementation: LPAREN IF UIDENT WITH
 ##
-## Ends in an error in state: 2286.
+## Ends in an error in state: 2343.
 ##
 ## _expr -> IF simple_expr . simple_expr ELSE expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF simple_expr . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10508,17 +10511,17 @@ implementation: LPAREN IF UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 874, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 855, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN IF WITH
 ##
-## Ends in an error in state: 473.
+## Ends in an error in state: 452.
 ##
 ## _expr -> IF . simple_expr simple_expr ELSE expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF . simple_expr simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10531,7 +10534,7 @@ implementation: LPAREN IF WITH
 
 implementation: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 456.
+## Ends in an error in state: 435.
 ##
 ## _expr -> LAZY . simple_expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10550,6 +10553,8 @@ implementation: LPAREN LBRACE WITH
 ## _simple_expr -> LBRACE . DOTDOTDOT expr_optional_constraint opt_comma RBRACE [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE . record_expr RBRACE [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE . record_expr error [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
+## _simple_expr -> LBRACE . record_expr_with_string_keys RBRACE [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
+## _simple_expr -> LBRACE . record_expr_with_string_keys error [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE . class_self_pattern_and_structure RBRACE [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE . class_self_pattern_and_structure error [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10575,7 +10580,7 @@ implementation: LPAREN LBRACELESS WITH
 
 implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ##
-## Ends in an error in state: 2195.
+## Ends in an error in state: 1108.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT expr_optional_constraint . RBRACKET [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10586,22 +10591,22 @@ implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 910, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 880, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 890, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 919, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 889, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1069, spurious reduction of production expr_optional_constraint -> expr
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 912, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 882, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 921, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 891, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1073, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKET UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2198.
+## Ends in an error in state: 1111.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint COMMA . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## opt_comma -> COMMA . [ RBRACKET ]
@@ -10614,7 +10619,7 @@ implementation: LPAREN LBRACKET UIDENT COMMA WITH
 
 implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2370.
+## Ends in an error in state: 2391.
 ##
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10627,16 +10632,16 @@ implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1090, spurious reduction of production expr_optional_constraint -> expr
-## In state 1086, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1094, spurious reduction of production expr_optional_constraint -> expr
+## In state 1090, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
@@ -10669,7 +10674,7 @@ implementation: LPAREN LBRACKETPERCENT UNDERSCORE
 
 implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2440.
+## Ends in an error in state: 2461.
 ##
 ## extension -> LBRACKETPERCENT attr_id payload . RBRACKET [ error WITH UNDERSCORE UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10680,30 +10685,30 @@ implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1901, spurious reduction of production post_item_attributes ->
-## In state 1902, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1903, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1815, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1904, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1816, spurious reduction of production structure -> structure_item
-## In state 1907, spurious reduction of production payload -> structure
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1828, spurious reduction of production post_item_attributes ->
+## In state 1829, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1830, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1744, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1737, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1831, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1745, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1738, spurious reduction of production structure -> structure_item
+## In state 1834, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 833.
+## Ends in an error in state: 832.
 ##
 ## _expr -> label EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10715,7 +10720,7 @@ implementation: LPAREN LIDENT EQUAL WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ##
-## Ends in an error in state: 2393.
+## Ends in an error in state: 2414.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr . RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10750,21 +10755,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 910, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 880, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 890, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 919, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 889, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 912, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 882, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 921, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 891, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2392.
+## Ends in an error in state: 2413.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA . expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10776,7 +10781,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2391.
+## Ends in an error in state: 2412.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr . COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10811,21 +10816,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 910, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 880, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 890, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 919, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 889, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 912, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 882, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 921, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 891, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2390.
+## Ends in an error in state: 2411.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN . expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10837,7 +10842,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2389.
+## Ends in an error in state: 2410.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN . LPAREN expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10849,7 +10854,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2388.
+## Ends in an error in state: 2409.
 ##
 ## _expr -> LPAREN COLONCOLON . RPAREN LPAREN expr COMMA expr RPAREN [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10861,7 +10866,7 @@ implementation: LPAREN LPAREN COLONCOLON WITH
 
 implementation: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2382.
+## Ends in an error in state: 2403.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -10877,12 +10882,12 @@ implementation: LPAREN LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 780, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 784, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 781, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 773, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 777, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 774, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
 ## In state 760, spurious reduction of production _module_expr -> simple_module_expr
-## In state 786, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 785, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 779, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 778, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
@@ -10903,7 +10908,7 @@ Expecting a module expression
 
 implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ##
-## Ends in an error in state: 2395.
+## Ends in an error in state: 2416.
 ##
 ## _simple_expr -> LPAREN expr_comma_list . RPAREN [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN expr_comma_list . error [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10916,12 +10921,12 @@ implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1090, spurious reduction of production expr_optional_constraint -> expr
-## In state 1147, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1094, spurious reduction of production expr_optional_constraint -> expr
+## In state 1154, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
@@ -10955,7 +10960,7 @@ Expecting one of the following:
 
 implementation: LPAREN MINUS WITH
 ##
-## Ends in an error in state: 788.
+## Ends in an error in state: 781.
 ##
 ## operator -> MINUS . [ RPAREN ]
 ## subtractive -> MINUS . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
@@ -10968,7 +10973,7 @@ implementation: LPAREN MINUS WITH
 
 implementation: LPAREN MINUSDOT WITH
 ##
-## Ends in an error in state: 787.
+## Ends in an error in state: 780.
 ##
 ## operator -> MINUSDOT . [ RPAREN ]
 ## subtractive -> MINUSDOT . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
@@ -10981,7 +10986,7 @@ implementation: LPAREN MINUSDOT WITH
 
 implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2386.
+## Ends in an error in state: 2407.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11001,7 +11006,7 @@ implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2384.
+## Ends in an error in state: 2405.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -11091,7 +11096,7 @@ implementation: LPAREN PREFIXOP WITH
 
 implementation: LPAREN STAR WITH
 ##
-## Ends in an error in state: 582.
+## Ends in an error in state: 607.
 ##
 ## val_ident -> LPAREN operator . RPAREN [ error UNDERSCORE UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11103,7 +11108,7 @@ implementation: LPAREN STAR WITH
 
 implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1075.
+## Ends in an error in state: 1079.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -11115,7 +11120,7 @@ implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 
 implementation: LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1072.
+## Ends in an error in state: 1076.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -11127,7 +11132,7 @@ implementation: LPAREN UIDENT COLON WITH
 
 implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1145.
+## Ends in an error in state: 1152.
 ##
 ## expr_comma_list -> expr_optional_constraint . COMMA expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -11144,15 +11149,15 @@ implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 271, spurious reduction of production _core_type -> core_type2
 ## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1071, spurious reduction of production type_constraint -> COLONGREATER core_type
-## In state 2401, spurious reduction of production expr_optional_constraint -> expr type_constraint
+## In state 1075, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 2422, spurious reduction of production expr_optional_constraint -> expr type_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1070.
+## Ends in an error in state: 1074.
 ##
 ## type_constraint -> COLONGREATER . core_type [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -11164,7 +11169,7 @@ implementation: LPAREN UIDENT COLONGREATER WITH
 
 implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 1151.
+## Ends in an error in state: 1158.
 ##
 ## expr_comma_list -> expr_comma_list COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -11176,7 +11181,7 @@ implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 
 implementation: LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1146.
+## Ends in an error in state: 1153.
 ##
 ## expr_comma_list -> expr_optional_constraint COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -11249,7 +11254,7 @@ implementation: PERCENT WITH WITH
 
 implementation: STRING LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 825.
+## Ends in an error in state: 824.
 ##
 ## label_expr -> LIDENT COLONCOLON . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11261,7 +11266,7 @@ implementation: STRING LIDENT COLONCOLON WITH
 
 implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 822.
+## Ends in an error in state: 821.
 ##
 ## label_expr -> LIDENT EXPLICITLY_PASSED_OPTIONAL . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11273,7 +11278,7 @@ implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: STRING WITH
 ##
-## Ends in an error in state: 1816.
+## Ends in an error in state: 1738.
 ##
 ## structure -> structure_item . [ RBRACKET RBRACE EOF ]
 ## structure -> structure_item . error structure [ RBRACKET RBRACE EOF ]
@@ -11286,24 +11291,24 @@ implementation: STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1901, spurious reduction of production post_item_attributes ->
-## In state 1902, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1903, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1815, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1904, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1828, spurious reduction of production post_item_attributes ->
+## In state 1829, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1830, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1744, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1737, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1831, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1745, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 Incomplete statement. Did you forget a ";"?
 
 implementation: SWITCH UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2449.
+## Ends in an error in state: 2470.
 ##
 ## _expr -> SWITCH simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11315,7 +11320,7 @@ implementation: SWITCH UIDENT LBRACE WITH
 
 implementation: SWITCH UIDENT WITH
 ##
-## Ends in an error in state: 2448.
+## Ends in an error in state: 2469.
 ##
 ## _expr -> SWITCH simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ SHARPOP SHARP LBRACE DOT ]
@@ -11334,10 +11339,10 @@ implementation: SWITCH UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 874, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 855, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -11356,7 +11361,7 @@ implementation: SWITCH WITH
 
 implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 ##
-## Ends in an error in state: 1060.
+## Ends in an error in state: 1064.
 ##
 ## _expr -> simple_expr DOT LBRACE expr RBRACE EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11368,7 +11373,7 @@ implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 
 implementation: TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 1058.
+## Ends in an error in state: 1062.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11404,21 +11409,21 @@ implementation: TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 910, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 880, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 890, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 919, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 889, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 912, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 882, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 921, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 891, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 1057.
+## Ends in an error in state: 1061.
 ##
 ## _expr -> simple_expr DOT LBRACE . expr RBRACE EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11431,7 +11436,7 @@ implementation: TRUE DOT LBRACE WITH
 
 implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 ##
-## Ends in an error in state: 1055.
+## Ends in an error in state: 1059.
 ##
 ## _expr -> simple_expr DOT LBRACKET expr RBRACKET EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11443,7 +11448,7 @@ implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 
 implementation: TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 1052.
+## Ends in an error in state: 1056.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11480,21 +11485,21 @@ implementation: TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1051.
+## Ends in an error in state: 1055.
 ##
 ## _expr -> simple_expr DOT LBRACKET . expr RBRACKET EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11508,7 +11513,7 @@ implementation: TRUE DOT LBRACKET WITH
 
 implementation: TRUE DOT LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1063.
+## Ends in an error in state: 1067.
 ##
 ## _expr -> simple_expr DOT label_longident EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11520,7 +11525,7 @@ implementation: TRUE DOT LIDENT EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 ##
-## Ends in an error in state: 1049.
+## Ends in an error in state: 1053.
 ##
 ## _expr -> simple_expr DOT LPAREN expr RPAREN EQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11532,7 +11537,7 @@ implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1046.
+## Ends in an error in state: 1050.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11569,21 +11574,21 @@ implementation: TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 816.
+## Ends in an error in state: 815.
 ##
 ## _expr -> simple_expr DOT LPAREN . expr RPAREN EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11597,7 +11602,7 @@ implementation: TRUE DOT LPAREN WITH
 
 implementation: TRUE DOT UIDENT DOT WITH
 ##
-## Ends in an error in state: 518.
+## Ends in an error in state: 543.
 ##
 ## label_longident -> mod_longident DOT . LIDENT [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident DOT . UIDENT [ DOT ]
@@ -11610,7 +11615,7 @@ implementation: TRUE DOT UIDENT DOT WITH
 
 implementation: TRUE DOT UIDENT WITH
 ##
-## Ends in an error in state: 517.
+## Ends in an error in state: 542.
 ##
 ## label_longident -> mod_longident . DOT LIDENT [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident . DOT UIDENT [ DOT ]
@@ -11623,7 +11628,7 @@ implementation: TRUE DOT UIDENT WITH
 
 implementation: TRUE DOT WITH
 ##
-## Ends in an error in state: 815.
+## Ends in an error in state: 814.
 ##
 ## _expr -> simple_expr DOT . label_longident EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> simple_expr DOT . LPAREN expr RPAREN EQUAL expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -11644,7 +11649,7 @@ implementation: TRUE DOT WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER CHAR BAR WITH
 ##
-## Ends in an error in state: 767.
+## Ends in an error in state: 1032.
 ##
 ## pattern_with_bar -> BAR . pattern [ WHEN EQUALGREATER ]
 ##
@@ -11656,7 +11661,7 @@ Expecting a match case
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT RBRACKET
 ##
-## Ends in an error in state: 780.
+## Ends in an error in state: 773.
 ##
 ## _simple_module_expr -> mod_longident . [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF DOT COLON AND ]
@@ -11669,7 +11674,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2117.
+## Ends in an error in state: 2185.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11681,7 +11686,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1162.
+## Ends in an error in state: 2174.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11693,7 +11698,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 ##
-## Ends in an error in state: 1161.
+## Ends in an error in state: 2173.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11705,7 +11710,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 ##
-## Ends in an error in state: 2122.
+## Ends in an error in state: 2190.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11717,7 +11722,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2125.
+## Ends in an error in state: 2193.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11729,7 +11734,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2124.
+## Ends in an error in state: 2192.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11740,14 +11745,14 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2123, spurious reduction of production post_item_attributes ->
+## In state 2191, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 ##
-## Ends in an error in state: 2121.
+## Ends in an error in state: 2189.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11759,7 +11764,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 ##
-## Ends in an error in state: 1160.
+## Ends in an error in state: 2172.
 ##
 ## _semi_terminated_seq_expr_row -> LET . MODULE UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI RBRACE BAR AND ]
@@ -11773,7 +11778,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 ##
-## Ends in an error in state: 2132.
+## Ends in an error in state: 2200.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ RBRACE BAR ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI RBRACE BAR AND ]
@@ -11793,7 +11798,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 2568.
+## Ends in an error in state: 2589.
 ##
 ## _expr -> TRY simple_expr LBRACE leading_bar_match_cases_to_sequence_body . RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## leading_bar_match_cases_to_sequence_body -> leading_bar_match_cases_to_sequence_body . leading_bar_match_case_to_sequence_body [ RBRACE BAR ]
@@ -11805,24 +11810,24 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 910, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 880, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 890, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 919, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 889, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2134, spurious reduction of production post_item_attributes ->
-## In state 2135, spurious reduction of production opt_semi ->
-## In state 2140, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
-## In state 2138, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
-## In state 2127, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
-## In state 2118, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
-## In state 2139, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2128, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
-## In state 2154, spurious reduction of production leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER semi_terminated_seq_expr
-## In state 2158, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 912, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 882, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 921, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 891, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2202, spurious reduction of production post_item_attributes ->
+## In state 2203, spurious reduction of production opt_semi ->
+## In state 2208, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
+## In state 2206, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
+## In state 2195, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
+## In state 2186, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
+## In state 2207, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2196, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2222, spurious reduction of production leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER semi_terminated_seq_expr
+## In state 2226, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
 ##
 
 Expecting one of the following:
@@ -11831,7 +11836,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2153.
+## Ends in an error in state: 2221.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11843,7 +11848,7 @@ Expecting the body of the matched pattern
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ##
-## Ends in an error in state: 768.
+## Ends in an error in state: 1033.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN EQUALGREATER BAR ]
 ## pattern_with_bar -> BAR pattern . [ WHEN EQUALGREATER ]
@@ -11855,7 +11860,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 654, spurious reduction of production pattern -> pattern_without_or
+## In state 673, spurious reduction of production pattern -> pattern_without_or
 ##
 
 Expecting one of the following:
@@ -11865,7 +11870,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1159.
+## Ends in an error in state: 2171.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar WHEN expr EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11877,7 +11882,7 @@ Expecting a sequence item
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 1158.
+## Ends in an error in state: 2170.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11912,21 +11917,21 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 910, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 880, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 890, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 919, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 889, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 912, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 882, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 921, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 891, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 770.
+## Ends in an error in state: 2169.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar WHEN . expr EQUALGREATER semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11938,7 +11943,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 
 implementation: TRY UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2567.
+## Ends in an error in state: 2588.
 ##
 ## _expr -> TRY simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11950,7 +11955,7 @@ implementation: TRY UIDENT LBRACE WITH
 
 implementation: TRY UIDENT UNDERSCORE
 ##
-## Ends in an error in state: 2564.
+## Ends in an error in state: 2585.
 ##
 ## _expr -> TRY simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> TRY simple_expr . WITH error [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -11970,17 +11975,17 @@ implementation: TRY UIDENT UNDERSCORE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 874, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 855, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT WITH WITH
 ##
-## Ends in an error in state: 2565.
+## Ends in an error in state: 2586.
 ##
 ## _expr -> TRY simple_expr WITH . error [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12005,7 +12010,7 @@ implementation: TRY WITH
 
 implementation: TYPE LIDENT AND LIDENT WITH
 ##
-## Ends in an error in state: 1827.
+## Ends in an error in state: 1749.
 ##
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -12016,14 +12021,14 @@ implementation: TYPE LIDENT AND LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1826, spurious reduction of production optional_type_parameters ->
+## In state 1748, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT AND WITH
 ##
-## Ends in an error in state: 1825.
+## Ends in an error in state: 1747.
 ##
 ## and_type_declaration -> AND . type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -12035,7 +12040,7 @@ implementation: TYPE LIDENT AND WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1334.
+## Ends in an error in state: 1754.
 ##
 ## constrain -> core_type EQUAL . core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -12047,7 +12052,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1333.
+## Ends in an error in state: 1753.
 ##
 ## constrain -> core_type . EQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -12070,7 +12075,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 
 implementation: TYPE LIDENT CONSTRAINT WITH
 ##
-## Ends in an error in state: 1332.
+## Ends in an error in state: 1752.
 ##
 ## constraints -> constraints CONSTRAINT . constrain [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -12082,7 +12087,7 @@ implementation: TYPE LIDENT CONSTRAINT WITH
 
 implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2523.
+## Ends in an error in state: 2544.
 ##
 ## constructor_declarations -> constructor_declarations_leading_bar . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations_leading_bar -> constructor_declarations_leading_bar . constructor_declaration_leading_bar [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
@@ -12094,17 +12099,17 @@ implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1402, spurious reduction of production attributes ->
-## In state 1403, spurious reduction of production attributes -> attribute attributes
-## In state 2508, spurious reduction of production constructor_declaration_leading_bar -> BAR UIDENT generalized_constructor_arguments attributes
-## In state 2528, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
+## In state 1324, spurious reduction of production attributes ->
+## In state 1325, spurious reduction of production attributes -> attribute attributes
+## In state 2529, spurious reduction of production constructor_declaration_leading_bar -> BAR UIDENT generalized_constructor_arguments attributes
+## In state 2549, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 ##
-## Ends in an error in state: 1829.
+## Ends in an error in state: 1751.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_declaration_details -> LIDENT optional_type_parameters type_kind constraints . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -12117,7 +12122,7 @@ implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 ##
-## Ends in an error in state: 1258.
+## Ends in an error in state: 1272.
 ##
 ## label_declarations -> label_declarations COMMA . label_declaration [ RBRACE COMMA ]
 ## opt_comma -> COMMA . [ RBRACE ]
@@ -12132,7 +12137,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2532.
+## Ends in an error in state: 2553.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12150,12 +12155,12 @@ implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ## In state 271, spurious reduction of production _core_type -> core_type2
 ## In state 280, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 267, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1255, spurious reduction of production _poly_type -> core_type
-## In state 1256, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1254, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 1252, spurious reduction of production attributes ->
-## In state 1253, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 1262, spurious reduction of production label_declarations -> label_declaration
+## In state 1269, spurious reduction of production _poly_type -> core_type
+## In state 1270, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1268, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 1266, spurious reduction of production attributes ->
+## In state 1267, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 1276, spurious reduction of production label_declarations -> label_declaration
 ##
 
 Expecting one of the following:
@@ -12164,7 +12169,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1246.
+## Ends in an error in state: 1260.
 ##
 ## label_declaration -> mutable_flag LIDENT COLON . poly_type attributes [ RBRACE COMMA ]
 ##
@@ -12176,7 +12181,7 @@ Expecting a type name describing this field
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 1245.
+## Ends in an error in state: 1259.
 ##
 ## label_declaration -> mutable_flag LIDENT . COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -12189,7 +12194,7 @@ Expecting ":"
 
 implementation: TYPE LIDENT EQUAL LBRACE MUTABLE LET
 ##
-## Ends in an error in state: 1244.
+## Ends in an error in state: 1258.
 ##
 ## label_declaration -> mutable_flag . LIDENT COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -12202,7 +12207,7 @@ Expecting a type field definition in the form of:
 
 implementation: TYPE LIDENT EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2531.
+## Ends in an error in state: 2552.
 ##
 ## type_kind -> EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -12215,7 +12220,7 @@ Expecting at least one type field definition in the form of:
 
     implementation: TYPE LIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 2495.
+## Ends in an error in state: 2516.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
 ## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
@@ -12229,7 +12234,7 @@ Expecting at least one type field definition in the form of:
 
 implementation: TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 2494.
+## Ends in an error in state: 2515.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL PRIVATE . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12257,7 +12262,7 @@ implementation: TYPE LIDENT EQUAL UIDENT WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 ##
-## Ends in an error in state: 2505.
+## Ends in an error in state: 2526.
 ##
 ## constructor_declaration_leading_bar -> BAR . UIDENT generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
 ## constructor_declaration_leading_bar -> BAR . LPAREN RPAREN generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
@@ -12273,7 +12278,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 2544.
+## Ends in an error in state: 2565.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12285,17 +12290,17 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDO
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1200, spurious reduction of production attributes ->
-## In state 1201, spurious reduction of production attributes -> attribute attributes
-## In state 1253, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 1262, spurious reduction of production label_declarations -> label_declaration
+## In state 1214, spurious reduction of production attributes ->
+## In state 1215, spurious reduction of production attributes -> attribute attributes
+## In state 1267, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 1276, spurious reduction of production label_declarations -> label_declaration
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2543.
+## Ends in an error in state: 2564.
 ##
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -12307,7 +12312,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 ##
-## Ends in an error in state: 2538.
+## Ends in an error in state: 2559.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL core_type EQUAL PRIVATE . constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12320,7 +12325,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2526.
+## Ends in an error in state: 2547.
 ##
 ## constructor_declarations -> constructor_declaration_no_leading_bar . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations -> constructor_declaration_no_leading_bar . constructor_declarations_leading_bar [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12332,16 +12337,16 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1402, spurious reduction of production attributes ->
-## In state 1403, spurious reduction of production attributes -> attribute attributes
-## In state 2490, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
+## In state 1324, spurious reduction of production attributes ->
+## In state 1325, spurious reduction of production attributes -> attribute attributes
+## In state 2511, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2536.
+## Ends in an error in state: 2557.
 ##
 ## type_kind -> EQUAL core_type EQUAL . constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type EQUAL . PRIVATE constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12356,7 +12361,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 2535.
+## Ends in an error in state: 2556.
 ##
 ## type_kind -> EQUAL core_type . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type . EQUAL constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12372,11 +12377,11 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 332, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 690, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 684, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 686, spurious reduction of production _core_type -> core_type2
-## In state 697, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 685, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 709, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 703, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 705, spurious reduction of production _core_type -> core_type2
+## In state 716, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 704, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
@@ -12404,7 +12409,7 @@ implementation: TYPE LIDENT EQUAL WITH
 
 implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1824.
+## Ends in an error in state: 1746.
 ##
 ## _structure_item_without_item_extension_sugar -> many_type_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -12416,9 +12421,9 @@ implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1384, spurious reduction of production post_item_attributes ->
-## In state 1385, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2550, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 1315, spurious reduction of production post_item_attributes ->
+## In state 1316, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2571, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
@@ -12475,7 +12480,7 @@ implementation: TYPE LIDENT PLUS WITH
 
 implementation: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 2554.
+## Ends in an error in state: 2575.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12487,7 +12492,7 @@ implementation: TYPE LIDENT PLUSEQ BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 2553.
+## Ends in an error in state: 2574.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12499,7 +12504,7 @@ implementation: TYPE LIDENT PLUSEQ PRIVATE BANG
 
 implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 2556.
+## Ends in an error in state: 2577.
 ##
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_rebind [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -12512,7 +12517,7 @@ implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 2552.
+## Ends in an error in state: 2573.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12560,7 +12565,7 @@ Expecting one of the following:
 
 implementation: TYPE UIDENT DOT WITH
 ##
-## Ends in an error in state: 1937.
+## Ends in an error in state: 1864.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -12574,7 +12579,7 @@ implementation: TYPE UIDENT DOT WITH
 
 implementation: TYPE UIDENT WITH
 ##
-## Ends in an error in state: 1936.
+## Ends in an error in state: 1863.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -12613,7 +12618,7 @@ implementation: TYPE WITH
 
 implementation: UIDENT AMPERAMPER WITH
 ##
-## Ends in an error in state: 1001.
+## Ends in an error in state: 1003.
 ##
 ## _expr -> expr AMPERAMPER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12625,7 +12630,7 @@ implementation: UIDENT AMPERAMPER WITH
 
 implementation: UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 999.
+## Ends in an error in state: 1001.
 ##
 ## _expr -> expr AMPERSAND . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12637,7 +12642,7 @@ implementation: UIDENT AMPERSAND WITH
 
 implementation: UIDENT BARBAR WITH
 ##
-## Ends in an error in state: 997.
+## Ends in an error in state: 999.
 ##
 ## _expr -> expr BARBAR . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12649,7 +12654,7 @@ implementation: UIDENT BARBAR WITH
 
 implementation: UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1003.
+## Ends in an error in state: 1005.
 ##
 ## _expr -> expr COLONEQUAL . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12661,7 +12666,7 @@ implementation: UIDENT COLONEQUAL WITH
 
 implementation: UIDENT DOT LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 1137.
+## Ends in an error in state: 1141.
 ##
 ## lbl_expr -> label_longident . COLON expr [ COMMA ]
 ## lbl_expr -> label_longident . [ COMMA ]
@@ -12675,7 +12680,7 @@ implementation: UIDENT DOT LBRACE LIDENT WITH
 
 implementation: UIDENT DOT LBRACE WITH
 ##
-## Ends in an error in state: 2208.
+## Ends in an error in state: 1121.
 ##
 ## _simple_expr -> mod_longident DOT LBRACE . RBRACE [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr RBRACE [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12689,7 +12694,7 @@ implementation: UIDENT DOT LBRACE WITH
 
 implementation: UIDENT DOT LBRACELESS WITH
 ##
-## Ends in an error in state: 2203.
+## Ends in an error in state: 1116.
 ##
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12702,7 +12707,7 @@ implementation: UIDENT DOT LBRACELESS WITH
 
 implementation: UIDENT DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2193.
+## Ends in an error in state: 1106.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12714,7 +12719,7 @@ implementation: UIDENT DOT LBRACKET WITH
 
 implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2189.
+## Ends in an error in state: 1091.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12727,23 +12732,23 @@ implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1090, spurious reduction of production expr_optional_constraint -> expr
-## In state 1086, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1094, spurious reduction of production expr_optional_constraint -> expr
+## In state 1090, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LBRACKETBAR WITH
 ##
-## Ends in an error in state: 2188.
+## Ends in an error in state: 1089.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12756,7 +12761,7 @@ implementation: UIDENT DOT LBRACKETBAR WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2181.
+## Ends in an error in state: 802.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12776,7 +12781,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2179.
+## Ends in an error in state: 800.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12789,7 +12794,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2178.
+## Ends in an error in state: 799.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -12804,19 +12809,19 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 780, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 784, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 781, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 773, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 777, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 774, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
 ## In state 760, spurious reduction of production _module_expr -> simple_module_expr
-## In state 786, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 785, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 779, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 778, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN MODULE WITH
 ##
-## Ends in an error in state: 756.
+## Ends in an error in state: 798.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON package_type RPAREN [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON error [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12829,7 +12834,7 @@ implementation: UIDENT DOT LPAREN MODULE WITH
 
 implementation: UIDENT DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1066.
+## Ends in an error in state: 1070.
 ##
 ## expr_comma_list -> expr_optional_constraint . COMMA expr_optional_constraint [ RPAREN COMMA ]
 ##
@@ -12840,22 +12845,22 @@ implementation: UIDENT DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2185, spurious reduction of production expr_optional_constraint -> expr
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1086, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN WITH
 ##
-## Ends in an error in state: 755.
+## Ends in an error in state: 797.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN . expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12872,7 +12877,7 @@ implementation: UIDENT DOT LPAREN WITH
 
 implementation: UIDENT DOT WITH
 ##
-## Ends in an error in state: 754.
+## Ends in an error in state: 796.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12898,7 +12903,7 @@ implementation: UIDENT DOT WITH
 
 implementation: UIDENT GREATER WITH
 ##
-## Ends in an error in state: 993.
+## Ends in an error in state: 995.
 ##
 ## _expr -> expr GREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr GREATER . GREATER expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -12911,7 +12916,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP0 WITH
 ##
-## Ends in an error in state: 991.
+## Ends in an error in state: 993.
 ##
 ## _expr -> expr INFIXOP0 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12923,7 +12928,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP1 WITH
 ##
-## Ends in an error in state: 985.
+## Ends in an error in state: 987.
 ##
 ## _expr -> expr INFIXOP1 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12935,7 +12940,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP2 WITH
 ##
-## Ends in an error in state: 983.
+## Ends in an error in state: 985.
 ##
 ## _expr -> expr INFIXOP2 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12947,7 +12952,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP3 WITH
 ##
-## Ends in an error in state: 969.
+## Ends in an error in state: 971.
 ##
 ## _expr -> expr INFIXOP3 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12959,7 +12964,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP4 WITH
 ##
-## Ends in an error in state: 837.
+## Ends in an error in state: 836.
 ##
 ## _expr -> expr INFIXOP4 . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12983,7 +12988,7 @@ Expecting an attribute id
 
 implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2418.
+## Ends in an error in state: 2439.
 ##
 ## attribute -> LBRACKETAT attr_id payload . RBRACKET [ error WITH UIDENT STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARRBRACKET BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12994,23 +12999,23 @@ implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1901, spurious reduction of production post_item_attributes ->
-## In state 1902, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1903, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1815, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1904, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1816, spurious reduction of production structure -> structure_item
-## In state 1907, spurious reduction of production payload -> structure
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1828, spurious reduction of production post_item_attributes ->
+## In state 1829, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1830, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1744, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1737, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1831, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1745, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1738, spurious reduction of production structure -> structure_item
+## In state 1834, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
@@ -13029,7 +13034,7 @@ Expecting an attributed id
 
 implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2415.
+## Ends in an error in state: 2436.
 ##
 ## item_attribute -> LBRACKETATAT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13040,30 +13045,30 @@ implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1901, spurious reduction of production post_item_attributes ->
-## In state 1902, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1903, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1815, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1904, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1816, spurious reduction of production structure -> structure_item
-## In state 1907, spurious reduction of production payload -> structure
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1828, spurious reduction of production post_item_attributes ->
+## In state 1829, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1830, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1744, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1737, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1831, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1745, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1738, spurious reduction of production structure -> structure_item
+## In state 1834, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
 
 implementation: UIDENT LESS WITH
 ##
-## Ends in an error in state: 989.
+## Ends in an error in state: 991.
 ##
 ## _expr -> expr LESS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13075,7 +13080,7 @@ Expecting an expression
 
 implementation: UIDENT LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 987.
+## Ends in an error in state: 989.
 ##
 ## _expr -> expr LESSDOTDOTGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13087,7 +13092,7 @@ Expecting an expression
 
 implementation: UIDENT LESSGREATER WITH
 ##
-## Ends in an error in state: 981.
+## Ends in an error in state: 983.
 ##
 ## _expr -> expr LESSGREATER . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13124,7 +13129,7 @@ Expecting one of the following:
 
 implementation: UIDENT MINUS WITH
 ##
-## Ends in an error in state: 979.
+## Ends in an error in state: 981.
 ##
 ## _expr -> expr MINUS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13136,7 +13141,7 @@ Expecting an expression
 
 implementation: UIDENT MINUSDOT WITH
 ##
-## Ends in an error in state: 977.
+## Ends in an error in state: 979.
 ##
 ## _expr -> expr MINUSDOT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13148,7 +13153,7 @@ Expecting an expression
 
 implementation: UIDENT OR WITH
 ##
-## Ends in an error in state: 975.
+## Ends in an error in state: 977.
 ##
 ## _expr -> expr OR . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13160,7 +13165,7 @@ Expecting an expression
 
 implementation: UIDENT PERCENT WITH
 ##
-## Ends in an error in state: 967.
+## Ends in an error in state: 969.
 ##
 ## _expr -> expr PERCENT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13172,7 +13177,7 @@ Expecting an expression
 
 implementation: UIDENT PLUS WITH
 ##
-## Ends in an error in state: 973.
+## Ends in an error in state: 975.
 ##
 ## _expr -> expr PLUS . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13184,7 +13189,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSDOT WITH
 ##
-## Ends in an error in state: 971.
+## Ends in an error in state: 973.
 ##
 ## _expr -> expr PLUSDOT . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13196,7 +13201,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 965.
+## Ends in an error in state: 967.
 ##
 ## _expr -> expr PLUSEQ . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13208,7 +13213,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1044.
+## Ends in an error in state: 1048.
 ##
 ## _expr -> expr QUESTION expr COLON . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13220,7 +13225,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT SEMI
 ##
-## Ends in an error in state: 1043.
+## Ends in an error in state: 1047.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -13255,14 +13260,14 @@ implementation: UIDENT QUESTION UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 910, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 880, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 890, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 919, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 889, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 912, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 882, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 921, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 891, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13271,7 +13276,7 @@ Expecting one of the following:
 
 implementation: UIDENT QUESTION WITH
 ##
-## Ends in an error in state: 850.
+## Ends in an error in state: 849.
 ##
 ## _expr -> expr QUESTION . expr COLON expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13283,7 +13288,7 @@ Expecting an expression
 
 implementation: UIDENT RBRACKET
 ##
-## Ends in an error in state: 2576.
+## Ends in an error in state: 2597.
 ##
 ## implementation -> structure . EOF [ # ]
 ##
@@ -13294,29 +13299,29 @@ implementation: UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1901, spurious reduction of production post_item_attributes ->
-## In state 1902, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1903, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1815, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1904, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1816, spurious reduction of production structure -> structure_item
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1828, spurious reduction of production post_item_attributes ->
+## In state 1829, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1830, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1744, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1737, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1831, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1745, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1738, spurious reduction of production structure -> structure_item
 ##
 
 Invalid token
 
 implementation: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 1905.
+## Ends in an error in state: 1832.
 ##
 ## structure -> structure_item SEMI . structure [ RBRACKET RBRACE EOF ]
 ##
@@ -13328,7 +13333,7 @@ Expecting a structure item
 
 implementation: UIDENT SHARP WITH
 ##
-## Ends in an error in state: 749.
+## Ends in an error in state: 791.
 ##
 ## _simple_expr -> simple_expr SHARP . label [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -13340,7 +13345,7 @@ Expecting an identifier
 
 implementation: UIDENT STAR WITH
 ##
-## Ends in an error in state: 835.
+## Ends in an error in state: 834.
 ##
 ## _expr -> expr STAR . expr [ error STAR SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13352,7 +13357,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 2296.
+## Ends in an error in state: 2353.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13387,14 +13392,14 @@ implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 796, spurious reduction of production constr_longident -> mod_longident
-## In state 910, spurious reduction of production _simple_expr -> constr_longident
-## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 872, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 880, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 890, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 919, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 889, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 753, spurious reduction of production constr_longident -> mod_longident
+## In state 912, spurious reduction of production _simple_expr -> constr_longident
+## In state 857, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 853, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 882, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 921, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 891, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13403,7 +13408,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 2295.
+## Ends in an error in state: 2352.
 ##
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -13415,7 +13420,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2293.
+## Ends in an error in state: 2350.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13451,14 +13456,14 @@ implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13467,7 +13472,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2292.
+## Ends in an error in state: 2349.
 ##
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr error [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -13480,7 +13485,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2290.
+## Ends in an error in state: 2347.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSGREATER LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13516,14 +13521,14 @@ implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 753, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 810, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 806, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 814, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 820, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 849, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 819, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 795, spurious reduction of production constr_longident -> mod_longident
+## In state 839, spurious reduction of production _simple_expr -> constr_longident
+## In state 809, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 805, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 813, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 819, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 848, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 818, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13532,7 +13537,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 472.
+## Ends in an error in state: 451.
 ##
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr error [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -13545,7 +13550,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT WITH
 ##
-## Ends in an error in state: 471.
+## Ends in an error in state: 450.
 ##
 ## _simple_expr -> simple_expr DOT . label_longident [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -2723,6 +2723,14 @@ _simple_expr:
       { let (exten, fields) = $2 in mkexp (Pexp_record(fields, exten)) }
   | as_loc(LBRACE) record_expr as_loc(error)
       { unclosed_exp (with_txt $1 "{") (with_txt $3 "}")}
+  | LBRACE record_expr_with_string_keys RBRACE
+      {
+        let (exten, fields) = $2 in
+        mkexp (Pexp_extension (mkloc ("bs.obj") (mklocation $symbolstartpos $endpos),
+               PStr [mkstrexp (mkexp (Pexp_record(fields, exten))) []]))
+      }
+  | as_loc(LBRACE) record_expr_with_string_keys as_loc(error)
+      { unclosed_exp (with_txt $1 "{") (with_txt $3 "}")}
   /* Todo: Why is this not a simple_expr? */
   | LBRACE class_self_pattern_and_structure RBRACE
       { mkexp (Pexp_object $2) }
@@ -3190,9 +3198,45 @@ lbl_expr:
       }
 ;
 
+record_expr_with_string_keys:
+    DOTDOTDOT expr_optional_constraint COMMA string_literal_expr_list { (Some $2, $4) }
+  | string_literal_expr_list_that_is_not_a_single_punned_field        { (None, $1)}
+;
+string_literal_expr_list:
+     string_literal_expr { [$1] }
+  |  string_literal_expr COMMA string_literal_expr_list { $1 :: $3 }
+  |  string_literal_expr COMMA { [$1] }
+;
+string_literal_expr:
+  STRING COLON expr
+      {
+        let loc = mklocation $symbolstartpos $endpos in
+        let (s, d) = $1 in
+        let lident_lident_loc = mkloc (Lident s) loc in
+        (lident_lident_loc, $3)
+      }
+  | STRING
+      {
+        let loc = mklocation $symbolstartpos $endpos in
+        let (s, d) = $1 in
+        let lident_lident_loc = mkloc (Lident s) loc in
+        (lident_lident_loc, mkexp (Pexp_ident lident_lident_loc))
+      }
+;
+
 non_punned_lbl_expression:
   as_loc(label_longident) COLON expr
       { ($1, $3) }
+;
+
+non_punned_string_literal_expression:
+  STRING COLON expr
+      {
+        let loc = mklocation $symbolstartpos $endpos in
+        let (s, d) = $1 in
+        let lident_lident_loc = mkloc (Lident s) loc in
+        (lident_lident_loc, $3)
+      }
 ;
 
 /**
@@ -3215,6 +3259,13 @@ lbl_expr_list_that_is_not_a_single_punned_field:
      { [$1] }
   | lbl_expr COMMA lbl_expr_list
       { $1::$3 }
+;
+
+string_literal_expr_list_that_is_not_a_single_punned_field:
+  | non_punned_string_literal_expression
+    { [$1] }
+  | string_literal_expr COMMA string_literal_expr_list
+    { $1::$3 }
 ;
 
 /**


### PR DESCRIPTION
See #759, this is a non-badly-merged version.

> This is a simple PR to support `{"key": 10}` to be internally represented as `[%bs.obj {key: 10}`. It allows for a nicer js interop through BuckleScript.
Related discussion: #712

> This supports punning which looks a bit weird `{"a": a}` becomes `{"a"}`.