### PR TITLE
Support attributes on class method names

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -332,5 +332,8 @@ let module Js = {
 
 type classAttributesOnKeys = <
   key1 [@bs.set] : string,
-  key2 [@bs.get null] : (Js.t int) [@onType2]
+  /* The follow two are the same */
+  key2 [@bs.get null] : (Js.t int) [@onType2],
+  key3 [@bs.get null] : (Js.t int) [@onType2],
+  key4 : Js.t (int [@justOnInt])
 >;

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -325,3 +325,12 @@ let myFun
    */
 /* Bucklescript FFI item attributes */
 external imul : int => int => int = "Math.imul" [@@bs.val];
+
+let module Js = {
+  type t 'a;
+};
+
+type classAttributesOnKeys = <
+  key1 [@bs.set] : string,
+  key2 [@bs.get null] : (Js.t int) [@onType2]
+>;

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -257,5 +257,10 @@ let module Js = {
 
 type classAttributesOnKeys = <
   key1 [@bs.set] : string,
-  key2 [@bs.get {null}] : Js.t int [@onType2]
+
+  /* The follow two are the same */
+  key2 [@bs.get {null}] : Js.t int [@onType2],
+  key3 [@bs.get {null}] : ((Js.t int) [@onType2]),
+
+  key4 : Js.t (int [@justOnInt])
 >;

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -250,3 +250,12 @@ let myFun = fun ((X hello | Y hello) [@onOrPattern]) => hello;
 /* Bucklescript FFI item attributes */
 
 external imul : int => int => int = "Math.imul" [@@bs.val];
+
+let module Js = {
+  type t 'a;
+};
+
+type classAttributesOnKeys = <
+  key1 [@bs.set] : string,
+  key2 [@bs.get {null}] : Js.t int [@onType2]
+>;

--- a/src/reason_parser.messages
+++ b/src/reason_parser.messages
@@ -79,14 +79,14 @@ use_file: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 964, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 934, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 944, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 973, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 943, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 2842, spurious reduction of production post_item_attributes ->
 ## In state 2843, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 2844, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
@@ -216,14 +216,14 @@ toplevel_phrase: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 964, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 934, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 944, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 973, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 943, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 2842, spurious reduction of production post_item_attributes ->
 ## In state 2843, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
 ## In state 2844, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
@@ -249,7 +249,7 @@ toplevel_phrase: WITH
 
 parse_pattern: EXCEPTION WITH
 ##
-## Ends in an error in state: 680.
+## Ends in an error in state: 702.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -261,7 +261,7 @@ parse_pattern: EXCEPTION WITH
 
 parse_pattern: LAZY WITH
 ##
-## Ends in an error in state: 664.
+## Ends in an error in state: 686.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -273,7 +273,7 @@ parse_pattern: LAZY WITH
 
 parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ##
-## Ends in an error in state: 737.
+## Ends in an error in state: 759.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error RBRACE COMMA BAR ]
 ## lbl_pattern -> label_longident COLON pattern . [ error RBRACE COMMA ]
@@ -285,14 +285,14 @@ parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 618, spurious reduction of production pattern -> pattern_without_or
+## In state 640, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 575.
+## Ends in an error in state: 597.
 ##
 ## lbl_pattern -> label_longident COLON . pattern [ error RBRACE COMMA ]
 ##
@@ -304,7 +304,7 @@ parse_pattern: LBRACE LIDENT COLON WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 661.
+## Ends in an error in state: 683.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -317,7 +317,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 570.
+## Ends in an error in state: 592.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA UNDERSCORE . opt_comma [ error RBRACE ]
 ##
@@ -329,7 +329,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 
 parse_pattern: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 569.
+## Ends in an error in state: 591.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA . [ error RBRACE ]
 ## lbl_pattern_list -> lbl_pattern COMMA . UNDERSCORE opt_comma [ error RBRACE ]
@@ -343,7 +343,7 @@ parse_pattern: LBRACE LIDENT COMMA WITH
 
 parse_pattern: LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 574.
+## Ends in an error in state: 596.
 ##
 ## lbl_pattern -> label_longident . COLON pattern [ error RBRACE COMMA ]
 ## lbl_pattern -> label_longident . [ error RBRACE COMMA ]
@@ -356,7 +356,7 @@ parse_pattern: LBRACE LIDENT WITH
 
 parse_pattern: LBRACE WITH
 ##
-## Ends in an error in state: 660.
+## Ends in an error in state: 682.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -369,7 +369,7 @@ parse_pattern: LBRACE WITH
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 657.
+## Ends in an error in state: 679.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET BAR ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT pattern . [ error SEMI RBRACKET ]
@@ -381,14 +381,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 618, spurious reduction of production pattern -> pattern_without_or
+## In state 640, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT WITH
 ##
-## Ends in an error in state: 656.
+## Ends in an error in state: 678.
 ##
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT . pattern [ error SEMI RBRACKET ]
 ##
@@ -400,7 +400,7 @@ Expecting a valid list identifier
 
 parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 658.
+## Ends in an error in state: 680.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ COMMA ]
@@ -413,14 +413,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 618, spurious reduction of production pattern -> pattern_without_or
+## In state 640, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 655.
+## Ends in an error in state: 677.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ COMMA ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA . DOTDOTDOT pattern [ error SEMI RBRACKET ]
@@ -434,7 +434,7 @@ parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKET UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 659.
+## Ends in an error in state: 681.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern . [ COMMA ]
@@ -447,14 +447,14 @@ parse_pattern: LBRACKET UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 618, spurious reduction of production pattern -> pattern_without_or
+## In state 640, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 651.
+## Ends in an error in state: 673.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -467,7 +467,7 @@ parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LBRACKET WITH
 ##
-## Ends in an error in state: 648.
+## Ends in an error in state: 670.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -481,7 +481,7 @@ parse_pattern: LBRACKET WITH
 
 parse_pattern: LBRACKETBAR MINUS WITH
 ##
-## Ends in an error in state: 557.
+## Ends in an error in state: 579.
 ##
 ## signed_constant -> MINUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> MINUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -497,7 +497,7 @@ parse_pattern: LBRACKETBAR MINUS WITH
 
 parse_pattern: LBRACKETBAR PLUS WITH
 ##
-## Ends in an error in state: 556.
+## Ends in an error in state: 578.
 ##
 ## signed_constant -> PLUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> PLUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -513,7 +513,7 @@ parse_pattern: LBRACKETBAR PLUS WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 638.
+## Ends in an error in state: 660.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -525,14 +525,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 618, spurious reduction of production pattern -> pattern_without_or
+## In state 640, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 637.
+## Ends in an error in state: 659.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ error SEMI COMMA BARRBRACKET ]
 ##
@@ -544,7 +544,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 647.
+## Ends in an error in state: 669.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -556,14 +556,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 618, spurious reduction of production pattern -> pattern_without_or
+## In state 640, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 644.
+## Ends in an error in state: 666.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -576,7 +576,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LBRACKETBAR WITH
 ##
-## Ends in an error in state: 633.
+## Ends in an error in state: 655.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -590,7 +590,7 @@ parse_pattern: LBRACKETBAR WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 2456.
+## Ends in an error in state: 2476.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -608,7 +608,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 2455.
+## Ends in an error in state: 2475.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -621,7 +621,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2454.
+## Ends in an error in state: 2474.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -639,7 +639,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2453.
+## Ends in an error in state: 2473.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -652,7 +652,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2452.
+## Ends in an error in state: 2472.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -665,7 +665,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2451.
+## Ends in an error in state: 2471.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -678,7 +678,7 @@ parse_pattern: LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN EXCEPTION WITH
 ##
-## Ends in an error in state: 585.
+## Ends in an error in state: 607.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -690,7 +690,7 @@ parse_pattern: LPAREN EXCEPTION WITH
 
 parse_pattern: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 576.
+## Ends in an error in state: 598.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -702,7 +702,7 @@ parse_pattern: LPAREN LAZY WITH
 
 parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 565.
+## Ends in an error in state: 587.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -715,7 +715,7 @@ parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 560.
+## Ends in an error in state: 582.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -728,7 +728,7 @@ parse_pattern: LPAREN LBRACE WITH
 
 parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 739.
+## Ends in an error in state: 761.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -741,7 +741,7 @@ parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LPAREN LBRACKET WITH
 ##
-## Ends in an error in state: 558.
+## Ends in an error in state: 580.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -755,7 +755,7 @@ parse_pattern: LPAREN LBRACKET WITH
 
 parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 744.
+## Ends in an error in state: 766.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -768,7 +768,7 @@ parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LPAREN LBRACKETBAR WITH
 ##
-## Ends in an error in state: 555.
+## Ends in an error in state: 577.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -782,7 +782,7 @@ parse_pattern: LPAREN LBRACKETBAR WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 752.
+## Ends in an error in state: 774.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -800,7 +800,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCOR
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 751.
+## Ends in an error in state: 773.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -813,7 +813,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 750.
+## Ends in an error in state: 772.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -831,7 +831,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 749.
+## Ends in an error in state: 771.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -844,7 +844,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 748.
+## Ends in an error in state: 770.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -857,7 +857,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 747.
+## Ends in an error in state: 769.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -870,7 +870,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 544.
+## Ends in an error in state: 566.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -883,7 +883,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 542.
+## Ends in an error in state: 564.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -897,7 +897,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 
 parse_pattern: LPAREN LPAREN MODULE WITH
 ##
-## Ends in an error in state: 541.
+## Ends in an error in state: 563.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -911,7 +911,7 @@ parse_pattern: LPAREN LPAREN MODULE WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 719.
+## Ends in an error in state: 741.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -926,7 +926,7 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 630.
+## Ends in an error in state: 652.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -938,23 +938,23 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 705, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
-## In state 712, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 711, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 715, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 727, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
+## In state 734, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 733, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 737, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 540.
+## Ends in an error in state: 562.
 ##
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -978,7 +978,7 @@ parse_pattern: LPAREN LPAREN WITH
 
 parse_pattern: LPAREN MINUS WITH
 ##
-## Ends in an error in state: 534.
+## Ends in an error in state: 556.
 ##
 ## operator -> MINUS . [ RPAREN ]
 ## signed_constant -> MINUS . INT [ error RPAREN LBRACKETAT DOTDOT COMMA COLONCOLON COLON BAR AS ]
@@ -995,7 +995,7 @@ parse_pattern: LPAREN MINUS WITH
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 264.
+## Ends in an error in state: 245.
 ##
 ## package_type -> mty_longident . [ error RPAREN ]
 ## package_type -> mty_longident . WITH package_type_cstrs [ error RPAREN ]
@@ -1007,15 +1007,15 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 260, spurious reduction of production ident -> UIDENT
-## In state 552, spurious reduction of production mty_longident -> ident
+## In state 241, spurious reduction of production ident -> UIDENT
+## In state 574, spurious reduction of production mty_longident -> ident
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WHILE
 ##
-## Ends in an error in state: 260.
+## Ends in an error in state: 241.
 ##
 ## ident -> UIDENT . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -1029,7 +1029,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WHILE
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2449.
+## Ends in an error in state: 2469.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ error RPAREN ]
 ##
@@ -1041,7 +1041,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2448.
+## Ends in an error in state: 2468.
 ##
 ## package_type_cstrs -> package_type_cstr . [ error RPAREN ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ error RPAREN ]
@@ -1053,20 +1053,20 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 728, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 722, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 724, spurious reduction of production _core_type -> core_type2
-## In state 735, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 723, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2446, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 384, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 750, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 744, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 746, spurious reduction of production _core_type -> core_type2
+## In state 757, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 745, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 2466, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 268.
+## Ends in an error in state: 249.
 ##
 ## package_type_cstr -> TYPE label_longident EQUAL . core_type [ error RPAREN AND ]
 ##
@@ -1078,7 +1078,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL WITH
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT WITH
 ##
-## Ends in an error in state: 267.
+## Ends in an error in state: 248.
 ##
 ## package_type_cstr -> TYPE label_longident . EQUAL core_type [ error RPAREN AND ]
 ##
@@ -1090,7 +1090,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT WITH
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 266.
+## Ends in an error in state: 247.
 ##
 ## package_type_cstr -> TYPE . label_longident EQUAL core_type [ error RPAREN AND ]
 ##
@@ -1102,7 +1102,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE WITH
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH WITH
 ##
-## Ends in an error in state: 265.
+## Ends in an error in state: 246.
 ##
 ## package_type -> mty_longident WITH . package_type_cstrs [ error RPAREN ]
 ##
@@ -1114,7 +1114,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH WITH
 
 parse_pattern: LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 259.
+## Ends in an error in state: 240.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1127,7 +1127,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON WITH
 
 parse_pattern: LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 257.
+## Ends in an error in state: 238.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . COLON package_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1141,7 +1141,7 @@ parse_pattern: LPAREN MODULE UIDENT WITH
 
 parse_pattern: LPAREN MODULE WITH
 ##
-## Ends in an error in state: 256.
+## Ends in an error in state: 237.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT COLON package_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1155,7 +1155,7 @@ parse_pattern: LPAREN MODULE WITH
 
 parse_pattern: LPAREN PLUS WITH
 ##
-## Ends in an error in state: 250.
+## Ends in an error in state: 231.
 ##
 ## operator -> PLUS . [ RPAREN ]
 ## signed_constant -> PLUS . INT [ error RPAREN LBRACKETAT DOTDOT COMMA COLONCOLON COLON BAR AS ]
@@ -1172,7 +1172,7 @@ parse_pattern: LPAREN PLUS WITH
 
 parse_pattern: LPAREN SHARP UIDENT DOT WITH
 ##
-## Ends in an error in state: 245.
+## Ends in an error in state: 226.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -1186,7 +1186,7 @@ parse_pattern: LPAREN SHARP UIDENT DOT WITH
 
 parse_pattern: LPAREN SHARP UIDENT WITH
 ##
-## Ends in an error in state: 244.
+## Ends in an error in state: 225.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -1206,7 +1206,7 @@ parse_pattern: LPAREN SHARP UIDENT WITH
 
 parse_pattern: LPAREN SHARP WITH
 ##
-## Ends in an error in state: 241.
+## Ends in an error in state: 222.
 ##
 ## _simple_pattern_not_ident -> SHARP . type_longident [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ##
@@ -1218,7 +1218,7 @@ parse_pattern: LPAREN SHARP WITH
 
 parse_pattern: LPAREN STRING DOTDOT WITH
 ##
-## Ends in an error in state: 590.
+## Ends in an error in state: 612.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ##
@@ -1230,7 +1230,7 @@ parse_pattern: LPAREN STRING DOTDOT WITH
 
 parse_pattern: LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 599.
+## Ends in an error in state: 621.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ error WITH UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS AND ]
 ##
@@ -1242,7 +1242,7 @@ parse_pattern: LPAREN UIDENT DOT WITH
 
 parse_pattern: LPAREN UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 577.
+## Ends in an error in state: 599.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1264,7 +1264,7 @@ parse_pattern: LPAREN UIDENT LPAREN WITH
 
 parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 609.
+## Ends in an error in state: 631.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1277,7 +1277,7 @@ parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 639.
+## Ends in an error in state: 661.
 ##
 ## _or_pattern -> pattern BAR . pattern [ error SEMI RPAREN RBRACKET RBRACE COMMA COLON BARRBRACKET BAR ]
 ##
@@ -1289,7 +1289,7 @@ parse_pattern: LPAREN UNDERSCORE BAR WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BACKQUOTE LIDENT GREATER
 ##
-## Ends in an error in state: 338.
+## Ends in an error in state: 360.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET tag_field . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## row_field -> tag_field . [ BAR ]
@@ -1301,15 +1301,15 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BACKQUOTE LIDENT GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 179, spurious reduction of production attributes ->
-## In state 2529, spurious reduction of production tag_field -> name_tag attributes
+## In state 278, spurious reduction of production attributes ->
+## In state 313, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 336.
+## Ends in an error in state: 358.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET BAR row_field_list . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -1322,7 +1322,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BAR UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BAR WITH
 ##
-## Ends in an error in state: 335.
+## Ends in an error in state: 357.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET BAR . row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1334,7 +1334,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BAR WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 342.
+## Ends in an error in state: 364.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR row_field_list . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -1347,7 +1347,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 341.
+## Ends in an error in state: 363.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR . row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1359,7 +1359,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE BAR WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE WITH
 ##
-## Ends in an error in state: 340.
+## Ends in an error in state: 362.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field . BAR row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1371,7 +1371,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKET WITH
 ##
-## Ends in an error in state: 334.
+## Ends in an error in state: 356.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET . tag_field RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> LBRACKET . BAR row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
@@ -1385,7 +1385,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER BAR ASSERT
 ##
-## Ends in an error in state: 331.
+## Ends in an error in state: 353.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar . row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1397,7 +1397,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER BAR ASSERT
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 332.
+## Ends in an error in state: 354.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar row_field_list . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -1410,7 +1410,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER WITH
 ##
-## Ends in an error in state: 329.
+## Ends in an error in state: 351.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER . opt_bar row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
@@ -1423,7 +1423,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETGREATER WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS BAR ASSERT
 ##
-## Ends in an error in state: 320.
+## Ends in an error in state: 345.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar . row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar . row_field_list GREATER name_tag_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
@@ -1436,7 +1436,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS BAR ASSERT
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 ##
-## Ends in an error in state: 324.
+## Ends in an error in state: 349.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER name_tag_list . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## name_tag_list -> name_tag_list . name_tag [ RBRACKET BACKQUOTE ]
@@ -1449,7 +1449,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE GREATER BACKQUOTE
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE GREATER WITH
 ##
-## Ends in an error in state: 323.
+## Ends in an error in state: 348.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER . name_tag_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1461,7 +1461,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE GREATER WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE WITH
 ##
-## Ends in an error in state: 321.
+## Ends in an error in state: 346.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . GREATER name_tag_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
@@ -1475,7 +1475,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS WITH
 ##
-## Ends in an error in state: 319.
+## Ends in an error in state: 344.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS . opt_bar row_field_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS . opt_bar row_field_list GREATER name_tag_list RBRACKET [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
@@ -1488,7 +1488,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKETLESS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LESS DOTDOT WITH
 ##
-## Ends in an error in state: 313.
+## Ends in an error in state: 338.
 ##
 ## _non_arrowed_simple_core_type -> LESS meth_list . GREATER [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1500,7 +1500,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LESS DOTDOT WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LESS WITH
 ##
-## Ends in an error in state: 312.
+## Ends in an error in state: 337.
 ##
 ## _non_arrowed_simple_core_type -> LESS . meth_list GREATER [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1512,7 +1512,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LESS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2444.
+## Ends in an error in state: 2464.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1524,7 +1524,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 ##
-## Ends in an error in state: 357.
+## Ends in an error in state: 379.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1536,7 +1536,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE QUESTION EQU
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 ##
-## Ends in an error in state: 356.
+## Ends in an error in state: 378.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION . EQUALGREATER core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1548,7 +1548,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE QUESTION WIT
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 355.
+## Ends in an error in state: 377.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . QUESTION EQUALGREATER core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
@@ -1562,7 +1562,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 354.
+## Ends in an error in state: 376.
 ##
 ## _core_type2 -> LIDENT COLONCOLON . non_arrowed_core_type QUESTION EQUALGREATER core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ## _core_type2 -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
@@ -1587,7 +1587,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT SHARP WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 359.
+## Ends in an error in state: 381.
 ##
 ## _non_arrowed_non_simple_core_type -> type_longident non_arrowed_simple_core_type_list . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
@@ -1600,7 +1600,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT UNDERSCORE WHILE
 
 parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE UIDENT COLONGREATER
 ##
-## Ends in an error in state: 273.
+## Ends in an error in state: 254.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN MODULE package_type . RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1612,7 +1612,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE UIDENT COLONGREATER
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
-## In state 279, spurious reduction of production mty_longident -> ident
+## In state 260, spurious reduction of production mty_longident -> ident
 ## In state 137, spurious reduction of production package_type -> mty_longident
 ##
 
@@ -1620,7 +1620,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE UIDENT COLONGREATER
 
 parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE WITH
 ##
-## Ends in an error in state: 272.
+## Ends in an error in state: 253.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN MODULE . package_type RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1632,7 +1632,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 296.
+## Ends in an error in state: 330.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN core_type_comma_list . RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## core_type_comma_list -> core_type_comma_list . COMMA core_type [ RPAREN COMMA ]
@@ -1644,13 +1644,13 @@ parse_pattern: LPAREN UNDERSCORE COLON LPAREN UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 309, spurious reduction of production core_type_comma_list -> core_type
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 334, spurious reduction of production core_type_comma_list -> core_type
 ##
 
 <SYNTAX ERROR>
@@ -1669,7 +1669,7 @@ parse_pattern: LPAREN UNDERSCORE COLON QUOTE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON SHARP LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 345.
+## Ends in an error in state: 367.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP class_longident non_arrowed_simple_core_type_list . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
@@ -1682,7 +1682,7 @@ parse_pattern: LPAREN UNDERSCORE COLON SHARP LIDENT UNDERSCORE WHILE
 
 parse_pattern: LPAREN UNDERSCORE COLON SHARP WITH
 ##
-## Ends in an error in state: 269.
+## Ends in an error in state: 250.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP . class_longident non_arrowed_simple_core_type_list [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ## _non_arrowed_simple_core_type -> SHARP . class_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
@@ -1695,7 +1695,7 @@ parse_pattern: LPAREN UNDERSCORE COLON SHARP WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS QUOTE WITH
 ##
-## Ends in an error in state: 730.
+## Ends in an error in state: 752.
 ##
 ## _core_type -> core_type2 AS QUOTE . ident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AND ]
 ##
@@ -1707,7 +1707,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS QUOTE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS WITH
 ##
-## Ends in an error in state: 729.
+## Ends in an error in state: 751.
 ##
 ## _core_type -> core_type2 AS . QUOTE ident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AND ]
 ##
@@ -1719,7 +1719,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 725.
+## Ends in an error in state: 747.
 ##
 ## _core_type2 -> core_type2 EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1731,7 +1731,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 760.
+## Ends in an error in state: 782.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1746,7 +1746,7 @@ parse_pattern: LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 632.
+## Ends in an error in state: 654.
 ##
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1758,7 +1758,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 704.
+## Ends in an error in state: 726.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ RPAREN COMMA ]
 ##
@@ -1770,7 +1770,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ##
-## Ends in an error in state: 755.
+## Ends in an error in state: 777.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -1782,18 +1782,18 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 692, spurious reduction of production pattern -> pattern_without_or
-## In state 703, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 712, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 711, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 715, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 714, spurious reduction of production pattern -> pattern_without_or
+## In state 725, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 734, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 733, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 737, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 714.
+## Ends in an error in state: 736.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1805,7 +1805,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 713.
+## Ends in an error in state: 735.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint . COMMA pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1816,17 +1816,17 @@ parse_pattern: LPAREN UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 618, spurious reduction of production pattern -> pattern_without_or
-## In state 757, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 712, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 711, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 640, spurious reduction of production pattern -> pattern_without_or
+## In state 779, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 734, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 733, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN WITH
 ##
-## Ends in an error in state: 239.
+## Ends in an error in state: 220.
 ##
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -1850,7 +1850,7 @@ parse_pattern: LPAREN WITH
 
 parse_pattern: MINUS WITH
 ##
-## Ends in an error in state: 233.
+## Ends in an error in state: 214.
 ##
 ## signed_constant -> MINUS . INT [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOTDOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## signed_constant -> MINUS . FLOAT [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOTDOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1866,7 +1866,7 @@ parse_pattern: MINUS WITH
 
 parse_pattern: PLUS WITH
 ##
-## Ends in an error in state: 227.
+## Ends in an error in state: 208.
 ##
 ## signed_constant -> PLUS . INT [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOTDOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## signed_constant -> PLUS . FLOAT [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF DOTDOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1882,7 +1882,7 @@ parse_pattern: PLUS WITH
 
 parse_pattern: SHARP WITH
 ##
-## Ends in an error in state: 222.
+## Ends in an error in state: 203.
 ##
 ## _simple_pattern_not_ident -> SHARP . type_longident [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ##
@@ -1894,7 +1894,7 @@ parse_pattern: SHARP WITH
 
 parse_pattern: STRING DOTDOT WITH
 ##
-## Ends in an error in state: 669.
+## Ends in an error in state: 691.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ##
@@ -1906,7 +1906,7 @@ parse_pattern: STRING DOTDOT WITH
 
 parse_pattern: UIDENT DOT WITH
 ##
-## Ends in an error in state: 436.
+## Ends in an error in state: 458.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ WITH WHEN UNDERSCORE UIDENT TRUE STRING SLASHGREATER SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN GREATER FLOAT FALSE EQUALGREATER EQUAL EOF DOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS AND ]
 ##
@@ -1918,7 +1918,7 @@ parse_pattern: UIDENT DOT WITH
 
 parse_pattern: UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 532.
+## Ends in an error in state: 554.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1940,7 +1940,7 @@ parse_pattern: UIDENT LPAREN WITH
 
 parse_pattern: UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 688.
+## Ends in an error in state: 710.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1953,7 +1953,7 @@ parse_pattern: UIDENT UNDERSCORE WITH
 
 parse_pattern: UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 706.
+## Ends in an error in state: 728.
 ##
 ## _or_pattern -> pattern BAR . pattern [ WHEN SEMI RPAREN RBRACKET IN EQUALGREATER EQUAL EOF COMMA COLON BAR ]
 ##
@@ -1977,7 +1977,7 @@ parse_pattern: UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 692, spurious reduction of production pattern -> pattern_without_or
+## In state 714, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
@@ -2031,14 +2031,14 @@ parse_expression: UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 964, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 934, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 944, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 973, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 943, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -2057,7 +2057,7 @@ parse_expression: WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 2523.
+## Ends in an error in state: 280.
 ##
 ## tag_field -> name_tag opt_ampersand . amper_type_list attributes [ RBRACKET GREATER BAR ]
 ##
@@ -2069,7 +2069,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 ##
-## Ends in an error in state: 2526.
+## Ends in an error in state: 307.
 ##
 ## amper_type_list -> amper_type_list AMPERSAND . core_type [ RBRACKET LBRACKETAT GREATER BAR AMPERSAND ]
 ##
@@ -2081,7 +2081,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ##
-## Ends in an error in state: 2530.
+## Ends in an error in state: 315.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET tag_field . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field -> tag_field . [ BAR ]
@@ -2093,15 +2093,15 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 179, spurious reduction of production attributes ->
-## In state 2529, spurious reduction of production tag_field -> name_tag attributes
+## In state 278, spurious reduction of production attributes ->
+## In state 313, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: LBRACKET BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 174.
+## Ends in an error in state: 273.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET BAR row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2114,7 +2114,7 @@ parse_core_type: LBRACKET BAR UNDERSCORE WITH
 
 parse_core_type: LBRACKET BAR WITH
 ##
-## Ends in an error in state: 169.
+## Ends in an error in state: 268.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET BAR . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2126,7 +2126,7 @@ parse_core_type: LBRACKET BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 2534.
+## Ends in an error in state: 319.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2139,7 +2139,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 2533.
+## Ends in an error in state: 318.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2151,7 +2151,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE WITH
 ##
-## Ends in an error in state: 2532.
+## Ends in an error in state: 317.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field . BAR row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2163,7 +2163,7 @@ parse_core_type: LBRACKET UNDERSCORE WITH
 
 parse_core_type: LBRACKET WITH
 ##
-## Ends in an error in state: 168.
+## Ends in an error in state: 267.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET . tag_field RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKET . BAR row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2177,7 +2177,7 @@ parse_core_type: LBRACKET WITH
 
 parse_core_type: LBRACKETGREATER BAR ASSERT
 ##
-## Ends in an error in state: 167.
+## Ends in an error in state: 266.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2189,7 +2189,7 @@ parse_core_type: LBRACKETGREATER BAR ASSERT
 
 parse_core_type: LBRACKETGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 2536.
+## Ends in an error in state: 321.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2202,7 +2202,7 @@ parse_core_type: LBRACKETGREATER UNDERSCORE WITH
 
 parse_core_type: LBRACKETGREATER WITH
 ##
-## Ends in an error in state: 165.
+## Ends in an error in state: 264.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER . opt_bar row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2215,7 +2215,7 @@ parse_core_type: LBRACKETGREATER WITH
 
 parse_core_type: LBRACKETLESS BAR ASSERT
 ##
-## Ends in an error in state: 164.
+## Ends in an error in state: 263.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar . row_field_list GREATER name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2228,7 +2228,7 @@ parse_core_type: LBRACKETLESS BAR ASSERT
 
 parse_core_type: LBRACKETLESS UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 176.
+## Ends in an error in state: 275.
 ##
 ## row_field_list -> row_field_list BAR . row_field [ RBRACKET GREATER BAR ]
 ##
@@ -2240,7 +2240,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2541.
+## Ends in an error in state: 326.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER name_tag_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## name_tag_list -> name_tag_list . name_tag [ RBRACKET BACKQUOTE ]
@@ -2253,7 +2253,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 ##
-## Ends in an error in state: 2540.
+## Ends in an error in state: 325.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER . name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2265,7 +2265,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE WITH
 ##
-## Ends in an error in state: 2538.
+## Ends in an error in state: 323.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . GREATER name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2279,7 +2279,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE WITH
 
 parse_core_type: LBRACKETLESS WITH
 ##
-## Ends in an error in state: 162.
+## Ends in an error in state: 261.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS . opt_bar row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS . opt_bar row_field_list GREATER name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2304,7 +2304,7 @@ parse_core_type: LESS DOTDOT WITH
 
 parse_core_type: LESS LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 ##
-## Ends in an error in state: 316.
+## Ends in an error in state: 341.
 ##
 ## meth_list -> field COMMA . meth_list [ GREATER ]
 ## opt_comma -> COMMA . [ GREATER ]
@@ -2317,7 +2317,7 @@ parse_core_type: LESS LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 ##
-## Ends in an error in state: 1311.
+## Ends in an error in state: 1331.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ##
@@ -2329,7 +2329,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1308.
+## Ends in an error in state: 1328.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -2342,7 +2342,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE WITH
 ##
-## Ends in an error in state: 1309.
+## Ends in an error in state: 1329.
 ##
 ## typevar_list -> typevar_list QUOTE . ident [ QUOTE DOT ]
 ##
@@ -2367,7 +2367,7 @@ parse_core_type: LESS LIDENT COLON QUOTE WITH
 
 parse_core_type: LESS LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 315.
+## Ends in an error in state: 340.
 ##
 ## meth_list -> field . COMMA meth_list [ GREATER ]
 ## meth_list -> field . opt_comma [ GREATER ]
@@ -2379,41 +2379,46 @@ parse_core_type: LESS LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1316, spurious reduction of production _poly_type -> core_type
-## In state 1317, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1315, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 2543, spurious reduction of production attributes ->
-## In state 2544, spurious reduction of production field -> label COLON poly_type attributes
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1336, spurious reduction of production _poly_type -> core_type
+## In state 1337, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1335, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 2544, spurious reduction of production field -> label attributes COLON poly_type
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: LESS LIDENT COLON WITH
 ##
-## Ends in an error in state: 161.
+## Ends in an error in state: 2543.
 ##
-## field -> label COLON . poly_type attributes [ GREATER COMMA ]
+## field -> label attributes COLON . poly_type [ GREATER COMMA ]
 ##
 ## The known suffix of the stack is as follows:
-## label COLON
+## label attributes COLON
 ##
 
 <SYNTAX ERROR>
 
 parse_core_type: LESS LIDENT WITH
 ##
-## Ends in an error in state: 160.
+## Ends in an error in state: 2542.
 ##
-## field -> label . COLON poly_type attributes [ GREATER COMMA ]
+## field -> label attributes . COLON poly_type [ GREATER COMMA ]
 ##
 ## The known suffix of the stack is as follows:
-## label
+## label attributes
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 160, spurious reduction of production attributes ->
 ##
 
 <SYNTAX ERROR>
@@ -2507,7 +2512,7 @@ parse_core_type: LIDENT SHARP WITH
 
 parse_core_type: LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 281.
+## Ends in an error in state: 282.
 ##
 ## _non_arrowed_non_simple_core_type -> type_longident non_arrowed_simple_core_type_list . [ WITH SEMI RPAREN RBRACKET RBRACE QUESTION LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2532,7 +2537,7 @@ parse_core_type: LPAREN MODULE UIDENT COLONGREATER
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
-## In state 279, spurious reduction of production mty_longident -> ident
+## In state 260, spurious reduction of production mty_longident -> ident
 ## In state 137, spurious reduction of production package_type -> mty_longident
 ##
 
@@ -2553,7 +2558,7 @@ parse_core_type: LPAREN MODULE UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
-## In state 279, spurious reduction of production mty_longident -> ident
+## In state 260, spurious reduction of production mty_longident -> ident
 ##
 
 <SYNTAX ERROR>
@@ -2584,12 +2589,12 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER W
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ## In state 2555, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
@@ -2657,7 +2662,7 @@ parse_core_type: LPAREN MODULE WITH
 
 parse_core_type: LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 298.
+## Ends in an error in state: 332.
 ##
 ## core_type_comma_list -> core_type_comma_list COMMA . core_type [ RPAREN COMMA ]
 ##
@@ -2669,7 +2674,7 @@ parse_core_type: LPAREN UNDERSCORE COMMA WITH
 
 parse_core_type: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1252.
+## Ends in an error in state: 1274.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN core_type_comma_list . RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## core_type_comma_list -> core_type_comma_list . COMMA core_type [ RPAREN COMMA ]
@@ -2681,13 +2686,13 @@ parse_core_type: LPAREN UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 309, spurious reduction of production core_type_comma_list -> core_type
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 334, spurious reduction of production core_type_comma_list -> core_type
 ##
 
 Expecting one of the following:
@@ -2760,7 +2765,7 @@ parse_core_type: SHARP WITH
 
 parse_core_type: UIDENT DOT WITH
 ##
-## Ends in an error in state: 225.
+## Ends in an error in state: 206.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ RPAREN LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ RPAREN DOT ]
@@ -2819,7 +2824,7 @@ parse_core_type: UIDENT LPAREN WITH
 
 parse_core_type: UIDENT WITH
 ##
-## Ends in an error in state: 224.
+## Ends in an error in state: 205.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -2839,7 +2844,7 @@ parse_core_type: UIDENT WITH
 
 parse_core_type: UNDERSCORE AS QUOTE WITH
 ##
-## Ends in an error in state: 305.
+## Ends in an error in state: 303.
 ##
 ## _core_type -> core_type2 AS QUOTE . ident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AND AMPERSAND ]
 ##
@@ -2851,7 +2856,7 @@ parse_core_type: UNDERSCORE AS QUOTE WITH
 
 parse_core_type: UNDERSCORE AS WITH
 ##
-## Ends in an error in state: 304.
+## Ends in an error in state: 302.
 ##
 ## _core_type -> core_type2 AS . QUOTE ident [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AND AMPERSAND ]
 ##
@@ -2863,7 +2868,7 @@ parse_core_type: UNDERSCORE AS WITH
 
 parse_core_type: UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 300.
+## Ends in an error in state: 298.
 ##
 ## _core_type2 -> core_type2 EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2886,12 +2891,12 @@ parse_core_type: UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
@@ -2910,7 +2915,7 @@ parse_core_type: WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 ##
-## Ends in an error in state: 2114.
+## Ends in an error in state: 2134.
 ##
 ## and_class_description -> AND . class_description_details post_item_attributes [ SEMI AND ]
 ##
@@ -2922,7 +2927,7 @@ interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ##
-## Ends in an error in state: 2113.
+## Ends in an error in state: 2133.
 ##
 ## _signature_item -> many_class_descriptions . [ SEMI ]
 ## many_class_descriptions -> many_class_descriptions . and_class_description [ SEMI AND ]
@@ -2934,22 +2939,22 @@ interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1750, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1754, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1748, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1752, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1763, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1761, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
-## In state 2086, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
-## In state 2087, spurious reduction of production post_item_attributes ->
-## In state 2088, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
+## In state 1770, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1774, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1768, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1772, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1783, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1781, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 2106, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
+## In state 2107, spurious reduction of production post_item_attributes ->
+## In state 2108, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 2085.
+## Ends in an error in state: 2105.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters COLON . class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -2961,7 +2966,7 @@ interface: CLASS LIDENT COLON WITH
 
 interface: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1504.
+## Ends in an error in state: 1524.
 ##
 ## type_parameter -> type_variance . type_variable [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLON CHAR BACKQUOTE ]
 ##
@@ -2973,7 +2978,7 @@ interface: CLASS LIDENT PLUS WITH
 
 interface: CLASS LIDENT WITH
 ##
-## Ends in an error in state: 2084.
+## Ends in an error in state: 2104.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters . COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS COLON ]
@@ -2986,7 +2991,7 @@ interface: CLASS LIDENT WITH
 
 interface: CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 2082.
+## Ends in an error in state: 2102.
 ##
 ## class_description_details -> virtual_flag . LIDENT class_type_parameters COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -2998,7 +3003,7 @@ interface: CLASS VIRTUAL LET
 
 interface: CLASS WITH
 ##
-## Ends in an error in state: 2073.
+## Ends in an error in state: 2093.
 ##
 ## many_class_descriptions -> CLASS . class_description_details post_item_attributes [ SEMI AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ SEMI AND ]
@@ -3011,7 +3016,7 @@ interface: CLASS WITH
 
 interface: EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1900.
+## Ends in an error in state: 1920.
 ##
 ## extension_constructor_declaration -> UIDENT . generalized_constructor_arguments attributes [ SEMI LBRACKETATAT BAR ]
 ##
@@ -3023,7 +3028,7 @@ interface: EXCEPTION UIDENT WITH
 
 interface: EXCEPTION WITH
 ##
-## Ends in an error in state: 2070.
+## Ends in an error in state: 2090.
 ##
 ## sig_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ SEMI ]
 ##
@@ -3035,7 +3040,7 @@ interface: EXCEPTION WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2065.
+## Ends in an error in state: 2085.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3047,7 +3052,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2064.
+## Ends in an error in state: 2084.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3058,19 +3063,19 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 2063.
+## Ends in an error in state: 2083.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3082,7 +3087,7 @@ interface: EXTERNAL LIDENT COLON WITH
 
 interface: EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 2062.
+## Ends in an error in state: 2082.
 ##
 ## _signature_item -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3094,7 +3099,7 @@ interface: EXTERNAL LIDENT WITH
 
 interface: EXTERNAL WITH
 ##
-## Ends in an error in state: 2061.
+## Ends in an error in state: 2081.
 ##
 ## _signature_item -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3106,7 +3111,7 @@ interface: EXTERNAL WITH
 
 interface: INCLUDE LBRACE OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2089.
+## Ends in an error in state: 2109.
 ##
 ## signature -> signature_item . SEMI signature [ error RBRACE ]
 ##
@@ -3117,18 +3122,18 @@ interface: INCLUDE LBRACE OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1926, spurious reduction of production post_item_attributes ->
-## In state 1927, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 2094, spurious reduction of production _signature_item -> open_statement
-## In state 2121, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 2095, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 1946, spurious reduction of production post_item_attributes ->
+## In state 1947, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 2114, spurious reduction of production _signature_item -> open_statement
+## In state 2141, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 2115, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2090.
+## Ends in an error in state: 2110.
 ##
 ## signature -> signature_item SEMI . signature [ error RBRACE ]
 ##
@@ -3140,7 +3145,7 @@ interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 
 interface: INCLUDE LBRACE WITH
 ##
-## Ends in an error in state: 1986.
+## Ends in an error in state: 2006.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LBRACE . signature error [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3153,7 +3158,7 @@ interface: INCLUDE LBRACE WITH
 
 interface: INCLUDE LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 1230.
+## Ends in an error in state: 1252.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _simple_module_type -> LBRACE . signature error [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3166,7 +3171,7 @@ interface: INCLUDE LPAREN LBRACE WITH
 
 interface: INCLUDE LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 1936.
+## Ends in an error in state: 1956.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3182,7 +3187,7 @@ interface: INCLUDE LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 2135.
+## Ends in an error in state: 2155.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3198,7 +3203,7 @@ interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 2143.
+## Ends in an error in state: 2163.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3213,7 +3218,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LID
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2142.
+## Ends in an error in state: 2162.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3225,7 +3230,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WIT
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2141.
+## Ends in an error in state: 2161.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3237,7 +3242,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2140.
+## Ends in an error in state: 2160.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3252,23 +3257,23 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
-## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 2015, spurious reduction of production _simple_module_type -> mty_longident
+## In state 2047, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 2043, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 2013, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 2048, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 2044, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 2014, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 2049, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 2045, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2139.
+## Ends in an error in state: 2159.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3280,7 +3285,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2138.
+## Ends in an error in state: 2158.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3292,7 +3297,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 1228.
+## Ends in an error in state: 1250.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3306,7 +3311,7 @@ interface: INCLUDE LPAREN LPAREN WITH
 
 interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2433.
+## Ends in an error in state: 2453.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF ]
@@ -3320,19 +3325,19 @@ interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1357, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1363, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1358, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1208, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1365, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1364, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1377, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1383, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1378, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1230, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1385, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1384, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN MODULE TYPE WITH
 ##
-## Ends in an error in state: 431.
+## Ends in an error in state: 453.
 ##
 ## _non_arrowed_module_type -> MODULE TYPE . module_expr [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3344,7 +3349,7 @@ interface: INCLUDE LPAREN MODULE TYPE WITH
 
 interface: INCLUDE LPAREN MODULE WITH
 ##
-## Ends in an error in state: 430.
+## Ends in an error in state: 452.
 ##
 ## _non_arrowed_module_type -> MODULE . TYPE module_expr [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3356,7 +3361,7 @@ interface: INCLUDE LPAREN MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 ##
-## Ends in an error in state: 550.
+## Ends in an error in state: 572.
 ##
 ## ident -> UIDENT . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## mod_ext2 -> mod_ext_longident DOT UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -3370,7 +3375,7 @@ interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 549.
+## Ends in an error in state: 571.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -3384,7 +3389,7 @@ interface: INCLUDE LPAREN UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 1975.
+## Ends in an error in state: 1995.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3399,7 +3404,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1974.
+## Ends in an error in state: 1994.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3411,7 +3416,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 548.
+## Ends in an error in state: 570.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -3431,7 +3436,7 @@ interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UIDENT WHILE
 ##
-## Ends in an error in state: 1229.
+## Ends in an error in state: 1251.
 ##
 ## functor_arg_name -> UIDENT . [ COLON ]
 ## ident -> UIDENT . [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3446,7 +3451,7 @@ interface: INCLUDE LPAREN UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 ##
-## Ends in an error in state: 1957.
+## Ends in an error in state: 1977.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3459,7 +3464,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1954.
+## Ends in an error in state: 1974.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ RPAREN LPAREN DOT ]
 ## mod_ext2 -> UIDENT LPAREN mod_ext_longident . RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3479,7 +3484,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UID
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1953.
+## Ends in an error in state: 1973.
 ##
 ## mod_ext2 -> UIDENT LPAREN . mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ##
@@ -3504,7 +3509,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WIT
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1951.
+## Ends in an error in state: 1971.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3516,7 +3521,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 1966.
+## Ends in an error in state: 1986.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3529,7 +3534,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 ##
-## Ends in an error in state: 1952.
+## Ends in an error in state: 1972.
 ##
 ## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ## mod_ext_longident -> UIDENT . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3542,7 +3547,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1967.
+## Ends in an error in state: 1987.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3554,7 +3559,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1950.
+## Ends in an error in state: 1970.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3567,7 +3572,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 1949.
+## Ends in an error in state: 1969.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3580,7 +3585,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 1970.
+## Ends in an error in state: 1990.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3592,7 +3597,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER A
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER EQUAL
 ##
-## Ends in an error in state: 1969.
+## Ends in an error in state: 1989.
 ##
 ## _module_type -> module_type WITH with_constraints . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## with_constraints -> with_constraints . AND with_constraint [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3604,21 +3609,21 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER E
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 728, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 722, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 724, spurious reduction of production _core_type -> core_type2
-## In state 735, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 723, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1945, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1972, spurious reduction of production with_constraints -> with_constraint
+## In state 384, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 750, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 744, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 746, spurious reduction of production _core_type -> core_type2
+## In state 757, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 745, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1965, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1992, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1944.
+## Ends in an error in state: 1964.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3630,7 +3635,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1946.
+## Ends in an error in state: 1966.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3642,7 +3647,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ##
-## Ends in an error in state: 1948.
+## Ends in an error in state: 1968.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3654,20 +3659,20 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 728, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 722, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 724, spurious reduction of production _core_type -> core_type2
-## In state 735, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 723, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1947, spurious reduction of production constraints ->
+## In state 384, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 750, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 744, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 746, spurious reduction of production _core_type -> core_type2
+## In state 757, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 745, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1967, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ##
-## Ends in an error in state: 1941.
+## Ends in an error in state: 1961.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3679,14 +3684,14 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1345, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 1365, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 1939.
+## Ends in an error in state: 1959.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3699,7 +3704,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH WITH
 ##
-## Ends in an error in state: 1938.
+## Ends in an error in state: 1958.
 ##
 ## _module_type -> module_type WITH . with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3711,7 +3716,7 @@ interface: INCLUDE LPAREN UIDENT WITH WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2128.
+## Ends in an error in state: 2148.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3726,23 +3731,23 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COL
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
-## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 2015, spurious reduction of production _simple_module_type -> mty_longident
+## In state 2047, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 2043, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 2013, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 2048, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 2044, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 2014, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 2049, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 2045, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2127.
+## Ends in an error in state: 2147.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3754,7 +3759,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2126.
+## Ends in an error in state: 2146.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3766,7 +3771,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2125.
+## Ends in an error in state: 2145.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3781,23 +3786,23 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
-## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 2015, spurious reduction of production _simple_module_type -> mty_longident
+## In state 2047, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 2043, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 2013, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 2048, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 2044, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 2014, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 2049, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 2045, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1985.
+## Ends in an error in state: 2005.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3809,7 +3814,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1984.
+## Ends in an error in state: 2004.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3821,7 +3826,7 @@ interface: INCLUDE LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN WITH
 ##
-## Ends in an error in state: 1932.
+## Ends in an error in state: 1952.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3835,7 +3840,7 @@ interface: INCLUDE LPAREN WITH
 
 interface: INCLUDE MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2259.
+## Ends in an error in state: 2279.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
@@ -3849,19 +3854,19 @@ interface: INCLUDE MODULE TYPE UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 790, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 794, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 791, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 777, spurious reduction of production _module_expr -> simple_module_expr
-## In state 796, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 795, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 812, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 816, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 813, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 799, spurious reduction of production _module_expr -> simple_module_expr
+## In state 818, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 817, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE MODULE TYPE WITH
 ##
-## Ends in an error in state: 484.
+## Ends in an error in state: 506.
 ##
 ## _non_arrowed_module_type -> MODULE TYPE . module_expr [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3873,7 +3878,7 @@ interface: INCLUDE MODULE TYPE WITH
 
 interface: INCLUDE MODULE WITH
 ##
-## Ends in an error in state: 483.
+## Ends in an error in state: 505.
 ##
 ## _non_arrowed_module_type -> MODULE . TYPE module_expr [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3885,7 +3890,7 @@ interface: INCLUDE MODULE WITH
 
 interface: INCLUDE UIDENT DOT UIDENT WHILE
 ##
-## Ends in an error in state: 277.
+## Ends in an error in state: 258.
 ##
 ## ident -> UIDENT . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF COLONGREATER AND ]
 ## mod_ext2 -> mod_ext_longident DOT UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -3899,7 +3904,7 @@ interface: INCLUDE UIDENT DOT UIDENT WHILE
 
 interface: INCLUDE UIDENT DOT WITH
 ##
-## Ends in an error in state: 276.
+## Ends in an error in state: 257.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -3913,7 +3918,7 @@ interface: INCLUDE UIDENT DOT WITH
 
 interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2021.
+## Ends in an error in state: 2041.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3928,23 +3933,23 @@ interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
-## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 2015, spurious reduction of production _simple_module_type -> mty_longident
+## In state 2047, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 2043, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 2013, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 2048, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 2044, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 2014, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 2049, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 2045, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2020.
+## Ends in an error in state: 2040.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3956,7 +3961,7 @@ interface: INCLUDE UIDENT EQUALGREATER WITH
 
 interface: INCLUDE UIDENT LPAREN UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 275.
+## Ends in an error in state: 256.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -4004,7 +4009,7 @@ interface: INCLUDE UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 2008.
+## Ends in an error in state: 2028.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4016,7 +4021,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 2010.
+## Ends in an error in state: 2030.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4042,7 +4047,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2011.
+## Ends in an error in state: 2031.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4054,7 +4059,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2007.
+## Ends in an error in state: 2027.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4067,7 +4072,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 2006.
+## Ends in an error in state: 2026.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4080,7 +4085,7 @@ interface: INCLUDE UIDENT WITH MODULE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2014.
+## Ends in an error in state: 2034.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4092,7 +4097,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ##
-## Ends in an error in state: 2013.
+## Ends in an error in state: 2033.
 ##
 ## _module_type -> module_type WITH with_constraints . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraints -> with_constraints . AND with_constraint [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4104,21 +4109,21 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2002, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 2016, spurious reduction of production with_constraints -> with_constraint
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 2022, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 2036, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 2001.
+## Ends in an error in state: 2021.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4130,7 +4135,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 2003.
+## Ends in an error in state: 2023.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4142,7 +4147,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ##
-## Ends in an error in state: 2005.
+## Ends in an error in state: 2025.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4154,20 +4159,20 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2004, spurious reduction of production constraints ->
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 2024, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1942.
+## Ends in an error in state: 1962.
 ##
 ## with_type_binder -> EQUAL . [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
 ## with_type_binder -> EQUAL . PRIVATE [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
@@ -4180,7 +4185,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ##
-## Ends in an error in state: 2000.
+## Ends in an error in state: 2020.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4192,14 +4197,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1999, spurious reduction of production optional_type_parameters ->
+## In state 2019, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 1998.
+## Ends in an error in state: 2018.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4212,7 +4217,7 @@ interface: INCLUDE UIDENT WITH TYPE WITH
 
 interface: INCLUDE UIDENT WITH WITH
 ##
-## Ends in an error in state: 1997.
+## Ends in an error in state: 2017.
 ##
 ## _module_type -> module_type WITH . with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4224,7 +4229,7 @@ interface: INCLUDE UIDENT WITH WITH
 
 interface: INCLUDE WITH
 ##
-## Ends in an error in state: 2058.
+## Ends in an error in state: 2078.
 ##
 ## _signature_item -> INCLUDE . module_type post_item_attributes [ SEMI ]
 ##
@@ -4236,7 +4241,7 @@ interface: INCLUDE WITH
 
 interface: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 2047.
+## Ends in an error in state: 2067.
 ##
 ## _signature_item -> LET val_ident COLON . core_type post_item_attributes [ SEMI ]
 ##
@@ -4248,7 +4253,7 @@ interface: LET LIDENT COLON WITH
 
 interface: LET LIDENT WITH
 ##
-## Ends in an error in state: 2046.
+## Ends in an error in state: 2066.
 ##
 ## _signature_item -> LET val_ident . COLON core_type post_item_attributes [ SEMI ]
 ##
@@ -4260,7 +4265,7 @@ interface: LET LIDENT WITH
 
 interface: LET LPAREN WITH
 ##
-## Ends in an error in state: 698.
+## Ends in an error in state: 720.
 ##
 ## val_ident -> LPAREN . operator RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -4272,7 +4277,7 @@ interface: LET LPAREN WITH
 
 interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
 ##
-## Ends in an error in state: 2104.
+## Ends in an error in state: 2124.
 ##
 ## and_module_rec_declaration -> AND . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4284,7 +4289,7 @@ interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
 
 interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2103.
+## Ends in an error in state: 2123.
 ##
 ## _signature_item -> many_module_rec_declarations . [ SEMI ]
 ## many_module_rec_declarations -> many_module_rec_declarations . and_module_rec_declaration [ SEMI AND ]
@@ -4296,16 +4301,16 @@ interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1578, spurious reduction of production post_item_attributes ->
-## In state 1579, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2045, spurious reduction of production many_module_rec_declarations -> LET MODULE REC module_rec_declaration_details post_item_attributes
+## In state 1598, spurious reduction of production post_item_attributes ->
+## In state 1599, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2065, spurious reduction of production many_module_rec_declarations -> LET MODULE REC module_rec_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 2043.
+## Ends in an error in state: 2063.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -4320,23 +4325,23 @@ interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
-## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 2015, spurious reduction of production _simple_module_type -> mty_longident
+## In state 2047, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 2043, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 2013, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 2048, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 2044, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 2014, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 2049, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 2045, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON WITH
 ##
-## Ends in an error in state: 2042.
+## Ends in an error in state: 2062.
 ##
 ## module_rec_declaration_details -> UIDENT COLON . module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4348,7 +4353,7 @@ interface: LET MODULE REC UIDENT COLON WITH
 
 interface: LET MODULE REC UIDENT WITH
 ##
-## Ends in an error in state: 2041.
+## Ends in an error in state: 2061.
 ##
 ## module_rec_declaration_details -> UIDENT . COLON module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4360,7 +4365,7 @@ interface: LET MODULE REC UIDENT WITH
 
 interface: LET MODULE REC WITH
 ##
-## Ends in an error in state: 2040.
+## Ends in an error in state: 2060.
 ##
 ## many_module_rec_declarations -> LET MODULE REC . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4372,7 +4377,7 @@ interface: LET MODULE REC WITH
 
 interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 2019.
+## Ends in an error in state: 2039.
 ##
 ## _module_declaration -> COLON module_type . [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -4387,23 +4392,23 @@ interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
-## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 2015, spurious reduction of production _simple_module_type -> mty_longident
+## In state 2047, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 2043, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 2013, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 2048, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 2044, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 2014, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 2049, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 2045, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2018.
+## Ends in an error in state: 2038.
 ##
 ## _module_declaration -> COLON . module_type [ SEMI LBRACKETATAT ]
 ##
@@ -4415,7 +4420,7 @@ interface: LET MODULE UIDENT COLON WITH
 
 interface: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2035.
+## Ends in an error in state: 2055.
 ##
 ## _signature_item -> LET MODULE UIDENT EQUAL . mod_longident post_item_attributes [ SEMI ]
 ##
@@ -4427,7 +4432,7 @@ interface: LET MODULE UIDENT EQUAL WITH
 
 interface: LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2033.
+## Ends in an error in state: 2053.
 ##
 ## _module_declaration -> LPAREN RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4439,7 +4444,7 @@ interface: LET MODULE UIDENT LPAREN RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2017.
+## Ends in an error in state: 2037.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4451,7 +4456,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1996.
+## Ends in an error in state: 2016.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type . RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -4466,23 +4471,23 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
-## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 2015, spurious reduction of production _simple_module_type -> mty_longident
+## In state 2047, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 2043, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 2013, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 2048, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 2044, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 2014, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 2049, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 2045, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1992.
+## Ends in an error in state: 2012.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON . module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4494,7 +4499,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1991.
+## Ends in an error in state: 2011.
 ##
 ## _module_declaration -> LPAREN UIDENT . COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4506,7 +4511,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT WITH
 
 interface: LET MODULE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1990.
+## Ends in an error in state: 2010.
 ##
 ## _module_declaration -> LPAREN . UIDENT COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_declaration -> LPAREN . RPAREN module_declaration [ SEMI LBRACKETATAT ]
@@ -4519,7 +4524,7 @@ interface: LET MODULE UIDENT LPAREN WITH
 
 interface: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1989.
+## Ends in an error in state: 2009.
 ##
 ## _signature_item -> LET MODULE UIDENT . module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> LET MODULE UIDENT . EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4532,7 +4537,7 @@ interface: LET MODULE UIDENT WITH
 
 interface: LET MODULE WITH
 ##
-## Ends in an error in state: 1988.
+## Ends in an error in state: 2008.
 ##
 ## _signature_item -> LET MODULE . UIDENT module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> LET MODULE . UIDENT EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4546,7 +4551,7 @@ interface: LET MODULE WITH
 
 interface: LET WITH
 ##
-## Ends in an error in state: 1987.
+## Ends in an error in state: 2007.
 ##
 ## _signature_item -> LET . val_ident COLON core_type post_item_attributes [ SEMI ]
 ## _signature_item -> LET . MODULE UIDENT module_declaration post_item_attributes [ SEMI ]
@@ -4561,7 +4566,7 @@ interface: LET WITH
 
 interface: MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1931.
+## Ends in an error in state: 1951.
 ##
 ## _signature_item -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ SEMI ]
 ##
@@ -4573,7 +4578,7 @@ interface: MODULE TYPE UIDENT EQUAL WITH
 
 interface: MODULE TYPE WITH
 ##
-## Ends in an error in state: 1929.
+## Ends in an error in state: 1949.
 ##
 ## _signature_item -> MODULE TYPE . ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4586,7 +4591,7 @@ interface: MODULE TYPE WITH
 
 interface: MODULE WITH
 ##
-## Ends in an error in state: 1928.
+## Ends in an error in state: 1948.
 ##
 ## _signature_item -> MODULE . TYPE ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4610,18 +4615,18 @@ interface: OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1926, spurious reduction of production post_item_attributes ->
-## In state 1927, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 2094, spurious reduction of production _signature_item -> open_statement
-## In state 2121, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 2095, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 1946, spurious reduction of production post_item_attributes ->
+## In state 1947, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 2114, spurious reduction of production _signature_item -> open_statement
+## In state 2141, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 2115, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 1899.
+## Ends in an error in state: 1919.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4633,7 +4638,7 @@ interface: TYPE LIDENT PLUSEQ BAR WITH
 
 interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 1898.
+## Ends in an error in state: 1918.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4645,7 +4650,7 @@ interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 
 interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 1917.
+## Ends in an error in state: 1937.
 ##
 ## sig_extension_constructors -> sig_extension_constructors BAR . extension_constructor_declaration [ SEMI LBRACKETATAT BAR ]
 ##
@@ -4657,7 +4662,7 @@ interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 interface: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 1897.
+## Ends in an error in state: 1917.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4669,7 +4674,7 @@ interface: TYPE LIDENT PLUSEQ WITH
 
 interface: TYPE LIDENT RBRACKET
 ##
-## Ends in an error in state: 1246.
+## Ends in an error in state: 1268.
 ##
 ## potentially_long_ident_and_optional_type_parameters -> LIDENT optional_type_parameters . [ PLUSEQ ]
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ SEMI LBRACKETATAT EOF AND ]
@@ -4681,7 +4686,7 @@ interface: TYPE LIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1233, spurious reduction of production optional_type_parameters ->
+## In state 1255, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
@@ -4700,7 +4705,7 @@ interface: TYPE LIDENT SEMI WITH
 
 interface: TYPE NONREC LET
 ##
-## Ends in an error in state: 1232.
+## Ends in an error in state: 1254.
 ##
 ## many_type_declarations -> TYPE nonrec_flag . type_declaration_details post_item_attributes [ SEMI AND ]
 ## sig_type_extension -> TYPE nonrec_flag . potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
@@ -4713,7 +4718,7 @@ interface: TYPE NONREC LET
 
 interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ##
-## Ends in an error in state: 1896.
+## Ends in an error in state: 1916.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters . PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4724,8 +4729,8 @@ interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1345, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
-## In state 1349, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
+## In state 1365, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 1369, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
 ##
 
 <SYNTAX ERROR>
@@ -4744,7 +4749,7 @@ interface: WITH
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1767.
+## Ends in an error in state: 1787.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4756,7 +4761,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WIT
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1765.
+## Ends in an error in state: 1785.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4768,7 +4773,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON WITH
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1758.
+## Ends in an error in state: 1778.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4780,7 +4785,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE 
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 1757.
+## Ends in an error in state: 1777.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4793,7 +4798,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE 
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1756.
+## Ends in an error in state: 1776.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4805,7 +4810,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: CLASS LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1759.
+## Ends in an error in state: 1779.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4817,18 +4822,18 @@ implementation: CLASS LIDENT COLON LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1755, spurious reduction of production type_longident -> LIDENT
-## In state 280, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
-## In state 287, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
-## In state 285, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
-## In state 289, spurious reduction of production non_arrowed_core_type -> non_arrowed_simple_core_type
+## In state 1775, spurious reduction of production type_longident -> LIDENT
+## In state 281, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
+## In state 288, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
+## In state 286, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
+## In state 290, spurious reduction of production non_arrowed_core_type -> non_arrowed_simple_core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1739.
+## Ends in an error in state: 1759.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4840,7 +4845,7 @@ implementation: CLASS LIDENT COLON NEW WITH
 
 implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1760.
+## Ends in an error in state: 1780.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4852,7 +4857,7 @@ implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT MINUS WITH
 ##
-## Ends in an error in state: 1517.
+## Ends in an error in state: 1537.
 ##
 ## signed_constant -> MINUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> MINUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -4869,7 +4874,7 @@ implementation: CLASS LIDENT MINUS WITH
 
 implementation: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1516.
+## Ends in an error in state: 1536.
 ##
 ## signed_constant -> PLUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> PLUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -4886,7 +4891,7 @@ implementation: CLASS LIDENT PLUS WITH
 
 implementation: CLASS LIDENT QUOTE WITH
 ##
-## Ends in an error in state: 1505.
+## Ends in an error in state: 1525.
 ##
 ## _type_variable -> QUOTE . ident [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLON CHAR BACKQUOTE ]
 ##
@@ -4898,7 +4903,7 @@ implementation: CLASS LIDENT QUOTE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1439.
+## Ends in an error in state: 1459.
 ##
 ## class_sig_body -> class_self_type . class_sig_fields opt_semi [ error RBRACE ]
 ##
@@ -4910,7 +4915,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 ##
-## Ends in an error in state: 1434.
+## Ends in an error in state: 1454.
 ##
 ## class_self_type -> AS core_type . SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -4921,19 +4926,19 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 ##
-## Ends in an error in state: 1433.
+## Ends in an error in state: 1453.
 ##
 ## class_self_type -> AS . core_type SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -4945,7 +4950,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1487.
+## Ends in an error in state: 1507.
 ##
 ## _class_sig_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4957,7 +4962,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1482.
+## Ends in an error in state: 1502.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT ]
 ## _class_sig_field -> INHERIT class_instance_type . [ error SEMI RBRACE ]
@@ -4970,16 +4975,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1480, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1486, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1478, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1500, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1506, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1498, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1474.
+## Ends in an error in state: 1494.
 ##
 ## _class_sig_field -> INHERIT . class_instance_type [ error SEMI RBRACE ]
 ## _class_sig_field -> INHERIT . class_instance_type item_attribute post_item_attributes [ error SEMI RBRACE ]
@@ -4992,7 +4997,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH RBRACKET WITH
 ##
-## Ends in an error in state: 1742.
+## Ends in an error in state: 1762.
 ##
 ## _class_instance_type -> LBRACE class_sig_body . RBRACE [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE class_sig_body . error [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5004,20 +5009,20 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1494, spurious reduction of production post_item_attributes ->
-## In state 1495, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
-## In state 1500, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
-## In state 1493, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
-## In state 1502, spurious reduction of production class_sig_fields -> class_sig_field
-## In state 1497, spurious reduction of production opt_semi ->
-## In state 1501, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
+## In state 1514, spurious reduction of production post_item_attributes ->
+## In state 1515, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
+## In state 1520, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
+## In state 1513, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
+## In state 1522, spurious reduction of production class_sig_fields -> class_sig_field
+## In state 1517, spurious reduction of production opt_semi ->
+## In state 1521, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 ##
-## Ends in an error in state: 1463.
+## Ends in an error in state: 1483.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label COLON . poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5029,7 +5034,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 ##
-## Ends in an error in state: 1462.
+## Ends in an error in state: 1482.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label . COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5041,7 +5046,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 ##
-## Ends in an error in state: 1459.
+## Ends in an error in state: 1479.
 ##
 ## private_virtual_flags -> PRIVATE . [ LIDENT ]
 ## private_virtual_flags -> PRIVATE . VIRTUAL [ LIDENT ]
@@ -5054,7 +5059,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1461.
+## Ends in an error in state: 1481.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags . label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5066,7 +5071,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 ##
-## Ends in an error in state: 1457.
+## Ends in an error in state: 1477.
 ##
 ## private_virtual_flags -> VIRTUAL . [ LIDENT ]
 ## private_virtual_flags -> VIRTUAL . PRIVATE [ LIDENT ]
@@ -5079,7 +5084,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 ##
-## Ends in an error in state: 1456.
+## Ends in an error in state: 1476.
 ##
 ## _class_sig_field -> METHOD . private_virtual_flags label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5091,7 +5096,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1454.
+## Ends in an error in state: 1474.
 ##
 ## value_type -> label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5103,7 +5108,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1453.
+## Ends in an error in state: 1473.
 ##
 ## value_type -> label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5115,7 +5120,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1449.
+## Ends in an error in state: 1469.
 ##
 ## value_type -> MUTABLE virtual_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5127,7 +5132,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 ##
-## Ends in an error in state: 1448.
+## Ends in an error in state: 1468.
 ##
 ## value_type -> MUTABLE virtual_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5139,7 +5144,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 ##
-## Ends in an error in state: 1447.
+## Ends in an error in state: 1467.
 ##
 ## value_type -> MUTABLE virtual_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5151,7 +5156,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1446.
+## Ends in an error in state: 1466.
 ##
 ## value_type -> MUTABLE . virtual_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5163,7 +5168,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1444.
+## Ends in an error in state: 1464.
 ##
 ## value_type -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5175,7 +5180,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1443.
+## Ends in an error in state: 1463.
 ##
 ## value_type -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5187,7 +5192,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1442.
+## Ends in an error in state: 1462.
 ##
 ## value_type -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5199,7 +5204,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1441.
+## Ends in an error in state: 1461.
 ##
 ## value_type -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5211,7 +5216,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 ##
-## Ends in an error in state: 1440.
+## Ends in an error in state: 1460.
 ##
 ## _class_sig_field -> VAL . value_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5223,7 +5228,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 ##
-## Ends in an error in state: 1741.
+## Ends in an error in state: 1761.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5236,7 +5241,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ##
-## Ends in an error in state: 1785.
+## Ends in an error in state: 1805.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## _non_arrowed_class_constructor_type -> class_instance_type . [ EQUALGREATER ]
@@ -5248,16 +5253,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1750, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1754, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1748, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1770, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1774, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1768, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1751.
+## Ends in an error in state: 1771.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
@@ -5270,7 +5275,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 ##
-## Ends in an error in state: 1750.
+## Ends in an error in state: 1770.
 ##
 ## _class_instance_type -> clty_longident . [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5283,7 +5288,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1779.
+## Ends in an error in state: 1799.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN class_constructor_type . RPAREN [ EQUALGREATER ]
 ##
@@ -5294,19 +5299,19 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1750, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1754, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1748, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1752, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1763, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1761, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1770, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1774, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1768, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1772, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1783, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1781, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 ##
-## Ends in an error in state: 1778.
+## Ends in an error in state: 1798.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN . class_constructor_type RPAREN [ EQUALGREATER ]
 ##
@@ -5318,7 +5323,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 ##
-## Ends in an error in state: 1746.
+## Ends in an error in state: 1766.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5332,7 +5337,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 ##
-## Ends in an error in state: 1745.
+## Ends in an error in state: 1765.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5352,7 +5357,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 
 implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ##
-## Ends in an error in state: 806.
+## Ends in an error in state: 828.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag simple_expr . simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARPOP SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -5371,17 +5376,17 @@ implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 857, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FOR UNDERSCORE WHEN
 ##
-## Ends in an error in state: 800.
+## Ends in an error in state: 822.
 ##
 ## _expr -> FOR pattern . IN simple_expr direction_flag simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _or_pattern -> pattern . BAR pattern [ IN BAR ]
@@ -5393,14 +5398,14 @@ implementation: FOR UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 692, spurious reduction of production pattern -> pattern_without_or
+## In state 714, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 768.
+## Ends in an error in state: 790.
 ##
 ## _simple_expr -> simple_expr . DOT label_longident [ UNDERSCORE UIDENT TRUE STRING SHARPOP SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
 ## _simple_expr -> simple_expr . DOT LPAREN expr RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARPOP SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
@@ -5419,17 +5424,17 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 857, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 767.
+## Ends in an error in state: 789.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern EQUAL . simple_expr [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ##
@@ -5441,7 +5446,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 765.
+## Ends in an error in state: 787.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -5455,7 +5460,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 
 implementation: FUN LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 531.
+## Ends in an error in state: 553.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -5469,7 +5474,7 @@ implementation: FUN LIDENT COLONCOLON WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2260.
+## Ends in an error in state: 2280.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -5484,23 +5489,23 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
-## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 2015, spurious reduction of production _simple_module_type -> mty_longident
+## In state 2047, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 2043, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 2013, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 2048, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 2044, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 2014, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 2049, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 2045, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 482.
+## Ends in an error in state: 504.
 ##
 ## functor_arg -> LPAREN functor_arg_name COLON . module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -5512,7 +5517,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 481.
+## Ends in an error in state: 503.
 ##
 ## functor_arg -> LPAREN functor_arg_name . COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -5524,7 +5529,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 
 implementation: INCLUDE FUN LPAREN WITH
 ##
-## Ends in an error in state: 477.
+## Ends in an error in state: 499.
 ##
 ## functor_arg -> LPAREN . RPAREN [ LPAREN EQUALGREATER COLON ]
 ## functor_arg -> LPAREN . functor_arg_name COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
@@ -5537,7 +5542,7 @@ implementation: INCLUDE FUN LPAREN WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1771.
+## Ends in an error in state: 1791.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5549,16 +5554,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1590, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1596, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1588, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1610, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1616, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1608, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1770.
+## Ends in an error in state: 1790.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5570,7 +5575,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1769.
+## Ends in an error in state: 1789.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type . EQUAL class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5581,19 +5586,19 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1750, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1754, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1748, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1752, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1763, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1761, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1770, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1774, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1768, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1772, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1783, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1781, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 1738.
+## Ends in an error in state: 1758.
 ##
 ## _constrained_class_declaration -> COLON . class_constructor_type EQUAL class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5605,7 +5610,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1832.
+## Ends in an error in state: 1852.
 ##
 ## and_class_declaration -> AND . class_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5617,7 +5622,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1831.
+## Ends in an error in state: 1851.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_class_declarations -> many_class_declarations . and_class_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5629,16 +5634,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1359, spurious reduction of production post_item_attributes ->
-## In state 1360, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1794, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
+## In state 1379, spurious reduction of production post_item_attributes ->
+## In state 1380, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1814, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1737.
+## Ends in an error in state: 1757.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5650,16 +5655,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1590, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1596, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1588, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1610, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1616, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1608, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1518.
+## Ends in an error in state: 1538.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5671,7 +5676,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 1783.
+## Ends in an error in state: 1803.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5683,16 +5688,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1590, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1596, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1588, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1610, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1616, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1608, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1782.
+## Ends in an error in state: 1802.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5704,7 +5709,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1781.
+## Ends in an error in state: 1801.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type . EQUALGREATER class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5716,7 +5721,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT R
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1777.
+## Ends in an error in state: 1797.
 ##
 ## class_fun_return -> COLON . non_arrowed_class_constructor_type EQUALGREATER class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5728,7 +5733,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 1776.
+## Ends in an error in state: 1796.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> EQUALGREATER class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5740,16 +5745,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1590, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1596, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1588, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1610, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1616, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1608, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1775.
+## Ends in an error in state: 1795.
 ##
 ## class_fun_return -> EQUALGREATER . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5761,7 +5766,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1774.
+## Ends in an error in state: 1794.
 ##
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_return [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5774,7 +5779,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1515.
+## Ends in an error in state: 1535.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . constrained_class_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5789,7 +5794,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1827.
+## Ends in an error in state: 1847.
 ##
 ## and_class_type_declaration -> AND . class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5801,7 +5806,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1826.
+## Ends in an error in state: 1846.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_type_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5813,16 +5818,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND R
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1359, spurious reduction of production post_item_attributes ->
-## In state 1360, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1512, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
+## In state 1379, spurious reduction of production post_item_attributes ->
+## In state 1380, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1532, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1503.
+## Ends in an error in state: 1523.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5834,16 +5839,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1480, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1486, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1478, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1500, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1506, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1498, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1430.
+## Ends in an error in state: 1450.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5855,7 +5860,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1427.
+## Ends in an error in state: 1447.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters . EQUAL class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS EQUAL ]
@@ -5868,7 +5873,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 ##
-## Ends in an error in state: 1425.
+## Ends in an error in state: 1445.
 ##
 ## class_type_declaration_details -> virtual_flag . LIDENT class_type_parameters EQUAL class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5880,7 +5885,7 @@ implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE WITH
 ##
-## Ends in an error in state: 1424.
+## Ends in an error in state: 1444.
 ##
 ## many_class_type_declarations -> CLASS TYPE . class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5892,7 +5897,7 @@ implementation: INCLUDE LBRACE CLASS TYPE WITH
 
 implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 1513.
+## Ends in an error in state: 1533.
 ##
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters constrained_class_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5906,7 +5911,7 @@ implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 
 implementation: INCLUDE LBRACE CLASS WITH
 ##
-## Ends in an error in state: 1422.
+## Ends in an error in state: 1442.
 ##
 ## many_class_declarations -> CLASS . class_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5919,7 +5924,7 @@ implementation: INCLUDE LBRACE CLASS WITH
 
 implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 ##
-## Ends in an error in state: 1397.
+## Ends in an error in state: 1417.
 ##
 ## extension_constructor_declaration -> LPAREN . RPAREN generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## extension_constructor_rebind -> LPAREN . RPAREN EQUAL constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -5932,7 +5937,7 @@ implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1384.
+## Ends in an error in state: 1404.
 ##
 ## generalized_constructor_arguments -> COLON . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -5944,7 +5949,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 ##
-## Ends in an error in state: 1379.
+## Ends in an error in state: 1399.
 ##
 ## constr_longident -> LBRACKET . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -5956,7 +5961,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 1378.
+## Ends in an error in state: 1398.
 ##
 ## constr_longident -> LPAREN . RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -5968,7 +5973,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1377.
+## Ends in an error in state: 1397.
 ##
 ## extension_constructor_rebind -> UIDENT EQUAL . constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ##
@@ -5980,7 +5985,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1387.
+## Ends in an error in state: 1407.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list COLON . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -5992,7 +5997,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1386.
+## Ends in an error in state: 1406.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . COLON core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
@@ -6006,7 +6011,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1376.
+## Ends in an error in state: 1396.
 ##
 ## extension_constructor_declaration -> UIDENT . generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## extension_constructor_rebind -> UIDENT . EQUAL constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -6019,7 +6024,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 
 implementation: INCLUDE LBRACE EXCEPTION WITH
 ##
-## Ends in an error in state: 1375.
+## Ends in an error in state: 1395.
 ##
 ## str_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## str_exception_declaration -> EXCEPTION . extension_constructor_rebind post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
@@ -6032,7 +6037,7 @@ implementation: INCLUDE LBRACE EXCEPTION WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 ##
-## Ends in an error in state: 1371.
+## Ends in an error in state: 1391.
 ##
 ## primitive_declaration -> STRING . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ## primitive_declaration -> STRING . primitive_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
@@ -6045,7 +6050,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WIT
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1370.
+## Ends in an error in state: 1390.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6057,7 +6062,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1369.
+## Ends in an error in state: 1389.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6068,19 +6073,19 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1368.
+## Ends in an error in state: 1388.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6092,7 +6097,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 1367.
+## Ends in an error in state: 1387.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6104,7 +6109,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 
 implementation: INCLUDE LBRACE EXTERNAL WITH
 ##
-## Ends in an error in state: 1366.
+## Ends in an error in state: 1386.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6116,7 +6121,7 @@ implementation: INCLUDE LBRACE EXTERNAL WITH
 
 implementation: INCLUDE LBRACE MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 429.
+## Ends in an error in state: 451.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6128,7 +6133,7 @@ implementation: INCLUDE LBRACE MODULE TYPE UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE MODULE TYPE WITH
 ##
-## Ends in an error in state: 427.
+## Ends in an error in state: 449.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE . ident post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
@@ -6141,7 +6146,7 @@ implementation: INCLUDE LBRACE MODULE TYPE WITH
 
 implementation: INCLUDE LBRACE MODULE WITH
 ##
-## Ends in an error in state: 426.
+## Ends in an error in state: 448.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
@@ -6154,7 +6159,7 @@ implementation: INCLUDE LBRACE MODULE WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1209.
+## Ends in an error in state: 1231.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER module_expr . [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6169,7 +6174,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHIL
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1207.
+## Ends in an error in state: 1229.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER . module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6181,7 +6186,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1206.
+## Ends in an error in state: 1228.
 ##
 ## _module_expr -> FUN functor_args . EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## functor_args -> functor_args . functor_arg [ LPAREN EQUALGREATER ]
@@ -6194,7 +6199,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 
 implementation: INCLUDE LPAREN FUN WITH
 ##
-## Ends in an error in state: 1205.
+## Ends in an error in state: 1227.
 ##
 ## _module_expr -> FUN . functor_args EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6206,7 +6211,7 @@ implementation: INCLUDE LPAREN FUN WITH
 
 implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2144.
+## Ends in an error in state: 2164.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -6221,24 +6226,24 @@ implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 260, spurious reduction of production ident -> UIDENT
-## In state 552, spurious reduction of production mty_longident -> ident
-## In state 1935, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1981, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1977, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1933, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1982, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1978, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1934, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1983, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1979, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 241, spurious reduction of production ident -> UIDENT
+## In state 574, spurious reduction of production mty_longident -> ident
+## In state 1955, spurious reduction of production _simple_module_type -> mty_longident
+## In state 2001, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1997, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1953, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 2002, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1998, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1954, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 2003, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1999, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1227.
+## Ends in an error in state: 1249.
 ##
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6251,7 +6256,7 @@ implementation: INCLUDE LPAREN UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2431.
+## Ends in an error in state: 2451.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -6268,19 +6273,19 @@ implementation: INCLUDE LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1357, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1363, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1358, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1208, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1365, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1364, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1377, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1383, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1378, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1230, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1385, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1384, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1221.
+## Ends in an error in state: 1243.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6292,7 +6297,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLON
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
-## In state 279, spurious reduction of production mty_longident -> ident
+## In state 260, spurious reduction of production mty_longident -> ident
 ## In state 137, spurious reduction of production package_type -> mty_longident
 ##
 
@@ -6300,7 +6305,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLON
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1220.
+## Ends in an error in state: 1242.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6312,7 +6317,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 2429.
+## Ends in an error in state: 2449.
 ##
 ## _module_expr -> LPAREN VAL expr COLON . error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6326,7 +6331,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1215.
+## Ends in an error in state: 1237.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6338,7 +6343,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
-## In state 279, spurious reduction of production mty_longident -> ident
+## In state 260, spurious reduction of production mty_longident -> ident
 ## In state 137, spurious reduction of production package_type -> mty_longident
 ##
 
@@ -6346,7 +6351,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 2427.
+## Ends in an error in state: 2447.
 ##
 ## _module_expr -> LPAREN VAL expr COLONGREATER . error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6359,7 +6364,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 2425.
+## Ends in an error in state: 2445.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -6400,21 +6405,21 @@ implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN VAL WITH
 ##
-## Ends in an error in state: 433.
+## Ends in an error in state: 455.
 ##
 ## _module_expr -> LPAREN VAL . expr COLON error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _module_expr -> LPAREN VAL . expr COLONGREATER error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6432,7 +6437,7 @@ implementation: INCLUDE LPAREN VAL WITH
 
 implementation: INCLUDE LPAREN WITH
 ##
-## Ends in an error in state: 432.
+## Ends in an error in state: 454.
 ##
 ## _module_expr -> LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _module_expr -> LPAREN . VAL expr COLON error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6455,7 +6460,7 @@ implementation: INCLUDE LPAREN WITH
 
 implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ##
-## Ends in an error in state: 2229.
+## Ends in an error in state: 2249.
 ##
 ## _simple_module_expr -> LBRACE structure . RBRACE [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6466,29 +6471,29 @@ implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1886, spurious reduction of production post_item_attributes ->
-## In state 1887, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1888, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1802, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1795, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1803, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1796, spurious reduction of production structure -> structure_item
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1906, spurious reduction of production post_item_attributes ->
+## In state 1907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1815, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1909, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1816, spurious reduction of production structure -> structure_item
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 490.
+## Ends in an error in state: 512.
 ##
 ## _simple_module_expr -> LBRACE . structure RBRACE [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6500,7 +6505,7 @@ implementation: INCLUDE UIDENT LBRACE WITH
 
 implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1224.
+## Ends in an error in state: 1246.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -6517,19 +6522,19 @@ implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1357, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1363, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1358, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1208, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1365, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1364, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1377, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1383, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1378, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1230, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1385, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1384, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 1217.
+## Ends in an error in state: 1239.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type COLONGREATER package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6542,7 +6547,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1214.
+## Ends in an error in state: 1236.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6554,7 +6559,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 1212.
+## Ends in an error in state: 1234.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -6592,21 +6597,21 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 964, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 934, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 944, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 973, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 943, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL WITH
 ##
-## Ends in an error in state: 1211.
+## Ends in an error in state: 1233.
 ##
 ## _simple_module_expr -> LPAREN VAL . expr RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL . expr COLON package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6621,7 +6626,7 @@ implementation: INCLUDE UIDENT LPAREN VAL WITH
 
 implementation: INCLUDE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1210.
+## Ends in an error in state: 1232.
 ##
 ## _module_expr -> module_expr LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN . module_expr COLON module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6641,7 +6646,7 @@ implementation: INCLUDE UIDENT LPAREN WITH
 
 implementation: INCLUDE UIDENT WHILE
 ##
-## Ends in an error in state: 1357.
+## Ends in an error in state: 1377.
 ##
 ## _simple_module_expr -> mod_longident . [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF DOT COLON AND ]
@@ -6654,7 +6659,7 @@ implementation: INCLUDE UIDENT WHILE
 
 implementation: INCLUDE WITH
 ##
-## Ends in an error in state: 1353.
+## Ends in an error in state: 1373.
 ##
 ## _structure_item_without_item_extension_sugar -> INCLUDE . module_expr post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6666,7 +6671,7 @@ implementation: INCLUDE WITH
 
 implementation: LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1612.
+## Ends in an error in state: 1632.
 ##
 ## class_self_pattern_and_structure -> class_self_pattern . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -6678,7 +6683,7 @@ implementation: LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: LBRACE AS UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1601.
+## Ends in an error in state: 1621.
 ##
 ## _class_self_pattern -> AS pattern . SEMI [ error VAL RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ## _or_pattern -> pattern . BAR pattern [ SEMI BAR ]
@@ -6690,14 +6695,14 @@ implementation: LBRACE AS UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 692, spurious reduction of production pattern -> pattern_without_or
+## In state 714, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE AS WITH
 ##
-## Ends in an error in state: 1600.
+## Ends in an error in state: 1620.
 ##
 ## _class_self_pattern -> AS . pattern SEMI [ error VAL RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ##
@@ -6709,7 +6714,7 @@ implementation: LBRACE AS WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1489.
+## Ends in an error in state: 1509.
 ##
 ## constrain_field -> core_type EQUAL . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -6721,7 +6726,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1488.
+## Ends in an error in state: 1508.
 ##
 ## constrain_field -> core_type . EQUAL core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -6732,19 +6737,19 @@ implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1691.
+## Ends in an error in state: 1711.
 ##
 ## _class_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -6756,7 +6761,7 @@ implementation: LBRACE CONSTRAINT WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2308.
+## Ends in an error in state: 2328.
 ##
 ## opt_comma -> COMMA . [ RBRACE ]
 ## record_expr -> DOTDOTDOT expr_optional_constraint COMMA . lbl_expr_list [ error RBRACE ]
@@ -6770,7 +6775,7 @@ implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ##
-## Ends in an error in state: 2307.
+## Ends in an error in state: 2327.
 ##
 ## _simple_expr -> LBRACE DOTDOTDOT expr_optional_constraint . opt_comma RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## record_expr -> DOTDOTDOT expr_optional_constraint . COMMA lbl_expr_list [ error RBRACE ]
@@ -6783,22 +6788,22 @@ implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1101, spurious reduction of production expr_optional_constraint -> expr
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 964, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 934, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 944, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 973, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 943, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1123, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE DOTDOTDOT WITH
 ##
-## Ends in an error in state: 2306.
+## Ends in an error in state: 2326.
 ##
 ## _simple_expr -> LBRACE DOTDOTDOT . expr_optional_constraint opt_comma RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## record_expr -> DOTDOTDOT . expr_optional_constraint COMMA lbl_expr_list [ error RBRACE ]
@@ -6812,7 +6817,7 @@ implementation: LBRACE DOTDOTDOT WITH
 
 implementation: LBRACE INHERIT BANG WITH
 ##
-## Ends in an error in state: 1685.
+## Ends in an error in state: 1705.
 ##
 ## _class_field -> INHERIT override_flag . class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -6824,7 +6829,7 @@ implementation: LBRACE INHERIT BANG WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1586.
+## Ends in an error in state: 1606.
 ##
 ## _class_expr -> CLASS class_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF COLON AS AND ]
@@ -6837,7 +6842,7 @@ implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1585.
+## Ends in an error in state: 1605.
 ##
 ## _class_expr -> CLASS class_longident . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> CLASS class_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6850,7 +6855,7 @@ implementation: LBRACE INHERIT CLASS LIDENT WITH
 
 implementation: LBRACE INHERIT CLASS WITH
 ##
-## Ends in an error in state: 1584.
+## Ends in an error in state: 1604.
 ##
 ## _class_expr -> CLASS . class_longident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> CLASS . class_longident non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6863,7 +6868,7 @@ implementation: LBRACE INHERIT CLASS WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1593.
+## Ends in an error in state: 1613.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER class_expr . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6876,7 +6881,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND R
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1583.
+## Ends in an error in state: 1603.
 ##
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER . class_expr [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ##
@@ -6888,7 +6893,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1582.
+## Ends in an error in state: 1602.
 ##
 ## _class_fun_def -> labeled_simple_pattern . EQUALGREATER class_expr [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern . class_fun_def [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6901,7 +6906,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 
 implementation: LBRACE INHERIT FUN WITH
 ##
-## Ends in an error in state: 1580.
+## Ends in an error in state: 1600.
 ##
 ## _class_expr -> FUN . class_fun_def [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ##
@@ -6913,7 +6918,7 @@ implementation: LBRACE INHERIT FUN WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 1606.
+## Ends in an error in state: 1626.
 ##
 ## _class_expr_lets_and_rest -> let_bindings SEMI . class_expr_lets_and_rest [ error RBRACE ]
 ##
@@ -6925,7 +6930,7 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ##
-## Ends in an error in state: 1605.
+## Ends in an error in state: 1625.
 ##
 ## _class_expr_lets_and_rest -> let_bindings . SEMI class_expr_lets_and_rest [ error RBRACE ]
 ## let_bindings -> let_bindings . and_let_binding [ SEMI AND ]
@@ -6937,22 +6942,22 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1575, spurious reduction of production let_binding_body -> pattern EQUAL expr
-## In state 1576, spurious reduction of production post_item_attributes ->
-## In state 1577, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
-## In state 1607, spurious reduction of production let_binding -> let_binding_impl
-## In state 1608, spurious reduction of production let_bindings -> let_binding
+## In state 934, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 944, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 973, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 943, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1595, spurious reduction of production let_binding_body -> pattern EQUAL expr
+## In state 1596, spurious reduction of production post_item_attributes ->
+## In state 1597, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
+## In state 1627, spurious reduction of production let_binding -> let_binding_impl
+## In state 1628, spurious reduction of production let_bindings -> let_binding
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE LET WITH
 ##
-## Ends in an error in state: 1521.
+## Ends in an error in state: 1541.
 ##
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI AND ]
 ##
@@ -6964,7 +6969,7 @@ implementation: LBRACE INHERIT LBRACE LET WITH
 
 implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ##
-## Ends in an error in state: 1704.
+## Ends in an error in state: 1724.
 ##
 ## _class_expr -> class_expr . attribute [ error RBRACE LBRACKETAT ]
 ## _class_expr_lets_and_rest -> class_expr . [ error RBRACE ]
@@ -6976,16 +6981,16 @@ implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1590, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1596, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1588, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1610, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1616, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1608, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 ##
-## Ends in an error in state: 1609.
+## Ends in an error in state: 1629.
 ##
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI AND ]
 ##
@@ -6996,15 +7001,15 @@ implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 416, spurious reduction of production attr_id -> single_attr_id
-## In state 419, spurious reduction of production item_extension_sugar -> PERCENT attr_id
+## In state 438, spurious reduction of production attr_id -> single_attr_id
+## In state 441, spurious reduction of production item_extension_sugar -> PERCENT attr_id
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE WITH
 ##
-## Ends in an error in state: 1520.
+## Ends in an error in state: 1540.
 ##
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest RBRACE [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7017,7 +7022,7 @@ implementation: LBRACE INHERIT LBRACE WITH
 
 implementation: LBRACE INHERIT LIDENT AS WITH
 ##
-## Ends in an error in state: 1687.
+## Ends in an error in state: 1707.
 ##
 ## parent_binder -> AS . LIDENT [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7029,7 +7034,7 @@ implementation: LBRACE INHERIT LIDENT AS WITH
 
 implementation: LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1686.
+## Ends in an error in state: 1706.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AS ]
 ## _class_field -> INHERIT override_flag class_expr . parent_binder post_item_attributes [ error SEMI RBRACE ]
@@ -7041,16 +7046,16 @@ implementation: LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1590, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1596, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1588, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1610, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1616, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1608, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT SEMI WITH
 ##
-## Ends in an error in state: 1700.
+## Ends in an error in state: 1720.
 ##
 ## semi_terminated_class_fields -> class_field SEMI . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -7062,7 +7067,7 @@ implementation: LBRACE INHERIT LIDENT SEMI WITH
 
 implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ##
-## Ends in an error in state: 1591.
+## Ends in an error in state: 1611.
 ##
 ## _class_expr -> class_simple_expr simple_labeled_expr_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## simple_labeled_expr_list -> simple_labeled_expr_list . labeled_simple_expr [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7074,20 +7079,20 @@ implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 855, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 860, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
-## In state 863, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 862, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 877, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 882, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
+## In state 885, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT WITH
 ##
-## Ends in an error in state: 1590.
+## Ends in an error in state: 1610.
 ##
 ## _class_expr -> class_simple_expr . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> class_simple_expr . simple_labeled_expr_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -7100,7 +7105,7 @@ implementation: LBRACE INHERIT LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1732.
+## Ends in an error in state: 1752.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -7112,7 +7117,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE 
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1731.
+## Ends in an error in state: 1751.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -7125,7 +7130,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE 
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1730.
+## Ends in an error in state: 1750.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -7137,7 +7142,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1723.
+## Ends in an error in state: 1743.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -7149,7 +7154,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 1722.
+## Ends in an error in state: 1742.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -7162,7 +7167,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1721.
+## Ends in an error in state: 1741.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -7174,7 +7179,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1724.
+## Ends in an error in state: 1744.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -7186,18 +7191,18 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1720, spurious reduction of production type_longident -> LIDENT
-## In state 280, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
-## In state 287, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
-## In state 285, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
-## In state 289, spurious reduction of production non_arrowed_core_type -> non_arrowed_simple_core_type
+## In state 1740, spurious reduction of production type_longident -> LIDENT
+## In state 281, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
+## In state 288, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
+## In state 286, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
+## In state 290, spurious reduction of production non_arrowed_core_type -> non_arrowed_simple_core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 ##
-## Ends in an error in state: 1432.
+## Ends in an error in state: 1452.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -7210,7 +7215,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1719.
+## Ends in an error in state: 1739.
 ##
 ## _class_constructor_type -> NEW class_instance_type . [ error RPAREN ]
 ## _class_instance_type -> class_instance_type . attribute [ error RPAREN LBRACKETAT ]
@@ -7222,16 +7227,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1480, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1486, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1478, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1500, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1506, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1498, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1481.
+## Ends in an error in state: 1501.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
@@ -7244,7 +7249,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 ##
-## Ends in an error in state: 1480.
+## Ends in an error in state: 1500.
 ##
 ## _class_instance_type -> clty_longident . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -7257,7 +7262,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 ##
-## Ends in an error in state: 1476.
+## Ends in an error in state: 1496.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -7271,7 +7276,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 ##
-## Ends in an error in state: 1475.
+## Ends in an error in state: 1495.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -7291,7 +7296,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1718.
+## Ends in an error in state: 1738.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ error RPAREN ]
 ##
@@ -7303,7 +7308,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1725.
+## Ends in an error in state: 1745.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -7315,7 +7320,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 ##
-## Ends in an error in state: 1717.
+## Ends in an error in state: 1737.
 ##
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7328,7 +7333,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ##
-## Ends in an error in state: 1714.
+## Ends in an error in state: 1734.
 ##
 ## _class_expr -> class_expr . attribute [ error RPAREN LBRACKETAT COLON ]
 ## _class_simple_expr -> LPAREN class_expr . COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7343,16 +7348,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1590, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1596, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1588, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1610, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1616, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1608, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN WITH
 ##
-## Ends in an error in state: 1519.
+## Ends in an error in state: 1539.
 ##
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7367,7 +7372,7 @@ implementation: LBRACE INHERIT LPAREN WITH
 
 implementation: LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1684.
+## Ends in an error in state: 1704.
 ##
 ## _class_field -> INHERIT . override_flag class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7379,7 +7384,7 @@ implementation: LBRACE INHERIT WITH
 
 implementation: LBRACE INITIALIZER EQUALGREATER WITH
 ##
-## Ends in an error in state: 1681.
+## Ends in an error in state: 1701.
 ##
 ## _class_field -> INITIALIZER EQUALGREATER . expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7391,7 +7396,7 @@ implementation: LBRACE INITIALIZER EQUALGREATER WITH
 
 implementation: LBRACE INITIALIZER WITH
 ##
-## Ends in an error in state: 1680.
+## Ends in an error in state: 1700.
 ##
 ## _class_field -> INITIALIZER . EQUALGREATER expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7403,7 +7408,7 @@ implementation: LBRACE INITIALIZER WITH
 
 implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 2322.
+## Ends in an error in state: 2342.
 ##
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -7415,17 +7420,17 @@ implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2285, spurious reduction of production opt_semi -> SEMI
-## In state 2296, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
-## In state 2294, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2283, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2305, spurious reduction of production opt_semi -> SEMI
+## In state 2316, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
+## In state 2314, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2303, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
 ##
 
 Expecting "}" to finish the block
 
 implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2272.
+## Ends in an error in state: 2292.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7437,7 +7442,7 @@ implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 
 implementation: LBRACE LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 476.
+## Ends in an error in state: 498.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7449,7 +7454,7 @@ implementation: LBRACE LET MODULE UIDENT WITH
 
 implementation: LBRACE LET MODULE WITH
 ##
-## Ends in an error in state: 475.
+## Ends in an error in state: 497.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7461,7 +7466,7 @@ implementation: LBRACE LET MODULE WITH
 
 implementation: LBRACE LET OPEN BANG WITH
 ##
-## Ends in an error in state: 2277.
+## Ends in an error in state: 2297.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7473,7 +7478,7 @@ implementation: LBRACE LET OPEN BANG WITH
 
 implementation: LBRACE LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2280.
+## Ends in an error in state: 2300.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7485,7 +7490,7 @@ implementation: LBRACE LET OPEN UIDENT SEMI WITH
 
 implementation: LBRACE LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2279.
+## Ends in an error in state: 2299.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7496,14 +7501,14 @@ implementation: LBRACE LET OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2278, spurious reduction of production post_item_attributes ->
+## In state 2298, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET OPEN WITH
 ##
-## Ends in an error in state: 2276.
+## Ends in an error in state: 2296.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7515,7 +7520,7 @@ implementation: LBRACE LET OPEN WITH
 
 implementation: LBRACE LET WITH
 ##
-## Ends in an error in state: 473.
+## Ends in an error in state: 495.
 ##
 ## _semi_terminated_seq_expr_row -> LET . MODULE UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ error SEMI RBRACE AND ]
@@ -7529,7 +7534,7 @@ implementation: LBRACE LET WITH
 
 implementation: LBRACE LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1171.
+## Ends in an error in state: 1193.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7565,21 +7570,21 @@ implementation: LBRACE LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1170.
+## Ends in an error in state: 1192.
 ##
 ## lbl_expr -> label_longident COLON . expr [ COMMA ]
 ## non_punned_lbl_expression -> label_longident COLON . expr [ error RBRACE ]
@@ -7592,7 +7597,7 @@ implementation: LBRACE LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1160.
+## Ends in an error in state: 1182.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7627,21 +7632,21 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 ##
-## Ends in an error in state: 1159.
+## Ends in an error in state: 1181.
 ##
 ## lbl_expr -> label_longident COLON . expr [ error RBRACE COMMA ]
 ##
@@ -7653,7 +7658,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 ##
-## Ends in an error in state: 1156.
+## Ends in an error in state: 1178.
 ##
 ## lbl_expr_list -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ## lbl_expr_list -> lbl_expr COMMA . [ error RBRACE ]
@@ -7666,7 +7671,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT WITH
 ##
-## Ends in an error in state: 1158.
+## Ends in an error in state: 1180.
 ##
 ## lbl_expr -> label_longident . COLON expr [ error RBRACE COMMA ]
 ## lbl_expr -> label_longident . [ error RBRACE COMMA ]
@@ -7679,7 +7684,7 @@ implementation: LBRACE LIDENT COMMA LIDENT WITH
 
 implementation: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 1167.
+## Ends in an error in state: 1189.
 ##
 ## lbl_expr_list_that_is_not_a_single_punned_field -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ##
@@ -7691,7 +7696,7 @@ implementation: LBRACE LIDENT COMMA WITH
 
 implementation: LBRACE METHOD BANG WITH
 ##
-## Ends in an error in state: 1637.
+## Ends in an error in state: 1657.
 ##
 ## method_ -> override_flag . PRIVATE VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag . VIRTUAL private_flag label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -7708,7 +7713,7 @@ implementation: LBRACE METHOD BANG WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1673.
+## Ends in an error in state: 1693.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7743,21 +7748,21 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1672.
+## Ends in an error in state: 1692.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT core_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7769,7 +7774,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1671.
+## Ends in an error in state: 1691.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT core_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7780,19 +7785,19 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1670.
+## Ends in an error in state: 1690.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT . core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7804,7 +7809,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 1668.
+## Ends in an error in state: 1688.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE . lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7816,7 +7821,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE WITH
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1676.
+## Ends in an error in state: 1696.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7851,21 +7856,21 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1675.
+## Ends in an error in state: 1695.
 ##
 ## method_ -> override_flag private_flag label COLON poly_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7877,7 +7882,7 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1674.
+## Ends in an error in state: 1694.
 ##
 ## method_ -> override_flag private_flag label COLON poly_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7888,22 +7893,22 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1316, spurious reduction of production _poly_type -> core_type
-## In state 1317, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1315, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1336, spurious reduction of production _poly_type -> core_type
+## In state 1337, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1335, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON WITH
 ##
-## Ends in an error in state: 1667.
+## Ends in an error in state: 1687.
 ##
 ## method_ -> override_flag private_flag label COLON . poly_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag private_flag label COLON . TYPE lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -7916,7 +7921,7 @@ implementation: LBRACE METHOD LIDENT COLON WITH
 
 implementation: LBRACE METHOD LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1666.
+## Ends in an error in state: 1686.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7951,21 +7956,21 @@ implementation: LBRACE METHOD LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1665.
+## Ends in an error in state: 1685.
 ##
 ## method_ -> override_flag private_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7977,7 +7982,7 @@ implementation: LBRACE METHOD LIDENT EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1699.
+## Ends in an error in state: 1719.
 ##
 ## semi_terminated_class_fields -> class_field . [ error RBRACE ]
 ## semi_terminated_class_fields -> class_field . SEMI semi_terminated_class_fields [ error RBRACE ]
@@ -7989,27 +7994,27 @@ implementation: LBRACE METHOD LIDENT EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1656, spurious reduction of production curried_binding -> EQUALGREATER expr
-## In state 1677, spurious reduction of production method_ -> override_flag private_flag label curried_binding
-## In state 1678, spurious reduction of production post_item_attributes ->
-## In state 1679, spurious reduction of production _class_field -> METHOD method_ post_item_attributes
-## In state 1702, spurious reduction of production mark_position_cf(_class_field) -> _class_field
-## In state 1695, spurious reduction of production class_field -> mark_position_cf(_class_field)
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1676, spurious reduction of production curried_binding -> EQUALGREATER expr
+## In state 1697, spurious reduction of production method_ -> override_flag private_flag label curried_binding
+## In state 1698, spurious reduction of production post_item_attributes ->
+## In state 1699, spurious reduction of production _class_field -> METHOD method_ post_item_attributes
+## In state 1722, spurious reduction of production mark_position_cf(_class_field) -> _class_field
+## In state 1715, spurious reduction of production class_field -> mark_position_cf(_class_field)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1647.
+## Ends in an error in state: 1667.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8021,7 +8026,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1646.
+## Ends in an error in state: 1666.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8033,7 +8038,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL WITH
 ##
-## Ends in an error in state: 1645.
+## Ends in an error in state: 1665.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8045,7 +8050,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL WITH
 
 implementation: LBRACE METHOD PRIVATE WITH
 ##
-## Ends in an error in state: 1644.
+## Ends in an error in state: 1664.
 ##
 ## method_ -> override_flag PRIVATE . VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## private_flag -> PRIVATE . [ LIDENT ]
@@ -8058,7 +8063,7 @@ implementation: LBRACE METHOD PRIVATE WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1467.
+## Ends in an error in state: 1487.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8070,7 +8075,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1466.
+## Ends in an error in state: 1486.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -8083,7 +8088,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WIT
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE WITH
 ##
-## Ends in an error in state: 1464.
+## Ends in an error in state: 1484.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ error SEMI RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AS ]
 ## typevar_list -> QUOTE . ident [ QUOTE DOT ]
@@ -8096,7 +8101,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1642.
+## Ends in an error in state: 1662.
 ##
 ## method_ -> override_flag VIRTUAL private_flag label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8108,7 +8113,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1641.
+## Ends in an error in state: 1661.
 ##
 ## method_ -> override_flag VIRTUAL private_flag label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8120,7 +8125,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT WITH
 
 implementation: LBRACE METHOD VIRTUAL PRIVATE LET
 ##
-## Ends in an error in state: 1640.
+## Ends in an error in state: 1660.
 ##
 ## method_ -> override_flag VIRTUAL private_flag . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8132,7 +8137,7 @@ implementation: LBRACE METHOD VIRTUAL PRIVATE LET
 
 implementation: LBRACE METHOD VIRTUAL WITH
 ##
-## Ends in an error in state: 1638.
+## Ends in an error in state: 1658.
 ##
 ## method_ -> override_flag VIRTUAL . private_flag label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8144,7 +8149,7 @@ implementation: LBRACE METHOD VIRTUAL WITH
 
 implementation: LBRACE METHOD WITH
 ##
-## Ends in an error in state: 1636.
+## Ends in an error in state: 1656.
 ##
 ## _class_field -> METHOD . method_ post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8156,7 +8161,7 @@ implementation: LBRACE METHOD WITH
 
 implementation: LBRACE PERCENT WITH TYPE
 ##
-## Ends in an error in state: 2287.
+## Ends in an error in state: 2307.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ error RBRACE ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ error SEMI RBRACE AND ]
@@ -8168,15 +8173,15 @@ implementation: LBRACE PERCENT WITH TYPE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 416, spurious reduction of production attr_id -> single_attr_id
-## In state 419, spurious reduction of production item_extension_sugar -> PERCENT attr_id
+## In state 438, spurious reduction of production attr_id -> single_attr_id
+## In state 441, spurious reduction of production item_extension_sugar -> PERCENT attr_id
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE UIDENT DOT WITH
 ##
-## Ends in an error in state: 2333.
+## Ends in an error in state: 2353.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
@@ -8203,7 +8208,7 @@ implementation: LBRACE UIDENT DOT WITH
 
 implementation: LBRACE VAL BANG WITH
 ##
-## Ends in an error in state: 1622.
+## Ends in an error in state: 1642.
 ##
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8218,7 +8223,7 @@ implementation: LBRACE VAL BANG WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1635.
+## Ends in an error in state: 1655.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8253,21 +8258,21 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL UIDENT RP
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 ##
-## Ends in an error in state: 1634.
+## Ends in an error in state: 1654.
 ##
 ## value -> override_flag mutable_flag label type_constraint EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8279,7 +8284,7 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1633.
+## Ends in an error in state: 1653.
 ##
 ## value -> override_flag mutable_flag label type_constraint . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8290,20 +8295,20 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1103, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1125, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1632.
+## Ends in an error in state: 1652.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8338,21 +8343,21 @@ implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1631.
+## Ends in an error in state: 1651.
 ##
 ## value -> override_flag mutable_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8364,7 +8369,7 @@ implementation: LBRACE VAL LIDENT EQUAL WITH
 
 implementation: LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1630.
+## Ends in an error in state: 1650.
 ##
 ## value -> override_flag mutable_flag label . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag mutable_flag label . type_constraint EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -8377,7 +8382,7 @@ implementation: LBRACE VAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1627.
+## Ends in an error in state: 1647.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8389,19 +8394,19 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 728, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 722, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 724, spurious reduction of production _core_type -> core_type2
-## In state 735, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 723, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 384, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 750, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 744, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 746, spurious reduction of production _core_type -> core_type2
+## In state 757, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 745, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1626.
+## Ends in an error in state: 1646.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8414,7 +8419,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1625.
+## Ends in an error in state: 1645.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8427,7 +8432,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 ##
-## Ends in an error in state: 1624.
+## Ends in an error in state: 1644.
 ##
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8440,7 +8445,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 
 implementation: LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1623.
+## Ends in an error in state: 1643.
 ##
 ## mutable_flag -> MUTABLE . [ LIDENT ]
 ## value -> override_flag MUTABLE . VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -8454,7 +8459,7 @@ implementation: LBRACE VAL MUTABLE WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1618.
+## Ends in an error in state: 1638.
 ##
 ## value -> VIRTUAL mutable_flag label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8466,19 +8471,19 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 728, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 722, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 724, spurious reduction of production _core_type -> core_type2
-## In state 735, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 723, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 384, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 750, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 744, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 746, spurious reduction of production _core_type -> core_type2
+## In state 757, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 745, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1617.
+## Ends in an error in state: 1637.
 ##
 ## value -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8491,7 +8496,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1616.
+## Ends in an error in state: 1636.
 ##
 ## value -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8504,7 +8509,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1615.
+## Ends in an error in state: 1635.
 ##
 ## value -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8517,7 +8522,7 @@ implementation: LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1614.
+## Ends in an error in state: 1634.
 ##
 ## value -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL . mutable_flag label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8530,7 +8535,7 @@ implementation: LBRACE VAL VIRTUAL WITH
 
 implementation: LBRACE VAL WITH
 ##
-## Ends in an error in state: 1613.
+## Ends in an error in state: 1633.
 ##
 ## _class_field -> VAL . value post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8542,7 +8547,7 @@ implementation: LBRACE VAL WITH
 
 implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2493.
+## Ends in an error in state: 2513.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8577,21 +8582,21 @@ implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACELESS LIDENT COLON WITH
 ##
-## Ends in an error in state: 203.
+## Ends in an error in state: 184.
 ##
 ## field_expr -> LIDENT COLON . expr [ error GREATERRBRACE COMMA ]
 ##
@@ -8603,7 +8608,7 @@ implementation: LBRACELESS LIDENT COLON WITH
 
 implementation: LBRACELESS LIDENT COMMA WITH
 ##
-## Ends in an error in state: 465.
+## Ends in an error in state: 487.
 ##
 ## field_expr_list -> field_expr_list COMMA . field_expr [ error GREATERRBRACE COMMA ]
 ## opt_comma -> COMMA . [ error GREATERRBRACE ]
@@ -8616,7 +8621,7 @@ implementation: LBRACELESS LIDENT COMMA WITH
 
 implementation: LBRACELESS LIDENT WITH
 ##
-## Ends in an error in state: 202.
+## Ends in an error in state: 183.
 ##
 ## field_expr -> LIDENT . COLON expr [ error GREATERRBRACE COMMA ]
 ## field_expr -> LIDENT . [ error GREATERRBRACE COMMA ]
@@ -8629,7 +8634,7 @@ implementation: LBRACELESS LIDENT WITH
 
 implementation: LBRACKET DOTDOTDOT WITH
 ##
-## Ends in an error in state: 1135.
+## Ends in an error in state: 1157.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT . expr_optional_constraint RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -8641,7 +8646,7 @@ implementation: LBRACKET DOTDOTDOT WITH
 
 implementation: LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 1138.
+## Ends in an error in state: 1160.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint . opt_comma RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## expr_comma_seq_extension -> expr_optional_constraint . COMMA expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -8653,15 +8658,15 @@ implementation: LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1101, spurious reduction of production expr_optional_constraint -> expr
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 964, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 934, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 944, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 973, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 943, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1123, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 Expecting one of the following:
@@ -8670,7 +8675,7 @@ Expecting one of the following:
 
 implementation: LBRACKET WITH
 ##
-## Ends in an error in state: 446.
+## Ends in an error in state: 468.
 ##
 ## _simple_expr -> LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## constr_longident -> LBRACKET . RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -8686,7 +8691,7 @@ Expecting one of the following:
 
 implementation: LBRACKETATATAT UNDERSCORE
 ##
-## Ends in an error in state: 493.
+## Ends in an error in state: 515.
 ##
 ## floating_attribute -> LBRACKETATATAT . attr_id payload RBRACKET [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -8698,7 +8703,7 @@ implementation: LBRACKETATATAT UNDERSCORE
 
 implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2225.
+## Ends in an error in state: 2245.
 ##
 ## floating_attribute -> LBRACKETATATAT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -8709,30 +8714,30 @@ implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1886, spurious reduction of production post_item_attributes ->
-## In state 1887, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1888, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1802, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1795, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1803, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1796, spurious reduction of production structure -> structure_item
-## In state 1892, spurious reduction of production payload -> structure
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1906, spurious reduction of production post_item_attributes ->
+## In state 1907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1815, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1909, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1816, spurious reduction of production structure -> structure_item
+## In state 1912, spurious reduction of production payload -> structure
 ##
 
 Expecting "]" to finish current floating attribute
 
 implementation: LBRACKETBAR BANG WITH
 ##
-## Ends in an error in state: 502.
+## Ends in an error in state: 524.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -8744,7 +8749,7 @@ implementation: LBRACKETBAR BANG WITH
 
 implementation: LBRACKETBAR MINUSDOT WITH
 ##
-## Ends in an error in state: 845.
+## Ends in an error in state: 867.
 ##
 ## _expr -> subtractive . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -8756,7 +8761,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR PLUSDOT WITH
 ##
-## Ends in an error in state: 879.
+## Ends in an error in state: 901.
 ##
 ## _expr -> additive . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -8768,7 +8773,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR PREFIXOP WITH
 ##
-## Ends in an error in state: 188.
+## Ends in an error in state: 169.
 ##
 ## _simple_expr -> PREFIXOP . simple_expr [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -8780,7 +8785,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1128.
+## Ends in an error in state: 1150.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8792,7 +8797,7 @@ Expecting a type name
 
 implementation: LBRACKETBAR UIDENT COLON WITH
 ##
-## Ends in an error in state: 1125.
+## Ends in an error in state: 1147.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8804,7 +8809,7 @@ implementation: LBRACKETBAR UIDENT COLON WITH
 
 implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1123.
+## Ends in an error in state: 1145.
 ##
 ## type_constraint -> COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8816,7 +8821,7 @@ implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 
 implementation: LBRACKETBAR UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1120.
+## Ends in an error in state: 1142.
 ##
 ## expr_comma_seq -> expr_comma_seq COMMA . expr_optional_constraint [ error COMMA BARRBRACKET ]
 ## opt_comma -> COMMA . [ error BARRBRACKET ]
@@ -8829,7 +8834,7 @@ implementation: LBRACKETBAR UIDENT COMMA WITH
 
 implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 ##
-## Ends in an error in state: 491.
+## Ends in an error in state: 513.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT . attr_id payload RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -8841,7 +8846,7 @@ implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH COLON WITH
 ##
-## Ends in an error in state: 1420.
+## Ends in an error in state: 1440.
 ##
 ## payload -> COLON . core_type [ RBRACKET ]
 ##
@@ -8865,7 +8870,7 @@ implementation: LBRACKETPERCENTPERCENT WITH DOT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ##
-## Ends in an error in state: 2459.
+## Ends in an error in state: 2479.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN RBRACKET BAR ]
 ## payload -> QUESTION pattern . [ RBRACKET ]
@@ -8878,14 +8883,14 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 692, spurious reduction of production pattern -> pattern_without_or
+## In state 714, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2461.
+## Ends in an error in state: 2481.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8920,21 +8925,21 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 964, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 934, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 944, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 973, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 943, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2460.
+## Ends in an error in state: 2480.
 ##
 ## payload -> QUESTION pattern WHEN . expr [ RBRACKET ]
 ##
@@ -8946,7 +8951,7 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN WITH
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION WITH
 ##
-## Ends in an error in state: 220.
+## Ends in an error in state: 201.
 ##
 ## payload -> QUESTION . pattern [ RBRACKET ]
 ## payload -> QUESTION . pattern WHEN expr [ RBRACKET ]
@@ -8959,7 +8964,7 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION WITH
 
 implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2227.
+## Ends in an error in state: 2247.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -8970,23 +8975,23 @@ implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1886, spurious reduction of production post_item_attributes ->
-## In state 1887, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1888, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1802, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1795, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1803, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1796, spurious reduction of production structure -> structure_item
-## In state 1892, spurious reduction of production payload -> structure
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1906, spurious reduction of production post_item_attributes ->
+## In state 1907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1815, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1909, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1816, spurious reduction of production structure -> structure_item
+## In state 1912, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
@@ -9006,7 +9011,7 @@ implementation: LBRACKETPERCENTPERCENT WITH WITH
 
 implementation: LET CHAR EQUAL CHAR AND WITH
 ##
-## Ends in an error in state: 1837.
+## Ends in an error in state: 1857.
 ##
 ## and_let_binding -> AND . let_binding_body post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9018,7 +9023,7 @@ implementation: LET CHAR EQUAL CHAR AND WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1853.
+## Ends in an error in state: 1873.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -9053,21 +9058,21 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1857.
+## Ends in an error in state: 1877.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9079,7 +9084,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1856.
+## Ends in an error in state: 1876.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9090,19 +9095,19 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1855.
+## Ends in an error in state: 1875.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9114,7 +9119,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1854.
+## Ends in an error in state: 1874.
 ##
 ## let_binding_body -> val_ident COLON typevar_list . DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -9127,7 +9132,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1851.
+## Ends in an error in state: 1871.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9139,7 +9144,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1850.
+## Ends in an error in state: 1870.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9150,19 +9155,19 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1849.
+## Ends in an error in state: 1869.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9174,7 +9179,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1547.
+## Ends in an error in state: 1567.
 ##
 ## lident_list -> LIDENT . [ DOT ]
 ## lident_list -> LIDENT . lident_list [ DOT ]
@@ -9187,7 +9192,7 @@ implementation: LET LIDENT COLON TYPE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 1847.
+## Ends in an error in state: 1867.
 ##
 ## let_binding_body -> val_ident COLON TYPE . lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9199,7 +9204,7 @@ implementation: LET LIDENT COLON TYPE WITH
 
 implementation: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 1846.
+## Ends in an error in state: 1866.
 ##
 ## let_binding_body -> val_ident COLON . typevar_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## let_binding_body -> val_ident COLON . TYPE lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9213,7 +9218,7 @@ implementation: LET LIDENT COLON WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1860.
+## Ends in an error in state: 1880.
 ##
 ## let_binding_body -> val_ident type_constraint EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9225,7 +9230,7 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 1859.
+## Ends in an error in state: 1879.
 ##
 ## let_binding_body -> val_ident type_constraint . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9236,20 +9241,20 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1103, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1125, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1844.
+## Ends in an error in state: 1864.
 ##
 ## _curried_binding_return_typed -> EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9261,7 +9266,7 @@ implementation: LET LIDENT EQUALGREATER WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1842.
+## Ends in an error in state: 1862.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9273,7 +9278,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1841.
+## Ends in an error in state: 1861.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9285,7 +9290,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1840.
+## Ends in an error in state: 1860.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9297,7 +9302,7 @@ implementation: LET LIDENT LPAREN TYPE WITH
 
 implementation: LET LIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1839.
+## Ends in an error in state: 1859.
 ##
 ## _curried_binding_return_typed -> LPAREN . TYPE LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -9320,7 +9325,7 @@ implementation: LET LIDENT LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1660.
+## Ends in an error in state: 1680.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -9355,21 +9360,21 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1659.
+## Ends in an error in state: 1679.
 ##
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9381,7 +9386,7 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1658.
+## Ends in an error in state: 1678.
 ##
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type . EQUALGREATER expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9395,7 +9400,7 @@ Expecting "=>" to start the function body
 
 implementation: LET LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1657.
+## Ends in an error in state: 1677.
 ##
 ## curried_binding_return_typed_ -> COLON . non_arrowed_core_type EQUALGREATER expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9407,7 +9412,7 @@ implementation: LET LIDENT UNDERSCORE COLON WITH
 
 implementation: LET LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1655.
+## Ends in an error in state: 1675.
 ##
 ## curried_binding -> EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9419,7 +9424,7 @@ Expecting an expression as function body
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1654.
+## Ends in an error in state: 1674.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9431,7 +9436,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1653.
+## Ends in an error in state: 1673.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9443,7 +9448,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1652.
+## Ends in an error in state: 1672.
 ##
 ## curried_binding -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9455,7 +9460,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 1651.
+## Ends in an error in state: 1671.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -9478,7 +9483,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 1661.
+## Ends in an error in state: 1681.
 ##
 ## curried_binding -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9490,7 +9495,7 @@ implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 
 implementation: LET LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1863.
+## Ends in an error in state: 1883.
 ##
 ## _curried_binding_return_typed -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9506,7 +9511,7 @@ Expecting one of the following:
 
 implementation: LET LIDENT WITH
 ##
-## Ends in an error in state: 1838.
+## Ends in an error in state: 1858.
 ##
 ## _simple_pattern -> val_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> val_ident . type_constraint EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9522,7 +9527,7 @@ implementation: LET LIDENT WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 ##
-## Ends in an error in state: 1822.
+## Ends in an error in state: 1842.
 ##
 ## and_nonlocal_module_bindings -> AND . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9534,7 +9539,7 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1821.
+## Ends in an error in state: 1841.
 ##
 ## _structure_item_without_item_extension_sugar -> many_nonlocal_module_bindings . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> many_nonlocal_module_bindings . and_nonlocal_module_bindings [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -9546,16 +9551,16 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WIT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1359, spurious reduction of production post_item_attributes ->
-## In state 1360, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2251, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
+## In state 1379, spurious reduction of production post_item_attributes ->
+## In state 1380, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2271, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE REC WITH
 ##
-## Ends in an error in state: 2249.
+## Ends in an error in state: 2269.
 ##
 ## many_nonlocal_module_bindings -> LET MODULE REC . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9567,7 +9572,7 @@ implementation: LET MODULE REC WITH
 
 implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2235.
+## Ends in an error in state: 2255.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9581,19 +9586,19 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1357, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1363, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1358, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1208, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1365, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1364, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1377, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1383, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1378, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1230, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1385, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1384, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2234.
+## Ends in an error in state: 2254.
 ##
 ## module_binding_body_expr -> COLON module_type EQUAL . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9605,7 +9610,7 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
 
 implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2233.
+## Ends in an error in state: 2253.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER EQUAL ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER EQUAL ]
@@ -9620,23 +9625,23 @@ implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
-## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 2015, spurious reduction of production _simple_module_type -> mty_longident
+## In state 2047, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 2043, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 2013, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 2048, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 2044, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 2014, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 2049, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 2045, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2232.
+## Ends in an error in state: 2252.
 ##
 ## module_binding_body_expr -> COLON . module_type EQUAL module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9648,7 +9653,7 @@ implementation: LET MODULE UIDENT COLON WITH
 
 implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2231.
+## Ends in an error in state: 2251.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9662,19 +9667,19 @@ implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1357, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1363, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1358, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1208, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1365, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1364, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1377, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1383, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1378, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1230, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1385, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1384, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 489.
+## Ends in an error in state: 511.
 ##
 ## module_binding_body_expr -> EQUAL . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9686,7 +9691,7 @@ implementation: LET MODULE UIDENT EQUAL WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2246.
+## Ends in an error in state: 2266.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER module_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9700,19 +9705,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1357, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1363, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1358, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1208, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1365, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1364, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1377, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1383, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1378, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1230, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1385, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1384, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2245.
+## Ends in an error in state: 2265.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9724,7 +9729,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2244.
+## Ends in an error in state: 2264.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type . EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_type -> non_arrowed_module_type . [ WITH LBRACKETAT EQUALGREATER ]
@@ -9737,20 +9742,20 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
-## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 260, spurious reduction of production mty_longident -> ident
+## In state 2015, spurious reduction of production _simple_module_type -> mty_longident
+## In state 2047, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 2043, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 2013, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 2048, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 2044, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER SEMI
 ##
-## Ends in an error in state: 2247.
+## Ends in an error in state: 2267.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER ]
@@ -9763,24 +9768,24 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT CO
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2002, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 2016, spurious reduction of production with_constraints -> with_constraint
-## In state 2013, spurious reduction of production _module_type -> module_type WITH with_constraints
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 2022, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 2036, spurious reduction of production with_constraints -> with_constraint
+## In state 2033, spurious reduction of production _module_type -> module_type WITH with_constraints
+## In state 2049, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 2045, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
 ##
-## Ends in an error in state: 2243.
+## Ends in an error in state: 2263.
 ##
 ## _module_binding_body_functor -> functor_args COLON . non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9792,7 +9797,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2242.
+## Ends in an error in state: 2262.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER module_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9806,19 +9811,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1357, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1363, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1358, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1208, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1365, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1364, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1377, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1383, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1378, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1230, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1385, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1384, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2241.
+## Ends in an error in state: 2261.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9830,7 +9835,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2240.
+## Ends in an error in state: 2260.
 ##
 ## _module_binding_body_functor -> functor_args . EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_binding_body_functor -> functor_args . COLON non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9844,7 +9849,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 
 implementation: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 488.
+## Ends in an error in state: 510.
 ##
 ## nonlocal_module_binding_details -> UIDENT . module_binding_body [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9856,7 +9861,7 @@ implementation: LET MODULE UIDENT WITH
 
 implementation: LET MODULE WITH
 ##
-## Ends in an error in state: 487.
+## Ends in an error in state: 509.
 ##
 ## _structure_item_without_item_extension_sugar -> LET MODULE . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> LET MODULE . REC nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -9869,7 +9874,7 @@ implementation: LET MODULE WITH
 
 implementation: LET REC ASSERT
 ##
-## Ends in an error in state: 2254.
+## Ends in an error in state: 2274.
 ##
 ## let_binding_impl -> LET rec_flag . let_binding_body post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9881,7 +9886,7 @@ implementation: LET REC ASSERT
 
 implementation: LET UIDENT UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1872.
+## Ends in an error in state: 1892.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EQUAL BAR ]
 ## let_binding_body -> pattern . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9893,17 +9898,17 @@ implementation: LET UIDENT UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 688, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
-## In state 691, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
-## In state 686, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
-## In state 692, spurious reduction of production pattern -> pattern_without_or
+## In state 710, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
+## In state 713, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
+## In state 708, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
+## In state 714, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1870.
+## Ends in an error in state: 1890.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9915,7 +9920,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1869.
+## Ends in an error in state: 1889.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9926,19 +9931,19 @@ implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1868.
+## Ends in an error in state: 1888.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON . core_type EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9950,7 +9955,7 @@ implementation: LET UNDERSCORE COLON WITH
 
 implementation: LET UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1873.
+## Ends in an error in state: 1893.
 ##
 ## let_binding_body -> pattern EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9962,7 +9967,7 @@ implementation: LET UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE WITH
 ##
-## Ends in an error in state: 1867.
+## Ends in an error in state: 1887.
 ##
 ## _simple_pattern -> simple_pattern_not_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> simple_pattern_not_ident . COLON core_type EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9975,7 +9980,7 @@ implementation: LET UNDERSCORE WITH
 
 implementation: LET WITH
 ##
-## Ends in an error in state: 486.
+## Ends in an error in state: 508.
 ##
 ## _structure_item_without_item_extension_sugar -> LET . MODULE nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -9989,7 +9994,7 @@ Incomplete let binding
 
 implementation: LPAREN ASSERT WITH
 ##
-## Ends in an error in state: 843.
+## Ends in an error in state: 865.
 ##
 ## _expr -> ASSERT . simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10001,7 +10006,7 @@ implementation: LPAREN ASSERT WITH
 
 implementation: LPAREN BACKQUOTE WITH
 ##
-## Ends in an error in state: 503.
+## Ends in an error in state: 525.
 ##
 ## name_tag -> BACKQUOTE . ident [ error UNDERSCORE UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10013,7 +10018,7 @@ implementation: LPAREN BACKQUOTE WITH
 
 implementation: LPAREN BANG WITH
 ##
-## Ends in an error in state: 818.
+## Ends in an error in state: 840.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP RPAREN QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## operator -> BANG . [ RPAREN ]
@@ -10026,7 +10031,7 @@ implementation: LPAREN BANG WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 ##
-## Ends in an error in state: 805.
+## Ends in an error in state: 827.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag . simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10038,7 +10043,7 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ##
-## Ends in an error in state: 802.
+## Ends in an error in state: 824.
 ##
 ## _expr -> FOR pattern IN simple_expr . direction_flag simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ TO SHARPOP SHARP DOWNTO DOT ]
@@ -10057,17 +10062,17 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 857, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FOR UNDERSCORE IN WITH
 ##
-## Ends in an error in state: 801.
+## Ends in an error in state: 823.
 ##
 ## _expr -> FOR pattern IN . simple_expr direction_flag simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10079,7 +10084,7 @@ implementation: LPAREN FOR UNDERSCORE IN WITH
 
 implementation: LPAREN FOR WITH
 ##
-## Ends in an error in state: 799.
+## Ends in an error in state: 821.
 ##
 ## _expr -> FOR . pattern IN simple_expr direction_flag simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10091,7 +10096,7 @@ implementation: LPAREN FOR WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2208.
+## Ends in an error in state: 2228.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10126,17 +10131,17 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2207.
+## Ends in an error in state: 2227.
 ##
 ## leading_bar_match_case -> pattern_with_bar EQUALGREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10148,7 +10153,7 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2206.
+## Ends in an error in state: 2226.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10183,17 +10188,17 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2205.
+## Ends in an error in state: 2225.
 ##
 ## leading_bar_match_case -> pattern_with_bar WHEN expr EQUALGREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10205,7 +10210,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2204.
+## Ends in an error in state: 2224.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10240,21 +10245,21 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 964, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 934, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 944, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 973, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 943, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2203.
+## Ends in an error in state: 2223.
 ##
 ## leading_bar_match_case -> pattern_with_bar WHEN . expr EQUALGREATER expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10266,7 +10271,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 525.
+## Ends in an error in state: 547.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10278,7 +10283,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 524.
+## Ends in an error in state: 546.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10290,7 +10295,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN LPAREN TYPE WITH
 ##
-## Ends in an error in state: 523.
+## Ends in an error in state: 545.
 ##
 ## _expr -> FUN LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10302,7 +10307,7 @@ implementation: LPAREN FUN LPAREN TYPE WITH
 
 implementation: LPAREN FUN LPAREN WITH
 ##
-## Ends in an error in state: 522.
+## Ends in an error in state: 544.
 ##
 ## _expr -> FUN LPAREN . TYPE LIDENT RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -10325,7 +10330,7 @@ implementation: LPAREN FUN LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2193.
+## Ends in an error in state: 2213.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10360,17 +10365,17 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2192.
+## Ends in an error in state: 2212.
 ##
 ## fun_def -> EQUALGREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10382,7 +10387,7 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 529.
+## Ends in an error in state: 551.
 ##
 ## fun_def -> LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10394,7 +10399,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 528.
+## Ends in an error in state: 550.
 ##
 ## fun_def -> LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10406,7 +10411,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 527.
+## Ends in an error in state: 549.
 ##
 ## fun_def -> LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10418,7 +10423,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 526.
+## Ends in an error in state: 548.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -10441,7 +10446,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 2198.
+## Ends in an error in state: 2218.
 ##
 ## fun_def -> labeled_simple_pattern . fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10453,7 +10458,7 @@ implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 
 implementation: LPAREN FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2212.
+## Ends in an error in state: 2232.
 ##
 ## _expr -> FUN labeled_simple_pattern . fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10465,7 +10470,7 @@ implementation: LPAREN FUN UNDERSCORE WITH
 
 implementation: LPAREN FUN WITH
 ##
-## Ends in an error in state: 521.
+## Ends in an error in state: 543.
 ##
 ## _expr -> FUN . labeled_simple_pattern fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> FUN . LPAREN TYPE LIDENT RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10479,7 +10484,7 @@ implementation: LPAREN FUN WITH
 
 implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 ##
-## Ends in an error in state: 520.
+## Ends in an error in state: 542.
 ##
 ## _expr -> IF simple_expr simple_expr ELSE . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10491,7 +10496,7 @@ implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 
 implementation: LPAREN IF UIDENT WITH
 ##
-## Ends in an error in state: 513.
+## Ends in an error in state: 535.
 ##
 ## _expr -> IF simple_expr . simple_expr ELSE expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF simple_expr . simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10511,17 +10516,17 @@ implementation: LPAREN IF UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 857, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN IF WITH
 ##
-## Ends in an error in state: 512.
+## Ends in an error in state: 534.
 ##
 ## _expr -> IF . simple_expr simple_expr ELSE expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF . simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10534,7 +10539,7 @@ implementation: LPAREN IF WITH
 
 implementation: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 495.
+## Ends in an error in state: 517.
 ##
 ## _expr -> LAZY . simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10546,7 +10551,7 @@ implementation: LPAREN LAZY WITH
 
 implementation: LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 471.
+## Ends in an error in state: 493.
 ##
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10566,7 +10571,7 @@ implementation: LPAREN LBRACE WITH
 
 implementation: LPAREN LBRACELESS WITH
 ##
-## Ends in an error in state: 462.
+## Ends in an error in state: 484.
 ##
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10580,7 +10585,7 @@ implementation: LPAREN LBRACELESS WITH
 
 implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ##
-## Ends in an error in state: 1136.
+## Ends in an error in state: 1158.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT expr_optional_constraint . RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10591,22 +10596,22 @@ implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1101, spurious reduction of production expr_optional_constraint -> expr
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 964, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 934, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 944, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 973, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 943, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1123, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKET UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1139.
+## Ends in an error in state: 1161.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint COMMA . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## opt_comma -> COMMA . [ RBRACKET ]
@@ -10619,7 +10624,7 @@ implementation: LPAREN LBRACKET UIDENT COMMA WITH
 
 implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2392.
+## Ends in an error in state: 2412.
 ##
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10632,23 +10637,23 @@ implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1122, spurious reduction of production expr_optional_constraint -> expr
-## In state 1118, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1144, spurious reduction of production expr_optional_constraint -> expr
+## In state 1140, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKETBAR WITH
 ##
-## Ends in an error in state: 445.
+## Ends in an error in state: 467.
 ##
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10662,7 +10667,7 @@ implementation: LPAREN LBRACKETBAR WITH
 
 implementation: LPAREN LBRACKETPERCENT UNDERSCORE
 ##
-## Ends in an error in state: 218.
+## Ends in an error in state: 199.
 ##
 ## extension -> LBRACKETPERCENT . attr_id payload RBRACKET [ error WITH UNDERSCORE UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10674,7 +10679,7 @@ implementation: LPAREN LBRACKETPERCENT UNDERSCORE
 
 implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2462.
+## Ends in an error in state: 2482.
 ##
 ## extension -> LBRACKETPERCENT attr_id payload . RBRACKET [ error WITH UNDERSCORE UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10685,30 +10690,30 @@ implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1886, spurious reduction of production post_item_attributes ->
-## In state 1887, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1888, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1802, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1795, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1803, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1796, spurious reduction of production structure -> structure_item
-## In state 1892, spurious reduction of production payload -> structure
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1906, spurious reduction of production post_item_attributes ->
+## In state 1907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1815, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1909, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1816, spurious reduction of production structure -> structure_item
+## In state 1912, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 865.
+## Ends in an error in state: 887.
 ##
 ## _expr -> label EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10720,7 +10725,7 @@ implementation: LPAREN LIDENT EQUAL WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ##
-## Ends in an error in state: 2483.
+## Ends in an error in state: 2503.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr . RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10755,21 +10760,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 964, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 934, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 944, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 973, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 943, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2482.
+## Ends in an error in state: 2502.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA . expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10781,7 +10786,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2481.
+## Ends in an error in state: 2501.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr . COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10816,21 +10821,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 964, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 934, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 944, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 973, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 943, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2480.
+## Ends in an error in state: 2500.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN . expr COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10842,7 +10847,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2479.
+## Ends in an error in state: 2499.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN . LPAREN expr COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10854,7 +10859,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2478.
+## Ends in an error in state: 2498.
 ##
 ## _expr -> LPAREN COLONCOLON . RPAREN LPAREN expr COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10866,7 +10871,7 @@ implementation: LPAREN LPAREN COLONCOLON WITH
 
 implementation: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2472.
+## Ends in an error in state: 2492.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -10882,19 +10887,19 @@ implementation: LPAREN LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 790, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 794, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 791, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 777, spurious reduction of production _module_expr -> simple_module_expr
-## In state 796, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 795, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 812, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 816, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 813, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 799, spurious reduction of production _module_expr -> simple_module_expr
+## In state 818, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 817, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN MODULE WITH
 ##
-## Ends in an error in state: 214.
+## Ends in an error in state: 195.
 ##
 ## _simple_expr -> LPAREN MODULE . module_expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE . module_expr COLON package_type RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10908,7 +10913,7 @@ Expecting a module expression
 
 implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ##
-## Ends in an error in state: 2485.
+## Ends in an error in state: 2505.
 ##
 ## _simple_expr -> LPAREN expr_comma_list . RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN expr_comma_list . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10921,19 +10926,19 @@ implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1122, spurious reduction of production expr_optional_constraint -> expr
-## In state 1182, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1144, spurious reduction of production expr_optional_constraint -> expr
+## In state 1204, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 208.
+## Ends in an error in state: 189.
 ##
 ## _expr -> LPAREN . COLONCOLON RPAREN LPAREN expr COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -10960,7 +10965,7 @@ Expecting one of the following:
 
 implementation: LPAREN MINUS WITH
 ##
-## Ends in an error in state: 798.
+## Ends in an error in state: 820.
 ##
 ## operator -> MINUS . [ RPAREN ]
 ## subtractive -> MINUS . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
@@ -10973,7 +10978,7 @@ implementation: LPAREN MINUS WITH
 
 implementation: LPAREN MINUSDOT WITH
 ##
-## Ends in an error in state: 797.
+## Ends in an error in state: 819.
 ##
 ## operator -> MINUSDOT . [ RPAREN ]
 ## subtractive -> MINUSDOT . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
@@ -10986,7 +10991,7 @@ implementation: LPAREN MINUSDOT WITH
 
 implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2476.
+## Ends in an error in state: 2496.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10998,7 +11003,7 @@ implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
-## In state 279, spurious reduction of production mty_longident -> ident
+## In state 260, spurious reduction of production mty_longident -> ident
 ## In state 137, spurious reduction of production package_type -> mty_longident
 ##
 
@@ -11006,7 +11011,7 @@ implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2474.
+## Ends in an error in state: 2494.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -11045,7 +11050,7 @@ implementation: LPAREN NEW UIDENT WITH
 
 implementation: LPAREN NEW WITH
 ##
-## Ends in an error in state: 189.
+## Ends in an error in state: 170.
 ##
 ## _simple_expr -> NEW . class_longident [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11057,7 +11062,7 @@ implementation: LPAREN NEW WITH
 
 implementation: LPAREN PLUS WITH
 ##
-## Ends in an error in state: 211.
+## Ends in an error in state: 192.
 ##
 ## additive -> PLUS . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
 ## operator -> PLUS . [ RPAREN ]
@@ -11070,7 +11075,7 @@ implementation: LPAREN PLUS WITH
 
 implementation: LPAREN PLUSDOT WITH
 ##
-## Ends in an error in state: 210.
+## Ends in an error in state: 191.
 ##
 ## additive -> PLUSDOT . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
 ## operator -> PLUSDOT . [ RPAREN ]
@@ -11083,7 +11088,7 @@ implementation: LPAREN PLUSDOT WITH
 
 implementation: LPAREN PREFIXOP WITH
 ##
-## Ends in an error in state: 196.
+## Ends in an error in state: 177.
 ##
 ## _simple_expr -> PREFIXOP . simple_expr [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP RPAREN QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## operator -> PREFIXOP . [ RPAREN ]
@@ -11096,7 +11101,7 @@ implementation: LPAREN PREFIXOP WITH
 
 implementation: LPAREN STAR WITH
 ##
-## Ends in an error in state: 627.
+## Ends in an error in state: 649.
 ##
 ## val_ident -> LPAREN operator . RPAREN [ error UNDERSCORE UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11108,7 +11113,7 @@ implementation: LPAREN STAR WITH
 
 implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1107.
+## Ends in an error in state: 1129.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -11120,7 +11125,7 @@ implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 
 implementation: LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1104.
+## Ends in an error in state: 1126.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -11132,7 +11137,7 @@ implementation: LPAREN UIDENT COLON WITH
 
 implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1180.
+## Ends in an error in state: 1202.
 ##
 ## expr_comma_list -> expr_optional_constraint . COMMA expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -11143,21 +11148,21 @@ implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1103, spurious reduction of production type_constraint -> COLONGREATER core_type
-## In state 2491, spurious reduction of production expr_optional_constraint -> expr type_constraint
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1125, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 2511, spurious reduction of production expr_optional_constraint -> expr type_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1102.
+## Ends in an error in state: 1124.
 ##
 ## type_constraint -> COLONGREATER . core_type [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -11169,7 +11174,7 @@ implementation: LPAREN UIDENT COLONGREATER WITH
 
 implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 1186.
+## Ends in an error in state: 1208.
 ##
 ## expr_comma_list -> expr_comma_list COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -11181,7 +11186,7 @@ implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 
 implementation: LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1181.
+## Ends in an error in state: 1203.
 ##
 ## expr_comma_list -> expr_optional_constraint COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -11193,7 +11198,7 @@ implementation: LPAREN UIDENT COMMA WITH
 
 implementation: OPEN BANG WITH
 ##
-## Ends in an error in state: 422.
+## Ends in an error in state: 444.
 ##
 ## open_statement -> OPEN override_flag . mod_longident post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -11205,7 +11210,7 @@ implementation: OPEN BANG WITH
 
 implementation: OPEN WITH
 ##
-## Ends in an error in state: 420.
+## Ends in an error in state: 442.
 ##
 ## open_statement -> OPEN . override_flag mod_longident post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -11217,7 +11222,7 @@ implementation: OPEN WITH
 
 implementation: PERCENT UNDERSCORE
 ##
-## Ends in an error in state: 365.
+## Ends in an error in state: 387.
 ##
 ## item_extension_sugar -> PERCENT . attr_id [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW NATIVEINT MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION CLASS CHAR BANG BACKQUOTE ASSERT ]
 ##
@@ -11229,7 +11234,7 @@ implementation: PERCENT UNDERSCORE
 
 implementation: PERCENT WITH DOT UNDERSCORE
 ##
-## Ends in an error in state: 417.
+## Ends in an error in state: 439.
 ##
 ## attr_id -> single_attr_id DOT . attr_id [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW NATIVEINT MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION CLASS CHAR BANG BACKQUOTE ASSERT ]
 ##
@@ -11241,7 +11246,7 @@ implementation: PERCENT WITH DOT UNDERSCORE
 
 implementation: PERCENT WITH WITH
 ##
-## Ends in an error in state: 416.
+## Ends in an error in state: 438.
 ##
 ## attr_id -> single_attr_id . [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW NATIVEINT MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION CLASS CHAR BANG BACKQUOTE ASSERT ]
 ## attr_id -> single_attr_id . DOT attr_id [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW NATIVEINT MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION CLASS CHAR BANG BACKQUOTE ASSERT ]
@@ -11254,7 +11259,7 @@ implementation: PERCENT WITH WITH
 
 implementation: STRING LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 857.
+## Ends in an error in state: 879.
 ##
 ## label_expr -> LIDENT COLONCOLON . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11266,7 +11271,7 @@ implementation: STRING LIDENT COLONCOLON WITH
 
 implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 854.
+## Ends in an error in state: 876.
 ##
 ## label_expr -> LIDENT EXPLICITLY_PASSED_OPTIONAL . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11278,7 +11283,7 @@ implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: STRING WITH
 ##
-## Ends in an error in state: 1796.
+## Ends in an error in state: 1816.
 ##
 ## structure -> structure_item . [ RBRACKET RBRACE EOF ]
 ## structure -> structure_item . error structure [ RBRACKET RBRACE EOF ]
@@ -11291,24 +11296,24 @@ implementation: STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1886, spurious reduction of production post_item_attributes ->
-## In state 1887, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1888, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1802, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1795, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1803, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1906, spurious reduction of production post_item_attributes ->
+## In state 1907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1815, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1909, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 Incomplete statement. Did you forget a ";"?
 
 implementation: SWITCH UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2517.
+## Ends in an error in state: 2537.
 ##
 ## _expr -> SWITCH simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11320,7 +11325,7 @@ implementation: SWITCH UIDENT LBRACE WITH
 
 implementation: SWITCH UIDENT WITH
 ##
-## Ends in an error in state: 2516.
+## Ends in an error in state: 2536.
 ##
 ## _expr -> SWITCH simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ SHARPOP SHARP LBRACE DOT ]
@@ -11339,17 +11344,17 @@ implementation: SWITCH UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 857, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: SWITCH WITH
 ##
-## Ends in an error in state: 183.
+## Ends in an error in state: 164.
 ##
 ## _expr -> SWITCH . simple_expr LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11361,7 +11366,7 @@ implementation: SWITCH WITH
 
 implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 ##
-## Ends in an error in state: 1092.
+## Ends in an error in state: 1114.
 ##
 ## _expr -> simple_expr DOT LBRACE expr RBRACE EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11373,7 +11378,7 @@ implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 
 implementation: TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 1090.
+## Ends in an error in state: 1112.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11409,21 +11414,21 @@ implementation: TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 964, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 934, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 944, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 973, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 943, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 1089.
+## Ends in an error in state: 1111.
 ##
 ## _expr -> simple_expr DOT LBRACE . expr RBRACE EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11436,7 +11441,7 @@ implementation: TRUE DOT LBRACE WITH
 
 implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 ##
-## Ends in an error in state: 1087.
+## Ends in an error in state: 1109.
 ##
 ## _expr -> simple_expr DOT LBRACKET expr RBRACKET EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11448,7 +11453,7 @@ implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 
 implementation: TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 1084.
+## Ends in an error in state: 1106.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11485,21 +11490,21 @@ implementation: TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1083.
+## Ends in an error in state: 1105.
 ##
 ## _expr -> simple_expr DOT LBRACKET . expr RBRACKET EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11513,7 +11518,7 @@ implementation: TRUE DOT LBRACKET WITH
 
 implementation: TRUE DOT LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1095.
+## Ends in an error in state: 1117.
 ##
 ## _expr -> simple_expr DOT label_longident EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11525,7 +11530,7 @@ implementation: TRUE DOT LIDENT EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 ##
-## Ends in an error in state: 1081.
+## Ends in an error in state: 1103.
 ##
 ## _expr -> simple_expr DOT LPAREN expr RPAREN EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11537,7 +11542,7 @@ implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1078.
+## Ends in an error in state: 1100.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11574,21 +11579,21 @@ implementation: TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 848.
+## Ends in an error in state: 870.
 ##
 ## _expr -> simple_expr DOT LPAREN . expr RPAREN EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11602,7 +11607,7 @@ implementation: TRUE DOT LPAREN WITH
 
 implementation: TRUE DOT UIDENT DOT WITH
 ##
-## Ends in an error in state: 563.
+## Ends in an error in state: 585.
 ##
 ## label_longident -> mod_longident DOT . LIDENT [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident DOT . UIDENT [ DOT ]
@@ -11615,7 +11620,7 @@ implementation: TRUE DOT UIDENT DOT WITH
 
 implementation: TRUE DOT UIDENT WITH
 ##
-## Ends in an error in state: 562.
+## Ends in an error in state: 584.
 ##
 ## label_longident -> mod_longident . DOT LIDENT [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident . DOT UIDENT [ DOT ]
@@ -11628,7 +11633,7 @@ implementation: TRUE DOT UIDENT WITH
 
 implementation: TRUE DOT WITH
 ##
-## Ends in an error in state: 847.
+## Ends in an error in state: 869.
 ##
 ## _expr -> simple_expr DOT . label_longident EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> simple_expr DOT . LPAREN expr RPAREN EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -11649,7 +11654,7 @@ implementation: TRUE DOT WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER CHAR BAR WITH
 ##
-## Ends in an error in state: 1060.
+## Ends in an error in state: 1082.
 ##
 ## pattern_with_bar -> BAR . pattern [ WHEN EQUALGREATER ]
 ##
@@ -11661,7 +11666,7 @@ Expecting a match case
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT RBRACKET
 ##
-## Ends in an error in state: 790.
+## Ends in an error in state: 812.
 ##
 ## _simple_module_expr -> mod_longident . [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF DOT COLON AND ]
@@ -11674,7 +11679,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2358.
+## Ends in an error in state: 2378.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11686,7 +11691,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2355.
+## Ends in an error in state: 2375.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11698,7 +11703,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 ##
-## Ends in an error in state: 2354.
+## Ends in an error in state: 2374.
 ##
 ## _semi_terminated_seq_expr_row -> LET MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11710,7 +11715,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 ##
-## Ends in an error in state: 2363.
+## Ends in an error in state: 2383.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11722,7 +11727,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2366.
+## Ends in an error in state: 2386.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11734,7 +11739,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2365.
+## Ends in an error in state: 2385.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11745,14 +11750,14 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2364, spurious reduction of production post_item_attributes ->
+## In state 2384, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 ##
-## Ends in an error in state: 2362.
+## Ends in an error in state: 2382.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11764,7 +11769,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 ##
-## Ends in an error in state: 2353.
+## Ends in an error in state: 2373.
 ##
 ## _semi_terminated_seq_expr_row -> LET . MODULE UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI RBRACE BAR AND ]
@@ -11778,7 +11783,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 ##
-## Ends in an error in state: 2373.
+## Ends in an error in state: 2393.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ RBRACE BAR ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI RBRACE BAR AND ]
@@ -11790,8 +11795,8 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 416, spurious reduction of production attr_id -> single_attr_id
-## In state 419, spurious reduction of production item_extension_sugar -> PERCENT attr_id
+## In state 438, spurious reduction of production attr_id -> single_attr_id
+## In state 441, spurious reduction of production item_extension_sugar -> PERCENT attr_id
 ##
 
 <SYNTAX ERROR>
@@ -11810,24 +11815,24 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2375, spurious reduction of production post_item_attributes ->
-## In state 2376, spurious reduction of production opt_semi ->
-## In state 2381, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
-## In state 2379, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
-## In state 2368, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
-## In state 2359, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
-## In state 2380, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2369, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
-## In state 2385, spurious reduction of production leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER semi_terminated_seq_expr
-## In state 2389, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 964, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 934, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 944, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 973, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 943, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2395, spurious reduction of production post_item_attributes ->
+## In state 2396, spurious reduction of production opt_semi ->
+## In state 2401, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
+## In state 2399, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
+## In state 2388, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
+## In state 2379, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
+## In state 2400, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2389, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2405, spurious reduction of production leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER semi_terminated_seq_expr
+## In state 2409, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
 ##
 
 Expecting one of the following:
@@ -11836,7 +11841,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2384.
+## Ends in an error in state: 2404.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11848,7 +11853,7 @@ Expecting the body of the matched pattern
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ##
-## Ends in an error in state: 1061.
+## Ends in an error in state: 1083.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN EQUALGREATER BAR ]
 ## pattern_with_bar -> BAR pattern . [ WHEN EQUALGREATER ]
@@ -11860,7 +11865,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 692, spurious reduction of production pattern -> pattern_without_or
+## In state 714, spurious reduction of production pattern -> pattern_without_or
 ##
 
 Expecting one of the following:
@@ -11870,7 +11875,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2352.
+## Ends in an error in state: 2372.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar WHEN expr EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11882,7 +11887,7 @@ Expecting a sequence item
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2351.
+## Ends in an error in state: 2371.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11917,21 +11922,21 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 964, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 934, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 944, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 973, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 943, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2350.
+## Ends in an error in state: 2370.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar WHEN . expr EQUALGREATER semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11975,10 +11980,10 @@ implementation: TRY UIDENT UNDERSCORE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 857, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -12010,7 +12015,7 @@ implementation: TRY WITH
 
 implementation: TYPE LIDENT AND LIDENT WITH
 ##
-## Ends in an error in state: 1807.
+## Ends in an error in state: 1827.
 ##
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -12021,14 +12026,14 @@ implementation: TYPE LIDENT AND LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1806, spurious reduction of production optional_type_parameters ->
+## In state 1826, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT AND WITH
 ##
-## Ends in an error in state: 1805.
+## Ends in an error in state: 1825.
 ##
 ## and_type_declaration -> AND . type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -12040,7 +12045,7 @@ implementation: TYPE LIDENT AND WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1812.
+## Ends in an error in state: 1832.
 ##
 ## constrain -> core_type EQUAL . core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -12052,7 +12057,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1811.
+## Ends in an error in state: 1831.
 ##
 ## constrain -> core_type . EQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -12063,19 +12068,19 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT CONSTRAINT WITH
 ##
-## Ends in an error in state: 1810.
+## Ends in an error in state: 1830.
 ##
 ## constraints -> constraints CONSTRAINT . constrain [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -12099,8 +12104,8 @@ implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1382, spurious reduction of production attributes ->
-## In state 1383, spurious reduction of production attributes -> attribute attributes
+## In state 1402, spurious reduction of production attributes ->
+## In state 1403, spurious reduction of production attributes -> attribute attributes
 ## In state 2580, spurious reduction of production constructor_declaration_leading_bar -> BAR UIDENT generalized_constructor_arguments attributes
 ## In state 2600, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
 ##
@@ -12109,7 +12114,7 @@ implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 
 implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 ##
-## Ends in an error in state: 1809.
+## Ends in an error in state: 1829.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_declaration_details -> LIDENT optional_type_parameters type_kind constraints . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -12122,7 +12127,7 @@ implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 ##
-## Ends in an error in state: 1319.
+## Ends in an error in state: 1339.
 ##
 ## label_declarations -> label_declarations COMMA . label_declaration [ RBRACE COMMA ]
 ## opt_comma -> COMMA . [ RBRACE ]
@@ -12149,18 +12154,18 @@ implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 303, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 294, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 299, spurious reduction of production _core_type -> core_type2
-## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1316, spurious reduction of production _poly_type -> core_type
-## In state 1317, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1315, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 1313, spurious reduction of production attributes ->
-## In state 1314, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 1323, spurious reduction of production label_declarations -> label_declaration
+## In state 292, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 301, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 295, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 297, spurious reduction of production _core_type -> core_type2
+## In state 309, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 296, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1336, spurious reduction of production _poly_type -> core_type
+## In state 1337, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1335, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 1333, spurious reduction of production attributes ->
+## In state 1334, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 1343, spurious reduction of production label_declarations -> label_declaration
 ##
 
 Expecting one of the following:
@@ -12169,7 +12174,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1307.
+## Ends in an error in state: 1327.
 ##
 ## label_declaration -> mutable_flag LIDENT COLON . poly_type attributes [ RBRACE COMMA ]
 ##
@@ -12181,7 +12186,7 @@ Expecting a type name describing this field
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 1306.
+## Ends in an error in state: 1326.
 ##
 ## label_declaration -> mutable_flag LIDENT . COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -12194,7 +12199,7 @@ Expecting ":"
 
 implementation: TYPE LIDENT EQUAL LBRACE MUTABLE LET
 ##
-## Ends in an error in state: 1305.
+## Ends in an error in state: 1325.
 ##
 ## label_declaration -> mutable_flag . LIDENT COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -12290,10 +12295,10 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDO
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1261, spurious reduction of production attributes ->
-## In state 1262, spurious reduction of production attributes -> attribute attributes
-## In state 1314, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 1323, spurious reduction of production label_declarations -> label_declaration
+## In state 311, spurious reduction of production attributes ->
+## In state 312, spurious reduction of production attributes -> attribute attributes
+## In state 1334, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 1343, spurious reduction of production label_declarations -> label_declaration
 ##
 
 <SYNTAX ERROR>
@@ -12337,8 +12342,8 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1382, spurious reduction of production attributes ->
-## In state 1383, spurious reduction of production attributes -> attribute attributes
+## In state 1402, spurious reduction of production attributes ->
+## In state 1403, spurious reduction of production attributes -> attribute attributes
 ## In state 2562, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
 ##
 
@@ -12376,12 +12381,12 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 728, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 722, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 724, spurious reduction of production _core_type -> core_type2
-## In state 735, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 723, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 384, spurious reduction of production _core_type2 -> non_arrowed_core_type
+## In state 750, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 744, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 746, spurious reduction of production _core_type -> core_type2
+## In state 757, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 745, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
@@ -12409,7 +12414,7 @@ implementation: TYPE LIDENT EQUAL WITH
 
 implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1804.
+## Ends in an error in state: 1824.
 ##
 ## _structure_item_without_item_extension_sugar -> many_type_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -12421,8 +12426,8 @@ implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1359, spurious reduction of production post_item_attributes ->
-## In state 1360, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1379, spurious reduction of production post_item_attributes ->
+## In state 1380, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
 ## In state 2622, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
@@ -12565,7 +12570,7 @@ Expecting one of the following:
 
 implementation: TYPE UIDENT DOT WITH
 ##
-## Ends in an error in state: 1922.
+## Ends in an error in state: 1942.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -12579,7 +12584,7 @@ implementation: TYPE UIDENT DOT WITH
 
 implementation: TYPE UIDENT WITH
 ##
-## Ends in an error in state: 1921.
+## Ends in an error in state: 1941.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -12618,7 +12623,7 @@ implementation: TYPE WITH
 
 implementation: UIDENT AMPERAMPER WITH
 ##
-## Ends in an error in state: 1031.
+## Ends in an error in state: 1053.
 ##
 ## _expr -> expr AMPERAMPER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12630,7 +12635,7 @@ implementation: UIDENT AMPERAMPER WITH
 
 implementation: UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 1029.
+## Ends in an error in state: 1051.
 ##
 ## _expr -> expr AMPERSAND . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12642,7 +12647,7 @@ implementation: UIDENT AMPERSAND WITH
 
 implementation: UIDENT BARBAR WITH
 ##
-## Ends in an error in state: 1027.
+## Ends in an error in state: 1049.
 ##
 ## _expr -> expr BARBAR . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12654,7 +12659,7 @@ implementation: UIDENT BARBAR WITH
 
 implementation: UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1033.
+## Ends in an error in state: 1055.
 ##
 ## _expr -> expr COLONEQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12666,7 +12671,7 @@ implementation: UIDENT COLONEQUAL WITH
 
 implementation: UIDENT DOT LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 1169.
+## Ends in an error in state: 1191.
 ##
 ## lbl_expr -> label_longident . COLON expr [ COMMA ]
 ## lbl_expr -> label_longident . [ COMMA ]
@@ -12680,7 +12685,7 @@ implementation: UIDENT DOT LBRACE LIDENT WITH
 
 implementation: UIDENT DOT LBRACE WITH
 ##
-## Ends in an error in state: 1149.
+## Ends in an error in state: 1171.
 ##
 ## _simple_expr -> mod_longident DOT LBRACE . RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12694,7 +12699,7 @@ implementation: UIDENT DOT LBRACE WITH
 
 implementation: UIDENT DOT LBRACELESS WITH
 ##
-## Ends in an error in state: 1144.
+## Ends in an error in state: 1166.
 ##
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12707,7 +12712,7 @@ implementation: UIDENT DOT LBRACELESS WITH
 
 implementation: UIDENT DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1134.
+## Ends in an error in state: 1156.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12719,7 +12724,7 @@ implementation: UIDENT DOT LBRACKET WITH
 
 implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 1119.
+## Ends in an error in state: 1141.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12732,23 +12737,23 @@ implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1122, spurious reduction of production expr_optional_constraint -> expr
-## In state 1118, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1144, spurious reduction of production expr_optional_constraint -> expr
+## In state 1140, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LBRACKETBAR WITH
 ##
-## Ends in an error in state: 1117.
+## Ends in an error in state: 1139.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12761,7 +12766,7 @@ implementation: UIDENT DOT LBRACKETBAR WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 816.
+## Ends in an error in state: 838.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12773,7 +12778,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
-## In state 279, spurious reduction of production mty_longident -> ident
+## In state 260, spurious reduction of production mty_longident -> ident
 ## In state 137, spurious reduction of production package_type -> mty_longident
 ##
 
@@ -12781,7 +12786,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 814.
+## Ends in an error in state: 836.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12794,7 +12799,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 813.
+## Ends in an error in state: 835.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -12809,19 +12814,19 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 790, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 794, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 791, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 777, spurious reduction of production _module_expr -> simple_module_expr
-## In state 796, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 795, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 812, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 816, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 813, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 799, spurious reduction of production _module_expr -> simple_module_expr
+## In state 818, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 817, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN MODULE WITH
 ##
-## Ends in an error in state: 812.
+## Ends in an error in state: 834.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON package_type RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12834,7 +12839,7 @@ implementation: UIDENT DOT LPAREN MODULE WITH
 
 implementation: UIDENT DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1098.
+## Ends in an error in state: 1120.
 ##
 ## expr_comma_list -> expr_optional_constraint . COMMA expr_optional_constraint [ RPAREN COMMA ]
 ##
@@ -12845,22 +12850,22 @@ implementation: UIDENT DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1114, spurious reduction of production expr_optional_constraint -> expr
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1136, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN WITH
 ##
-## Ends in an error in state: 811.
+## Ends in an error in state: 833.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN . expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12877,7 +12882,7 @@ implementation: UIDENT DOT LPAREN WITH
 
 implementation: UIDENT DOT WITH
 ##
-## Ends in an error in state: 810.
+## Ends in an error in state: 832.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12903,7 +12908,7 @@ implementation: UIDENT DOT WITH
 
 implementation: UIDENT GREATER WITH
 ##
-## Ends in an error in state: 1023.
+## Ends in an error in state: 1045.
 ##
 ## _expr -> expr GREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr GREATER . GREATER expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -12916,7 +12921,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP0 WITH
 ##
-## Ends in an error in state: 1021.
+## Ends in an error in state: 1043.
 ##
 ## _expr -> expr INFIXOP0 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12928,7 +12933,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP1 WITH
 ##
-## Ends in an error in state: 1017.
+## Ends in an error in state: 1039.
 ##
 ## _expr -> expr INFIXOP1 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12940,7 +12945,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP2 WITH
 ##
-## Ends in an error in state: 1015.
+## Ends in an error in state: 1037.
 ##
 ## _expr -> expr INFIXOP2 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12952,7 +12957,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP3 WITH
 ##
-## Ends in an error in state: 1001.
+## Ends in an error in state: 1023.
 ##
 ## _expr -> expr INFIXOP3 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12964,7 +12969,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP4 WITH
 ##
-## Ends in an error in state: 869.
+## Ends in an error in state: 891.
 ##
 ## _expr -> expr INFIXOP4 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12976,7 +12981,7 @@ Expecting an expression
 
 implementation: UIDENT LBRACKETAT UNDERSCORE
 ##
-## Ends in an error in state: 363.
+## Ends in an error in state: 385.
 ##
 ## attribute -> LBRACKETAT . attr_id payload RBRACKET [ error WITH UIDENT STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARRBRACKET BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12988,7 +12993,7 @@ Expecting an attribute id
 
 implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2440.
+## Ends in an error in state: 2460.
 ##
 ## attribute -> LBRACKETAT attr_id payload . RBRACKET [ error WITH UIDENT STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARRBRACKET BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12999,30 +13004,30 @@ implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1886, spurious reduction of production post_item_attributes ->
-## In state 1887, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1888, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1802, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1795, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1803, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1796, spurious reduction of production structure -> structure_item
-## In state 1892, spurious reduction of production payload -> structure
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1906, spurious reduction of production post_item_attributes ->
+## In state 1907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1815, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1909, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1816, spurious reduction of production structure -> structure_item
+## In state 1912, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
 
 implementation: UIDENT LBRACKETATAT UNDERSCORE
 ##
-## Ends in an error in state: 424.
+## Ends in an error in state: 446.
 ##
 ## item_attribute -> LBRACKETATAT . attr_id payload RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13034,7 +13039,7 @@ Expecting an attributed id
 
 implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2437.
+## Ends in an error in state: 2457.
 ##
 ## item_attribute -> LBRACKETATAT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13045,30 +13050,30 @@ implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1886, spurious reduction of production post_item_attributes ->
-## In state 1887, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1888, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1802, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1795, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1803, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1796, spurious reduction of production structure -> structure_item
-## In state 1892, spurious reduction of production payload -> structure
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1906, spurious reduction of production post_item_attributes ->
+## In state 1907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1815, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1909, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1816, spurious reduction of production structure -> structure_item
+## In state 1912, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
 
 implementation: UIDENT LESS WITH
 ##
-## Ends in an error in state: 1019.
+## Ends in an error in state: 1041.
 ##
 ## _expr -> expr LESS . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13080,7 +13085,7 @@ Expecting an expression
 
 implementation: UIDENT LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1013.
+## Ends in an error in state: 1035.
 ##
 ## _expr -> expr LESSDOTDOTGREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13092,7 +13097,7 @@ Expecting an expression
 
 implementation: UIDENT LESSGREATER WITH
 ##
-## Ends in an error in state: 198.
+## Ends in an error in state: 179.
 ##
 ## jsx -> LESSGREATER . simple_expr_list LESSSLASHGREATER [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -13104,7 +13109,7 @@ Expecting an expression
 
 implementation: UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 192.
+## Ends in an error in state: 173.
 ##
 ## _simple_expr -> LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . expr error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -13129,7 +13134,7 @@ Expecting one of the following:
 
 implementation: UIDENT MINUS WITH
 ##
-## Ends in an error in state: 1011.
+## Ends in an error in state: 1033.
 ##
 ## _expr -> expr MINUS . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13141,7 +13146,7 @@ Expecting an expression
 
 implementation: UIDENT MINUSDOT WITH
 ##
-## Ends in an error in state: 1009.
+## Ends in an error in state: 1031.
 ##
 ## _expr -> expr MINUSDOT . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13153,7 +13158,7 @@ Expecting an expression
 
 implementation: UIDENT OR WITH
 ##
-## Ends in an error in state: 1007.
+## Ends in an error in state: 1029.
 ##
 ## _expr -> expr OR . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13165,7 +13170,7 @@ Expecting an expression
 
 implementation: UIDENT PERCENT WITH
 ##
-## Ends in an error in state: 999.
+## Ends in an error in state: 1021.
 ##
 ## _expr -> expr PERCENT . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13177,7 +13182,7 @@ Expecting an expression
 
 implementation: UIDENT PLUS WITH
 ##
-## Ends in an error in state: 1005.
+## Ends in an error in state: 1027.
 ##
 ## _expr -> expr PLUS . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13189,7 +13194,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSDOT WITH
 ##
-## Ends in an error in state: 1003.
+## Ends in an error in state: 1025.
 ##
 ## _expr -> expr PLUSDOT . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13201,7 +13206,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 997.
+## Ends in an error in state: 1019.
 ##
 ## _expr -> expr PLUSEQ . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13213,7 +13218,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1076.
+## Ends in an error in state: 1098.
 ##
 ## _expr -> expr QUESTION expr COLON . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13225,7 +13230,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT SEMI
 ##
-## Ends in an error in state: 1075.
+## Ends in an error in state: 1097.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -13260,14 +13265,14 @@ implementation: UIDENT QUESTION UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 964, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 934, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 944, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 973, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 943, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13276,7 +13281,7 @@ Expecting one of the following:
 
 implementation: UIDENT QUESTION WITH
 ##
-## Ends in an error in state: 884.
+## Ends in an error in state: 906.
 ##
 ## _expr -> expr QUESTION . expr COLON expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13299,29 +13304,29 @@ implementation: UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1886, spurious reduction of production post_item_attributes ->
-## In state 1887, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1888, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1802, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1795, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1803, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1796, spurious reduction of production structure -> structure_item
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1906, spurious reduction of production post_item_attributes ->
+## In state 1907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1815, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1909, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1816, spurious reduction of production structure -> structure_item
 ##
 
 Invalid token
 
 implementation: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 1890.
+## Ends in an error in state: 1910.
 ##
 ## structure -> structure_item SEMI . structure [ RBRACKET RBRACE EOF ]
 ##
@@ -13333,7 +13338,7 @@ Expecting a structure item
 
 implementation: UIDENT SHARP WITH
 ##
-## Ends in an error in state: 517.
+## Ends in an error in state: 539.
 ##
 ## _simple_expr -> simple_expr SHARP . label [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -13345,7 +13350,7 @@ Expecting an identifier
 
 implementation: UIDENT STAR WITH
 ##
-## Ends in an error in state: 867.
+## Ends in an error in state: 889.
 ##
 ## _expr -> expr STAR . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13357,7 +13362,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 2221.
+## Ends in an error in state: 2241.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13392,14 +13397,14 @@ implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 792, spurious reduction of production constr_longident -> mod_longident
+## In state 964, spurious reduction of production _simple_expr -> constr_longident
+## In state 859, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 849, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 934, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 944, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 973, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 943, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13408,7 +13413,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 2220.
+## Ends in an error in state: 2240.
 ##
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -13420,7 +13425,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2218.
+## Ends in an error in state: 2238.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13456,14 +13461,14 @@ implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13472,7 +13477,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2217.
+## Ends in an error in state: 2237.
 ##
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -13485,7 +13490,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2215.
+## Ends in an error in state: 2235.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13521,14 +13526,14 @@ implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 831, spurious reduction of production constr_longident -> mod_longident
+## In state 894, spurious reduction of production _simple_expr -> constr_longident
+## In state 864, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 841, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 868, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 874, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 903, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 873, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13537,7 +13542,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 511.
+## Ends in an error in state: 533.
 ##
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -13550,7 +13555,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT WITH
 ##
-## Ends in an error in state: 510.
+## Ends in an error in state: 532.
 ##
 ## _simple_expr -> simple_expr DOT . label_longident [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -4238,7 +4238,7 @@ meth_list_with_leading_lesslident:
 ;
 
 field:
-    label COLON poly_type attributes           { ($1, $4, $3) }
+    label attributes COLON poly_type           { ($1, $2, $4) }
 ;
 label:
     LIDENT                                      { $1 }

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2706,7 +2706,11 @@ class printer  ()= object(self:'self)
               | [] -> label ~space:true
                       (label ~space:true (atom s) (atom ":"))
                       (self#core_type ct)
-              | _::_ -> makeList ~postSpace:true [atom s; (self#attributes attrs); atom ":"; self#core_type ct]
+              | _::_ ->
+                makeList
+                  ~postSpace:true
+                  ~break:IfNeed
+                  [atom s; (self#attributes attrs); atom ":"; self#core_type ct]
             )
           in
           let openness = match o with

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2701,13 +2701,13 @@ class printer  ()= object(self:'self)
             makeList ~wrap:("(",")") ~sep:"," ~postSpace:true ~break:IfNeed (List.map (self#core_type) l)
         | Ptyp_object (l, o) ->
           let core_field_type (s, attrs, ct) =
-            self#attach_std_attrs
-              attrs
-              (
-                label ~space:true
-                  (label ~space:true (atom s) (atom ":"))
-                  (self#core_type ct)
-              )
+            let l = extractStdAttrs attrs in
+            (match l with
+              | [] -> label ~space:true
+                      (label ~space:true (atom s) (atom ":"))
+                      (self#core_type ct)
+              | _::_ -> makeList ~postSpace:true [atom s; (self#attributes attrs); atom ":"; self#core_type ct]
+            )
           in
           let openness = match o with
             | Closed -> []


### PR DESCRIPTION
In OCaml when you do `type something = <foo : int [@bs.set]>`, the attribute actually gets set on the method `foo` instead of the type int, even if it looks like it's on the type. In Reason, we attach it on the type.
This seemed to be hard to fix because it required moving around a bunch of grammar rules (currently the attribute gets eaten up by a rule deep in the CFG, which ocaml fixed by having a whole other rule without those attributes called [poly_type_no_attr](https://github.com/ocaml/ocaml/blob/f872d67d4e97a6072f5891b5aef3c5f7e39e4a25/parsing/parser.mly#L2201)).
My fix is a simple one, simply make the syntax be `type something = <foo [@bs.set] : int>`. I think this is horribly confusing but it's a very quick temporary fix to unblock anyone trying to use those attributes. Buckle script won't work as intended without this fix because it won't see the attributes on the keys making `##` and `#=` basically useless.