### PR TITLE
Basic versioning support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,15 +70,18 @@ update_error:
 
 .PHONY: build clean update_error compile_error
 
-VERSION      := $$(opam query --version)
-NAME_VERSION := $$(opam query --name-version)
-ARCHIVE      := $$(opam query --archive)
+ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+SUBSTS:=$(ROOT_DIR)/pkg/substs
 
 release:
-	git tag -a v$(VERSION) -m "Version $(VERSION)."
-	git push origin v$(VERSION)
-	opam publish prepare $(NAME_VERSION) $(ARCHIVE)
-	opam publish submit $(NAME_VERSION)
-	rm -rf $(NAME_VERSION)
+ifndef version
+	$(error enviorment variable 'version' is undefined)
+endif
+	$(SUBSTS) $(ROOT_DIR)/package.json.in
+	$(SUBSTS) $(ROOT_DIR)/opam.in
+	git add package.json opam
+	git commit -m "Version $(version)"
+	git tag -a $(version) -m "Version $(version)."
+	git push "git@github.com:facebook/Reason.git" $(version)
 
 .PHONY: release

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ update_error:
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 SUBSTS:=$(ROOT_DIR)/pkg/substs
 
-release:
+release: test
 ifndef version
 	$(error enviorment variable 'version' is undefined)
 endif

--- a/Makefile
+++ b/Makefile
@@ -83,5 +83,6 @@ endif
 	git commit -m "Version $(version)"
 	git tag -a $(version) -m "Version $(version)."
 	git push "git@github.com:facebook/Reason.git" $(version)
+	npm publish --access public
 
 .PHONY: release

--- a/opam
+++ b/opam
@@ -1,7 +1,7 @@
 
 opam-version: "1.2"
 name: "reason"
-version: "1.2.2"
+version: "1.2.4"
 maintainer: "Jordan Walke <jordojw@gmail.com>"
 authors: [ "Jordan Walke <jordojw@gmail.com>" ]
 license: "BSD"

--- a/opam
+++ b/opam
@@ -1,7 +1,7 @@
 
 opam-version: "1.2"
 name: "reason"
-version: "1.2.4"
+version: "1.2.5"
 maintainer: "Jordan Walke <jordojw@gmail.com>"
 authors: [ "Jordan Walke <jordojw@gmail.com>" ]
 license: "BSD"

--- a/opam
+++ b/opam
@@ -1,6 +1,7 @@
+
 opam-version: "1.2"
 name: "reason"
-version: "0.0.6"
+version: "1.2.2"
 maintainer: "Jordan Walke <jordojw@gmail.com>"
 authors: [ "Jordan Walke <jordojw@gmail.com>" ]
 license: "BSD"

--- a/opam.in
+++ b/opam.in
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+name: "reason"
+version: "@version@"
+maintainer: "Jordan Walke <jordojw@gmail.com>"
+authors: [ "Jordan Walke <jordojw@gmail.com>" ]
+license: "BSD"
+homepage: "https://github.com/facebook/reason"
+doc: "http://facebook.github.io/reason"
+bug-reports: "https://github.com/facebook/reason/issues"
+dev-repo: "git://github.com/facebook/reason.git"
+tags: [ "syntax" ]
+substs: [ "pkg/META" ]
+build: [
+  [make "compile_error"]
+  ["ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                         "native-dynlink=%{ocaml-native-dynlink}%"
+                         "utop=%{utop:installed}%"]
+]
+build-test: [
+  "ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_reason.byte" "--"
+]
+depends: [
+  "easy-format"  {>= "1.2.0"}
+  "ocamlfind"    {build}
+  "utop"         {>= "1.17"}
+  "BetterErrors" {>= "0.0.1"}
+  "menhir"       {>= "20160303"}
+  "re"           {>= "1.5.0"}
+]
+depopts: [
+]
+conflicts: [
+  "utop" {< "1.17"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 
 {
-    "version": "1.2.2",
+    "version": "1.2.4",
     "description": "Reason Meta Language Toolchain",
     "repository": {
       "type": "git",
@@ -24,7 +24,7 @@
             "val": "./_build/ocamlfind/lib"
         },
         "version": {
-            "val": "1.2.2",
+            "val": "1.2.4",
             "global": true,
             "globalCollisionBehavior": "clobber"
         },
@@ -42,7 +42,7 @@
         "reason_version": {
             "global": true,
             "globalCollisionBehavior": "clobber",
-            "val": "1.2.2"
+            "val": "1.2.4"
         }
     },
     "name": "reason",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
+
 {
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Reason Meta Language Toolchain",
     "repository": {
       "type": "git",
@@ -23,7 +24,7 @@
             "val": "./_build/ocamlfind/lib"
         },
         "version": {
-            "val": "0.0.6",
+            "val": "1.2.2",
             "global": true,
             "globalCollisionBehavior": "clobber"
         },
@@ -41,7 +42,7 @@
         "reason_version": {
             "global": true,
             "globalCollisionBehavior": "clobber",
-            "val": "0.0.6"
+            "val": "1.2.2"
         }
     },
     "name": "reason",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 
 {
-    "version": "1.2.4",
+    "version": "1.2.5",
     "description": "Reason Meta Language Toolchain",
     "repository": {
       "type": "git",
@@ -24,7 +24,7 @@
             "val": "./_build/ocamlfind/lib"
         },
         "version": {
-            "val": "1.2.4",
+            "val": "1.2.5",
             "global": true,
             "globalCollisionBehavior": "clobber"
         },
@@ -42,7 +42,7 @@
         "reason_version": {
             "global": true,
             "globalCollisionBehavior": "clobber",
-            "val": "1.2.4"
+            "val": "1.2.5"
         }
     },
     "name": "reason",

--- a/package.json.in
+++ b/package.json.in
@@ -46,25 +46,30 @@
     },
     "name": "reason",
     "dependencies": {
-        "merlin": "https://github.com/npm-opam/merlin",
-        "re": "https://github.com/npm-opam/re",
-        "ocamlfind": "https://github.com/npm-opam/ocamlfind",
-        "BetterErrors": "https://github.com/npm-opam/BetterErrors",
-        "ocaml": "https://github.com/npm-opam/ocaml.git#npm-4.02.3",
+        "@opam-alpha/merlin": "^ 2.5.0",
+        "@opam-alpha/re": "^ 1.5.0",
+        "@opam-alpha/ocamlfind": "*",
+        "@opam-alpha/BetterErrors": ">= 0.0.1",
+        "@opam-alpha/easy-format": "^ 1.2.0",
+        "@opam-alpha/merlin-extend": "^ 0.3.0",
+        "@opam-alpha/menhir": ">= 20160303.0.0",
+        "@opam-alpha/ocaml": "= 4.02.3",
         "dependency-env": "https://github.com/npm-ml/dependency-env.git",
         "substs": "https://github.com/yunxing/substs.git",
-        "easy-format": "https://github.com/npm-opam/easy-format",
-        "merlin-extend": "https://github.com/npm-opam/merlin-extend",
         "opam-installer-bin": "https://github.com/yunxing/opam-installer-bin.git",
         "nopam": "https://github.com/yunxing/nopam.git",
-        "utop-bin": "https://github.com/reasonml/utop-bin",
-        "menhir": "https://github.com/npm-opam/menhir"
+        "utop-bin": "https://github.com/reasonml/utop-bin"
+
     },
     "scripts": {
         "editor": "eval $(dependencyEnv) && eval $EDITOR",
         "postinstall": "eval $(dependencyEnv) && nopam && substs pkg/META.in && make compile_error && ocaml pkg/build.ml native=true native-dynlink=true utop=${utop_installed:-false} && (opam-installer --prefix=$opam_prefix || true)",
+        "clean": "eval $(dependencyEnv) && nopam && make clean",
         "env": "eval $(dependencyEnv) && env",
         "formatTest": "eval $(dependencyEnv) && cd formatTest; ./test.sh",
         "whereisrefmt": "eval $(dependencyEnv) && which refmt"
+    },
+    "engines" : {
+      "npm" : ">=3.10.0"
     }
 }

--- a/package.json.in
+++ b/package.json.in
@@ -1,0 +1,70 @@
+{
+    "version": "@version@",
+    "description": "Reason Meta Language Toolchain",
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/facebook/reason.git"
+    },
+    "keywords": [
+      "reason"
+    ],
+    "license": "BSD",
+    "homepage": "https://github.com/facebook/reason",
+    "exportedEnvVars": {
+        "reason_installed": {
+            "global": true,
+            "globalCollisionBehavior": "clobber",
+            "val": "true"
+        },
+        "FINDLIB": {
+            "global": true,
+            "resolveAsRelativePath": true,
+            "globalCollisionBehavior": "joinPath",
+            "val": "./_build/ocamlfind/lib"
+        },
+        "version": {
+            "val": "@version@",
+            "global": true,
+            "globalCollisionBehavior": "clobber"
+        },
+        "PATH": {
+            "global": true,
+            "resolveAsRelativePath": true,
+            "globalCollisionBehavior": "joinPath",
+            "val": "./_build/ocamlfind/bin"
+        },
+        "reason_enable": {
+            "global": true,
+            "globalCollisionBehavior": "clobber",
+            "val": "enable"
+        },
+        "reason_version": {
+            "global": true,
+            "globalCollisionBehavior": "clobber",
+            "val": "@version@"
+        }
+    },
+    "name": "reason",
+    "dependencies": {
+        "merlin": "https://github.com/npm-opam/merlin",
+        "re": "https://github.com/npm-opam/re",
+        "ocamlfind": "https://github.com/npm-opam/ocamlfind",
+        "BetterErrors": "https://github.com/npm-opam/BetterErrors",
+        "ocaml": "https://github.com/npm-opam/ocaml.git#npm-4.02.3",
+        "dependency-env": "https://github.com/npm-ml/dependency-env.git",
+        "substs": "https://github.com/yunxing/substs.git",
+        "easy-format": "https://github.com/npm-opam/easy-format",
+        "merlin-extend": "https://github.com/npm-opam/merlin-extend",
+        "opam-installer-bin": "https://github.com/yunxing/opam-installer-bin.git",
+        "nopam": "https://github.com/yunxing/nopam.git",
+        "utop-bin": "https://github.com/reasonml/utop-bin",
+        "menhir": "https://github.com/npm-opam/menhir"
+    },
+    "scripts": {
+        "editor": "eval $(dependencyEnv) && eval $EDITOR",
+        "postinstall": "eval $(dependencyEnv) && nopam && substs pkg/META.in && make compile_error && ocaml pkg/build.ml native=true native-dynlink=true utop=${utop_installed:-false} && (opam-installer --prefix=$opam_prefix || true)",
+        "env": "eval $(dependencyEnv) && env",
+        "formatTest": "eval $(dependencyEnv) && cd formatTest; ./test.sh",
+        "whereisrefmt": "eval $(dependencyEnv) && which refmt"
+    }
+}

--- a/pkg/substs
+++ b/pkg/substs
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+
+re='(.*)@(.*)@(.*)'
+replaced=${1%.in}
+echo "" > $replaced
+cat $1 | while IFS='' read line
+do
+    while [[ $line =~ $re ]]; do
+        line=${BASH_REMATCH[1]}$(eval echo "\$${BASH_REMATCH[2]}")${BASH_REMATCH[3]}
+    done
+    echo "$line" >> $replaced
+done


### PR DESCRIPTION
This PR provides basic versioning support in our opam file and package.json. 

After running "env version=x.y.z make release", package.json and opam will be regenerated with the new version number. Also, a new commit and a new tag will be generated and pushed to github. 

See https://github.com/facebook/reason/tree/1.2.3 for an example