### PR TITLE
Check in Reactjs ppx transform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ src_test/_tags
 .DS_Store
 formatTest/customMLFiles/*.ml
 formatTest/customMLFormatOutput.re
+miscTests/reactjs_jsx_ppx_tests/actual*.txt
 .jenga
 src/reason_parser.messages.bak
 src/reason_parser_message.ml

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ run_utop: build
 
 test: build
 	./miscTests/rtopIntegrationTest.sh
+	./miscTests/jsxPpxTest.sh
 	cd formatTest; ./test.sh
 
 clean:

--- a/miscTests/jsxPpxTest.sh
+++ b/miscTests/jsxPpxTest.sh
@@ -1,0 +1,26 @@
+echo "Testing reactjs @JSX ppx..."
+
+testPath="miscTests/reactjs_jsx_ppx_tests"
+
+for i in 1 2 3 4 5 6
+do
+  test="$testPath/test$i.re"
+
+  expected=`cat $testPath/expected$i.txt`
+
+  ocamlc -dsource -ppx ./reactjs_jsx_ppx.native -pp ./refmt_impl.native -impl $test \
+    2>&1| sed '$ d' | sed '$ d' > $testPath/actual${i}.txt
+    # remove the last two lines. It's noise about command failure and changes at
+    # every run because the temporary file name in the error message changes
+
+  actual=`cat $testPath/actual$i.txt`
+
+  if [[ "$expected" = "$actual" ]]; then
+    echo "OK"
+  else
+    echo "Wrong"
+    # show the error
+    diff -u $testPath/expected$i.txt $testPath/actual$i.txt
+    exit 1
+  fi
+done

--- a/miscTests/reactjs_jsx_ppx_tests/expected1.txt
+++ b/miscTests/reactjs_jsx_ppx_tests/expected1.txt
@@ -1,0 +1,40 @@
+type dom = {
+  createElement: unit -> unit;}
+let div = { createElement = (fun ()  -> ()) }
+let _ = div.createElement ()
+module Gah = struct let createElement () = () end
+let _ = Gah.createElement ()
+let asd = ((Bar.createElement ~foo:1 ~bar:2 ["a"; "b"])[@jsxa ][@foo ])
+let asd =
+  ((ReactRe.createElement Bar.comp (Bar.props ~foo:1 ~bar:2 ())
+      [|(Obj.magic "a");(Obj.magic "b")|])[@foo ])
+let _ =
+  ReactRe.createElement Baz.Beee.comp (Baz.Beee.props ~baz:2 ())
+    [|(Obj.magic "a");(Obj.magic "b")|]
+let _ = ReactRe.createElement Bar.comp Js.null [|(Obj.magic foo)|]
+let _ = ReactRe.createElement Bar.comp (Bar.props ~foo:1 ~bar:2 ()) [||]
+let _ =
+  ReactRe.createElement Bar.comp
+    (Bar.props
+       ~foo:(ReactRe.createElement Baz.comp
+               (Baz.props ~baz:(ReactRe.createElement Baaz.comp Js.null [||])
+                  ()) [||]) ()) [||]
+let _ = ReactRe.createElement Div.comp (Div.props ~foo:1 ~bar:2 ()) [||]
+let _ =
+  ReactRe.createElement Bar.comp Js.null
+    [|(Obj.magic
+         (ReactRe.createElement Baz.Beee.comp
+            (Baz.Beee.props ~baz:2
+               ~kek:(ReactRe.createElement Foo.comp Js.null [||]) ())
+            [|(Obj.magic "a");(Obj.magic "b")|]));(Obj.magic
+                                                     (ReactRe.createElement
+                                                        Bar.comp Js.null 
+                                                        [||]))|]
+let _ =
+  ReactRe.createElement "bar"
+    ([%bs.obj
+       {
+         foo = 1;
+         children =
+           (ReactRe.createElement "baz" ([%bs.obj { qux = 2 }]) [||])
+       }]) [||]

--- a/miscTests/reactjs_jsx_ppx_tests/expected2.txt
+++ b/miscTests/reactjs_jsx_ppx_tests/expected2.txt
@@ -1,0 +1,3 @@
+Invalid_argument("JSX: `createElement` should be preceeded by a module name.")
+File "miscTests/reactjs_jsx_ppx_tests/test2.re", line 1:
+Error: Error while running external preprocessor

--- a/miscTests/reactjs_jsx_ppx_tests/expected3.txt
+++ b/miscTests/reactjs_jsx_ppx_tests/expected3.txt
@@ -1,0 +1,3 @@
+Invalid_argument("JSX: the last argument to `Foo.createElement` must be a list (of children).")
+File "miscTests/reactjs_jsx_ppx_tests/test3.re", line 1:
+Error: Error while running external preprocessor

--- a/miscTests/reactjs_jsx_ppx_tests/expected4.txt
+++ b/miscTests/reactjs_jsx_ppx_tests/expected4.txt
@@ -1,0 +1,3 @@
+Invalid_argument("JSX: the JSX attribute should be attached to a `YourModuleName.createElement` call. We saw `createElementLol` instead")
+File "miscTests/reactjs_jsx_ppx_tests/test4.re", line 1:
+Error: Error while running external preprocessor

--- a/miscTests/reactjs_jsx_ppx_tests/expected5.txt
+++ b/miscTests/reactjs_jsx_ppx_tests/expected5.txt
@@ -1,0 +1,3 @@
+Invalid_argument("JSX: `createElement` should be preceeded by a simple, direct module name.")
+File "miscTests/reactjs_jsx_ppx_tests/test5.re", line 1:
+Error: Error while running external preprocessor

--- a/miscTests/reactjs_jsx_ppx_tests/expected6.txt
+++ b/miscTests/reactjs_jsx_ppx_tests/expected6.txt
@@ -1,0 +1,3 @@
+Invalid_argument("JSX: `createElement` should be preceeded by a simple, direct module name.")
+File "miscTests/reactjs_jsx_ppx_tests/test6.re", line 1:
+Error: Error while running external preprocessor

--- a/miscTests/reactjs_jsx_ppx_tests/test1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test1.re
@@ -1,0 +1,44 @@
+/* dont touch these; no annotation */
+type dom = {createElement: unit => unit};
+
+let div = {createElement: fun () => ()};
+
+div.createElement ();
+
+let module Gah = {
+  let createElement () => ();
+};
+
+Gah.createElement ();
+
+/* don't transform */
+let asd = Bar.createElement foo::1 bar::2 ["a", "b"] [@jsxa] [@foo];
+
+/* transform, keep [@foo] */
+let asd = Bar.createElement foo::1 bar::2 ["a", "b"] [@JSX] [@foo];
+
+/* nested modules */
+Baz.Beee.createElement baz::2 ["a", "b"] [@JSX];
+
+/* no prop */
+Bar.createElement [foo] [@JSX];
+
+/* empty children */
+Bar.createElement foo::1 bar::2 [] [@JSX];
+
+/* createElement nested in props */
+Bar.createElement foo::(Baz.createElement baz::(Baaz.createElement [] [@JSX]) [] [@JSX]) [] [@JSX];
+
+/* dom elements */
+Div.createElement foo::1 bar::2 [] [@JSX];
+
+/* createElement nested in children */
+Bar.createElement
+[
+  Baz.Beee.createElement baz::2
+    kek::(Foo.createElement [] [@JSX]) ["a", "b"] [@JSX],
+  Bar.createElement [] [@JSX]
+]
+[@JSX];
+
+(bar foo::1 children::((baz qux::2 [])[@JSX]) [])[@JSX ];

--- a/miscTests/reactjs_jsx_ppx_tests/test2.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test2.re
@@ -1,0 +1,3 @@
+/* hello comments */
+
+       (createElement [||])[@JSX]

--- a/miscTests/reactjs_jsx_ppx_tests/test3.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test3.re
@@ -1,0 +1,3 @@
+/* hello comments */
+
+       (Foo.createElement ())[@JSX]

--- a/miscTests/reactjs_jsx_ppx_tests/test4.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test4.re
@@ -1,0 +1,3 @@
+/* hello comments */
+
+       (Foo.createElementLol ())[@JSX]

--- a/miscTests/reactjs_jsx_ppx_tests/test5.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test5.re
@@ -1,0 +1,4 @@
+/* hello comments */
+
+        let div children => 1;
+        (((fun () => div) ()) [])[@JSX];

--- a/miscTests/reactjs_jsx_ppx_tests/test6.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test6.re
@@ -1,0 +1,4 @@
+/* hello comments */
+
+        let div children => 1;
+        (((fun () => div)) [])[@JSX];

--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -49,6 +49,7 @@ let () =
     Pkg.bin "_reasonbuild/_build/myocamlbuild" ~dst:"reasonbuild";
     Pkg.bin  ~auto:true "src/reason_error_reporter" ~dst:"refmterr";
     Pkg.bin  ~auto:true "src/reason_format_type" ~dst:"refmttype";
+    Pkg.bin  ~auto:true "src/reactjs_jsx_ppx" ~dst:"reactjs_jsx_ppx";
     Pkg.share "editorSupport/emacs/refmt.el" ~dst:"../emacs/site-lisp/refmt.el";
     Pkg.share "editorSupport/emacs/reason-mode.el" ~dst:"../emacs/site-lisp/reason-mode.el";
     (* atom-reason *)

--- a/src/reactjs_jsx_ppx.ml
+++ b/src/reactjs_jsx_ppx.ml
@@ -1,0 +1,213 @@
+(* transform `Foo.createElement props1::a props2::b [foo, bar]`
+  into
+  `ReactRe.createElement Foo.comp (Foo.props props1::a, props2::b ()) [|foo, bar|]`
+  and `div props1::a props2::b [foo, bar]`
+  into
+  `ReactRe.createElement div [%bs.obj {props1: 1, props2: b}] [|foo, bar|]`
+*)
+(* Why do we need a transform, instead of just using the previous
+  Foo.createElement format? Because that one currently doesn't type check well for
+  the existing React.js, and doesn't produce great output from BuckleScript. *)
+open Ast_mapper
+open Ast_helper
+open Asttypes
+open Parsetree
+open Longident
+
+(* actual ppx logic *)
+let rec listToArray' lst accum =
+  (* not in the sense of converting a list to an array; convert the AST
+    reprensentation of a list to the AST reprensentation of an array *)
+  match lst with
+  | {pexp_desc = Pexp_construct ({txt = Lident "[]"}, None)} -> accum
+  | {
+      pexp_desc = Pexp_construct (
+        {txt = Lident "::"},
+        Some {pexp_desc = Pexp_tuple (v::acc::[])}
+      )
+  } -> listToArray' acc (v::accum)
+  | _ -> raise (
+    Invalid_argument "JSX: the last argument to `Foo.createElement` must be a list (of children)."
+  )
+
+let listToArray lst = listToArray' lst [] |> List.rev
+
+(* turn bla::1 blaa::2 into [%bs.obj {bla: 1, blaa: 2}] *)
+let functionCallWithLabelsToBSObj callWithLabels =
+  (* structure *)
+  let record = callWithLabels
+    |> List.map (fun (label, expression) ->
+      ({loc = default_loc.contents; txt = Lident label}, expression)
+    )
+  in
+  Exp.extension (
+    {loc = default_loc.contents; txt = "bs.obj"},
+    PStr [Str.eval (Exp.record record None)]
+  )
+
+(* props might contain `createElement` calls too; parse them recursively *)
+let recursivelyMapPropsCall ~props ~mapper =
+  props
+  |> List.map (fun (label, expression) -> (label, mapper.expr mapper expression))
+
+(* construct Obj.magic, for children array usage below *)
+let objMagicNode a =
+  Exp.apply
+    (Exp.ident {
+      loc = default_loc.contents;
+      txt = Ldot (Lident "Obj", "magic");
+    })
+    [("", a)]
+
+(* given that we're gathered all we have, construct the AST for `ReactRe.createElement ?? ?? [|childrenHere|]` *)
+let constructReactReCall ~attributes ~callNode ~props ~children ~mapper =
+  Exp.apply
+    (* throw away the [@JSX] attribute and keep the others, if any *)
+    ~attrs:(attributes |> List.filter (fun (attribute, _) -> attribute.txt <> "JSX"))
+    (* ReactRe.createElement *)
+    (Exp.ident {
+      loc = default_loc.contents;
+      txt = Ldot (Lident "ReactRe", "createElement");
+    })
+    (* Foo.comp or "div" *)
+    [
+      ("", callNode);
+      (* prop1::bla, prop2::blabla or [%bs.obj {props1: bla, props2: blabla}] *)
+      ("", props);
+      (* [|moreCreateElementCallsHere|] *)
+      ("", Exp.array (
+        (* children array needs to be homogenous. Reactjs' children clearly are
+          not (supports string, number, react elements, recursive react children
+          array, etc.). There's no good way of typing them while preserving
+          interop right now, so we'll cast them to Obj.magic for now. *)
+          listToArray children |> List.map (fun a -> mapper.expr mapper a |> objMagicNode)
+        )
+      )
+    ]
+
+let splitPropsCallLabelsFromChildren propsAndChildren =
+  match propsAndChildren with
+  | [] ->
+    (* should never happen; nevertheless, provide a traceable error just in case *)
+    raise (
+      Invalid_argument "JSX: somehow props and children are nonexistent"
+    )
+  (* no props, only children. We get a pair of (label, value). Don't care about
+    label *)
+  | children::[] -> (None, snd children)
+  | propsAndChildren ->
+    (* composite components: *)
+    (*                   V---actualProps--V   *)
+    (* Foo.createElement prop1::a props2::b [...] *)
+    (*                                      ^ reactChildren  *)
+    (* dom components: *)
+    (*     V---actualProps--V   *)
+    (* div prop1::a props2::b [...] *)
+    (*                        ^ reactChildren  *)
+    let last lst = List.length lst - 1 |> List.nth lst in
+    let allButLast lst = List.rev lst |> List.tl |> List.rev in
+    let actualProps = allButLast propsAndChildren in
+    let reactChildren = snd (last propsAndChildren) in
+    (Some actualProps, reactChildren)
+
+(* TODO: line number are all wrong *)
+let jsxMapper argv = {
+  default_mapper with
+  expr = (fun mapper expression -> match expression with
+    (* spotted a function application! Does it have the @JSX attribute *)
+    | {
+        pexp_desc = Pexp_apply ({pexp_desc = createElementWrap}, propsAndChildren);
+        pexp_attributes
+      } when Syntax_util.attribute_exists "JSX" pexp_attributes ->
+      (* usually, when a pattern also has a `when` clause, we lose the ability
+        for the compiler to warn that we didn't cover all the cases; it's fine
+        here since we have a catch-all below that maps over the rest using
+        `identity` *)
+        (match createElementWrap with
+        | Pexp_ident fooCreateElement ->
+          (match fooCreateElement with
+          | {txt = Lident "createElement"} ->
+            raise (Invalid_argument "JSX: `createElement` should be preceeded by a module name.")
+          (* Foo.createElement prop1::foo prop2:bar [] *)
+          | {txt = Ldot (moduleNames, "createElement")} ->
+            let (propsWithLabels, children) =
+              splitPropsCallLabelsFromChildren propsAndChildren
+            in
+            let propsOrNull = match propsWithLabels with
+            | Some props ->
+              let unit = Exp.construct
+                {loc = default_loc.contents; txt = Lident "()"} None
+              in
+              Exp.apply
+                (* Foo.props *)
+                (Exp.ident {
+                  loc = default_loc.contents;
+                  txt = Ldot (moduleNames, "props")
+                })
+                (* see comment at the top of file. We need a () at the end to
+                  signify "finished applying the function!". The ideal API
+                  Foo.createElement circumvents this because the non-labelled
+                  children _is_ the last argument *)
+                ((recursivelyMapPropsCall ~props ~mapper) @ [("", unit)])
+            | None ->
+              (* if there's no prop, transform to `Js.null` *)
+              Exp.ident {
+                loc = default_loc.contents;
+                txt = Ldot (Lident "Js", "null")
+              }
+            in
+              constructReactReCall ~attributes:pexp_attributes
+              ~callNode:(Exp.ident {
+                  loc = default_loc.contents;
+                  txt = Ldot (moduleNames, "comp")
+                })
+              ~props:propsOrNull
+              ~children
+              ~mapper
+          (* div prop1::foo prop2:bar [] *)
+          (* the div is Pexp_ident "div" *)
+          (* similar code to the above case, with a few exceptions *)
+          | {txt = Lident lowercaseIdentifier} ->
+            let (propsWithLabels,children) =
+              splitPropsCallLabelsFromChildren propsAndChildren
+            in
+            let propsOrNull = match propsWithLabels with
+              | Some props ->
+                (* [bs.obj {foo: bar, baz: qux}] *)
+                functionCallWithLabelsToBSObj (recursivelyMapPropsCall ~props ~mapper)
+              | None ->
+                (* if there's no prop, transform to `Js.null` *)
+                Exp.ident {
+                  loc = default_loc.contents;
+                  txt = Ldot (Lident "Js", "null")
+                }
+              in
+              constructReactReCall
+                ~attributes:pexp_attributes
+                ~callNode:(Exp.constant (Const_string (lowercaseIdentifier, None)))
+                ~props:propsOrNull ~children ~mapper
+          | {txt = Ldot (_, anythingNotCreateElement)} ->
+            raise (
+              Invalid_argument
+                ("JSX: the JSX attribute should be attached to a `YourModuleName.createElement` call. We saw `"
+                  ^ anythingNotCreateElement
+                  ^ "` instead"
+                )
+            )
+          | {txt = Lapply _} ->
+            (* don't think there's ever a case where this is reached *)
+            raise (
+              Invalid_argument "JSX: encountered a weird case while processing the code. Please report this!"
+            )
+          )
+        | anythingElseThanIdent ->
+            raise (
+              Invalid_argument "JSX: `createElement` should be preceeded by a simple, direct module name."
+            )
+
+        )
+    (* Delegate to the default mapper, a deep identity traversal *)
+    | x -> default_mapper.expr mapper x)
+}
+
+let () = register "JSX" jsxMapper


### PR DESCRIPTION
This converts our ideal JSX `createElement` transform into one that works with the current ReactJS, compiled through BuckleScript (actual bindings coming soon! Wanted to stress test it a bit more beforehand).

The locations are wrong I think; I'll fix them later.