### PR TITLE
Change `let module Foo` into `module Foo`.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1078,9 +1078,9 @@ definitions which are all equivalent.
 
 ```reason
 /* All of the following are equivalent. */
-let module ModuleFunc (A:ASig) (B:BSig) => {};
-let module ModuleFunc = fun (A:ASig) (B:BSig) => {};
-let module ModuleFunc = fun (A:ASig) => fun (B:BSig) => {};
+module ModuleFunc (A:ASig) (B:BSig) => {};
+module ModuleFunc = fun (A:ASig) (B:BSig) => {};
+module ModuleFunc = fun (A:ASig) => fun (B:BSig) => {};
 ```
 
 ##### Record *Value* "Punning"

--- a/docs/mlCompared.html
+++ b/docs/mlCompared.html
@@ -557,15 +557,15 @@ module definition is local/top level.
 (\*Top level \*)
 module X = ..
 (\*Local \*)
-let module X = ..
+module X = ..
 module type Y = ...</pre>
     </td>
     <td>
       <pre>
 /\* Top level \*/
-let module X = ..
+module X = ..
 /\* Local \*/
-let module X = ..
+module X = ..
 module type Y = ..</pre>
     </td>
   </tr>
@@ -842,12 +842,12 @@ module type MySig = {
   type t = int;
   let x: int;
 };
-let module MyModule: MySig = {
+module MyModule: MySig = {
   type t = int;
   let x = 10;
 };
-let module MyModule = {
-  let module NestedModule = {
+module MyModule = {
+  module NestedModule = {
      let msg = "hello";
   };
 };
@@ -904,7 +904,7 @@ module F =
     </td>
     <td>
       <pre>
-let module F =
+module F =
   fun (A:ASig) =>
   fun (B:BSig) =>
     {};</pre>
@@ -920,7 +920,7 @@ module F =
     </td>
     <td>
       <pre>
-let module F =
+module F =
   fun (A:ASig)
       (B:BSig) => {};</pre>
     </td>
@@ -935,7 +935,7 @@ module F
     </td>
     <td>
       <pre>
-let module F
+module F
            (A:ASig)
            (B:BSig) =>
              {};</pre>
@@ -944,11 +944,11 @@ let module F
   <tr>
     <td>
       <pre>
-let module Res = F(A)(B)</pre>
+module Res = F(A)(B)</pre>
     </td>
     <td>
       <pre>
-let module Res = F A B;</pre>
+module Res = F A B;</pre>
     </td>
   </tr>
 </table>

--- a/docs/modules.html
+++ b/docs/modules.html
@@ -45,11 +45,11 @@ Modules are like records, but with the following differences.
 
 
 ###### Creating Modules
-To create a module, use the `let module` keywords instead of `let`, and ensure
+To create a module, use the `module` keyword instead of `let`, and ensure
 that the variable name given to the module begins with a capital letter.
 
 ```reason
-let module MyModule = {
+module MyModule = {
   /* Module contents here */
 };
 ```
@@ -60,7 +60,7 @@ place in a `.re` file, you may place inside a module definition's `{}` block.
 That means that you can include `let` bindings, and even `type` definitions.
 
 ```reason
-let module MyModule = {
+module MyModule = {
   type twoStrings = (string, string);
   let makePair = fun s => {
     let returnVal = (s, s): twoString;
@@ -79,8 +79,8 @@ let twoStrings: MyModule.twoString = MyModule.makePair "hello modules";
 ```
 
 ```reason
-let module MyModule = {
-  let module NestedModule = {
+module MyModule = {
+  module NestedModule = {
      let msg = "hello";
   };
 };
@@ -95,10 +95,10 @@ content. This can often fulfill the role of "inheritance".
 
 
 ```reason
-let module Login = {
+module Login = {
    let login = fun auth => 0;
 };
-let module RepeatedLogin = {
+module RepeatedLogin = {
   include Login;
   let loginTwice = fun auth => {
     (login auth, login auth)
@@ -184,11 +184,11 @@ because `XTInt.x` is in fact of type `XTint.t`. `XTint.t` also happens to be an
 it only required that `x` be of type `t`.
 
 ```reason
-let module XTInt: HasXAndTInt = {
+module XTInt: HasXAndTInt = {
    type t = int;
    let x = 20;
 };
-let module XTInt: HasXAndTAbstract = {
+module XTInt: HasXAndTAbstract = {
    type t = int;
    let x = 20;
 };
@@ -210,12 +210,12 @@ lost track of the type itself, but not lost track of the fact that the type of
 `Constrained.x` is identical to the type of `Constrained.t`.
 
 ```reason
-let module XYAndT = {
+module XYAndT = {
    type t = int;
    let x = 20;
    let y = "you'll never see me!";
 };
-let module Constrained: HasXAndTAbstract = XYAndT;
+module Constrained: HasXAndTAbstract = XYAndT;
 ```
 > This kind of "constraining" allows *hiding* of information that should be
 > considered implementation details.
@@ -267,7 +267,7 @@ The syntax for defining and using module functions is very much like the syntax 
 defining and using regular functions. The primary differences are:
 
 
-- Module functions use the `let module` keywords instead of `let` and the `fun` 
+- Module functions use the `module` keyword instead of `let` and the `fun`
 keyword designates functor in this case.
 - Module functions accept modules as arguments and return a module.
 - Module functions *require* annotating arguments.
@@ -277,7 +277,7 @@ keyword designates functor in this case.
 module type HasT = {
   type t;
 };
-let module Pairify = fun (X: HasT) => {
+module Pairify = fun (X: HasT) => {
    type p = (X.t, X.t);
    let create = fun (x: X.t) => (x, x);
 };
@@ -288,7 +288,7 @@ In this case, a module *literal* is passed as the module functions argument, but
 could have passed the name of a module instead.
 
 ```reason
-let module IntPair = Pairify {
+module IntPair = Pairify {
   type t = int;
 };
 
@@ -321,7 +321,7 @@ module type ParifyT = (HasTInstance: HasT) => {
   let create: HasTInstance.t => p;
 };
 
-let module Pairify: ParifyT = fun (X:HasT) => {
+module Pairify: ParifyT = fun (X:HasT) => {
   type p = (X.t, X.t);
   let create = fun (x: X.t) => (x, x);
 };

--- a/docs/tools.html
+++ b/docs/tools.html
@@ -253,7 +253,7 @@ Then only the constructor identifiers that were listed will be assumed to accept
 
 let x = TupleConstructor (1, 2);
 let y = MultiArgumentsConstructor 1 2;
-let module Test = {
+module Test = {
   type a = | And of (int, int) | Or of (int, int);
 };
 let a = Test.And (1, 2);

--- a/formatTest/typeCheckedTests/expected_output/arityConversion.re
+++ b/formatTest/typeCheckedTests/expected_output/arityConversion.re
@@ -10,7 +10,7 @@ let b =
   MultiArgumentsConstructor 1 2
   [@implicit_arity];
 
-let module Test = {
+module Test = {
   type a =
     | And (int, int)
     | Or (int, int);
@@ -22,7 +22,7 @@ Test.Or (1, 2);
 
 Some 1;
 
-let module M = {
+module M = {
   type t =
     | TupleConstructorInModule (int, int);
   type t2 =

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -284,7 +284,7 @@ and anotherClassType = {
 }
 [@@structureItem];
 
-let module NestedModule = {
+module NestedModule = {
   [@@@floatingNestedStructureItem hello];
 };
 

--- a/formatTest/typeCheckedTests/expected_output/comments.re
+++ b/formatTest/typeCheckedTests/expected_output/comments.re
@@ -137,7 +137,7 @@ let equal i1 i2 =>
 let equal i1 i2 =>
   compare (compare 0 0) (compare 1 1) /* END OF LINE HERE */;
 
-let module Temp = {
+module Temp = {
   let v = true;
   let logIt str () => print_string str;
 };

--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -1,30 +1,30 @@
 type component = {displayName: string};
 
-let module Bar = {
+module Bar = {
   let createElement c::c=? children => {
     displayName: "test"
   };
 };
 
-let module Nesting = {
+module Nesting = {
   let createElement children => {
     displayName: "test"
   };
 };
 
-let module Much = {
+module Much = {
   let createElement children => {
     displayName: "test"
   };
 };
 
-let module Foo = {
+module Foo = {
   let createElement a::a=? b::b=? children => {
     displayName: "test"
   };
 };
 
-let module One = {
+module One = {
   let createElement
       test::test=?
       foo::foo=?
@@ -38,13 +38,13 @@ let module One = {
   };
 };
 
-let module Two = {
+module Two = {
   let createElement foo::foo=? children => {
     displayName: "test"
   };
 };
 
-let module Sibling = {
+module Sibling = {
   let createElement
       foo::foo=?
       (children: list component) => {
@@ -52,44 +52,44 @@ let module Sibling = {
   };
 };
 
-let module Test = {
+module Test = {
   let createElement yo::yo=? children => {
     displayName: "test"
   };
 };
 
-let module So = {
+module So = {
   let createElement children => {
     displayName: "test"
   };
 };
 
-let module Foo2 = {
+module Foo2 = {
   let createElement children => {
     displayName: "test"
   };
 };
 
-let module Text = {
+module Text = {
   let createElement children => {
     displayName: "test"
   };
 };
 
-let module Exp = {
+module Exp = {
   let createElement children => {
     displayName: "test"
   };
 };
 
-let module Pun = {
+module Pun = {
   let createElement intended::intended=? children => {
     displayName: "test"
   };
 };
 
-let module Namespace = {
-  let module Foo = {
+module Namespace = {
+  module Foo = {
     let createElement
         intended::intended=?
         children => {
@@ -98,7 +98,7 @@ let module Namespace = {
   };
 };
 
-let module LotsOfArguments = {
+module LotsOfArguments = {
   let createElement
       argument1::argument1=?
       argument2::argument2=?
@@ -115,19 +115,19 @@ let div argument1::argument1=? children => {
   displayName: "test"
 };
 
-let module List1 = {
+module List1 = {
   let createElement children => {
     displayName: "test"
   };
 };
 
-let module List2 = {
+module List2 = {
   let createElement children => {
     displayName: "test"
   };
 };
 
-let module List3 = {
+module List3 = {
   let createElement children => {
     displayName: "test"
   };

--- a/formatTest/typeCheckedTests/expected_output/mlSyntax.re
+++ b/formatTest/typeCheckedTests/expected_output/mlSyntax.re
@@ -93,7 +93,7 @@ let nestedSome = Some (1, 2, Some (1, 2, 3));
 
 let nestedSomeSimple = Some (Some (1, 2, 3));
 
-let module EM = {
+module EM = {
 
   /** Exception */
   exception E int int;

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -247,7 +247,7 @@ class tupleClass 'a 'b (init: ('a, 'b)) => {
   method pr = init;
 };
 
-let module HasTupleClasses: {
+module HasTupleClasses: {
 
   /**
    * exportedClass.

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -54,7 +54,7 @@
 /**
  **
  */
-let module JustString = {
+module JustString = {
   include Map.Make Int32; /* Comment eol include */
 };
 

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.rei
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.rei
@@ -1,3 +1,3 @@
-let module JustString: {
+module JustString: {
   include Map.S; /* Comment eol include */
 };

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -217,7 +217,7 @@ and anotherClassType = {
 [@@structureItem];
 
 
-let module NestedModule = {
+module NestedModule = {
   [@@@floatingNestedStructureItem hello];
 };
 module type HasAttrs = {

--- a/formatTest/typeCheckedTests/input/jsx.re
+++ b/formatTest/typeCheckedTests/input/jsx.re
@@ -1,65 +1,65 @@
 type component = {displayName: string};
 
-let module Bar = {
+module Bar = {
   let createElement c::c=? children => {displayName: "test"};
 };
 
-let module Nesting = {
+module Nesting = {
   let createElement children => {displayName: "test"};
 };
 
-let module Much = {
+module Much = {
   let createElement children => {displayName: "test"};
 };
 
-let module Foo = {
+module Foo = {
     let createElement a::a=? b::b=? children => {displayName: "test"};
 };
 
-let module One = {
+module One = {
     let createElement test::test=? foo::foo=? children => {displayName: "test"};
     let createElementobvioustypo test::test children => {displayName: "test"};
 };
 
-let module Two = {
+module Two = {
     let createElement foo::foo=? children => {displayName: "test"};
 };
 
-let module Sibling = {
+module Sibling = {
     let createElement foo::foo=? (children: list component) => {displayName: "test"};
 };
 
-let module Test = {
+module Test = {
     let createElement yo::yo=? children => {displayName: "test"};
 };
 
-let module So = {
+module So = {
     let createElement children => {displayName: "test"};
 };
 
-let module Foo2 = {
+module Foo2 = {
     let createElement children => {displayName: "test"};
 };
 
-let module Text = {
+module Text = {
     let createElement children => {displayName: "test"};
 };
 
-let module Exp = {
+module Exp = {
     let createElement children => {displayName: "test"};
 };
 
-let module Pun = {
+module Pun = {
     let createElement intended::intended=? children => {displayName: "test"};
 };
 
-let module Namespace = {
-    let module Foo = {
+module Namespace = {
+    module Foo = {
         let createElement intended::intended=? children => {displayName: "test"};
     };
 };
 
-let module LotsOfArguments = {
+module LotsOfArguments = {
     let createElement argument1::argument1=? argument2::argument2=? argument3::argument3=? argument4::argument4=? argument5::argument5=? argument6::argument6=? children => {displayName: "test"};
 };
 
@@ -67,15 +67,15 @@ let div argument1::argument1=? children => {
     displayName: "test"
 };
 
-let module List1 = {
+module List1 = {
     let createElement children => {displayName: "test"};
 };
 
-let module List2 = {
+module List2 = {
     let createElement children => {displayName: "test"};
 };
 
-let module List3 = {
+module List3 = {
     let createElement children => {displayName: "test"};
 };
 

--- a/formatTest/typeCheckedTests/input/oo.re
+++ b/formatTest/typeCheckedTests/input/oo.re
@@ -216,7 +216,7 @@ class tupleClass 'a 'b (init: ('a, 'b)) => {
   method pr => init;
 };
 
-let module HasTupleClasses : {
+module HasTupleClasses : {
   /**
    * exportedClass.
    */

--- a/formatTest/typeCheckedTests/input/reasonComments.re
+++ b/formatTest/typeCheckedTests/input/reasonComments.re
@@ -37,7 +37,7 @@
  **
  */
 
-let module JustString = {
+module JustString = {
   include Map.Make Int32; /* Comment eol include */
 };
 

--- a/formatTest/typeCheckedTests/input/reasonComments.rei
+++ b/formatTest/typeCheckedTests/input/reasonComments.rei
@@ -1,3 +1,3 @@
-let module JustString : {
+module JustString : {
   include Map.S; /* Comment eol include */
 };

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -586,3 +586,7 @@ open M;
 open M.Inner;
 
 open M;
+
+module OldModuleSyntax = {
+  module InnerOldModule = {};
+};

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -24,7 +24,7 @@ let run () => TestUtils.printSection "Modules";
  * values. Modules, on the other hand do allow fields to reference other
  * fields. Appropriately, each field is introduced via the keyword `let`.
  */
-let module MyFirstModule = {
+module MyFirstModule = {
   let x = 0;
   let y = x + x;
 };
@@ -33,7 +33,7 @@ let result = MyFirstModule.x + MyFirstModule.y;
 
 
 /**
- * - A module is introduced with the `let module` phrase.
+ * - A module is introduced with the `module` phrase.
  * - A module *must* have a capital letter as its first character.
  * - The exported fields of a module must be listed within `{}` braces and each
  * exported value binding is specified via a `let` keyword.
@@ -43,7 +43,7 @@ let result = MyFirstModule.x + MyFirstModule.y;
  * Another way that modules are more powerful than records, is that they may
  * also export types.
  */
-let module MySecondModule = {
+module MySecondModule = {
   type someType = int;
   let x = 0;
   let y = x + x;
@@ -76,7 +76,7 @@ module type MySecondModuleType = {
  * written code that matches your understanding. For example, `MySecondModule`
  * could have been written as:
 
- let module MySecondModule: MySecondModuleType = {
+ module MySecondModule: MySecondModuleType = {
  type someType = int;
  let x = 0;
  let y = x + x;
@@ -98,12 +98,12 @@ module type MySecondModuleType = {
  * language.
  */
 let opensAModuleLocally = {
-  let module MyLocalModule = {
+  module MyLocalModule = {
     type i = int;
     let x: i = 10;
   };
   /* Notice how local modules names may be used twice and are shadowed */
-  let module MyLocalModule: MySecondModuleType = {
+  module MyLocalModule: MySecondModuleType = {
     type someType = int;
     let x: someType = 10;
     let y: someType = 20;
@@ -114,12 +114,12 @@ let opensAModuleLocally = {
 
 module type HasTT = {type tt;};
 
-let module SubModule: HasTT = {
+module SubModule: HasTT = {
   type tt = int;
 };
 
 module type HasEmbeddedHasTT = {
-  let module SubModuleThatHasTT = SubModule;
+  module SubModuleThatHasTT = SubModule;
 };
 
 module type HasPolyType = {type t 'a;};
@@ -130,25 +130,24 @@ module type HasDestructivelySubstitutedPolyType =
 module type HasDestructivelySubstitutedSubPolyModule = {
   /* Cannot perform destructive substitution on submodules! */
   /* module X: HasPolyType with type t := list (int, int); */
-  let module X:
-    HasDestructivelySubstitutedPolyType;
+  module X: HasDestructivelySubstitutedPolyType;
 };
 
 module type HasSubPolyModule = {
   /* Cannot perform destructive substitution on submodules! */
   /* module X: HasPolyType with type t := list (int, int); */
-  let module X: HasPolyType;
+  module X: HasPolyType;
 };
 
-let module EmbedsSubPolyModule: HasSubPolyModule = {
-  let module X = {
+module EmbedsSubPolyModule: HasSubPolyModule = {
+  module X = {
     type t 'a = list 'a;
   };
 };
 
-let module EmbedsDestructivelySubstitutedPolyModule:
+module EmbedsDestructivelySubstitutedPolyModule:
   HasDestructivelySubstitutedSubPolyModule = {
-  let module X = {
+  module X = {
     type t = list (int, int);
   };
 };
@@ -164,7 +163,7 @@ module type HasDestructivelySubstitutedMultiPolyType =
       Hashtbl.t 'a 'b and
     type substituteThat 'a 'b := Hashtbl.t 'a 'b;
 
-let module InliningSig: {let x: int; let y: int;} = {
+module InliningSig: {let x: int; let y: int;} = {
   /*
    * Comment inside of signature.
    */
@@ -173,7 +172,7 @@ let module InliningSig: {let x: int; let y: int;} = {
   let y = 20;
 };
 
-let module MyFunctor (M: HasTT) => {
+module MyFunctor (M: HasTT) => {
   type reexportedTT = M.tt;
   /* Inline comment inside module. */
 
@@ -188,11 +187,11 @@ let module MyFunctor (M: HasTT) => {
    bottom of this file. [Actually, forgiving the trailing SEMI might not be
    such a great idea].
    */
-let module MyFunctorResult = MyFunctor {
+module MyFunctorResult = MyFunctor {
   type tt = string;
 };
 
-let module LookNoParensNeeded = MyFunctor {
+module LookNoParensNeeded = MyFunctor {
   type tt = string;
 };
 
@@ -202,22 +201,22 @@ module type ASig = {let a: int;};
 
 module type BSig = {let b: int;};
 
-let module AMod = {
+module AMod = {
   let a = 10;
 };
 
-let module BMod = {
+module BMod = {
   let b = 10;
 };
 
-let module CurriedSugar (A: ASig) (B: BSig) => {
+module CurriedSugar (A: ASig) (B: BSig) => {
   let result = A.a + B.b;
 };
 
 /* Right now [CurriedSuperSugar] is parsed as being indistinguishable from
    the above.
 
-   let module CurriedSuperSugar (A:ASig) (B:BSig): SigResult => ({
+   module CurriedSuperSugar (A:ASig) (B:BSig): SigResult => ({
    let result = A.a + B.b;
    }: SigResult);
 
@@ -230,39 +229,39 @@ let module CurriedSugar (A: ASig) (B: BSig) => {
    module x (A:Foo) :Bar => Baz;
 
    */
-let module CurriedSugarWithReturnType
-           (A: ASig)
-           (B: BSig)
-           :SigResult => {
+module CurriedSugarWithReturnType
+       (A: ASig)
+       (B: BSig)
+       :SigResult => {
   let result = A.a + B.b;
 };
 
 /* This is parsed as being equivalent to the above example */
-let module CurriedSugarWithAnnotatedReturnVal
-           (A: ASig)
-           (B: BSig)
-           :SigResult => {
+module CurriedSugarWithAnnotatedReturnVal
+       (A: ASig)
+       (B: BSig)
+       :SigResult => {
   let result = A.a + B.b;
 };
 
-let module CurriedNoSugar (A: ASig) (B: BSig) => {
+module CurriedNoSugar (A: ASig) (B: BSig) => {
   let result = A.a + B.b;
 };
 
 let letsTryThatSyntaxInLocalModuleBindings () => {
-  let module CurriedSugarWithReturnType
-             (A: ASig)
-             (B: BSig)
-             :SigResult => {
+  module CurriedSugarWithReturnType
+         (A: ASig)
+         (B: BSig)
+         :SigResult => {
     let result = A.a + B.b;
   };
-  let module CurriedSugarWithAnnotatedReturnVal
-             (A: ASig)
-             (B: BSig)
-             :SigResult => {
+  module CurriedSugarWithAnnotatedReturnVal
+         (A: ASig)
+         (B: BSig)
+         :SigResult => {
     let result = A.a + B.b;
   };
-  let module CurriedNoSugar (A: ASig) (B: BSig) => {
+  module CurriedNoSugar (A: ASig) (B: BSig) => {
     let result = A.a + B.b;
   };
   /*
@@ -270,29 +269,28 @@ let letsTryThatSyntaxInLocalModuleBindings () => {
    * parsed!
    *
    * let thisDoesntWorkInOCaml () =
-   * let module LocalModule(A:sig end) = struct let x = 10 end in
-   * let module Out = (LocalModule (struct end)) in
+   * module LocalModule(A:sig end) = struct let x = 10 end in
+   * module Out = (LocalModule (struct end)) in
    * let outVal = (LocalModule (struct end)).x in
    * let res = Out.x in
    * res;;
    */
-  let module TempModule =
-    CurriedNoSugar AMod BMod;
-  let module TempModule2 =
+  module TempModule = CurriedNoSugar AMod BMod;
+  module TempModule2 =
     CurriedSugarWithAnnotatedReturnVal AMod BMod;
   TempModule.result + TempModule2.result
 };
 
 module type EmptySig = {};
 
-let module MakeAModule (X: EmptySig) => {
+module MakeAModule (X: EmptySig) => {
   let a = 10;
 };
 
-let module CurriedSugarFunctorResult =
+module CurriedSugarFunctorResult =
   CurriedSugar AMod BMod;
 
-let module CurriedSugarFunctorResultInline =
+module CurriedSugarFunctorResultInline =
   CurriedSugar
     {
       let a = 10;
@@ -301,10 +299,10 @@ let module CurriedSugarFunctorResultInline =
       let b = 10;
     };
 
-let module CurriedNoSugarFunctorResult =
+module CurriedNoSugarFunctorResult =
   CurriedNoSugar AMod BMod;
 
-let module CurriedNoSugarFunctorResultInline =
+module CurriedNoSugarFunctorResultInline =
   CurriedNoSugar
     {
       let a = 10;
@@ -313,7 +311,7 @@ let module CurriedNoSugarFunctorResultInline =
       let b = 10;
     };
 
-let module ResultFromNonSimpleFunctorArg =
+module ResultFromNonSimpleFunctorArg =
   CurriedNoSugar
     (
       MakeAModule {}
@@ -341,14 +339,14 @@ module type FunctorType3 =
 /* The actual functors themselves now have curried sugar (which the pretty
  * printer will enforce as well */
 /* The following: */
-let module CurriedSugarWithAnnotation2:
+module CurriedSugarWithAnnotation2:
   ASig => BSig => SigResult =
   fun (A: ASig) (B: BSig) => {
     let result = A.a + B.b;
   };
 
 /* Becomes: */
-let module CurriedSugarWithAnnotation:
+module CurriedSugarWithAnnotation:
   ASig => BSig => SigResult =
   fun (A: ASig) (B: BSig) => {
     let result = A.a + B.b;
@@ -356,7 +354,7 @@ let module CurriedSugarWithAnnotation:
 
 /* "functors" that are not in sugar curried form cannot annotate a return type
  * for now, so we settle for: */
-let module CurriedSugarWithAnnotationAndReturnAnnotated:
+module CurriedSugarWithAnnotationAndReturnAnnotated:
   ASig => BSig => SigResult =
   fun (A: ASig) (B: BSig) => (
     {
@@ -365,25 +363,25 @@ let module CurriedSugarWithAnnotationAndReturnAnnotated:
       SigResult
   );
 
-let module ReturnsAFunctor
-           (A: ASig)
-           (B: BSig)
-           :(ASig => BSig => SigResult) =>
+module ReturnsAFunctor
+       (A: ASig)
+       (B: BSig)
+       :(ASig => BSig => SigResult) =>
   fun (A: ASig) (B: BSig) => {
     let result = 10;
   };
 
-let module ReturnsSigResult
-           (A: ASig)
-           (B: BSig)
-           :SigResult => {
+module ReturnsSigResult
+       (A: ASig)
+       (B: BSig)
+       :SigResult => {
   let result = 10;
 };
 
-let module ReturnsAFunctor2
-           (A: ASig)
-           (B: BSig)
-           :(ASig => BSig => SigResult) =>
+module ReturnsAFunctor2
+       (A: ASig)
+       (B: BSig)
+       :(ASig => BSig => SigResult) =>
   fun (A: ASig) (B: BSig) => {
     let result = 10;
   };
@@ -392,7 +390,7 @@ let module ReturnsAFunctor2
  * Recursive modules.
  * TODO: Test [Psig_recmodule]
  */
-let module rec A: {
+module rec A: {
   type t =
     | Leaf string
     | Node ASet.t;
@@ -416,7 +414,7 @@ and ASet: Set.S with type elt = A.t = Set.Make A;
  * How recursive modules appear in signatures.
  */
 module type HasRecursiveModules = {
-  let module rec A: {
+  module rec A: {
     type t =
       | Leaf string
       | Node ASet.t;
@@ -428,30 +426,30 @@ module type HasRecursiveModules = {
 /* From http://stackoverflow.com/questions/1986374/higher-order-type-constructors-and-functors-in-ocaml */
 module type Type = {type t;};
 
-let module Char = {
+module Char = {
   type t = char;
 };
 
-let module List (X: Type) => {
+module List (X: Type) => {
   type t = list X.t;
 };
 
-let module Maybe (X: Type) => {
+module Maybe (X: Type) => {
   type t = option X.t;
 };
 
-let module Id (X: Type) => X;
+module Id (X: Type) => X;
 
-let module Compose
-           (F: Type => Type)
-           (G: Type => Type)
-           (X: Type) => F (
+module Compose
+       (F: Type => Type)
+       (G: Type => Type)
+       (X: Type) => F (
   G X
 );
 
 let l: Compose(List)(Maybe)(Char).t = [Some 'a'];
 
-let module Example2 (F: Type => Type) (X: Type) => {
+module Example2 (F: Type => Type) (X: Type) => {
 
   /**
    * Note: This is the one remaining syntactic issue where
@@ -469,10 +467,10 @@ Printf.printf
   CurriedNoSugarFunctorResultInline.result;
 
 /* We would have: */
-/* let module CurriedSugarWithAnnotation: ASig => BSig => SigResult =
+/* module CurriedSugarWithAnnotation: ASig => BSig => SigResult =
    fun (A:ASig) (B:BSig) => {let result = A.a + B.b;; */
 /*
- let module Typeahead = React.Create {
+ module Typeahead = React.Create {
  type props = {initialCount: int};
  type state = {count: int};
  let getInitialState props => {count: 10};
@@ -491,7 +489,7 @@ include YourLib.CreateComponent {
 
 module type HasInt = {let x: int;};
 
-let module MyModule = {
+module MyModule = {
   let x = 10;
 };
 
@@ -509,20 +507,20 @@ let acceptsAndUnpacksFirstClass
     ((module M): (module HasInt)) =>
   M.x + M.x;
 
-let module SecondClass = (val myFirstClass);
+module SecondClass = (val myFirstClass);
 
-let module SecondClass2 = (
+module SecondClass2 = (
   val ((module MyModule): (module HasInt))
 );
 
 let p = SecondClass.x;
 
 /* Opening Modules */
-let module M = {
-  let module Inner = {};
+module M = {
+  module Inner = {};
 };
 
-let module N = {
+module N = {
   open M;
   let z = M.(34);
   let z = {

--- a/formatTest/unit_tests/expected_output/polymorphism.re
+++ b/formatTest/unit_tests/expected_output/polymorphism.re
@@ -16,7 +16,7 @@ type intListTranformer = list int => list int;
 
 type x = list (int, string);
 
-let module HoldsAType = {
+module HoldsAType = {
   type hasPrime 'a 'b 'c =
     Hashtbl.t (list 'a) (list 'b);
 };
@@ -85,7 +85,7 @@ let certainlyRequiresWrapping:
 /* Fringe features */
 /*
   /* This parses, but doesn't type check */
-  let module TryExtendingType = {type t = Hello of string;};
+  module TryExtendingType = {type t = Hello of string;};
   type TryExtendingType.t += LookANewExtension of string;
  */
 "end";

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -353,7 +353,7 @@ let blah a {blahBlah} => a;
 
 let blah a {blahBlah} => a;
 
-let module TryToExportTwice = {
+module TryToExportTwice = {
   let myVal = "hello";
 };
 

--- a/formatTest/unit_tests/expected_output/trailingSpaces.re
+++ b/formatTest/unit_tests/expected_output/trailingSpaces.re
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
-let module M = Something.Create {
+module M = Something.Create {
   type resource1 = MyModule.MySubmodule.t;
   type resource2 = MyModule.MySubmodule.t;
 };

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
-let module LocalModule = {
+module LocalModule = {
   type accessedThroughModule =
     | AccessedThroughModule;
   type accessedThroughModuleWithArg =

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -2360,28 +2360,28 @@ module type ASig = {let a: int;};
 
 module type BSig = {let b: int;};
 
-let module AMod = {
+module AMod = {
   let a = 10;
 };
 
-let module BMod = {
+module BMod = {
   let b = 10;
 };
 
-let module CurriedSugar
-           /* Commenting before First curried functor arg */
-           /* If these comments aren't formatted correctly
-            * see how functor args' locations aren't set
-            * correclty due to the fold_left.
-            */
-           (A: ASig)
-           /* Commenting before Second curried functor arg */
-           (B: BSig) => {
+module CurriedSugar
+       /* Commenting before First curried functor arg */
+       /* If these comments aren't formatted correctly
+        * see how functor args' locations aren't set
+        * correclty due to the fold_left.
+        */
+       (A: ASig)
+       /* Commenting before Second curried functor arg */
+       (B: BSig) => {
   let result = A.a + B.b;
   /* Comment at bottom of module expression */
 };
 
-let module CurriedSugarFunctorResult =
+module CurriedSugarFunctorResult =
   /* Commenting before functor name*/
   CurriedSugar
     /* Commenting before functor arg 1 in app */
@@ -2389,7 +2389,7 @@ let module CurriedSugarFunctorResult =
     /* Commenting before functor arg 2 in app */
     BMod;
 
-let module CurriedSugarFunctorResultInline =
+module CurriedSugarFunctorResultInline =
   /* Commenting before functor name*/
   CurriedSugar
     /* Commenting before functor arg 1 in app */

--- a/formatTest/unit_tests/input/modules.re
+++ b/formatTest/unit_tests/input/modules.re
@@ -447,3 +447,8 @@ let y = 44;
 open M;
 open M.Inner;
 open M;
+
+let module OldModuleSyntax = {
+    let module InnerOldModule = {
+    };
+};

--- a/formatTest/unit_tests/input/modules.re
+++ b/formatTest/unit_tests/input/modules.re
@@ -29,7 +29,7 @@ let run = fun () => {
  * fields. Appropriately, each field is introduced via the keyword `let`.
  */
 
-let module MyFirstModule = {
+module MyFirstModule = {
   let x = 0;
   let y = x + x;
 };
@@ -37,7 +37,7 @@ let module MyFirstModule = {
 let result = MyFirstModule.x + MyFirstModule.y;
 
 /**
- * - A module is introduced with the `let module` phrase.
+ * - A module is introduced with the `module` phrase.
  * - A module *must* have a capital letter as its first character.
  * - The exported fields of a module must be listed within `{}` braces and each
  * exported value binding is specified via a `let` keyword.
@@ -47,7 +47,7 @@ let result = MyFirstModule.x + MyFirstModule.y;
  * Another way that modules are more powerful than records, is that they may
  * also export types.
  */
-let module MySecondModule = {
+module MySecondModule = {
   type someType = int;
   let x = 0;
   let y = x + x;
@@ -78,7 +78,7 @@ module type MySecondModuleType = {
  * written code that matches your understanding. For example, `MySecondModule`
  * could have been written as:
 
- let module MySecondModule: MySecondModuleType = {
+ module MySecondModule: MySecondModuleType = {
  type someType = int;
  let x = 0;
  let y = x + x;
@@ -101,12 +101,12 @@ module type MySecondModuleType = {
  */
 
 let opensAModuleLocally = {
-  let module MyLocalModule = {
+  module MyLocalModule = {
     type i = int;
     let x:i = 10;
   };
   /* Notice how local modules names may be used twice and are shadowed */
-  let module MyLocalModule: MySecondModuleType = {
+  module MyLocalModule: MySecondModuleType = {
     type someType = int;
     let x:someType = 10;
     let y:someType = 20;
@@ -119,12 +119,12 @@ module type HasTT = {
   type tt;
 };
 
-let module SubModule: HasTT = {
+module SubModule: HasTT = {
   type tt = int;
 };
 
 module type HasEmbeddedHasTT = {
-  let module SubModuleThatHasTT = SubModule;
+  module SubModuleThatHasTT = SubModule;
 };
 
 module type HasPolyType = {type t 'a;};
@@ -135,22 +135,22 @@ module type HasDestructivelySubstitutedPolyType =
 module type HasDestructivelySubstitutedSubPolyModule = {
   /* Cannot perform destructive substitution on submodules! */
   /* module X: HasPolyType with type t := list (int, int); */
-  let module X: HasDestructivelySubstitutedPolyType;
+  module X: HasDestructivelySubstitutedPolyType;
 };
 module type HasSubPolyModule = {
   /* Cannot perform destructive substitution on submodules! */
   /* module X: HasPolyType with type t := list (int, int); */
-  let module X: HasPolyType;
+  module X: HasPolyType;
 };
 
-let module EmbedsSubPolyModule: HasSubPolyModule = {
-  let module X = {
+module EmbedsSubPolyModule: HasSubPolyModule = {
+  module X = {
     type t 'a = list 'a;
   };
 };
 
-let module EmbedsDestructivelySubstitutedPolyModule: HasDestructivelySubstitutedSubPolyModule = {
-  let module X = {
+module EmbedsDestructivelySubstitutedPolyModule: HasDestructivelySubstitutedSubPolyModule = {
+  module X = {
     type t = list (int, int);
   };
 };
@@ -167,7 +167,7 @@ type substituteThat 'a 'b := Hashtbl.t 'a 'b
 );
 
 
-let module InliningSig: {let x: int; let y:int;} = {
+module InliningSig: {let x: int; let y:int;} = {
   /*
    * Comment inside of signature.
    */
@@ -176,7 +176,7 @@ let module InliningSig: {let x: int; let y:int;} = {
   let y = 20;
 };
 
-let module MyFunctor = fun (M: HasTT) => {
+module MyFunctor = fun (M: HasTT) => {
   type reexportedTT = M.tt;
   /* Inline comment inside module. */
   /** Following special comment inside module. */
@@ -190,18 +190,18 @@ let module MyFunctor = fun (M: HasTT) => {
    bottom of this file. [Actually, forgiving the trailing SEMI might not be
    such a great idea].
    */
-let module MyFunctorResult = MyFunctor ({type tt = string;});
+module MyFunctorResult = MyFunctor ({type tt = string;});
 
-let module LookNoParensNeeded = MyFunctor {type tt = string;};
+module LookNoParensNeeded = MyFunctor {type tt = string;};
 
 module type SigResult = {let result:int;};
 
 module type ASig = {let a:int;};
 module type BSig = {let b:int;};
-let module AMod = {let a = 10;};
-let module BMod = {let b = 10;};
+module AMod = {let a = 10;};
+module BMod = {let b = 10;};
 
-let module CurriedSugar (A:ASig) (B:BSig) => {
+module CurriedSugar (A:ASig) (B:BSig) => {
   let result = A.a + B.b;
 };
 
@@ -209,7 +209,7 @@ let module CurriedSugar (A:ASig) (B:BSig) => {
 /* Right now [CurriedSuperSugar] is parsed as being indistinguishable from
    the above.
 
-   let module CurriedSuperSugar (A:ASig) (B:BSig): SigResult => ({
+   module CurriedSuperSugar (A:ASig) (B:BSig): SigResult => ({
    let result = A.a + B.b;
    }: SigResult);
 
@@ -222,28 +222,28 @@ let module CurriedSugar (A:ASig) (B:BSig) => {
    module x (A:Foo) :Bar => Baz;
 
    */
-let module CurriedSugarWithReturnType (A:ASig) (B:BSig): SigResult => {
+module CurriedSugarWithReturnType (A:ASig) (B:BSig): SigResult => {
   let result = A.a + B.b;
 };
 
 /* This is parsed as being equivalent to the above example */
-let module CurriedSugarWithAnnotatedReturnVal (A:ASig) (B:BSig) => ({
+module CurriedSugarWithAnnotatedReturnVal (A:ASig) (B:BSig) => ({
   let result = A.a + B.b;
 }: SigResult);
 
-let module CurriedNoSugar = fun (A:ASig) => fun (B:BSig) => {
+module CurriedNoSugar = fun (A:ASig) => fun (B:BSig) => {
   let result = A.a + B.b;
 };
 
 let letsTryThatSyntaxInLocalModuleBindings () => {
-  let module CurriedSugarWithReturnType (A:ASig) (B:BSig): SigResult => {
+  module CurriedSugarWithReturnType (A:ASig) (B:BSig): SigResult => {
     let result = A.a + B.b;
   };
-  let module CurriedSugarWithAnnotatedReturnVal (A:ASig) (B:BSig) => ({
+  module CurriedSugarWithAnnotatedReturnVal (A:ASig) (B:BSig) => ({
     let result = A.a + B.b;
   }: SigResult);
 
-  let module CurriedNoSugar = fun (A:ASig) => fun (B:BSig) => {
+  module CurriedNoSugar = fun (A:ASig) => fun (B:BSig) => {
     let result = A.a + B.b;
   };
 
@@ -252,28 +252,28 @@ let letsTryThatSyntaxInLocalModuleBindings () => {
    * parsed!
    *
    * let thisDoesntWorkInOCaml () =
-   * let module LocalModule(A:sig end) = struct let x = 10 end in
-   * let module Out = (LocalModule (struct end)) in
+   * module LocalModule(A:sig end) = struct let x = 10 end in
+   * module Out = (LocalModule (struct end)) in
    * let outVal = (LocalModule (struct end)).x in
    * let res = Out.x in
    * res;;
    */
 
-  let module TempModule = CurriedNoSugar AMod BMod;
-  let module TempModule2 = CurriedSugarWithAnnotatedReturnVal AMod BMod;
+  module TempModule = CurriedNoSugar AMod BMod;
+  module TempModule2 = CurriedSugarWithAnnotatedReturnVal AMod BMod;
   TempModule.result + TempModule2.result;
 };
 
 
 
 module type EmptySig = {};
-let module MakeAModule (X:EmptySig) => {let a = 10;};
-let module CurriedSugarFunctorResult = CurriedSugar AMod BMod;
-let module CurriedSugarFunctorResultInline = CurriedSugar {let a=10;} {let b=10;};
-let module CurriedNoSugarFunctorResult = CurriedNoSugar AMod BMod;
-let module CurriedNoSugarFunctorResultInline = CurriedNoSugar {let a=10;} {let b=10;};
+module MakeAModule (X:EmptySig) => {let a = 10;};
+module CurriedSugarFunctorResult = CurriedSugar AMod BMod;
+module CurriedSugarFunctorResultInline = CurriedSugar {let a=10;} {let b=10;};
+module CurriedNoSugarFunctorResult = CurriedNoSugar AMod BMod;
+module CurriedNoSugarFunctorResultInline = CurriedNoSugar {let a=10;} {let b=10;};
 
-let module ResultFromNonSimpleFunctorArg = CurriedNoSugar (MakeAModule {}) BMod;
+module ResultFromNonSimpleFunctorArg = CurriedNoSugar (MakeAModule {}) BMod;
 
 
 /* TODO: Functor type signatures should more resemble value signatures */
@@ -289,36 +289,36 @@ module type FunctorType3 = (Blah:ASig) => (ThisIsIgnored:BSig) => SigResult;
 /* The actual functors themselves now have curried sugar (which the pretty
  * printer will enforce as well */
 /* The following: */
-let module CurriedSugarWithAnnotation2: ASig => BSig => SigResult =
+module CurriedSugarWithAnnotation2: ASig => BSig => SigResult =
   fun (A:ASig) => fun (B:BSig) => {let result = A.a + B.b;};
 
 /* Becomes: */
-let module CurriedSugarWithAnnotation: ASig => BSig => SigResult =
+module CurriedSugarWithAnnotation: ASig => BSig => SigResult =
   fun (A:ASig) (B:BSig) => {let result = A.a + B.b;};
 
 
 /* "functors" that are not in sugar curried form cannot annotate a return type
  * for now, so we settle for: */
-let module CurriedSugarWithAnnotationAndReturnAnnotated: ASig => BSig => SigResult =
+module CurriedSugarWithAnnotationAndReturnAnnotated: ASig => BSig => SigResult =
   fun (A:ASig) (B:BSig) => ({let result = A.a + B.b;}: SigResult);
 
-let module ReturnsAFunctor (A:ASig) (B:BSig): (ASig => BSig => SigResult) =>
+module ReturnsAFunctor (A:ASig) (B:BSig): (ASig => BSig => SigResult) =>
   fun (A:ASig) (B:BSig) => {
     let result = 10;
   };
 
-let module ReturnsSigResult (A:ASig) (B:BSig): SigResult => {
+module ReturnsSigResult (A:ASig) (B:BSig): SigResult => {
   let result = 10;
 };
 
-let module ReturnsAFunctor2 (A:ASig) (B:BSig): (ASig => BSig => SigResult) =>
+module ReturnsAFunctor2 (A:ASig) (B:BSig): (ASig => BSig => SigResult) =>
   fun (A:ASig) (B:BSig) => {let result = 10;};
 
 /*
  * Recursive modules.
  * TODO: Test [Psig_recmodule]
  */
-let module rec A : {
+module rec A : {
   type t = Leaf string | Node ASet.t;
   let compare: t => t => int;
 } = {
@@ -337,7 +337,7 @@ and ASet: Set.S with type elt = A.t = Set.Make A;
  * How recursive modules appear in signatures.
  */
 module type HasRecursiveModules = {
-  let module rec A: {
+  module rec A: {
     type t = | Leaf string | Node ASet.t;
     let compare: t => t => int;
   }
@@ -347,13 +347,13 @@ module type HasRecursiveModules = {
 
 /* From http://stackoverflow.com/questions/1986374/higher-order-type-constructors-and-functors-in-ocaml */
 module type Type = {type t;};
-let module Char = {type t = char;};
-let module List (X:Type) => {type t = list X.t;};
-let module Maybe (X:Type) => {type t = option X.t;};
-let module Id (X:Type) => X;
-let module Compose (F:Type=>Type) (G:Type=>Type) (X:Type) => F(G(X));
+module Char = {type t = char;};
+module List (X:Type) => {type t = list X.t;};
+module Maybe (X:Type) => {type t = option X.t;};
+module Id (X:Type) => X;
+module Compose (F:Type=>Type) (G:Type=>Type) (X:Type) => F(G(X));
 let l : Compose(List)(Maybe)(Char).t = [Some 'a'];
-let module Example2 (F:Type=>Type) (X:Type) => {
+module Example2 (F:Type=>Type) (X:Type) => {
   /**
    * Note: This is the one remaining syntactic issue where
    * modules/functions do not have syntax unified with values.
@@ -368,11 +368,11 @@ let module Example2 (F:Type=>Type) (X:Type) => {
 Printf.printf "\nModules And Functors: %n\n" (CurriedNoSugarFunctorResultInline.result);
 
 /* We would have: */
-/* let module CurriedSugarWithAnnotation: ASig => BSig => SigResult =
+/* module CurriedSugarWithAnnotation: ASig => BSig => SigResult =
     fun (A:ASig) (B:BSig) => {let result = A.a + B.b;; */
 
 /*
- let module Typeahead = React.Create {
+ module Typeahead = React.Create {
  type props = {initialCount: int};
  type state = {count: int};
  let getInitialState props => {count: 10};
@@ -395,7 +395,7 @@ include YourLib.CreateComponent {
 
 module type HasInt = {let x: int;};
 
-let module MyModule = {let x = 10;};
+module MyModule = {let x = 10;};
 
 let myFirstClass = (module MyModule : HasInt);
 
@@ -405,18 +405,18 @@ let acceptsAndUnpacksFirstClass (module M : HasInt) => M.x + M.x;
 
 let acceptsAndUnpacksFirstClass ((module M) : (module HasInt)) => M.x + M.x;
 
-let module SecondClass = (val myFirstClass);
+module SecondClass = (val myFirstClass);
 
-let module SecondClass2 = (val (module MyModule: HasInt));
+module SecondClass2 = (val (module MyModule: HasInt));
 
 let p = SecondClass.x;
 
 /* Opening Modules */
-let module M = {
-  let module Inner = {};
+module M = {
+  module Inner = {};
 };
 
-let module N = {
+module N = {
 open M;
 let z = { open M; 34; };
 let z = { open M; 34; 35; };

--- a/formatTest/unit_tests/input/polymorphism.re
+++ b/formatTest/unit_tests/input/polymorphism.re
@@ -18,7 +18,7 @@ type intListTranformer = list int => list int;
 type x = list (int, string);
 
 
-let module HoldsAType = {
+module HoldsAType = {
   type hasPrime 'a 'b 'c = Hashtbl.t (list 'a) (list 'b);
 };
 
@@ -79,7 +79,7 @@ let certainlyRequiresWrapping:
 
 /*
   /* This parses, but doesn't type check */
-  let module TryExtendingType = {type t = Hello of string;};
+  module TryExtendingType = {type t = Hello of string;};
   type TryExtendingType.t += LookANewExtension of string;
  */
 "end";

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -313,7 +313,7 @@ type blah = {blahBlah: int};
 let blah = fun (a) {blahBlah} => a;
 let blah a {blahBlah} => a;
 
-let module TryToExportTwice = {
+module TryToExportTwice = {
   let myVal = "hello";
 };
 

--- a/formatTest/unit_tests/input/trailingSpaces.re
+++ b/formatTest/unit_tests/input/trailingSpaces.re
@@ -1,6 +1,6 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
-let module M = Something.Create {
+module M = Something.Create {
   type resource1 = MyModule.MySubmodule.t;
   type resource2 = MyModule.MySubmodule.t;
 };

--- a/formatTest/unit_tests/input/variants.re
+++ b/formatTest/unit_tests/input/variants.re
@@ -1,6 +1,6 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
-let module LocalModule = {
+module LocalModule = {
   type accessedThroughModule = | AccessedThroughModule;
   type accessedThroughModuleWithArg =
     | AccessedThroughModuleWith int | AccessedThroughModuleWithTwo int int;

--- a/formatTest/unit_tests/input/wrappingTest.re
+++ b/formatTest/unit_tests/input/wrappingTest.re
@@ -1707,9 +1707,9 @@ let result =
 
 module type ASig = {let a:int;};
 module type BSig = {let b:int;};
-let module AMod = {let a = 10;};
-let module BMod = {let b = 10;};
-let module CurriedSugar
+module AMod = {let a = 10;};
+module BMod = {let b = 10;};
+module CurriedSugar
     /* Commenting before First curried functor arg */
     /* If these comments aren't formatted correctly
      * see how functor args' locations aren't set
@@ -1722,7 +1722,7 @@ let module CurriedSugar
   /* Comment at bottom of module expression */
 };
 
-let module CurriedSugarFunctorResult =
+module CurriedSugarFunctorResult =
   /* Commenting before functor name*/
   CurriedSugar
     /* Commenting before functor arg 1 in app */
@@ -1730,7 +1730,7 @@ let module CurriedSugarFunctorResult =
     /* Commenting before functor arg 2 in app */
     BMod;
 
-let module CurriedSugarFunctorResultInline =
+module CurriedSugarFunctorResultInline =
   /* Commenting before functor name*/
   CurriedSugar
     /* Commenting before functor arg 1 in app */

--- a/miscTests/reactjs_jsx_ppx_tests/test1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test1.re
@@ -5,7 +5,7 @@ let div = {createElement: fun () => ()};
 
 div.createElement ();
 
-let module Gah = {
+module Gah = {
   let createElement () => ();
 };
 

--- a/src/reason_parser.messages
+++ b/src/reason_parser.messages
@@ -42,7 +42,7 @@
 
 use_file: SHARP LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2851.
+## Ends in an error in state: 2847.
 ##
 ## _use_file -> toplevel_directive SEMI . use_file [ # ]
 ##
@@ -54,7 +54,7 @@ use_file: SHARP LIDENT SEMI WITH
 
 use_file: SHARP LIDENT TRUE WITH
 ##
-## Ends in an error in state: 2850.
+## Ends in an error in state: 2846.
 ##
 ## _use_file -> toplevel_directive . SEMI use_file [ # ]
 ## _use_file -> toplevel_directive . EOF [ # ]
@@ -67,7 +67,7 @@ use_file: SHARP LIDENT TRUE WITH
 
 use_file: UIDENT RPAREN
 ##
-## Ends in an error in state: 2853.
+## Ends in an error in state: 2849.
 ##
 ## _use_file -> structure_item . SEMI use_file [ # ]
 ## _use_file -> structure_item . EOF [ # ]
@@ -79,28 +79,28 @@ use_file: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2842, spurious reduction of production post_item_attributes ->
-## In state 2843, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 2844, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 2822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 2816, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 2846, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 2823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 950, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2838, spurious reduction of production post_item_attributes ->
+## In state 2839, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 2840, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 2818, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 2812, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 2842, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 2819, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 use_file: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2854.
+## Ends in an error in state: 2850.
 ##
 ## _use_file -> structure_item SEMI . use_file [ # ]
 ##
@@ -112,7 +112,7 @@ use_file: UIDENT SEMI WITH
 
 use_file: WITH
 ##
-## Ends in an error in state: 2847.
+## Ends in an error in state: 2843.
 ##
 ## use_file' -> . use_file [ # ]
 ##
@@ -124,7 +124,7 @@ use_file: WITH
 
 toplevel_phrase: SHARP UIDENT EOF
 ##
-## Ends in an error in state: 2814.
+## Ends in an error in state: 2810.
 ##
 ## _toplevel_phrase -> toplevel_directive . SEMI [ # ]
 ##
@@ -135,14 +135,14 @@ toplevel_phrase: SHARP UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2714, spurious reduction of production toplevel_directive -> SHARP ident
+## In state 2712, spurious reduction of production toplevel_directive -> SHARP ident
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 ##
-## Ends in an error in state: 2721.
+## Ends in an error in state: 2719.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ SEMI EOF DOT ]
 ## val_longident -> mod_longident DOT . val_ident [ SEMI EOF ]
@@ -155,7 +155,7 @@ toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 
 toplevel_phrase: SHARP UIDENT UIDENT WITH
 ##
-## Ends in an error in state: 2720.
+## Ends in an error in state: 2718.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ SEMI EOF DOT ]
 ## toplevel_directive -> SHARP ident mod_longident . [ SEMI EOF ]
@@ -169,7 +169,7 @@ toplevel_phrase: SHARP UIDENT UIDENT WITH
 
 toplevel_phrase: SHARP UIDENT WITH
 ##
-## Ends in an error in state: 2714.
+## Ends in an error in state: 2712.
 ##
 ## toplevel_directive -> SHARP ident . [ SEMI EOF ]
 ## toplevel_directive -> SHARP ident . STRING [ SEMI EOF ]
@@ -187,7 +187,7 @@ toplevel_phrase: SHARP UIDENT WITH
 
 toplevel_phrase: SHARP WITH
 ##
-## Ends in an error in state: 2713.
+## Ends in an error in state: 2711.
 ##
 ## toplevel_directive -> SHARP . ident [ SEMI EOF ]
 ## toplevel_directive -> SHARP . ident STRING [ SEMI EOF ]
@@ -205,7 +205,7 @@ toplevel_phrase: SHARP WITH
 
 toplevel_phrase: UIDENT RPAREN
 ##
-## Ends in an error in state: 2817.
+## Ends in an error in state: 2813.
 ##
 ## _toplevel_phrase -> structure_item . SEMI [ # ]
 ##
@@ -216,28 +216,28 @@ toplevel_phrase: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2842, spurious reduction of production post_item_attributes ->
-## In state 2843, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 2844, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 2822, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 2816, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 2846, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 2823, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 950, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2838, spurious reduction of production post_item_attributes ->
+## In state 2839, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 2840, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 2818, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 2812, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 2842, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 2819, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: WITH
 ##
-## Ends in an error in state: 2676.
+## Ends in an error in state: 2674.
 ##
 ## toplevel_phrase' -> . toplevel_phrase [ # ]
 ##
@@ -249,7 +249,7 @@ toplevel_phrase: WITH
 
 parse_pattern: EXCEPTION WITH
 ##
-## Ends in an error in state: 680.
+## Ends in an error in state: 582.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -261,7 +261,7 @@ parse_pattern: EXCEPTION WITH
 
 parse_pattern: LAZY WITH
 ##
-## Ends in an error in state: 664.
+## Ends in an error in state: 571.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -273,7 +273,7 @@ parse_pattern: LAZY WITH
 
 parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ##
-## Ends in an error in state: 737.
+## Ends in an error in state: 662.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error RBRACE COMMA BAR ]
 ## lbl_pattern -> label_longident COLON pattern . [ error RBRACE COMMA ]
@@ -285,14 +285,14 @@ parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 618, spurious reduction of production pattern -> pattern_without_or
+## In state 534, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 575.
+## Ends in an error in state: 483.
 ##
 ## lbl_pattern -> label_longident COLON . pattern [ error RBRACE COMMA ]
 ##
@@ -304,7 +304,7 @@ parse_pattern: LBRACE LIDENT COLON WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 661.
+## Ends in an error in state: 568.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -317,7 +317,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 570.
+## Ends in an error in state: 478.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA UNDERSCORE . opt_comma [ error RBRACE ]
 ##
@@ -329,7 +329,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 
 parse_pattern: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 569.
+## Ends in an error in state: 477.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA . [ error RBRACE ]
 ## lbl_pattern_list -> lbl_pattern COMMA . UNDERSCORE opt_comma [ error RBRACE ]
@@ -343,7 +343,7 @@ parse_pattern: LBRACE LIDENT COMMA WITH
 
 parse_pattern: LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 574.
+## Ends in an error in state: 482.
 ##
 ## lbl_pattern -> label_longident . COLON pattern [ error RBRACE COMMA ]
 ## lbl_pattern -> label_longident . [ error RBRACE COMMA ]
@@ -356,7 +356,7 @@ parse_pattern: LBRACE LIDENT WITH
 
 parse_pattern: LBRACE WITH
 ##
-## Ends in an error in state: 660.
+## Ends in an error in state: 567.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -369,7 +369,7 @@ parse_pattern: LBRACE WITH
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 657.
+## Ends in an error in state: 559.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET BAR ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT pattern . [ error SEMI RBRACKET ]
@@ -381,14 +381,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 618, spurious reduction of production pattern -> pattern_without_or
+## In state 534, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT WITH
 ##
-## Ends in an error in state: 656.
+## Ends in an error in state: 558.
 ##
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT . pattern [ error SEMI RBRACKET ]
 ##
@@ -400,7 +400,7 @@ Expecting a valid list identifier
 
 parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 658.
+## Ends in an error in state: 565.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ COMMA ]
@@ -413,14 +413,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 618, spurious reduction of production pattern -> pattern_without_or
+## In state 534, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 655.
+## Ends in an error in state: 557.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ COMMA ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA . DOTDOTDOT pattern [ error SEMI RBRACKET ]
@@ -434,7 +434,7 @@ parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKET UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 659.
+## Ends in an error in state: 566.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern . [ COMMA ]
@@ -447,14 +447,14 @@ parse_pattern: LBRACKET UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 618, spurious reduction of production pattern -> pattern_without_or
+## In state 534, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 651.
+## Ends in an error in state: 553.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -467,7 +467,7 @@ parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LBRACKET WITH
 ##
-## Ends in an error in state: 648.
+## Ends in an error in state: 549.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -481,7 +481,7 @@ parse_pattern: LBRACKET WITH
 
 parse_pattern: LBRACKETBAR MINUS WITH
 ##
-## Ends in an error in state: 557.
+## Ends in an error in state: 442.
 ##
 ## signed_constant -> MINUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> MINUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -497,7 +497,7 @@ parse_pattern: LBRACKETBAR MINUS WITH
 
 parse_pattern: LBRACKETBAR PLUS WITH
 ##
-## Ends in an error in state: 556.
+## Ends in an error in state: 441.
 ##
 ## signed_constant -> PLUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> PLUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -513,7 +513,7 @@ parse_pattern: LBRACKETBAR PLUS WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 638.
+## Ends in an error in state: 670.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -525,14 +525,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 618, spurious reduction of production pattern -> pattern_without_or
+## In state 534, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 637.
+## Ends in an error in state: 669.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ error SEMI COMMA BARRBRACKET ]
 ##
@@ -544,7 +544,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 647.
+## Ends in an error in state: 674.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -556,14 +556,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 618, spurious reduction of production pattern -> pattern_without_or
+## In state 534, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 644.
+## Ends in an error in state: 685.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -576,7 +576,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LBRACKETBAR WITH
 ##
-## Ends in an error in state: 633.
+## Ends in an error in state: 440.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -590,7 +590,7 @@ parse_pattern: LBRACKETBAR WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 2456.
+## Ends in an error in state: 2454.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -608,7 +608,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 2455.
+## Ends in an error in state: 2453.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -621,7 +621,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2454.
+## Ends in an error in state: 2452.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -639,7 +639,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2453.
+## Ends in an error in state: 2451.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -652,7 +652,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2452.
+## Ends in an error in state: 2450.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -665,7 +665,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2451.
+## Ends in an error in state: 2449.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -678,7 +678,7 @@ parse_pattern: LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN EXCEPTION WITH
 ##
-## Ends in an error in state: 585.
+## Ends in an error in state: 498.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -690,7 +690,7 @@ parse_pattern: LPAREN EXCEPTION WITH
 
 parse_pattern: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 576.
+## Ends in an error in state: 484.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -702,7 +702,7 @@ parse_pattern: LPAREN LAZY WITH
 
 parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 565.
+## Ends in an error in state: 473.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -715,7 +715,7 @@ parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 560.
+## Ends in an error in state: 468.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -728,7 +728,7 @@ parse_pattern: LPAREN LBRACE WITH
 
 parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 739.
+## Ends in an error in state: 664.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -741,7 +741,7 @@ parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LPAREN LBRACKET WITH
 ##
-## Ends in an error in state: 558.
+## Ends in an error in state: 466.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -755,7 +755,7 @@ parse_pattern: LPAREN LBRACKET WITH
 
 parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 744.
+## Ends in an error in state: 671.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -768,7 +768,7 @@ parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LPAREN LBRACKETBAR WITH
 ##
-## Ends in an error in state: 555.
+## Ends in an error in state: 465.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -782,7 +782,7 @@ parse_pattern: LPAREN LBRACKETBAR WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 752.
+## Ends in an error in state: 680.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -800,7 +800,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCOR
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 751.
+## Ends in an error in state: 679.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -813,7 +813,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 750.
+## Ends in an error in state: 678.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -831,7 +831,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 749.
+## Ends in an error in state: 677.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -844,7 +844,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 748.
+## Ends in an error in state: 676.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -857,7 +857,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 747.
+## Ends in an error in state: 675.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -870,7 +870,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 544.
+## Ends in an error in state: 452.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -883,7 +883,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 542.
+## Ends in an error in state: 450.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -897,7 +897,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 
 parse_pattern: LPAREN LPAREN MODULE WITH
 ##
-## Ends in an error in state: 541.
+## Ends in an error in state: 449.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -911,7 +911,7 @@ parse_pattern: LPAREN LPAREN MODULE WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 719.
+## Ends in an error in state: 656.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -926,7 +926,7 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 630.
+## Ends in an error in state: 546.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -944,17 +944,17 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 705, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
-## In state 712, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 711, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 715, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 623, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
+## In state 630, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 629, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 620, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 540.
+## Ends in an error in state: 448.
 ##
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -978,7 +978,7 @@ parse_pattern: LPAREN LPAREN WITH
 
 parse_pattern: LPAREN MINUS WITH
 ##
-## Ends in an error in state: 534.
+## Ends in an error in state: 462.
 ##
 ## operator -> MINUS . [ RPAREN ]
 ## signed_constant -> MINUS . INT [ error RPAREN LBRACKETAT DOTDOT COMMA COLONCOLON COLON BAR AS ]
@@ -1008,7 +1008,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 260, spurious reduction of production ident -> UIDENT
-## In state 552, spurious reduction of production mty_longident -> ident
+## In state 460, spurious reduction of production mty_longident -> ident
 ##
 
 <SYNTAX ERROR>
@@ -1029,7 +1029,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WHILE
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2449.
+## Ends in an error in state: 2447.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ error RPAREN ]
 ##
@@ -1041,7 +1041,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2448.
+## Ends in an error in state: 2446.
 ##
 ## package_type_cstrs -> package_type_cstr . [ error RPAREN ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ error RPAREN ]
@@ -1054,12 +1054,12 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 728, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 722, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 724, spurious reduction of production _core_type -> core_type2
-## In state 735, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 723, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2446, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 643, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 637, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 639, spurious reduction of production _core_type -> core_type2
+## In state 650, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 638, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 2444, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
@@ -1218,7 +1218,7 @@ parse_pattern: LPAREN SHARP WITH
 
 parse_pattern: LPAREN STRING DOTDOT WITH
 ##
-## Ends in an error in state: 590.
+## Ends in an error in state: 506.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ##
@@ -1230,7 +1230,7 @@ parse_pattern: LPAREN STRING DOTDOT WITH
 
 parse_pattern: LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 599.
+## Ends in an error in state: 515.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ error WITH UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS AND ]
 ##
@@ -1242,7 +1242,7 @@ parse_pattern: LPAREN UIDENT DOT WITH
 
 parse_pattern: LPAREN UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 577.
+## Ends in an error in state: 485.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1264,7 +1264,7 @@ parse_pattern: LPAREN UIDENT LPAREN WITH
 
 parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 609.
+## Ends in an error in state: 525.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1277,7 +1277,7 @@ parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 639.
+## Ends in an error in state: 560.
 ##
 ## _or_pattern -> pattern BAR . pattern [ error SEMI RPAREN RBRACKET RBRACE COMMA COLON BARRBRACKET BAR ]
 ##
@@ -1302,7 +1302,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BACKQUOTE LIDENT GREATER
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 179, spurious reduction of production attributes ->
-## In state 2529, spurious reduction of production tag_field -> name_tag attributes
+## In state 2527, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
@@ -1512,7 +1512,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LESS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2444.
+## Ends in an error in state: 2442.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1695,7 +1695,7 @@ parse_pattern: LPAREN UNDERSCORE COLON SHARP WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS QUOTE WITH
 ##
-## Ends in an error in state: 730.
+## Ends in an error in state: 645.
 ##
 ## _core_type -> core_type2 AS QUOTE . ident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AND ]
 ##
@@ -1707,7 +1707,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS QUOTE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS WITH
 ##
-## Ends in an error in state: 729.
+## Ends in an error in state: 644.
 ##
 ## _core_type -> core_type2 AS . QUOTE ident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AND ]
 ##
@@ -1719,7 +1719,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 725.
+## Ends in an error in state: 640.
 ##
 ## _core_type2 -> core_type2 EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1731,7 +1731,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 760.
+## Ends in an error in state: 634.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1746,7 +1746,7 @@ parse_pattern: LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 632.
+## Ends in an error in state: 548.
 ##
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1758,7 +1758,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 704.
+## Ends in an error in state: 622.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ RPAREN COMMA ]
 ##
@@ -1770,7 +1770,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ##
-## Ends in an error in state: 755.
+## Ends in an error in state: 573.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -1782,18 +1782,18 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 692, spurious reduction of production pattern -> pattern_without_or
-## In state 703, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 712, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 711, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 715, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 610, spurious reduction of production pattern -> pattern_without_or
+## In state 621, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 630, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 629, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 620, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 714.
+## Ends in an error in state: 576.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1805,7 +1805,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 713.
+## Ends in an error in state: 575.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint . COMMA pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1816,10 +1816,10 @@ parse_pattern: LPAREN UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 618, spurious reduction of production pattern -> pattern_without_or
-## In state 757, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 712, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 711, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 534, spurious reduction of production pattern -> pattern_without_or
+## In state 631, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 630, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 629, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
 ##
 
 <SYNTAX ERROR>
@@ -1894,7 +1894,7 @@ parse_pattern: SHARP WITH
 
 parse_pattern: STRING DOTDOT WITH
 ##
-## Ends in an error in state: 669.
+## Ends in an error in state: 588.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ##
@@ -1906,7 +1906,7 @@ parse_pattern: STRING DOTDOT WITH
 
 parse_pattern: UIDENT DOT WITH
 ##
-## Ends in an error in state: 436.
+## Ends in an error in state: 597.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ WITH WHEN UNDERSCORE UIDENT TRUE STRING SLASHGREATER SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN GREATER FLOAT FALSE EQUALGREATER EQUAL EOF DOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS AND ]
 ##
@@ -1918,7 +1918,7 @@ parse_pattern: UIDENT DOT WITH
 
 parse_pattern: UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 532.
+## Ends in an error in state: 572.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1940,7 +1940,7 @@ parse_pattern: UIDENT LPAREN WITH
 
 parse_pattern: UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 688.
+## Ends in an error in state: 606.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1953,7 +1953,7 @@ parse_pattern: UIDENT UNDERSCORE WITH
 
 parse_pattern: UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 706.
+## Ends in an error in state: 624.
 ##
 ## _or_pattern -> pattern BAR . pattern [ WHEN SEMI RPAREN RBRACKET IN EQUALGREATER EQUAL EOF COMMA COLON BAR ]
 ##
@@ -1965,7 +1965,7 @@ parse_pattern: UNDERSCORE BAR WITH
 
 parse_pattern: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2673.
+## Ends in an error in state: 2671.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EOF BAR ]
 ## parse_pattern -> pattern . EOF [ # ]
@@ -1977,14 +1977,14 @@ parse_pattern: UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 692, spurious reduction of production pattern -> pattern_without_or
+## In state 610, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: WITH
 ##
-## Ends in an error in state: 2672.
+## Ends in an error in state: 2670.
 ##
 ## parse_pattern' -> . parse_pattern [ # ]
 ##
@@ -1996,7 +1996,7 @@ parse_pattern: WITH
 
 parse_expression: UIDENT SEMI
 ##
-## Ends in an error in state: 2670.
+## Ends in an error in state: 2668.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -2031,21 +2031,21 @@ parse_expression: UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 950, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 parse_expression: WITH
 ##
-## Ends in an error in state: 2668.
+## Ends in an error in state: 2666.
 ##
 ## parse_expression' -> . parse_expression [ # ]
 ##
@@ -2057,7 +2057,7 @@ parse_expression: WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 2523.
+## Ends in an error in state: 2521.
 ##
 ## tag_field -> name_tag opt_ampersand . amper_type_list attributes [ RBRACKET GREATER BAR ]
 ##
@@ -2069,7 +2069,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 ##
-## Ends in an error in state: 2526.
+## Ends in an error in state: 2524.
 ##
 ## amper_type_list -> amper_type_list AMPERSAND . core_type [ RBRACKET LBRACKETAT GREATER BAR AMPERSAND ]
 ##
@@ -2081,7 +2081,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ##
-## Ends in an error in state: 2530.
+## Ends in an error in state: 2528.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET tag_field . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field -> tag_field . [ BAR ]
@@ -2094,7 +2094,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 179, spurious reduction of production attributes ->
-## In state 2529, spurious reduction of production tag_field -> name_tag attributes
+## In state 2527, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
@@ -2126,7 +2126,7 @@ parse_core_type: LBRACKET BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 2534.
+## Ends in an error in state: 2532.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2139,7 +2139,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 2533.
+## Ends in an error in state: 2531.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2151,7 +2151,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE WITH
 ##
-## Ends in an error in state: 2532.
+## Ends in an error in state: 2530.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field . BAR row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2189,7 +2189,7 @@ parse_core_type: LBRACKETGREATER BAR ASSERT
 
 parse_core_type: LBRACKETGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 2536.
+## Ends in an error in state: 2534.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2240,7 +2240,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2541.
+## Ends in an error in state: 2539.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER name_tag_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## name_tag_list -> name_tag_list . name_tag [ RBRACKET BACKQUOTE ]
@@ -2253,7 +2253,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 ##
-## Ends in an error in state: 2540.
+## Ends in an error in state: 2538.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER . name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2265,7 +2265,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE WITH
 ##
-## Ends in an error in state: 2538.
+## Ends in an error in state: 2536.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . GREATER name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2317,7 +2317,7 @@ parse_core_type: LESS LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 ##
-## Ends in an error in state: 1311.
+## Ends in an error in state: 1328.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ##
@@ -2329,7 +2329,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1308.
+## Ends in an error in state: 1325.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -2342,7 +2342,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE WITH
 ##
-## Ends in an error in state: 1309.
+## Ends in an error in state: 1326.
 ##
 ## typevar_list -> typevar_list QUOTE . ident [ QUOTE DOT ]
 ##
@@ -2385,11 +2385,11 @@ parse_core_type: LESS LIDENT COLON UNDERSCORE WITH
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1316, spurious reduction of production _poly_type -> core_type
-## In state 1317, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1315, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 2543, spurious reduction of production attributes ->
-## In state 2544, spurious reduction of production field -> label COLON poly_type attributes
+## In state 1333, spurious reduction of production _poly_type -> core_type
+## In state 1334, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1332, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 2541, spurious reduction of production attributes ->
+## In state 2542, spurious reduction of production field -> label COLON poly_type attributes
 ##
 
 <SYNTAX ERROR>
@@ -2432,7 +2432,7 @@ parse_core_type: LESS WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2553.
+## Ends in an error in state: 2551.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2444,7 +2444,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 ##
-## Ends in an error in state: 2551.
+## Ends in an error in state: 2549.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2456,7 +2456,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 ##
-## Ends in an error in state: 2550.
+## Ends in an error in state: 2548.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION . EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2468,7 +2468,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2549.
+## Ends in an error in state: 2547.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . QUESTION EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2560,7 +2560,7 @@ parse_core_type: LPAREN MODULE UIDENT SEMI
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2558.
+## Ends in an error in state: 2556.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ RPAREN COLONGREATER ]
 ##
@@ -2572,7 +2572,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER A
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2557.
+## Ends in an error in state: 2555.
 ##
 ## package_type_cstrs -> package_type_cstr . [ RPAREN COLONGREATER ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ RPAREN COLONGREATER ]
@@ -2590,7 +2590,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER W
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2555, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 2553, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
@@ -2669,7 +2669,7 @@ parse_core_type: LPAREN UNDERSCORE COMMA WITH
 
 parse_core_type: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1252.
+## Ends in an error in state: 1269.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN core_type_comma_list . RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## core_type_comma_list -> core_type_comma_list . COMMA core_type [ RPAREN COMMA ]
@@ -2708,7 +2708,7 @@ parse_core_type: QUOTE WITH
 
 parse_core_type: SHARP LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 2560.
+## Ends in an error in state: 2558.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP class_longident non_arrowed_simple_core_type_list . [ WITH SEMI RPAREN RBRACKET RBRACE QUESTION LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2875,7 +2875,7 @@ parse_core_type: UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2666.
+## Ends in an error in state: 2664.
 ##
 ## parse_core_type -> core_type . EOF [ # ]
 ##
@@ -2898,7 +2898,7 @@ parse_core_type: UNDERSCORE WITH
 
 parse_core_type: WITH
 ##
-## Ends in an error in state: 2664.
+## Ends in an error in state: 2662.
 ##
 ## parse_core_type' -> . parse_core_type [ # ]
 ##
@@ -2910,7 +2910,7 @@ parse_core_type: WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 ##
-## Ends in an error in state: 2114.
+## Ends in an error in state: 2013.
 ##
 ## and_class_description -> AND . class_description_details post_item_attributes [ SEMI AND ]
 ##
@@ -2922,7 +2922,7 @@ interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ##
-## Ends in an error in state: 2113.
+## Ends in an error in state: 2012.
 ##
 ## _signature_item -> many_class_descriptions . [ SEMI ]
 ## many_class_descriptions -> many_class_descriptions . and_class_description [ SEMI AND ]
@@ -2934,22 +2934,22 @@ interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1750, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1754, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1748, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1752, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1763, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1761, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
-## In state 2086, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
-## In state 2087, spurious reduction of production post_item_attributes ->
-## In state 2088, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
+## In state 1751, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1755, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1749, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1753, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1764, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1762, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1982, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
+## In state 1983, spurious reduction of production post_item_attributes ->
+## In state 1984, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 2085.
+## Ends in an error in state: 1981.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters COLON . class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -2961,7 +2961,7 @@ interface: CLASS LIDENT COLON WITH
 
 interface: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1504.
+## Ends in an error in state: 1510.
 ##
 ## type_parameter -> type_variance . type_variable [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLON CHAR BACKQUOTE ]
 ##
@@ -2973,7 +2973,7 @@ interface: CLASS LIDENT PLUS WITH
 
 interface: CLASS LIDENT WITH
 ##
-## Ends in an error in state: 2084.
+## Ends in an error in state: 1980.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters . COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS COLON ]
@@ -2986,7 +2986,7 @@ interface: CLASS LIDENT WITH
 
 interface: CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 2082.
+## Ends in an error in state: 1978.
 ##
 ## class_description_details -> virtual_flag . LIDENT class_type_parameters COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -2998,7 +2998,7 @@ interface: CLASS VIRTUAL LET
 
 interface: CLASS WITH
 ##
-## Ends in an error in state: 2073.
+## Ends in an error in state: 1969.
 ##
 ## many_class_descriptions -> CLASS . class_description_details post_item_attributes [ SEMI AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ SEMI AND ]
@@ -3011,7 +3011,7 @@ interface: CLASS WITH
 
 interface: EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1900.
+## Ends in an error in state: 1872.
 ##
 ## extension_constructor_declaration -> UIDENT . generalized_constructor_arguments attributes [ SEMI LBRACKETATAT BAR ]
 ##
@@ -3023,7 +3023,7 @@ interface: EXCEPTION UIDENT WITH
 
 interface: EXCEPTION WITH
 ##
-## Ends in an error in state: 2070.
+## Ends in an error in state: 1966.
 ##
 ## sig_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ SEMI ]
 ##
@@ -3035,7 +3035,7 @@ interface: EXCEPTION WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2065.
+## Ends in an error in state: 1961.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3047,7 +3047,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2064.
+## Ends in an error in state: 1960.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3070,7 +3070,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 interface: EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 2063.
+## Ends in an error in state: 1959.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3082,7 +3082,7 @@ interface: EXTERNAL LIDENT COLON WITH
 
 interface: EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 2062.
+## Ends in an error in state: 1958.
 ##
 ## _signature_item -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3094,7 +3094,7 @@ interface: EXTERNAL LIDENT WITH
 
 interface: EXTERNAL WITH
 ##
-## Ends in an error in state: 2061.
+## Ends in an error in state: 1957.
 ##
 ## _signature_item -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3106,7 +3106,7 @@ interface: EXTERNAL WITH
 
 interface: INCLUDE LBRACE OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2089.
+## Ends in an error in state: 1985.
 ##
 ## signature -> signature_item . SEMI signature [ error RBRACE ]
 ##
@@ -3117,18 +3117,18 @@ interface: INCLUDE LBRACE OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1926, spurious reduction of production post_item_attributes ->
-## In state 1927, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 2094, spurious reduction of production _signature_item -> open_statement
-## In state 2121, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 2095, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 1898, spurious reduction of production post_item_attributes ->
+## In state 1899, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 1990, spurious reduction of production _signature_item -> open_statement
+## In state 2020, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 1991, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2090.
+## Ends in an error in state: 1986.
 ##
 ## signature -> signature_item SEMI . signature [ error RBRACE ]
 ##
@@ -3140,7 +3140,7 @@ interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 
 interface: INCLUDE LBRACE WITH
 ##
-## Ends in an error in state: 1986.
+## Ends in an error in state: 1905.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LBRACE . signature error [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3153,7 +3153,7 @@ interface: INCLUDE LBRACE WITH
 
 interface: INCLUDE LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 1230.
+## Ends in an error in state: 1247.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _simple_module_type -> LBRACE . signature error [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3166,7 +3166,7 @@ interface: INCLUDE LPAREN LBRACE WITH
 
 interface: INCLUDE LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 1936.
+## Ends in an error in state: 2129.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3182,7 +3182,7 @@ interface: INCLUDE LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 2135.
+## Ends in an error in state: 2053.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3198,7 +3198,7 @@ interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 2143.
+## Ends in an error in state: 2104.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3213,7 +3213,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LID
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2142.
+## Ends in an error in state: 2103.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3225,7 +3225,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WIT
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2141.
+## Ends in an error in state: 2102.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3237,7 +3237,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2140.
+## Ends in an error in state: 2101.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3253,22 +3253,22 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2139.
+## Ends in an error in state: 2100.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3280,7 +3280,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2138.
+## Ends in an error in state: 2099.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3292,7 +3292,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 1228.
+## Ends in an error in state: 1246.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3306,7 +3306,7 @@ interface: INCLUDE LPAREN LPAREN WITH
 
 interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2433.
+## Ends in an error in state: 2128.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF ]
@@ -3320,19 +3320,19 @@ interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1357, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1363, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1358, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1208, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1365, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1364, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2109, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2113, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2110, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1235, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2115, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2114, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN MODULE TYPE WITH
 ##
-## Ends in an error in state: 431.
+## Ends in an error in state: 781.
 ##
 ## _non_arrowed_module_type -> MODULE TYPE . module_expr [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3344,7 +3344,7 @@ interface: INCLUDE LPAREN MODULE TYPE WITH
 
 interface: INCLUDE LPAREN MODULE WITH
 ##
-## Ends in an error in state: 430.
+## Ends in an error in state: 780.
 ##
 ## _non_arrowed_module_type -> MODULE . TYPE module_expr [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3356,7 +3356,7 @@ interface: INCLUDE LPAREN MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 ##
-## Ends in an error in state: 550.
+## Ends in an error in state: 458.
 ##
 ## ident -> UIDENT . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## mod_ext2 -> mod_ext_longident DOT UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -3370,7 +3370,7 @@ interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 549.
+## Ends in an error in state: 457.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -3384,7 +3384,7 @@ interface: INCLUDE LPAREN UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 1975.
+## Ends in an error in state: 2090.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3399,7 +3399,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1974.
+## Ends in an error in state: 2089.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3411,7 +3411,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 548.
+## Ends in an error in state: 456.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -3431,7 +3431,7 @@ interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UIDENT WHILE
 ##
-## Ends in an error in state: 1229.
+## Ends in an error in state: 779.
 ##
 ## functor_arg_name -> UIDENT . [ COLON ]
 ## ident -> UIDENT . [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3446,7 +3446,7 @@ interface: INCLUDE LPAREN UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 ##
-## Ends in an error in state: 1957.
+## Ends in an error in state: 2072.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3459,7 +3459,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1954.
+## Ends in an error in state: 2069.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ RPAREN LPAREN DOT ]
 ## mod_ext2 -> UIDENT LPAREN mod_ext_longident . RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3479,7 +3479,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UID
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1953.
+## Ends in an error in state: 2068.
 ##
 ## mod_ext2 -> UIDENT LPAREN . mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ##
@@ -3504,7 +3504,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WIT
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1951.
+## Ends in an error in state: 2066.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3516,7 +3516,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 1966.
+## Ends in an error in state: 2081.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3529,7 +3529,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 ##
-## Ends in an error in state: 1952.
+## Ends in an error in state: 2067.
 ##
 ## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ## mod_ext_longident -> UIDENT . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3542,7 +3542,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1967.
+## Ends in an error in state: 2082.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3554,7 +3554,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1950.
+## Ends in an error in state: 2065.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3567,7 +3567,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 1949.
+## Ends in an error in state: 2064.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3580,7 +3580,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 1970.
+## Ends in an error in state: 2085.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3592,7 +3592,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER A
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER EQUAL
 ##
-## Ends in an error in state: 1969.
+## Ends in an error in state: 2084.
 ##
 ## _module_type -> module_type WITH with_constraints . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## with_constraints -> with_constraints . AND with_constraint [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3605,20 +3605,20 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER E
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 728, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 722, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 724, spurious reduction of production _core_type -> core_type2
-## In state 735, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 723, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1945, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1972, spurious reduction of production with_constraints -> with_constraint
+## In state 643, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 637, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 639, spurious reduction of production _core_type -> core_type2
+## In state 650, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 638, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 2060, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 2087, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1944.
+## Ends in an error in state: 2059.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3630,7 +3630,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1946.
+## Ends in an error in state: 2061.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3642,7 +3642,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ##
-## Ends in an error in state: 1948.
+## Ends in an error in state: 2063.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3655,19 +3655,19 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 728, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 722, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 724, spurious reduction of production _core_type -> core_type2
-## In state 735, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 723, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1947, spurious reduction of production constraints ->
+## In state 643, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 637, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 639, spurious reduction of production _core_type -> core_type2
+## In state 650, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 638, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 2062, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ##
-## Ends in an error in state: 1941.
+## Ends in an error in state: 2058.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3679,14 +3679,14 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1345, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 1362, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 1939.
+## Ends in an error in state: 2056.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3699,7 +3699,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH WITH
 ##
-## Ends in an error in state: 1938.
+## Ends in an error in state: 2055.
 ##
 ## _module_type -> module_type WITH . with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3711,7 +3711,7 @@ interface: INCLUDE LPAREN UIDENT WITH WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2128.
+## Ends in an error in state: 2137.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3727,22 +3727,22 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COL
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2127.
+## Ends in an error in state: 2136.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3754,7 +3754,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2126.
+## Ends in an error in state: 2135.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3766,7 +3766,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2125.
+## Ends in an error in state: 2134.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3782,22 +3782,22 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1985.
+## Ends in an error in state: 2133.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3809,7 +3809,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1984.
+## Ends in an error in state: 2132.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3821,7 +3821,7 @@ interface: INCLUDE LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN WITH
 ##
-## Ends in an error in state: 1932.
+## Ends in an error in state: 778.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3835,7 +3835,7 @@ interface: INCLUDE LPAREN WITH
 
 interface: INCLUDE MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2259.
+## Ends in an error in state: 2403.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
@@ -3849,19 +3849,19 @@ interface: INCLUDE MODULE TYPE UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 790, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 794, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 791, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 777, spurious reduction of production _module_expr -> simple_module_expr
-## In state 796, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 795, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 754, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 758, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 755, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 736, spurious reduction of production _module_expr -> simple_module_expr
+## In state 760, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 759, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE MODULE TYPE WITH
 ##
-## Ends in an error in state: 484.
+## Ends in an error in state: 435.
 ##
 ## _non_arrowed_module_type -> MODULE TYPE . module_expr [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3873,7 +3873,7 @@ interface: INCLUDE MODULE TYPE WITH
 
 interface: INCLUDE MODULE WITH
 ##
-## Ends in an error in state: 483.
+## Ends in an error in state: 434.
 ##
 ## _non_arrowed_module_type -> MODULE . TYPE module_expr [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3913,7 +3913,7 @@ interface: INCLUDE UIDENT DOT WITH
 
 interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2021.
+## Ends in an error in state: 1947.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3929,22 +3929,22 @@ interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2020.
+## Ends in an error in state: 1946.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4004,7 +4004,7 @@ interface: INCLUDE UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 2008.
+## Ends in an error in state: 1937.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4016,7 +4016,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 2010.
+## Ends in an error in state: 1939.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4042,7 +4042,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2011.
+## Ends in an error in state: 1940.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4054,7 +4054,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2007.
+## Ends in an error in state: 1936.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4067,7 +4067,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 2006.
+## Ends in an error in state: 1935.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4080,7 +4080,7 @@ interface: INCLUDE UIDENT WITH MODULE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2014.
+## Ends in an error in state: 1943.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4092,7 +4092,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ##
-## Ends in an error in state: 2013.
+## Ends in an error in state: 1942.
 ##
 ## _module_type -> module_type WITH with_constraints . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraints -> with_constraints . AND with_constraint [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4110,15 +4110,15 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2002, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 2016, spurious reduction of production with_constraints -> with_constraint
+## In state 1931, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1945, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 2001.
+## Ends in an error in state: 1930.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4130,7 +4130,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 2003.
+## Ends in an error in state: 1932.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4142,7 +4142,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ##
-## Ends in an error in state: 2005.
+## Ends in an error in state: 1934.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4160,14 +4160,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2004, spurious reduction of production constraints ->
+## In state 1933, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1942.
+## Ends in an error in state: 1928.
 ##
 ## with_type_binder -> EQUAL . [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
 ## with_type_binder -> EQUAL . PRIVATE [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
@@ -4180,7 +4180,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ##
-## Ends in an error in state: 2000.
+## Ends in an error in state: 1927.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4192,14 +4192,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1999, spurious reduction of production optional_type_parameters ->
+## In state 1926, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 1998.
+## Ends in an error in state: 1925.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4212,7 +4212,7 @@ interface: INCLUDE UIDENT WITH TYPE WITH
 
 interface: INCLUDE UIDENT WITH WITH
 ##
-## Ends in an error in state: 1997.
+## Ends in an error in state: 1924.
 ##
 ## _module_type -> module_type WITH . with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4224,7 +4224,7 @@ interface: INCLUDE UIDENT WITH WITH
 
 interface: INCLUDE WITH
 ##
-## Ends in an error in state: 2058.
+## Ends in an error in state: 1919.
 ##
 ## _signature_item -> INCLUDE . module_type post_item_attributes [ SEMI ]
 ##
@@ -4236,7 +4236,7 @@ interface: INCLUDE WITH
 
 interface: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 2047.
+## Ends in an error in state: 1908.
 ##
 ## _signature_item -> LET val_ident COLON . core_type post_item_attributes [ SEMI ]
 ##
@@ -4248,7 +4248,7 @@ interface: LET LIDENT COLON WITH
 
 interface: LET LIDENT WITH
 ##
-## Ends in an error in state: 2046.
+## Ends in an error in state: 1907.
 ##
 ## _signature_item -> LET val_ident . COLON core_type post_item_attributes [ SEMI ]
 ##
@@ -4260,7 +4260,7 @@ interface: LET LIDENT WITH
 
 interface: LET LPAREN WITH
 ##
-## Ends in an error in state: 698.
+## Ends in an error in state: 616.
 ##
 ## val_ident -> LPAREN . operator RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -4270,9 +4270,9 @@ interface: LET LPAREN WITH
 
 <SYNTAX ERROR>
 
-interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
+interface: MODULE REC UIDENT COLON LIDENT AND WITH
 ##
-## Ends in an error in state: 2104.
+## Ends in an error in state: 2000.
 ##
 ## and_module_rec_declaration -> AND . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4282,9 +4282,9 @@ interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
 
 <SYNTAX ERROR>
 
-interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
+interface: MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2103.
+## Ends in an error in state: 1999.
 ##
 ## _signature_item -> many_module_rec_declarations . [ SEMI ]
 ## many_module_rec_declarations -> many_module_rec_declarations . and_module_rec_declaration [ SEMI AND ]
@@ -4296,16 +4296,16 @@ interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1578, spurious reduction of production post_item_attributes ->
-## In state 1579, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2045, spurious reduction of production many_module_rec_declarations -> LET MODULE REC module_rec_declaration_details post_item_attributes
+## In state 1584, spurious reduction of production post_item_attributes ->
+## In state 1585, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2046, spurious reduction of production many_module_rec_declarations -> MODULE REC module_rec_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
-interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
+interface: MODULE REC UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 2043.
+## Ends in an error in state: 2003.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -4321,22 +4321,22 @@ interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
-interface: LET MODULE REC UIDENT COLON WITH
+interface: MODULE REC UIDENT COLON WITH
 ##
-## Ends in an error in state: 2042.
+## Ends in an error in state: 2002.
 ##
 ## module_rec_declaration_details -> UIDENT COLON . module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4346,9 +4346,9 @@ interface: LET MODULE REC UIDENT COLON WITH
 
 <SYNTAX ERROR>
 
-interface: LET MODULE REC UIDENT WITH
+interface: MODULE REC UIDENT WITH
 ##
-## Ends in an error in state: 2041.
+## Ends in an error in state: 2001.
 ##
 ## module_rec_declaration_details -> UIDENT . COLON module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4358,21 +4358,21 @@ interface: LET MODULE REC UIDENT WITH
 
 <SYNTAX ERROR>
 
-interface: LET MODULE REC WITH
+interface: MODULE REC WITH
 ##
-## Ends in an error in state: 2040.
+## Ends in an error in state: 2044.
 ##
-## many_module_rec_declarations -> LET MODULE REC . module_rec_declaration_details post_item_attributes [ SEMI AND ]
+## many_module_rec_declarations -> MODULE REC . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
 ## The known suffix of the stack is as follows:
-## LET MODULE REC
+## MODULE REC
 ##
 
 <SYNTAX ERROR>
 
-interface: LET MODULE UIDENT COLON UIDENT RPAREN
+interface: MODULE UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 2019.
+## Ends in an error in state: 2027.
 ##
 ## _module_declaration -> COLON module_type . [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -4388,22 +4388,22 @@ interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
-interface: LET MODULE UIDENT COLON WITH
+interface: MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2018.
+## Ends in an error in state: 2026.
 ##
 ## _module_declaration -> COLON . module_type [ SEMI LBRACKETATAT ]
 ##
@@ -4413,21 +4413,21 @@ interface: LET MODULE UIDENT COLON WITH
 
 <SYNTAX ERROR>
 
-interface: LET MODULE UIDENT EQUAL WITH
+interface: MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2035.
+## Ends in an error in state: 2033.
 ##
-## _signature_item -> LET MODULE UIDENT EQUAL . mod_longident post_item_attributes [ SEMI ]
+## _signature_item -> MODULE UIDENT EQUAL . mod_longident post_item_attributes [ SEMI ]
 ##
 ## The known suffix of the stack is as follows:
-## LET MODULE UIDENT EQUAL
+## MODULE UIDENT EQUAL
 ##
 
 <SYNTAX ERROR>
 
-interface: LET MODULE UIDENT LPAREN RPAREN WITH
+interface: MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2033.
+## Ends in an error in state: 2031.
 ##
 ## _module_declaration -> LPAREN RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4437,9 +4437,9 @@ interface: LET MODULE UIDENT LPAREN RPAREN WITH
 
 <SYNTAX ERROR>
 
-interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
+interface: MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2017.
+## Ends in an error in state: 2025.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4449,9 +4449,9 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 
 <SYNTAX ERROR>
 
-interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
+interface: MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1996.
+## Ends in an error in state: 2024.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type . RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -4467,22 +4467,22 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
-interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
+interface: MODULE UIDENT LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1992.
+## Ends in an error in state: 1904.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON . module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4492,9 +4492,9 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 
 <SYNTAX ERROR>
 
-interface: LET MODULE UIDENT LPAREN UIDENT WITH
+interface: MODULE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1991.
+## Ends in an error in state: 1903.
 ##
 ## _module_declaration -> LPAREN UIDENT . COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4504,9 +4504,9 @@ interface: LET MODULE UIDENT LPAREN UIDENT WITH
 
 <SYNTAX ERROR>
 
-interface: LET MODULE UIDENT LPAREN WITH
+interface: MODULE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1990.
+## Ends in an error in state: 1902.
 ##
 ## _module_declaration -> LPAREN . UIDENT COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_declaration -> LPAREN . RPAREN module_declaration [ SEMI LBRACKETATAT ]
@@ -4517,41 +4517,24 @@ interface: LET MODULE UIDENT LPAREN WITH
 
 <SYNTAX ERROR>
 
-interface: LET MODULE UIDENT WITH
+interface: MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1989.
+## Ends in an error in state: 1901.
 ##
-## _signature_item -> LET MODULE UIDENT . module_declaration post_item_attributes [ SEMI ]
-## _signature_item -> LET MODULE UIDENT . EQUAL mod_longident post_item_attributes [ SEMI ]
-##
-## The known suffix of the stack is as follows:
-## LET MODULE UIDENT
-##
-
-<SYNTAX ERROR>
-
-interface: LET MODULE WITH
-##
-## Ends in an error in state: 1988.
-##
-## _signature_item -> LET MODULE . UIDENT module_declaration post_item_attributes [ SEMI ]
-## _signature_item -> LET MODULE . UIDENT EQUAL mod_longident post_item_attributes [ SEMI ]
-## many_module_rec_declarations -> LET MODULE . REC module_rec_declaration_details post_item_attributes [ SEMI AND ]
+## _signature_item -> MODULE UIDENT . module_declaration post_item_attributes [ SEMI ]
+## _signature_item -> MODULE UIDENT . EQUAL mod_longident post_item_attributes [ SEMI ]
 ##
 ## The known suffix of the stack is as follows:
-## LET MODULE
+## MODULE UIDENT
 ##
 
 <SYNTAX ERROR>
 
 interface: LET WITH
 ##
-## Ends in an error in state: 1987.
+## Ends in an error in state: 1906.
 ##
 ## _signature_item -> LET . val_ident COLON core_type post_item_attributes [ SEMI ]
-## _signature_item -> LET . MODULE UIDENT module_declaration post_item_attributes [ SEMI ]
-## _signature_item -> LET . MODULE UIDENT EQUAL mod_longident post_item_attributes [ SEMI ]
-## many_module_rec_declarations -> LET . MODULE REC module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET
@@ -4561,7 +4544,7 @@ interface: LET WITH
 
 interface: MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1931.
+## Ends in an error in state: 2040.
 ##
 ## _signature_item -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ SEMI ]
 ##
@@ -4573,7 +4556,7 @@ interface: MODULE TYPE UIDENT EQUAL WITH
 
 interface: MODULE TYPE WITH
 ##
-## Ends in an error in state: 1929.
+## Ends in an error in state: 2038.
 ##
 ## _signature_item -> MODULE TYPE . ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4586,10 +4569,13 @@ interface: MODULE TYPE WITH
 
 interface: MODULE WITH
 ##
-## Ends in an error in state: 1928.
+## Ends in an error in state: 1900.
 ##
+## _signature_item -> MODULE . UIDENT module_declaration post_item_attributes [ SEMI ]
+## _signature_item -> MODULE . UIDENT EQUAL mod_longident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE . TYPE ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ SEMI ]
+## many_module_rec_declarations -> MODULE . REC module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## MODULE
@@ -4599,7 +4585,7 @@ interface: MODULE WITH
 
 interface: OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2658.
+## Ends in an error in state: 2656.
 ##
 ## signature -> signature_item . SEMI signature [ EOF ]
 ##
@@ -4610,18 +4596,18 @@ interface: OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1926, spurious reduction of production post_item_attributes ->
-## In state 1927, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 2094, spurious reduction of production _signature_item -> open_statement
-## In state 2121, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 2095, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 1898, spurious reduction of production post_item_attributes ->
+## In state 1899, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 1990, spurious reduction of production _signature_item -> open_statement
+## In state 2020, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 1991, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 1899.
+## Ends in an error in state: 1871.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4633,7 +4619,7 @@ interface: TYPE LIDENT PLUSEQ BAR WITH
 
 interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 1898.
+## Ends in an error in state: 1870.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4645,7 +4631,7 @@ interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 
 interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 1917.
+## Ends in an error in state: 1889.
 ##
 ## sig_extension_constructors -> sig_extension_constructors BAR . extension_constructor_declaration [ SEMI LBRACKETATAT BAR ]
 ##
@@ -4657,7 +4643,7 @@ interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 interface: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 1897.
+## Ends in an error in state: 1869.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4669,7 +4655,7 @@ interface: TYPE LIDENT PLUSEQ WITH
 
 interface: TYPE LIDENT RBRACKET
 ##
-## Ends in an error in state: 1246.
+## Ends in an error in state: 1263.
 ##
 ## potentially_long_ident_and_optional_type_parameters -> LIDENT optional_type_parameters . [ PLUSEQ ]
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ SEMI LBRACKETATAT EOF AND ]
@@ -4681,14 +4667,14 @@ interface: TYPE LIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1233, spurious reduction of production optional_type_parameters ->
+## In state 1250, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2659.
+## Ends in an error in state: 2657.
 ##
 ## signature -> signature_item SEMI . signature [ EOF ]
 ##
@@ -4700,7 +4686,7 @@ interface: TYPE LIDENT SEMI WITH
 
 interface: TYPE NONREC LET
 ##
-## Ends in an error in state: 1232.
+## Ends in an error in state: 1249.
 ##
 ## many_type_declarations -> TYPE nonrec_flag . type_declaration_details post_item_attributes [ SEMI AND ]
 ## sig_type_extension -> TYPE nonrec_flag . potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
@@ -4713,7 +4699,7 @@ interface: TYPE NONREC LET
 
 interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ##
-## Ends in an error in state: 1896.
+## Ends in an error in state: 1868.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters . PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4724,15 +4710,15 @@ interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1345, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
-## In state 1349, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
+## In state 1362, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 1366, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
 ##
 
 <SYNTAX ERROR>
 
 interface: WITH
 ##
-## Ends in an error in state: 2657.
+## Ends in an error in state: 2655.
 ##
 ## interface' -> . interface [ # ]
 ##
@@ -4744,7 +4730,7 @@ interface: WITH
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1767.
+## Ends in an error in state: 1768.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4756,7 +4742,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WIT
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1765.
+## Ends in an error in state: 1766.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4768,7 +4754,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON WITH
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1758.
+## Ends in an error in state: 1759.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4780,7 +4766,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE 
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 1757.
+## Ends in an error in state: 1758.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4793,7 +4779,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE 
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1756.
+## Ends in an error in state: 1757.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4805,7 +4791,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: CLASS LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1759.
+## Ends in an error in state: 1760.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4817,7 +4803,7 @@ implementation: CLASS LIDENT COLON LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1755, spurious reduction of production type_longident -> LIDENT
+## In state 1756, spurious reduction of production type_longident -> LIDENT
 ## In state 280, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
 ## In state 287, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
 ## In state 285, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
@@ -4828,7 +4814,7 @@ implementation: CLASS LIDENT COLON LIDENT WITH
 
 implementation: CLASS LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1739.
+## Ends in an error in state: 1740.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4840,7 +4826,7 @@ implementation: CLASS LIDENT COLON NEW WITH
 
 implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1760.
+## Ends in an error in state: 1761.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4852,7 +4838,7 @@ implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT MINUS WITH
 ##
-## Ends in an error in state: 1517.
+## Ends in an error in state: 1523.
 ##
 ## signed_constant -> MINUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> MINUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -4869,7 +4855,7 @@ implementation: CLASS LIDENT MINUS WITH
 
 implementation: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1516.
+## Ends in an error in state: 1522.
 ##
 ## signed_constant -> PLUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> PLUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -4886,7 +4872,7 @@ implementation: CLASS LIDENT PLUS WITH
 
 implementation: CLASS LIDENT QUOTE WITH
 ##
-## Ends in an error in state: 1505.
+## Ends in an error in state: 1511.
 ##
 ## _type_variable -> QUOTE . ident [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLON CHAR BACKQUOTE ]
 ##
@@ -4898,7 +4884,7 @@ implementation: CLASS LIDENT QUOTE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1439.
+## Ends in an error in state: 1445.
 ##
 ## class_sig_body -> class_self_type . class_sig_fields opt_semi [ error RBRACE ]
 ##
@@ -4910,7 +4896,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 ##
-## Ends in an error in state: 1434.
+## Ends in an error in state: 1440.
 ##
 ## class_self_type -> AS core_type . SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -4933,7 +4919,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 ##
-## Ends in an error in state: 1433.
+## Ends in an error in state: 1439.
 ##
 ## class_self_type -> AS . core_type SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -4945,7 +4931,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1487.
+## Ends in an error in state: 1493.
 ##
 ## _class_sig_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4957,7 +4943,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1482.
+## Ends in an error in state: 1488.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT ]
 ## _class_sig_field -> INHERIT class_instance_type . [ error SEMI RBRACE ]
@@ -4970,16 +4956,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1480, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1486, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1478, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1486, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1492, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1484, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1474.
+## Ends in an error in state: 1480.
 ##
 ## _class_sig_field -> INHERIT . class_instance_type [ error SEMI RBRACE ]
 ## _class_sig_field -> INHERIT . class_instance_type item_attribute post_item_attributes [ error SEMI RBRACE ]
@@ -4992,7 +4978,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH RBRACKET WITH
 ##
-## Ends in an error in state: 1742.
+## Ends in an error in state: 1743.
 ##
 ## _class_instance_type -> LBRACE class_sig_body . RBRACE [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE class_sig_body . error [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5004,20 +4990,20 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1494, spurious reduction of production post_item_attributes ->
-## In state 1495, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
-## In state 1500, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
-## In state 1493, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
-## In state 1502, spurious reduction of production class_sig_fields -> class_sig_field
-## In state 1497, spurious reduction of production opt_semi ->
-## In state 1501, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
+## In state 1500, spurious reduction of production post_item_attributes ->
+## In state 1501, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
+## In state 1506, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
+## In state 1499, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
+## In state 1508, spurious reduction of production class_sig_fields -> class_sig_field
+## In state 1503, spurious reduction of production opt_semi ->
+## In state 1507, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 ##
-## Ends in an error in state: 1463.
+## Ends in an error in state: 1469.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label COLON . poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5029,7 +5015,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 ##
-## Ends in an error in state: 1462.
+## Ends in an error in state: 1468.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label . COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5041,7 +5027,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 ##
-## Ends in an error in state: 1459.
+## Ends in an error in state: 1465.
 ##
 ## private_virtual_flags -> PRIVATE . [ LIDENT ]
 ## private_virtual_flags -> PRIVATE . VIRTUAL [ LIDENT ]
@@ -5054,7 +5040,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1461.
+## Ends in an error in state: 1467.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags . label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5066,7 +5052,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 ##
-## Ends in an error in state: 1457.
+## Ends in an error in state: 1463.
 ##
 ## private_virtual_flags -> VIRTUAL . [ LIDENT ]
 ## private_virtual_flags -> VIRTUAL . PRIVATE [ LIDENT ]
@@ -5079,7 +5065,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 ##
-## Ends in an error in state: 1456.
+## Ends in an error in state: 1462.
 ##
 ## _class_sig_field -> METHOD . private_virtual_flags label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5091,7 +5077,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1454.
+## Ends in an error in state: 1460.
 ##
 ## value_type -> label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5103,7 +5089,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1453.
+## Ends in an error in state: 1459.
 ##
 ## value_type -> label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5115,7 +5101,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1449.
+## Ends in an error in state: 1455.
 ##
 ## value_type -> MUTABLE virtual_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5127,7 +5113,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 ##
-## Ends in an error in state: 1448.
+## Ends in an error in state: 1454.
 ##
 ## value_type -> MUTABLE virtual_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5139,7 +5125,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 ##
-## Ends in an error in state: 1447.
+## Ends in an error in state: 1453.
 ##
 ## value_type -> MUTABLE virtual_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5151,7 +5137,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1446.
+## Ends in an error in state: 1452.
 ##
 ## value_type -> MUTABLE . virtual_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5163,7 +5149,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1444.
+## Ends in an error in state: 1450.
 ##
 ## value_type -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5175,7 +5161,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1443.
+## Ends in an error in state: 1449.
 ##
 ## value_type -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5187,7 +5173,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1442.
+## Ends in an error in state: 1448.
 ##
 ## value_type -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5199,7 +5185,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1441.
+## Ends in an error in state: 1447.
 ##
 ## value_type -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5211,7 +5197,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 ##
-## Ends in an error in state: 1440.
+## Ends in an error in state: 1446.
 ##
 ## _class_sig_field -> VAL . value_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5223,7 +5209,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 ##
-## Ends in an error in state: 1741.
+## Ends in an error in state: 1742.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5236,7 +5222,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ##
-## Ends in an error in state: 1785.
+## Ends in an error in state: 1786.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## _non_arrowed_class_constructor_type -> class_instance_type . [ EQUALGREATER ]
@@ -5248,16 +5234,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1750, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1754, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1748, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1751, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1755, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1749, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1751.
+## Ends in an error in state: 1752.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
@@ -5270,7 +5256,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 ##
-## Ends in an error in state: 1750.
+## Ends in an error in state: 1751.
 ##
 ## _class_instance_type -> clty_longident . [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5283,7 +5269,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1779.
+## Ends in an error in state: 1780.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN class_constructor_type . RPAREN [ EQUALGREATER ]
 ##
@@ -5294,19 +5280,19 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1750, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1754, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1748, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1752, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1763, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1761, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1751, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1755, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1749, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1753, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1764, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1762, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 ##
-## Ends in an error in state: 1778.
+## Ends in an error in state: 1779.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN . class_constructor_type RPAREN [ EQUALGREATER ]
 ##
@@ -5318,7 +5304,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 ##
-## Ends in an error in state: 1746.
+## Ends in an error in state: 1747.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5332,7 +5318,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 ##
-## Ends in an error in state: 1745.
+## Ends in an error in state: 1746.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5352,7 +5338,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 
 implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ##
-## Ends in an error in state: 806.
+## Ends in an error in state: 817.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag simple_expr . simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARPOP SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -5371,17 +5357,17 @@ implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 846, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FOR UNDERSCORE WHEN
 ##
-## Ends in an error in state: 800.
+## Ends in an error in state: 811.
 ##
 ## _expr -> FOR pattern . IN simple_expr direction_flag simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _or_pattern -> pattern . BAR pattern [ IN BAR ]
@@ -5393,14 +5379,14 @@ implementation: FOR UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 692, spurious reduction of production pattern -> pattern_without_or
+## In state 610, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 768.
+## Ends in an error in state: 2373.
 ##
 ## _simple_expr -> simple_expr . DOT label_longident [ UNDERSCORE UIDENT TRUE STRING SHARPOP SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
 ## _simple_expr -> simple_expr . DOT LPAREN expr RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARPOP SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
@@ -5419,17 +5405,17 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 846, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 767.
+## Ends in an error in state: 701.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern EQUAL . simple_expr [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ##
@@ -5441,7 +5427,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 765.
+## Ends in an error in state: 699.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -5455,7 +5441,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 
 implementation: FUN LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 531.
+## Ends in an error in state: 698.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -5469,7 +5455,7 @@ implementation: FUN LIDENT COLONCOLON WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2260.
+## Ends in an error in state: 2404.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -5485,22 +5471,22 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 482.
+## Ends in an error in state: 433.
 ##
 ## functor_arg -> LPAREN functor_arg_name COLON . module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -5512,7 +5498,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 481.
+## Ends in an error in state: 432.
 ##
 ## functor_arg -> LPAREN functor_arg_name . COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -5524,7 +5510,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 
 implementation: INCLUDE FUN LPAREN WITH
 ##
-## Ends in an error in state: 477.
+## Ends in an error in state: 428.
 ##
 ## functor_arg -> LPAREN . RPAREN [ LPAREN EQUALGREATER COLON ]
 ## functor_arg -> LPAREN . functor_arg_name COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
@@ -5537,7 +5523,7 @@ implementation: INCLUDE FUN LPAREN WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1771.
+## Ends in an error in state: 1772.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5549,16 +5535,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1590, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1596, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1588, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1596, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1602, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1594, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1770.
+## Ends in an error in state: 1771.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5570,7 +5556,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1769.
+## Ends in an error in state: 1770.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type . EQUAL class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5581,19 +5567,19 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1750, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1754, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1748, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1752, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1763, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1761, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1751, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1755, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1749, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1753, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1764, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1762, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 1738.
+## Ends in an error in state: 1739.
 ##
 ## _constrained_class_declaration -> COLON . class_constructor_type EQUAL class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5605,7 +5591,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1832.
+## Ends in an error in state: 1833.
 ##
 ## and_class_declaration -> AND . class_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5617,7 +5603,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1831.
+## Ends in an error in state: 1832.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_class_declarations -> many_class_declarations . and_class_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5629,16 +5615,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1359, spurious reduction of production post_item_attributes ->
-## In state 1360, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1794, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
+## In state 1379, spurious reduction of production post_item_attributes ->
+## In state 1380, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1795, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1737.
+## Ends in an error in state: 1738.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5650,16 +5636,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1590, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1596, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1588, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1596, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1602, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1594, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1518.
+## Ends in an error in state: 1524.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5671,7 +5657,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 1783.
+## Ends in an error in state: 1784.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5683,16 +5669,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1590, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1596, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1588, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1596, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1602, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1594, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1782.
+## Ends in an error in state: 1783.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5704,7 +5690,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1781.
+## Ends in an error in state: 1782.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type . EQUALGREATER class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5716,7 +5702,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT R
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1777.
+## Ends in an error in state: 1778.
 ##
 ## class_fun_return -> COLON . non_arrowed_class_constructor_type EQUALGREATER class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5728,7 +5714,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 1776.
+## Ends in an error in state: 1777.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> EQUALGREATER class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5740,16 +5726,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1590, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1596, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1588, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1596, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1602, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1594, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1775.
+## Ends in an error in state: 1776.
 ##
 ## class_fun_return -> EQUALGREATER . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5761,7 +5747,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1774.
+## Ends in an error in state: 1775.
 ##
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_return [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5774,7 +5760,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1515.
+## Ends in an error in state: 1521.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . constrained_class_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5789,7 +5775,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1827.
+## Ends in an error in state: 1828.
 ##
 ## and_class_type_declaration -> AND . class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5801,7 +5787,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1826.
+## Ends in an error in state: 1827.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_type_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5813,16 +5799,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND R
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1359, spurious reduction of production post_item_attributes ->
-## In state 1360, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1512, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
+## In state 1379, spurious reduction of production post_item_attributes ->
+## In state 1380, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1518, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1503.
+## Ends in an error in state: 1509.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5834,16 +5820,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1480, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1486, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1478, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1486, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1492, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1484, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1430.
+## Ends in an error in state: 1436.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5855,7 +5841,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1427.
+## Ends in an error in state: 1433.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters . EQUAL class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS EQUAL ]
@@ -5868,7 +5854,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 ##
-## Ends in an error in state: 1425.
+## Ends in an error in state: 1431.
 ##
 ## class_type_declaration_details -> virtual_flag . LIDENT class_type_parameters EQUAL class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5880,7 +5866,7 @@ implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE WITH
 ##
-## Ends in an error in state: 1424.
+## Ends in an error in state: 1430.
 ##
 ## many_class_type_declarations -> CLASS TYPE . class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5892,7 +5878,7 @@ implementation: INCLUDE LBRACE CLASS TYPE WITH
 
 implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 1513.
+## Ends in an error in state: 1519.
 ##
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters constrained_class_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5906,7 +5892,7 @@ implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 
 implementation: INCLUDE LBRACE CLASS WITH
 ##
-## Ends in an error in state: 1422.
+## Ends in an error in state: 1428.
 ##
 ## many_class_declarations -> CLASS . class_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5919,7 +5905,7 @@ implementation: INCLUDE LBRACE CLASS WITH
 
 implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 ##
-## Ends in an error in state: 1397.
+## Ends in an error in state: 1403.
 ##
 ## extension_constructor_declaration -> LPAREN . RPAREN generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## extension_constructor_rebind -> LPAREN . RPAREN EQUAL constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -5932,7 +5918,7 @@ implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1384.
+## Ends in an error in state: 1390.
 ##
 ## generalized_constructor_arguments -> COLON . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -5944,7 +5930,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 ##
-## Ends in an error in state: 1379.
+## Ends in an error in state: 1385.
 ##
 ## constr_longident -> LBRACKET . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -5956,7 +5942,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 1378.
+## Ends in an error in state: 1384.
 ##
 ## constr_longident -> LPAREN . RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -5968,7 +5954,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1377.
+## Ends in an error in state: 1383.
 ##
 ## extension_constructor_rebind -> UIDENT EQUAL . constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ##
@@ -5980,7 +5966,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1387.
+## Ends in an error in state: 1393.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list COLON . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -5992,7 +5978,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1386.
+## Ends in an error in state: 1392.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . COLON core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
@@ -6006,7 +5992,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1376.
+## Ends in an error in state: 1382.
 ##
 ## extension_constructor_declaration -> UIDENT . generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## extension_constructor_rebind -> UIDENT . EQUAL constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -6019,7 +6005,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 
 implementation: INCLUDE LBRACE EXCEPTION WITH
 ##
-## Ends in an error in state: 1375.
+## Ends in an error in state: 1381.
 ##
 ## str_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## str_exception_declaration -> EXCEPTION . extension_constructor_rebind post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
@@ -6032,7 +6018,7 @@ implementation: INCLUDE LBRACE EXCEPTION WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 ##
-## Ends in an error in state: 1371.
+## Ends in an error in state: 1375.
 ##
 ## primitive_declaration -> STRING . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ## primitive_declaration -> STRING . primitive_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
@@ -6045,7 +6031,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WIT
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1370.
+## Ends in an error in state: 1374.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6057,7 +6043,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1369.
+## Ends in an error in state: 1373.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6080,7 +6066,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1368.
+## Ends in an error in state: 1372.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6092,7 +6078,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 1367.
+## Ends in an error in state: 1371.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6104,7 +6090,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 
 implementation: INCLUDE LBRACE EXTERNAL WITH
 ##
-## Ends in an error in state: 1366.
+## Ends in an error in state: 1370.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6116,7 +6102,7 @@ implementation: INCLUDE LBRACE EXTERNAL WITH
 
 implementation: INCLUDE LBRACE MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 429.
+## Ends in an error in state: 2426.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6128,7 +6114,7 @@ implementation: INCLUDE LBRACE MODULE TYPE UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE MODULE TYPE WITH
 ##
-## Ends in an error in state: 427.
+## Ends in an error in state: 2424.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE . ident post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
@@ -6139,22 +6125,9 @@ implementation: INCLUDE LBRACE MODULE TYPE WITH
 
 <SYNTAX ERROR>
 
-implementation: INCLUDE LBRACE MODULE WITH
-##
-## Ends in an error in state: 426.
-##
-## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
-## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## MODULE
-##
-
-<SYNTAX ERROR>
-
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1209.
+## Ends in an error in state: 1236.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER module_expr . [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6169,7 +6142,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHIL
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1207.
+## Ends in an error in state: 1234.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER . module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6181,7 +6154,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1206.
+## Ends in an error in state: 1233.
 ##
 ## _module_expr -> FUN functor_args . EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## functor_args -> functor_args . functor_arg [ LPAREN EQUALGREATER ]
@@ -6194,7 +6167,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 
 implementation: INCLUDE LPAREN FUN WITH
 ##
-## Ends in an error in state: 1205.
+## Ends in an error in state: 1232.
 ##
 ## _module_expr -> FUN . functor_args EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6206,7 +6179,7 @@ implementation: INCLUDE LPAREN FUN WITH
 
 implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2144.
+## Ends in an error in state: 2105.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -6222,23 +6195,23 @@ implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 260, spurious reduction of production ident -> UIDENT
-## In state 552, spurious reduction of production mty_longident -> ident
-## In state 1935, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1981, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1977, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1933, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1982, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1978, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1934, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1983, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1979, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 460, spurious reduction of production mty_longident -> ident
+## In state 2052, spurious reduction of production _simple_module_type -> mty_longident
+## In state 2096, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 2092, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 2050, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 2097, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 2093, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 2051, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 2098, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 2094, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1227.
+## Ends in an error in state: 1245.
 ##
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6251,7 +6224,7 @@ implementation: INCLUDE LPAREN UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2431.
+## Ends in an error in state: 2126.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -6268,19 +6241,19 @@ implementation: INCLUDE LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1357, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1363, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1358, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1208, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1365, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1364, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2109, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2113, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2110, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1235, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2115, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2114, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1221.
+## Ends in an error in state: 1223.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6300,7 +6273,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLON
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1220.
+## Ends in an error in state: 1222.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6312,7 +6285,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 2429.
+## Ends in an error in state: 1218.
 ##
 ## _module_expr -> LPAREN VAL expr COLON . error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6326,7 +6299,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1215.
+## Ends in an error in state: 1216.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6346,7 +6319,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 2427.
+## Ends in an error in state: 1214.
 ##
 ## _module_expr -> LPAREN VAL expr COLONGREATER . error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6359,7 +6332,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 2425.
+## Ends in an error in state: 1211.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -6400,21 +6373,21 @@ implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN VAL WITH
 ##
-## Ends in an error in state: 433.
+## Ends in an error in state: 783.
 ##
 ## _module_expr -> LPAREN VAL . expr COLON error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _module_expr -> LPAREN VAL . expr COLONGREATER error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6432,7 +6405,7 @@ implementation: INCLUDE LPAREN VAL WITH
 
 implementation: INCLUDE LPAREN WITH
 ##
-## Ends in an error in state: 432.
+## Ends in an error in state: 782.
 ##
 ## _module_expr -> LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _module_expr -> LPAREN . VAL expr COLON error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6455,7 +6428,7 @@ implementation: INCLUDE LPAREN WITH
 
 implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ##
-## Ends in an error in state: 2229.
+## Ends in an error in state: 2124.
 ##
 ## _simple_module_expr -> LBRACE structure . RBRACE [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6466,29 +6439,29 @@ implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1886, spurious reduction of production post_item_attributes ->
-## In state 1887, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1888, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1802, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1795, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1803, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1796, spurious reduction of production structure -> structure_item
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1858, spurious reduction of production post_item_attributes ->
+## In state 1859, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1860, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1803, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1796, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1804, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1797, spurious reduction of production structure -> structure_item
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 490.
+## Ends in an error in state: 1226.
 ##
 ## _simple_module_expr -> LBRACE . structure RBRACE [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6500,7 +6473,7 @@ implementation: INCLUDE UIDENT LBRACE WITH
 
 implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1224.
+## Ends in an error in state: 1242.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -6517,19 +6490,19 @@ implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1357, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1363, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1358, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1208, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1365, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1364, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2109, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2113, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2110, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1235, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2115, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2114, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 1217.
+## Ends in an error in state: 1241.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type COLONGREATER package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6542,7 +6515,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1214.
+## Ends in an error in state: 1240.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6554,7 +6527,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 1212.
+## Ends in an error in state: 1239.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -6592,21 +6565,21 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 950, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL WITH
 ##
-## Ends in an error in state: 1211.
+## Ends in an error in state: 1238.
 ##
 ## _simple_module_expr -> LPAREN VAL . expr RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL . expr COLON package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6621,7 +6594,7 @@ implementation: INCLUDE UIDENT LPAREN VAL WITH
 
 implementation: INCLUDE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1210.
+## Ends in an error in state: 1237.
 ##
 ## _module_expr -> module_expr LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN . module_expr COLON module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6641,7 +6614,7 @@ implementation: INCLUDE UIDENT LPAREN WITH
 
 implementation: INCLUDE UIDENT WHILE
 ##
-## Ends in an error in state: 1357.
+## Ends in an error in state: 2109.
 ##
 ## _simple_module_expr -> mod_longident . [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF DOT COLON AND ]
@@ -6654,7 +6627,7 @@ implementation: INCLUDE UIDENT WHILE
 
 implementation: INCLUDE WITH
 ##
-## Ends in an error in state: 1353.
+## Ends in an error in state: 1231.
 ##
 ## _structure_item_without_item_extension_sugar -> INCLUDE . module_expr post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6666,7 +6639,7 @@ implementation: INCLUDE WITH
 
 implementation: LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1612.
+## Ends in an error in state: 1618.
 ##
 ## class_self_pattern_and_structure -> class_self_pattern . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -6678,7 +6651,7 @@ implementation: LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: LBRACE AS UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1601.
+## Ends in an error in state: 1607.
 ##
 ## _class_self_pattern -> AS pattern . SEMI [ error VAL RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ## _or_pattern -> pattern . BAR pattern [ SEMI BAR ]
@@ -6690,14 +6663,14 @@ implementation: LBRACE AS UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 692, spurious reduction of production pattern -> pattern_without_or
+## In state 610, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE AS WITH
 ##
-## Ends in an error in state: 1600.
+## Ends in an error in state: 1606.
 ##
 ## _class_self_pattern -> AS . pattern SEMI [ error VAL RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ##
@@ -6709,7 +6682,7 @@ implementation: LBRACE AS WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1489.
+## Ends in an error in state: 1495.
 ##
 ## constrain_field -> core_type EQUAL . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -6721,7 +6694,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1488.
+## Ends in an error in state: 1494.
 ##
 ## constrain_field -> core_type . EQUAL core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -6744,7 +6717,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 
 implementation: LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1691.
+## Ends in an error in state: 1692.
 ##
 ## _class_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -6756,7 +6729,7 @@ implementation: LBRACE CONSTRAINT WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2308.
+## Ends in an error in state: 2184.
 ##
 ## opt_comma -> COMMA . [ RBRACE ]
 ## record_expr -> DOTDOTDOT expr_optional_constraint COMMA . lbl_expr_list [ error RBRACE ]
@@ -6770,7 +6743,7 @@ implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ##
-## Ends in an error in state: 2307.
+## Ends in an error in state: 2183.
 ##
 ## _simple_expr -> LBRACE DOTDOTDOT expr_optional_constraint . opt_comma RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## record_expr -> DOTDOTDOT expr_optional_constraint . COMMA lbl_expr_list [ error RBRACE ]
@@ -6783,22 +6756,22 @@ implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1101, spurious reduction of production expr_optional_constraint -> expr
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 950, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1107, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE DOTDOTDOT WITH
 ##
-## Ends in an error in state: 2306.
+## Ends in an error in state: 2182.
 ##
 ## _simple_expr -> LBRACE DOTDOTDOT . expr_optional_constraint opt_comma RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## record_expr -> DOTDOTDOT . expr_optional_constraint COMMA lbl_expr_list [ error RBRACE ]
@@ -6812,7 +6785,7 @@ implementation: LBRACE DOTDOTDOT WITH
 
 implementation: LBRACE INHERIT BANG WITH
 ##
-## Ends in an error in state: 1685.
+## Ends in an error in state: 1686.
 ##
 ## _class_field -> INHERIT override_flag . class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -6824,7 +6797,7 @@ implementation: LBRACE INHERIT BANG WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1586.
+## Ends in an error in state: 1592.
 ##
 ## _class_expr -> CLASS class_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF COLON AS AND ]
@@ -6837,7 +6810,7 @@ implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1585.
+## Ends in an error in state: 1591.
 ##
 ## _class_expr -> CLASS class_longident . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> CLASS class_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6850,7 +6823,7 @@ implementation: LBRACE INHERIT CLASS LIDENT WITH
 
 implementation: LBRACE INHERIT CLASS WITH
 ##
-## Ends in an error in state: 1584.
+## Ends in an error in state: 1590.
 ##
 ## _class_expr -> CLASS . class_longident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> CLASS . class_longident non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6863,7 +6836,7 @@ implementation: LBRACE INHERIT CLASS WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1593.
+## Ends in an error in state: 1599.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER class_expr . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6876,7 +6849,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND R
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1583.
+## Ends in an error in state: 1589.
 ##
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER . class_expr [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ##
@@ -6888,7 +6861,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1582.
+## Ends in an error in state: 1588.
 ##
 ## _class_fun_def -> labeled_simple_pattern . EQUALGREATER class_expr [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern . class_fun_def [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6901,7 +6874,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 
 implementation: LBRACE INHERIT FUN WITH
 ##
-## Ends in an error in state: 1580.
+## Ends in an error in state: 1586.
 ##
 ## _class_expr -> FUN . class_fun_def [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ##
@@ -6913,7 +6886,7 @@ implementation: LBRACE INHERIT FUN WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 1606.
+## Ends in an error in state: 1612.
 ##
 ## _class_expr_lets_and_rest -> let_bindings SEMI . class_expr_lets_and_rest [ error RBRACE ]
 ##
@@ -6925,7 +6898,7 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ##
-## Ends in an error in state: 1605.
+## Ends in an error in state: 1611.
 ##
 ## _class_expr_lets_and_rest -> let_bindings . SEMI class_expr_lets_and_rest [ error RBRACE ]
 ## let_bindings -> let_bindings . and_let_binding [ SEMI AND ]
@@ -6937,24 +6910,24 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1575, spurious reduction of production let_binding_body -> pattern EQUAL expr
-## In state 1576, spurious reduction of production post_item_attributes ->
-## In state 1577, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
-## In state 1607, spurious reduction of production let_binding -> let_binding_impl
-## In state 1608, spurious reduction of production let_bindings -> let_binding
+## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1581, spurious reduction of production let_binding_body -> pattern EQUAL expr
+## In state 1582, spurious reduction of production post_item_attributes ->
+## In state 1583, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
+## In state 1613, spurious reduction of production let_binding -> let_binding_impl
+## In state 1614, spurious reduction of production let_bindings -> let_binding
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE LET WITH
 ##
-## Ends in an error in state: 1521.
+## Ends in an error in state: 1527.
 ##
-## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI AND ]
+## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI EOF AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET
@@ -6964,7 +6937,7 @@ implementation: LBRACE INHERIT LBRACE LET WITH
 
 implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ##
-## Ends in an error in state: 1704.
+## Ends in an error in state: 1705.
 ##
 ## _class_expr -> class_expr . attribute [ error RBRACE LBRACKETAT ]
 ## _class_expr_lets_and_rest -> class_expr . [ error RBRACE ]
@@ -6976,16 +6949,16 @@ implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1590, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1596, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1588, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1596, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1602, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1594, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 ##
-## Ends in an error in state: 1609.
+## Ends in an error in state: 1615.
 ##
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI AND ]
 ##
@@ -7004,7 +6977,7 @@ implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 
 implementation: LBRACE INHERIT LBRACE WITH
 ##
-## Ends in an error in state: 1520.
+## Ends in an error in state: 1526.
 ##
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest RBRACE [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7017,7 +6990,7 @@ implementation: LBRACE INHERIT LBRACE WITH
 
 implementation: LBRACE INHERIT LIDENT AS WITH
 ##
-## Ends in an error in state: 1687.
+## Ends in an error in state: 1688.
 ##
 ## parent_binder -> AS . LIDENT [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7029,7 +7002,7 @@ implementation: LBRACE INHERIT LIDENT AS WITH
 
 implementation: LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1686.
+## Ends in an error in state: 1687.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AS ]
 ## _class_field -> INHERIT override_flag class_expr . parent_binder post_item_attributes [ error SEMI RBRACE ]
@@ -7041,16 +7014,16 @@ implementation: LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1590, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1596, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1588, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1596, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1602, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1594, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT SEMI WITH
 ##
-## Ends in an error in state: 1700.
+## Ends in an error in state: 1701.
 ##
 ## semi_terminated_class_fields -> class_field SEMI . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -7062,7 +7035,7 @@ implementation: LBRACE INHERIT LIDENT SEMI WITH
 
 implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ##
-## Ends in an error in state: 1591.
+## Ends in an error in state: 1597.
 ##
 ## _class_expr -> class_simple_expr simple_labeled_expr_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## simple_labeled_expr_list -> simple_labeled_expr_list . labeled_simple_expr [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7074,20 +7047,20 @@ implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 840, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 855, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 860, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
-## In state 863, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 851, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 866, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 871, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
+## In state 874, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT WITH
 ##
-## Ends in an error in state: 1590.
+## Ends in an error in state: 1596.
 ##
 ## _class_expr -> class_simple_expr . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> class_simple_expr . simple_labeled_expr_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -7100,7 +7073,7 @@ implementation: LBRACE INHERIT LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1732.
+## Ends in an error in state: 1733.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -7112,7 +7085,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE 
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1731.
+## Ends in an error in state: 1732.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -7125,7 +7098,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE 
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1730.
+## Ends in an error in state: 1731.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -7137,7 +7110,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1723.
+## Ends in an error in state: 1724.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -7149,7 +7122,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 1722.
+## Ends in an error in state: 1723.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -7162,7 +7135,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1721.
+## Ends in an error in state: 1722.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -7174,7 +7147,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1724.
+## Ends in an error in state: 1725.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -7186,7 +7159,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1720, spurious reduction of production type_longident -> LIDENT
+## In state 1721, spurious reduction of production type_longident -> LIDENT
 ## In state 280, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
 ## In state 287, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
 ## In state 285, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
@@ -7197,7 +7170,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 ##
-## Ends in an error in state: 1432.
+## Ends in an error in state: 1438.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -7210,7 +7183,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1719.
+## Ends in an error in state: 1720.
 ##
 ## _class_constructor_type -> NEW class_instance_type . [ error RPAREN ]
 ## _class_instance_type -> class_instance_type . attribute [ error RPAREN LBRACKETAT ]
@@ -7222,16 +7195,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1480, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1486, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1478, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1486, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1492, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1484, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1481.
+## Ends in an error in state: 1487.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
@@ -7244,7 +7217,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 ##
-## Ends in an error in state: 1480.
+## Ends in an error in state: 1486.
 ##
 ## _class_instance_type -> clty_longident . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -7257,7 +7230,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 ##
-## Ends in an error in state: 1476.
+## Ends in an error in state: 1482.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -7271,7 +7244,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 ##
-## Ends in an error in state: 1475.
+## Ends in an error in state: 1481.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -7291,7 +7264,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1718.
+## Ends in an error in state: 1719.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ error RPAREN ]
 ##
@@ -7303,7 +7276,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1725.
+## Ends in an error in state: 1726.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -7315,7 +7288,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 ##
-## Ends in an error in state: 1717.
+## Ends in an error in state: 1718.
 ##
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7328,7 +7301,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ##
-## Ends in an error in state: 1714.
+## Ends in an error in state: 1715.
 ##
 ## _class_expr -> class_expr . attribute [ error RPAREN LBRACKETAT COLON ]
 ## _class_simple_expr -> LPAREN class_expr . COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7343,16 +7316,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1590, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1596, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1588, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1596, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1602, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1594, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN WITH
 ##
-## Ends in an error in state: 1519.
+## Ends in an error in state: 1525.
 ##
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7367,7 +7340,7 @@ implementation: LBRACE INHERIT LPAREN WITH
 
 implementation: LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1684.
+## Ends in an error in state: 1685.
 ##
 ## _class_field -> INHERIT . override_flag class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7379,7 +7352,7 @@ implementation: LBRACE INHERIT WITH
 
 implementation: LBRACE INITIALIZER EQUALGREATER WITH
 ##
-## Ends in an error in state: 1681.
+## Ends in an error in state: 1682.
 ##
 ## _class_field -> INITIALIZER EQUALGREATER . expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7391,7 +7364,7 @@ implementation: LBRACE INITIALIZER EQUALGREATER WITH
 
 implementation: LBRACE INITIALIZER WITH
 ##
-## Ends in an error in state: 1680.
+## Ends in an error in state: 1681.
 ##
 ## _class_field -> INITIALIZER . EQUALGREATER expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7403,7 +7376,7 @@ implementation: LBRACE INITIALIZER WITH
 
 implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 2322.
+## Ends in an error in state: 2198.
 ##
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -7415,53 +7388,53 @@ implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2285, spurious reduction of production opt_semi -> SEMI
-## In state 2296, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
-## In state 2294, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2283, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2159, spurious reduction of production opt_semi -> SEMI
+## In state 2170, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
+## In state 2168, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2157, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
 ##
 
 Expecting "}" to finish the block
 
-implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
+implementation: LBRACE MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2272.
+## Ends in an error in state: 2145.
 ##
-## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
+## _semi_terminated_seq_expr_row -> MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
 ## The known suffix of the stack is as follows:
-## LET MODULE UIDENT module_binding_body post_item_attributes SEMI
+## MODULE UIDENT module_binding_body post_item_attributes SEMI
 ##
 
 <SYNTAX ERROR>
 
-implementation: LBRACE LET MODULE UIDENT WITH
+implementation: LBRACE MODULE UIDENT WITH
 ##
-## Ends in an error in state: 476.
+## Ends in an error in state: 774.
 ##
-## _semi_terminated_seq_expr_row -> LET MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
+## _semi_terminated_seq_expr_row -> MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
 ## The known suffix of the stack is as follows:
-## LET MODULE UIDENT
+## MODULE UIDENT
 ##
 
 <SYNTAX ERROR>
 
-implementation: LBRACE LET MODULE WITH
+implementation: LBRACE MODULE WITH
 ##
-## Ends in an error in state: 475.
+## Ends in an error in state: 773.
 ##
-## _semi_terminated_seq_expr_row -> LET MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
+## _semi_terminated_seq_expr_row -> MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
 ## The known suffix of the stack is as follows:
-## LET MODULE
+## MODULE
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET OPEN BANG WITH
 ##
-## Ends in an error in state: 2277.
+## Ends in an error in state: 2151.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7473,7 +7446,7 @@ implementation: LBRACE LET OPEN BANG WITH
 
 implementation: LBRACE LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2280.
+## Ends in an error in state: 2154.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7485,7 +7458,7 @@ implementation: LBRACE LET OPEN UIDENT SEMI WITH
 
 implementation: LBRACE LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2279.
+## Ends in an error in state: 2153.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7496,14 +7469,14 @@ implementation: LBRACE LET OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2278, spurious reduction of production post_item_attributes ->
+## In state 2152, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET OPEN WITH
 ##
-## Ends in an error in state: 2276.
+## Ends in an error in state: 2150.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7515,9 +7488,8 @@ implementation: LBRACE LET OPEN WITH
 
 implementation: LBRACE LET WITH
 ##
-## Ends in an error in state: 473.
+## Ends in an error in state: 2146.
 ##
-## _semi_terminated_seq_expr_row -> LET . MODULE UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ error SEMI RBRACE AND ]
 ## option(LET) -> LET . [ OPEN ]
 ##
@@ -7529,7 +7501,7 @@ implementation: LBRACE LET WITH
 
 implementation: LBRACE LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1171.
+## Ends in an error in state: 1177.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7565,21 +7537,21 @@ implementation: LBRACE LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1170.
+## Ends in an error in state: 1176.
 ##
 ## lbl_expr -> label_longident COLON . expr [ COMMA ]
 ## non_punned_lbl_expression -> label_longident COLON . expr [ error RBRACE ]
@@ -7592,7 +7564,7 @@ implementation: LBRACE LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1160.
+## Ends in an error in state: 1166.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7627,21 +7599,21 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 ##
-## Ends in an error in state: 1159.
+## Ends in an error in state: 1165.
 ##
 ## lbl_expr -> label_longident COLON . expr [ error RBRACE COMMA ]
 ##
@@ -7653,7 +7625,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 ##
-## Ends in an error in state: 1156.
+## Ends in an error in state: 1162.
 ##
 ## lbl_expr_list -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ## lbl_expr_list -> lbl_expr COMMA . [ error RBRACE ]
@@ -7666,7 +7638,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT WITH
 ##
-## Ends in an error in state: 1158.
+## Ends in an error in state: 1164.
 ##
 ## lbl_expr -> label_longident . COLON expr [ error RBRACE COMMA ]
 ## lbl_expr -> label_longident . [ error RBRACE COMMA ]
@@ -7679,7 +7651,7 @@ implementation: LBRACE LIDENT COMMA LIDENT WITH
 
 implementation: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 1167.
+## Ends in an error in state: 1173.
 ##
 ## lbl_expr_list_that_is_not_a_single_punned_field -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ##
@@ -7691,7 +7663,7 @@ implementation: LBRACE LIDENT COMMA WITH
 
 implementation: LBRACE METHOD BANG WITH
 ##
-## Ends in an error in state: 1637.
+## Ends in an error in state: 1643.
 ##
 ## method_ -> override_flag . PRIVATE VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag . VIRTUAL private_flag label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -7708,7 +7680,7 @@ implementation: LBRACE METHOD BANG WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1673.
+## Ends in an error in state: 1667.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7743,21 +7715,21 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1672.
+## Ends in an error in state: 1666.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT core_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7769,7 +7741,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1671.
+## Ends in an error in state: 1665.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT core_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7792,7 +7764,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1670.
+## Ends in an error in state: 1664.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT . core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7804,7 +7776,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 1668.
+## Ends in an error in state: 1662.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE . lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7816,7 +7788,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE WITH
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1676.
+## Ends in an error in state: 1670.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7851,21 +7823,21 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1675.
+## Ends in an error in state: 1669.
 ##
 ## method_ -> override_flag private_flag label COLON poly_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7877,7 +7849,7 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1674.
+## Ends in an error in state: 1668.
 ##
 ## method_ -> override_flag private_flag label COLON poly_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7894,16 +7866,16 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE WITH
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1316, spurious reduction of production _poly_type -> core_type
-## In state 1317, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1315, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 1333, spurious reduction of production _poly_type -> core_type
+## In state 1334, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1332, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON WITH
 ##
-## Ends in an error in state: 1667.
+## Ends in an error in state: 1661.
 ##
 ## method_ -> override_flag private_flag label COLON . poly_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag private_flag label COLON . TYPE lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -7916,7 +7888,7 @@ implementation: LBRACE METHOD LIDENT COLON WITH
 
 implementation: LBRACE METHOD LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1666.
+## Ends in an error in state: 1660.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7951,21 +7923,21 @@ implementation: LBRACE METHOD LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1665.
+## Ends in an error in state: 1659.
 ##
 ## method_ -> override_flag private_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7977,7 +7949,7 @@ implementation: LBRACE METHOD LIDENT EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1699.
+## Ends in an error in state: 1700.
 ##
 ## semi_terminated_class_fields -> class_field . [ error RBRACE ]
 ## semi_terminated_class_fields -> class_field . SEMI semi_terminated_class_fields [ error RBRACE ]
@@ -7989,27 +7961,27 @@ implementation: LBRACE METHOD LIDENT EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1656, spurious reduction of production curried_binding -> EQUALGREATER expr
-## In state 1677, spurious reduction of production method_ -> override_flag private_flag label curried_binding
-## In state 1678, spurious reduction of production post_item_attributes ->
-## In state 1679, spurious reduction of production _class_field -> METHOD method_ post_item_attributes
-## In state 1702, spurious reduction of production mark_position_cf(_class_field) -> _class_field
-## In state 1695, spurious reduction of production class_field -> mark_position_cf(_class_field)
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1658, spurious reduction of production curried_binding -> EQUALGREATER expr
+## In state 1678, spurious reduction of production method_ -> override_flag private_flag label curried_binding
+## In state 1679, spurious reduction of production post_item_attributes ->
+## In state 1680, spurious reduction of production _class_field -> METHOD method_ post_item_attributes
+## In state 1703, spurious reduction of production mark_position_cf(_class_field) -> _class_field
+## In state 1696, spurious reduction of production class_field -> mark_position_cf(_class_field)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1647.
+## Ends in an error in state: 1653.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8021,7 +7993,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1646.
+## Ends in an error in state: 1652.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8033,7 +8005,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL WITH
 ##
-## Ends in an error in state: 1645.
+## Ends in an error in state: 1651.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8045,7 +8017,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL WITH
 
 implementation: LBRACE METHOD PRIVATE WITH
 ##
-## Ends in an error in state: 1644.
+## Ends in an error in state: 1650.
 ##
 ## method_ -> override_flag PRIVATE . VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## private_flag -> PRIVATE . [ LIDENT ]
@@ -8058,7 +8030,7 @@ implementation: LBRACE METHOD PRIVATE WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1467.
+## Ends in an error in state: 1473.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8070,7 +8042,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1466.
+## Ends in an error in state: 1472.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -8083,7 +8055,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WIT
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE WITH
 ##
-## Ends in an error in state: 1464.
+## Ends in an error in state: 1470.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ error SEMI RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AS ]
 ## typevar_list -> QUOTE . ident [ QUOTE DOT ]
@@ -8096,7 +8068,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1642.
+## Ends in an error in state: 1648.
 ##
 ## method_ -> override_flag VIRTUAL private_flag label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8108,7 +8080,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1641.
+## Ends in an error in state: 1647.
 ##
 ## method_ -> override_flag VIRTUAL private_flag label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8120,7 +8092,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT WITH
 
 implementation: LBRACE METHOD VIRTUAL PRIVATE LET
 ##
-## Ends in an error in state: 1640.
+## Ends in an error in state: 1646.
 ##
 ## method_ -> override_flag VIRTUAL private_flag . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8132,7 +8104,7 @@ implementation: LBRACE METHOD VIRTUAL PRIVATE LET
 
 implementation: LBRACE METHOD VIRTUAL WITH
 ##
-## Ends in an error in state: 1638.
+## Ends in an error in state: 1644.
 ##
 ## method_ -> override_flag VIRTUAL . private_flag label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8144,7 +8116,7 @@ implementation: LBRACE METHOD VIRTUAL WITH
 
 implementation: LBRACE METHOD WITH
 ##
-## Ends in an error in state: 1636.
+## Ends in an error in state: 1642.
 ##
 ## _class_field -> METHOD . method_ post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8156,7 +8128,7 @@ implementation: LBRACE METHOD WITH
 
 implementation: LBRACE PERCENT WITH TYPE
 ##
-## Ends in an error in state: 2287.
+## Ends in an error in state: 2161.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ error RBRACE ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ error SEMI RBRACE AND ]
@@ -8176,7 +8148,7 @@ implementation: LBRACE PERCENT WITH TYPE
 
 implementation: LBRACE UIDENT DOT WITH
 ##
-## Ends in an error in state: 2333.
+## Ends in an error in state: 2209.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
@@ -8203,7 +8175,7 @@ implementation: LBRACE UIDENT DOT WITH
 
 implementation: LBRACE VAL BANG WITH
 ##
-## Ends in an error in state: 1622.
+## Ends in an error in state: 1628.
 ##
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8218,7 +8190,7 @@ implementation: LBRACE VAL BANG WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1635.
+## Ends in an error in state: 1641.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8253,21 +8225,21 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL UIDENT RP
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 ##
-## Ends in an error in state: 1634.
+## Ends in an error in state: 1640.
 ##
 ## value -> override_flag mutable_flag label type_constraint EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8279,7 +8251,7 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1633.
+## Ends in an error in state: 1639.
 ##
 ## value -> override_flag mutable_flag label type_constraint . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8296,14 +8268,14 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1103, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1109, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1632.
+## Ends in an error in state: 1638.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8338,21 +8310,21 @@ implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1631.
+## Ends in an error in state: 1637.
 ##
 ## value -> override_flag mutable_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8364,7 +8336,7 @@ implementation: LBRACE VAL LIDENT EQUAL WITH
 
 implementation: LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1630.
+## Ends in an error in state: 1636.
 ##
 ## value -> override_flag mutable_flag label . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag mutable_flag label . type_constraint EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -8377,7 +8349,7 @@ implementation: LBRACE VAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1627.
+## Ends in an error in state: 1633.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8390,18 +8362,18 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 728, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 722, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 724, spurious reduction of production _core_type -> core_type2
-## In state 735, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 723, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 643, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 637, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 639, spurious reduction of production _core_type -> core_type2
+## In state 650, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 638, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1626.
+## Ends in an error in state: 1632.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8414,7 +8386,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1625.
+## Ends in an error in state: 1631.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8427,7 +8399,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 ##
-## Ends in an error in state: 1624.
+## Ends in an error in state: 1630.
 ##
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8440,7 +8412,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 
 implementation: LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1623.
+## Ends in an error in state: 1629.
 ##
 ## mutable_flag -> MUTABLE . [ LIDENT ]
 ## value -> override_flag MUTABLE . VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -8454,7 +8426,7 @@ implementation: LBRACE VAL MUTABLE WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1618.
+## Ends in an error in state: 1624.
 ##
 ## value -> VIRTUAL mutable_flag label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8467,18 +8439,18 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 728, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 722, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 724, spurious reduction of production _core_type -> core_type2
-## In state 735, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 723, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 643, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 637, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 639, spurious reduction of production _core_type -> core_type2
+## In state 650, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 638, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1617.
+## Ends in an error in state: 1623.
 ##
 ## value -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8491,7 +8463,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1616.
+## Ends in an error in state: 1622.
 ##
 ## value -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8504,7 +8476,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1615.
+## Ends in an error in state: 1621.
 ##
 ## value -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8517,7 +8489,7 @@ implementation: LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1614.
+## Ends in an error in state: 1620.
 ##
 ## value -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL . mutable_flag label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8530,7 +8502,7 @@ implementation: LBRACE VAL VIRTUAL WITH
 
 implementation: LBRACE VAL WITH
 ##
-## Ends in an error in state: 1613.
+## Ends in an error in state: 1619.
 ##
 ## _class_field -> VAL . value post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8542,7 +8514,7 @@ implementation: LBRACE VAL WITH
 
 implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2493.
+## Ends in an error in state: 2491.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8577,14 +8549,14 @@ implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -8603,7 +8575,7 @@ implementation: LBRACELESS LIDENT COLON WITH
 
 implementation: LBRACELESS LIDENT COMMA WITH
 ##
-## Ends in an error in state: 465.
+## Ends in an error in state: 766.
 ##
 ## field_expr_list -> field_expr_list COMMA . field_expr [ error GREATERRBRACE COMMA ]
 ## opt_comma -> COMMA . [ error GREATERRBRACE ]
@@ -8629,7 +8601,7 @@ implementation: LBRACELESS LIDENT WITH
 
 implementation: LBRACKET DOTDOTDOT WITH
 ##
-## Ends in an error in state: 1135.
+## Ends in an error in state: 1141.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT . expr_optional_constraint RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -8641,7 +8613,7 @@ implementation: LBRACKET DOTDOTDOT WITH
 
 implementation: LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 1138.
+## Ends in an error in state: 1144.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint . opt_comma RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## expr_comma_seq_extension -> expr_optional_constraint . COMMA expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -8653,15 +8625,15 @@ implementation: LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1101, spurious reduction of production expr_optional_constraint -> expr
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 950, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1107, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 Expecting one of the following:
@@ -8670,7 +8642,7 @@ Expecting one of the following:
 
 implementation: LBRACKET WITH
 ##
-## Ends in an error in state: 446.
+## Ends in an error in state: 721.
 ##
 ## _simple_expr -> LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## constr_longident -> LBRACKET . RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -8686,7 +8658,7 @@ Expecting one of the following:
 
 implementation: LBRACKETATATAT UNDERSCORE
 ##
-## Ends in an error in state: 493.
+## Ends in an error in state: 1229.
 ##
 ## floating_attribute -> LBRACKETATATAT . attr_id payload RBRACKET [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -8698,7 +8670,7 @@ implementation: LBRACKETATATAT UNDERSCORE
 
 implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2225.
+## Ends in an error in state: 2120.
 ##
 ## floating_attribute -> LBRACKETATATAT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -8709,30 +8681,30 @@ implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1886, spurious reduction of production post_item_attributes ->
-## In state 1887, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1888, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1802, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1795, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1803, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1796, spurious reduction of production structure -> structure_item
-## In state 1892, spurious reduction of production payload -> structure
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1858, spurious reduction of production post_item_attributes ->
+## In state 1859, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1860, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1803, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1796, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1804, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1797, spurious reduction of production structure -> structure_item
+## In state 1864, spurious reduction of production payload -> structure
 ##
 
 Expecting "]" to finish current floating attribute
 
 implementation: LBRACKETBAR BANG WITH
 ##
-## Ends in an error in state: 502.
+## Ends in an error in state: 785.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -8744,7 +8716,7 @@ implementation: LBRACKETBAR BANG WITH
 
 implementation: LBRACKETBAR MINUSDOT WITH
 ##
-## Ends in an error in state: 845.
+## Ends in an error in state: 856.
 ##
 ## _expr -> subtractive . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -8756,7 +8728,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR PLUSDOT WITH
 ##
-## Ends in an error in state: 879.
+## Ends in an error in state: 890.
 ##
 ## _expr -> additive . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -8780,7 +8752,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1128.
+## Ends in an error in state: 1134.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8792,7 +8764,7 @@ Expecting a type name
 
 implementation: LBRACKETBAR UIDENT COLON WITH
 ##
-## Ends in an error in state: 1125.
+## Ends in an error in state: 1131.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8804,7 +8776,7 @@ implementation: LBRACKETBAR UIDENT COLON WITH
 
 implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1123.
+## Ends in an error in state: 1129.
 ##
 ## type_constraint -> COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8816,7 +8788,7 @@ implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 
 implementation: LBRACKETBAR UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1120.
+## Ends in an error in state: 1126.
 ##
 ## expr_comma_seq -> expr_comma_seq COMMA . expr_optional_constraint [ error COMMA BARRBRACKET ]
 ## opt_comma -> COMMA . [ error BARRBRACKET ]
@@ -8829,7 +8801,7 @@ implementation: LBRACKETBAR UIDENT COMMA WITH
 
 implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 ##
-## Ends in an error in state: 491.
+## Ends in an error in state: 1227.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT . attr_id payload RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -8841,7 +8813,7 @@ implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH COLON WITH
 ##
-## Ends in an error in state: 1420.
+## Ends in an error in state: 1426.
 ##
 ## payload -> COLON . core_type [ RBRACKET ]
 ##
@@ -8865,7 +8837,7 @@ implementation: LBRACKETPERCENTPERCENT WITH DOT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ##
-## Ends in an error in state: 2459.
+## Ends in an error in state: 2457.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN RBRACKET BAR ]
 ## payload -> QUESTION pattern . [ RBRACKET ]
@@ -8878,14 +8850,14 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 692, spurious reduction of production pattern -> pattern_without_or
+## In state 610, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2461.
+## Ends in an error in state: 2459.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8920,21 +8892,21 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 950, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2460.
+## Ends in an error in state: 2458.
 ##
 ## payload -> QUESTION pattern WHEN . expr [ RBRACKET ]
 ##
@@ -8959,7 +8931,7 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION WITH
 
 implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2227.
+## Ends in an error in state: 2122.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -8970,23 +8942,23 @@ implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1886, spurious reduction of production post_item_attributes ->
-## In state 1887, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1888, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1802, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1795, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1803, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1796, spurious reduction of production structure -> structure_item
-## In state 1892, spurious reduction of production payload -> structure
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1858, spurious reduction of production post_item_attributes ->
+## In state 1859, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1860, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1803, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1796, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1804, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1797, spurious reduction of production structure -> structure_item
+## In state 1864, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
@@ -9006,7 +8978,7 @@ implementation: LBRACKETPERCENTPERCENT WITH WITH
 
 implementation: LET CHAR EQUAL CHAR AND WITH
 ##
-## Ends in an error in state: 1837.
+## Ends in an error in state: 1838.
 ##
 ## and_let_binding -> AND . let_binding_body post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9018,7 +8990,7 @@ implementation: LET CHAR EQUAL CHAR AND WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1853.
+## Ends in an error in state: 2385.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -9053,21 +9025,21 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1857.
+## Ends in an error in state: 2389.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9079,7 +9051,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1856.
+## Ends in an error in state: 2388.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9102,7 +9074,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1855.
+## Ends in an error in state: 2387.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9114,7 +9086,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1854.
+## Ends in an error in state: 2386.
 ##
 ## let_binding_body -> val_ident COLON typevar_list . DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -9127,7 +9099,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1851.
+## Ends in an error in state: 2383.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9139,7 +9111,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1850.
+## Ends in an error in state: 2382.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9162,7 +9134,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1849.
+## Ends in an error in state: 2381.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9174,7 +9146,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1547.
+## Ends in an error in state: 1553.
 ##
 ## lident_list -> LIDENT . [ DOT ]
 ## lident_list -> LIDENT . lident_list [ DOT ]
@@ -9187,7 +9159,7 @@ implementation: LET LIDENT COLON TYPE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 1847.
+## Ends in an error in state: 2379.
 ##
 ## let_binding_body -> val_ident COLON TYPE . lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9199,7 +9171,7 @@ implementation: LET LIDENT COLON TYPE WITH
 
 implementation: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 1846.
+## Ends in an error in state: 2378.
 ##
 ## let_binding_body -> val_ident COLON . typevar_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## let_binding_body -> val_ident COLON . TYPE lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9213,7 +9185,7 @@ implementation: LET LIDENT COLON WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1860.
+## Ends in an error in state: 2392.
 ##
 ## let_binding_body -> val_ident type_constraint EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9225,7 +9197,7 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 1859.
+## Ends in an error in state: 2391.
 ##
 ## let_binding_body -> val_ident type_constraint . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9242,14 +9214,14 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1103, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1109, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1844.
+## Ends in an error in state: 2376.
 ##
 ## _curried_binding_return_typed -> EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9261,7 +9233,7 @@ implementation: LET LIDENT EQUALGREATER WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1842.
+## Ends in an error in state: 692.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9273,7 +9245,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1841.
+## Ends in an error in state: 691.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9285,7 +9257,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1840.
+## Ends in an error in state: 690.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9297,7 +9269,7 @@ implementation: LET LIDENT LPAREN TYPE WITH
 
 implementation: LET LIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1839.
+## Ends in an error in state: 689.
 ##
 ## _curried_binding_return_typed -> LPAREN . TYPE LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -9320,7 +9292,7 @@ implementation: LET LIDENT LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1660.
+## Ends in an error in state: 1675.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -9355,21 +9327,21 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1659.
+## Ends in an error in state: 1674.
 ##
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9381,7 +9353,7 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1658.
+## Ends in an error in state: 1673.
 ##
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type . EQUALGREATER expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9395,7 +9367,7 @@ Expecting "=>" to start the function body
 
 implementation: LET LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1657.
+## Ends in an error in state: 1672.
 ##
 ## curried_binding_return_typed_ -> COLON . non_arrowed_core_type EQUALGREATER expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9407,7 +9379,7 @@ implementation: LET LIDENT UNDERSCORE COLON WITH
 
 implementation: LET LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1655.
+## Ends in an error in state: 1657.
 ##
 ## curried_binding -> EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9419,7 +9391,7 @@ Expecting an expression as function body
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1654.
+## Ends in an error in state: 696.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9431,7 +9403,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1653.
+## Ends in an error in state: 695.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9443,7 +9415,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 1652.
+## Ends in an error in state: 694.
 ##
 ## curried_binding -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9455,7 +9427,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 1651.
+## Ends in an error in state: 693.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -9478,7 +9450,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 1661.
+## Ends in an error in state: 1671.
 ##
 ## curried_binding -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9490,7 +9462,7 @@ implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 
 implementation: LET LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1863.
+## Ends in an error in state: 2395.
 ##
 ## _curried_binding_return_typed -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9506,7 +9478,7 @@ Expecting one of the following:
 
 implementation: LET LIDENT WITH
 ##
-## Ends in an error in state: 1838.
+## Ends in an error in state: 688.
 ##
 ## _simple_pattern -> val_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> val_ident . type_constraint EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9520,9 +9492,9 @@ implementation: LET LIDENT WITH
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
+implementation: MODULE REC UIDENT EQUAL UIDENT AND WITH
 ##
-## Ends in an error in state: 1822.
+## Ends in an error in state: 1823.
 ##
 ## and_nonlocal_module_bindings -> AND . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9532,9 +9504,9 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WITH
+implementation: MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1821.
+## Ends in an error in state: 1822.
 ##
 ## _structure_item_without_item_extension_sugar -> many_nonlocal_module_bindings . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> many_nonlocal_module_bindings . and_nonlocal_module_bindings [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -9546,28 +9518,28 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WIT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1359, spurious reduction of production post_item_attributes ->
-## In state 1360, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2251, spurious reduction of production many_nonlocal_module_bindings -> LET MODULE REC nonlocal_module_binding_details post_item_attributes
+## In state 1379, spurious reduction of production post_item_attributes ->
+## In state 1380, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2432, spurious reduction of production many_nonlocal_module_bindings -> MODULE REC nonlocal_module_binding_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE REC WITH
+implementation: MODULE REC WITH
 ##
-## Ends in an error in state: 2249.
+## Ends in an error in state: 2430.
 ##
-## many_nonlocal_module_bindings -> LET MODULE REC . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
+## many_nonlocal_module_bindings -> MODULE REC . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
 ## The known suffix of the stack is as follows:
-## LET MODULE REC
+## MODULE REC
 ##
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
+implementation: MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2235.
+## Ends in an error in state: 2411.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9581,19 +9553,19 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1357, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1363, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1358, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1208, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1365, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1364, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2109, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2113, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2110, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1235, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2115, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2114, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
+implementation: MODULE UIDENT COLON UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2234.
+## Ends in an error in state: 2410.
 ##
 ## module_binding_body_expr -> COLON module_type EQUAL . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9603,9 +9575,9 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE UIDENT COLON UIDENT SEMI
+implementation: MODULE UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2233.
+## Ends in an error in state: 2409.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER EQUAL ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER EQUAL ]
@@ -9621,22 +9593,22 @@ implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1994, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE UIDENT COLON WITH
+implementation: MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2232.
+## Ends in an error in state: 2408.
 ##
 ## module_binding_body_expr -> COLON . module_type EQUAL module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9646,9 +9618,9 @@ implementation: LET MODULE UIDENT COLON WITH
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE UIDENT EQUAL UIDENT WITH
+implementation: MODULE UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2231.
+## Ends in an error in state: 2407.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9662,19 +9634,19 @@ implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1357, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1363, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1358, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1208, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1365, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1364, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2109, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2113, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2110, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1235, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2115, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2114, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE UIDENT EQUAL WITH
+implementation: MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 489.
+## Ends in an error in state: 2406.
 ##
 ## module_binding_body_expr -> EQUAL . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9684,9 +9656,9 @@ implementation: LET MODULE UIDENT EQUAL WITH
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT WITH
+implementation: MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2246.
+## Ends in an error in state: 2422.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER module_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9700,19 +9672,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1357, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1363, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1358, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1208, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1365, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1364, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2109, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2113, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2110, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1235, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2115, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2114, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
+implementation: MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2245.
+## Ends in an error in state: 2421.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9722,9 +9694,9 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
+implementation: MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2244.
+## Ends in an error in state: 2420.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type . EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_type -> non_arrowed_module_type . [ WITH LBRACKETAT EQUALGREATER ]
@@ -9738,19 +9710,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1995, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2027, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2023, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1993, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2028, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2024, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
 ##
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER SEMI
+implementation: MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER SEMI
 ##
-## Ends in an error in state: 2247.
+## Ends in an error in state: 2179.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER ]
@@ -9769,18 +9741,18 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT CO
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2002, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 2016, spurious reduction of production with_constraints -> with_constraint
-## In state 2013, spurious reduction of production _module_type -> module_type WITH with_constraints
-## In state 2029, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2025, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1931, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1945, spurious reduction of production with_constraints -> with_constraint
+## In state 1942, spurious reduction of production _module_type -> module_type WITH with_constraints
+## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
+implementation: MODULE UIDENT LPAREN RPAREN COLON WITH
 ##
-## Ends in an error in state: 2243.
+## Ends in an error in state: 2419.
 ##
 ## _module_binding_body_functor -> functor_args COLON . non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9790,9 +9762,9 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
+implementation: MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2242.
+## Ends in an error in state: 2418.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER module_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9806,19 +9778,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1357, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1363, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1358, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1208, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1365, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1364, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 2109, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 2113, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 2110, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1235, spurious reduction of production _module_expr -> simple_module_expr
+## In state 2115, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 2114, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
+implementation: MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2241.
+## Ends in an error in state: 2417.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9828,9 +9800,9 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE UIDENT LPAREN RPAREN WITH
+implementation: MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2240.
+## Ends in an error in state: 2416.
 ##
 ## _module_binding_body_functor -> functor_args . EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_binding_body_functor -> functor_args . COLON non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9842,9 +9814,9 @@ implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE UIDENT WITH
+implementation: MODULE UIDENT WITH
 ##
-## Ends in an error in state: 488.
+## Ends in an error in state: 427.
 ##
 ## nonlocal_module_binding_details -> UIDENT . module_binding_body [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9854,22 +9826,24 @@ implementation: LET MODULE UIDENT WITH
 
 <SYNTAX ERROR>
 
-implementation: LET MODULE WITH
+implementation: MODULE WITH
 ##
-## Ends in an error in state: 487.
+## Ends in an error in state: 426.
 ##
-## _structure_item_without_item_extension_sugar -> LET MODULE . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
-## many_nonlocal_module_bindings -> LET MODULE . REC nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
+## _structure_item_without_item_extension_sugar -> MODULE . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
+## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
+## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
+## many_nonlocal_module_bindings -> MODULE . REC nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
 ## The known suffix of the stack is as follows:
-## LET MODULE
+## MODULE
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET REC ASSERT
 ##
-## Ends in an error in state: 2254.
+## Ends in an error in state: 439.
 ##
 ## let_binding_impl -> LET rec_flag . let_binding_body post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9881,7 +9855,7 @@ implementation: LET REC ASSERT
 
 implementation: LET UIDENT UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1872.
+## Ends in an error in state: 1844.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EQUAL BAR ]
 ## let_binding_body -> pattern . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9893,17 +9867,17 @@ implementation: LET UIDENT UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 688, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
-## In state 691, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
-## In state 686, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
-## In state 692, spurious reduction of production pattern -> pattern_without_or
+## In state 606, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
+## In state 609, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
+## In state 604, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
+## In state 610, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1870.
+## Ends in an error in state: 1842.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9915,7 +9889,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1869.
+## Ends in an error in state: 1841.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9938,7 +9912,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 
 implementation: LET UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1868.
+## Ends in an error in state: 1840.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON . core_type EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9950,7 +9924,7 @@ implementation: LET UNDERSCORE COLON WITH
 
 implementation: LET UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1873.
+## Ends in an error in state: 1845.
 ##
 ## let_binding_body -> pattern EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9962,7 +9936,7 @@ implementation: LET UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE WITH
 ##
-## Ends in an error in state: 1867.
+## Ends in an error in state: 1839.
 ##
 ## _simple_pattern -> simple_pattern_not_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> simple_pattern_not_ident . COLON core_type EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9975,11 +9949,9 @@ implementation: LET UNDERSCORE WITH
 
 implementation: LET WITH
 ##
-## Ends in an error in state: 486.
+## Ends in an error in state: 437.
 ##
-## _structure_item_without_item_extension_sugar -> LET . MODULE nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
-## many_nonlocal_module_bindings -> LET . MODULE REC nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET
@@ -9989,7 +9961,7 @@ Incomplete let binding
 
 implementation: LPAREN ASSERT WITH
 ##
-## Ends in an error in state: 843.
+## Ends in an error in state: 854.
 ##
 ## _expr -> ASSERT . simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10001,7 +9973,7 @@ implementation: LPAREN ASSERT WITH
 
 implementation: LPAREN BACKQUOTE WITH
 ##
-## Ends in an error in state: 503.
+## Ends in an error in state: 500.
 ##
 ## name_tag -> BACKQUOTE . ident [ error UNDERSCORE UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10013,7 +9985,7 @@ implementation: LPAREN BACKQUOTE WITH
 
 implementation: LPAREN BANG WITH
 ##
-## Ends in an error in state: 818.
+## Ends in an error in state: 829.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP RPAREN QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## operator -> BANG . [ RPAREN ]
@@ -10026,7 +9998,7 @@ implementation: LPAREN BANG WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 ##
-## Ends in an error in state: 805.
+## Ends in an error in state: 816.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag . simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10038,7 +10010,7 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ##
-## Ends in an error in state: 802.
+## Ends in an error in state: 813.
 ##
 ## _expr -> FOR pattern IN simple_expr . direction_flag simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ TO SHARPOP SHARP DOWNTO DOT ]
@@ -10057,17 +10029,17 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 846, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FOR UNDERSCORE IN WITH
 ##
-## Ends in an error in state: 801.
+## Ends in an error in state: 812.
 ##
 ## _expr -> FOR pattern IN . simple_expr direction_flag simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10079,7 +10051,7 @@ implementation: LPAREN FOR UNDERSCORE IN WITH
 
 implementation: LPAREN FOR WITH
 ##
-## Ends in an error in state: 799.
+## Ends in an error in state: 810.
 ##
 ## _expr -> FOR . pattern IN simple_expr direction_flag simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10091,7 +10063,7 @@ implementation: LPAREN FOR WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2208.
+## Ends in an error in state: 1194.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10126,17 +10098,17 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2207.
+## Ends in an error in state: 1193.
 ##
 ## leading_bar_match_case -> pattern_with_bar EQUALGREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10148,7 +10120,7 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2206.
+## Ends in an error in state: 1192.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10183,17 +10155,17 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2205.
+## Ends in an error in state: 1191.
 ##
 ## leading_bar_match_case -> pattern_with_bar WHEN expr EQUALGREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10205,7 +10177,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2204.
+## Ends in an error in state: 1190.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10240,21 +10212,21 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 950, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2203.
+## Ends in an error in state: 1189.
 ##
 ## leading_bar_match_case -> pattern_with_bar WHEN . expr EQUALGREATER expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10266,7 +10238,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 525.
+## Ends in an error in state: 804.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10278,7 +10250,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 524.
+## Ends in an error in state: 803.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10290,7 +10262,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN LPAREN TYPE WITH
 ##
-## Ends in an error in state: 523.
+## Ends in an error in state: 802.
 ##
 ## _expr -> FUN LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10302,7 +10274,7 @@ implementation: LPAREN FUN LPAREN TYPE WITH
 
 implementation: LPAREN FUN LPAREN WITH
 ##
-## Ends in an error in state: 522.
+## Ends in an error in state: 801.
 ##
 ## _expr -> FUN LPAREN . TYPE LIDENT RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -10325,7 +10297,7 @@ implementation: LPAREN FUN LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2193.
+## Ends in an error in state: 1179.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10360,17 +10332,17 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2192.
+## Ends in an error in state: 809.
 ##
 ## fun_def -> EQUALGREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10382,7 +10354,7 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 529.
+## Ends in an error in state: 808.
 ##
 ## fun_def -> LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10394,7 +10366,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 528.
+## Ends in an error in state: 807.
 ##
 ## fun_def -> LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10406,7 +10378,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 527.
+## Ends in an error in state: 806.
 ##
 ## fun_def -> LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10418,7 +10390,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 526.
+## Ends in an error in state: 805.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -10441,7 +10413,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 2198.
+## Ends in an error in state: 1184.
 ##
 ## fun_def -> labeled_simple_pattern . fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10453,7 +10425,7 @@ implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 
 implementation: LPAREN FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2212.
+## Ends in an error in state: 1198.
 ##
 ## _expr -> FUN labeled_simple_pattern . fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10465,7 +10437,7 @@ implementation: LPAREN FUN UNDERSCORE WITH
 
 implementation: LPAREN FUN WITH
 ##
-## Ends in an error in state: 521.
+## Ends in an error in state: 800.
 ##
 ## _expr -> FUN . labeled_simple_pattern fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> FUN . LPAREN TYPE LIDENT RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10479,7 +10451,7 @@ implementation: LPAREN FUN WITH
 
 implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 ##
-## Ends in an error in state: 520.
+## Ends in an error in state: 799.
 ##
 ## _expr -> IF simple_expr simple_expr ELSE . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10491,7 +10463,7 @@ implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 
 implementation: LPAREN IF UIDENT WITH
 ##
-## Ends in an error in state: 513.
+## Ends in an error in state: 794.
 ##
 ## _expr -> IF simple_expr . simple_expr ELSE expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF simple_expr . simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10511,17 +10483,17 @@ implementation: LPAREN IF UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 846, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN IF WITH
 ##
-## Ends in an error in state: 512.
+## Ends in an error in state: 793.
 ##
 ## _expr -> IF . simple_expr simple_expr ELSE expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF . simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10534,7 +10506,7 @@ implementation: LPAREN IF WITH
 
 implementation: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 495.
+## Ends in an error in state: 784.
 ##
 ## _expr -> LAZY . simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10546,7 +10518,7 @@ implementation: LPAREN LAZY WITH
 
 implementation: LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 471.
+## Ends in an error in state: 772.
 ##
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10566,7 +10538,7 @@ implementation: LPAREN LBRACE WITH
 
 implementation: LPAREN LBRACELESS WITH
 ##
-## Ends in an error in state: 462.
+## Ends in an error in state: 763.
 ##
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10580,7 +10552,7 @@ implementation: LPAREN LBRACELESS WITH
 
 implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ##
-## Ends in an error in state: 1136.
+## Ends in an error in state: 1142.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT expr_optional_constraint . RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10591,22 +10563,22 @@ implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1101, spurious reduction of production expr_optional_constraint -> expr
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 950, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1107, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKET UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1139.
+## Ends in an error in state: 1145.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint COMMA . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## opt_comma -> COMMA . [ RBRACKET ]
@@ -10619,7 +10591,7 @@ implementation: LPAREN LBRACKET UIDENT COMMA WITH
 
 implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2392.
+## Ends in an error in state: 2331.
 ##
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10632,23 +10604,23 @@ implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1122, spurious reduction of production expr_optional_constraint -> expr
-## In state 1118, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1128, spurious reduction of production expr_optional_constraint -> expr
+## In state 1124, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKETBAR WITH
 ##
-## Ends in an error in state: 445.
+## Ends in an error in state: 720.
 ##
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10674,7 +10646,7 @@ implementation: LPAREN LBRACKETPERCENT UNDERSCORE
 
 implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2462.
+## Ends in an error in state: 2460.
 ##
 ## extension -> LBRACKETPERCENT attr_id payload . RBRACKET [ error WITH UNDERSCORE UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10685,30 +10657,30 @@ implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1886, spurious reduction of production post_item_attributes ->
-## In state 1887, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1888, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1802, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1795, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1803, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1796, spurious reduction of production structure -> structure_item
-## In state 1892, spurious reduction of production payload -> structure
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1858, spurious reduction of production post_item_attributes ->
+## In state 1859, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1860, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1803, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1796, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1804, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1797, spurious reduction of production structure -> structure_item
+## In state 1864, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 865.
+## Ends in an error in state: 876.
 ##
 ## _expr -> label EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10720,7 +10692,7 @@ implementation: LPAREN LIDENT EQUAL WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ##
-## Ends in an error in state: 2483.
+## Ends in an error in state: 2481.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr . RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10755,21 +10727,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 950, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2482.
+## Ends in an error in state: 2480.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA . expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10781,7 +10753,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2481.
+## Ends in an error in state: 2479.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr . COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10816,21 +10788,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 950, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2480.
+## Ends in an error in state: 2478.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN . expr COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10842,7 +10814,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2479.
+## Ends in an error in state: 2477.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN . LPAREN expr COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10854,7 +10826,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2478.
+## Ends in an error in state: 2476.
 ##
 ## _expr -> LPAREN COLONCOLON . RPAREN LPAREN expr COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10866,7 +10838,7 @@ implementation: LPAREN LPAREN COLONCOLON WITH
 
 implementation: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2472.
+## Ends in an error in state: 2470.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -10882,12 +10854,12 @@ implementation: LPAREN LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 790, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 794, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 791, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 777, spurious reduction of production _module_expr -> simple_module_expr
-## In state 796, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 795, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 754, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 758, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 755, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 736, spurious reduction of production _module_expr -> simple_module_expr
+## In state 760, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 759, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
@@ -10908,7 +10880,7 @@ Expecting a module expression
 
 implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ##
-## Ends in an error in state: 2485.
+## Ends in an error in state: 2483.
 ##
 ## _simple_expr -> LPAREN expr_comma_list . RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN expr_comma_list . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10921,12 +10893,12 @@ implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1122, spurious reduction of production expr_optional_constraint -> expr
-## In state 1182, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1128, spurious reduction of production expr_optional_constraint -> expr
+## In state 2279, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
@@ -10960,7 +10932,7 @@ Expecting one of the following:
 
 implementation: LPAREN MINUS WITH
 ##
-## Ends in an error in state: 798.
+## Ends in an error in state: 762.
 ##
 ## operator -> MINUS . [ RPAREN ]
 ## subtractive -> MINUS . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
@@ -10973,7 +10945,7 @@ implementation: LPAREN MINUS WITH
 
 implementation: LPAREN MINUSDOT WITH
 ##
-## Ends in an error in state: 797.
+## Ends in an error in state: 761.
 ##
 ## operator -> MINUSDOT . [ RPAREN ]
 ## subtractive -> MINUSDOT . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
@@ -10986,7 +10958,7 @@ implementation: LPAREN MINUSDOT WITH
 
 implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2476.
+## Ends in an error in state: 2474.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11006,7 +10978,7 @@ implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2474.
+## Ends in an error in state: 2472.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -11096,7 +11068,7 @@ implementation: LPAREN PREFIXOP WITH
 
 implementation: LPAREN STAR WITH
 ##
-## Ends in an error in state: 627.
+## Ends in an error in state: 543.
 ##
 ## val_ident -> LPAREN operator . RPAREN [ error UNDERSCORE UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11108,7 +11080,7 @@ implementation: LPAREN STAR WITH
 
 implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1107.
+## Ends in an error in state: 1113.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -11120,7 +11092,7 @@ implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 
 implementation: LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1104.
+## Ends in an error in state: 1110.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -11132,7 +11104,7 @@ implementation: LPAREN UIDENT COLON WITH
 
 implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1180.
+## Ends in an error in state: 2277.
 ##
 ## expr_comma_list -> expr_optional_constraint . COMMA expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -11149,15 +11121,15 @@ implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1103, spurious reduction of production type_constraint -> COLONGREATER core_type
-## In state 2491, spurious reduction of production expr_optional_constraint -> expr type_constraint
+## In state 1109, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 2489, spurious reduction of production expr_optional_constraint -> expr type_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1102.
+## Ends in an error in state: 1108.
 ##
 ## type_constraint -> COLONGREATER . core_type [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -11169,7 +11141,7 @@ implementation: LPAREN UIDENT COLONGREATER WITH
 
 implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 1186.
+## Ends in an error in state: 2283.
 ##
 ## expr_comma_list -> expr_comma_list COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -11181,7 +11153,7 @@ implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 
 implementation: LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1181.
+## Ends in an error in state: 2278.
 ##
 ## expr_comma_list -> expr_optional_constraint COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -11254,7 +11226,7 @@ implementation: PERCENT WITH WITH
 
 implementation: STRING LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 857.
+## Ends in an error in state: 868.
 ##
 ## label_expr -> LIDENT COLONCOLON . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11266,7 +11238,7 @@ implementation: STRING LIDENT COLONCOLON WITH
 
 implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 854.
+## Ends in an error in state: 865.
 ##
 ## label_expr -> LIDENT EXPLICITLY_PASSED_OPTIONAL . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11278,7 +11250,7 @@ implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: STRING WITH
 ##
-## Ends in an error in state: 1796.
+## Ends in an error in state: 1797.
 ##
 ## structure -> structure_item . [ RBRACKET RBRACE EOF ]
 ## structure -> structure_item . error structure [ RBRACKET RBRACE EOF ]
@@ -11291,24 +11263,24 @@ implementation: STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1886, spurious reduction of production post_item_attributes ->
-## In state 1887, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1888, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1802, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1795, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1803, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1858, spurious reduction of production post_item_attributes ->
+## In state 1859, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1860, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1803, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1796, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1804, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 Incomplete statement. Did you forget a ";"?
 
 implementation: SWITCH UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2517.
+## Ends in an error in state: 2515.
 ##
 ## _expr -> SWITCH simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11320,7 +11292,7 @@ implementation: SWITCH UIDENT LBRACE WITH
 
 implementation: SWITCH UIDENT WITH
 ##
-## Ends in an error in state: 2516.
+## Ends in an error in state: 2514.
 ##
 ## _expr -> SWITCH simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ SHARPOP SHARP LBRACE DOT ]
@@ -11339,10 +11311,10 @@ implementation: SWITCH UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 846, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -11361,7 +11333,7 @@ implementation: SWITCH WITH
 
 implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 ##
-## Ends in an error in state: 1092.
+## Ends in an error in state: 1098.
 ##
 ## _expr -> simple_expr DOT LBRACE expr RBRACE EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11373,7 +11345,7 @@ implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 
 implementation: TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 1090.
+## Ends in an error in state: 1096.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11409,21 +11381,21 @@ implementation: TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 950, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 1089.
+## Ends in an error in state: 1095.
 ##
 ## _expr -> simple_expr DOT LBRACE . expr RBRACE EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11436,7 +11408,7 @@ implementation: TRUE DOT LBRACE WITH
 
 implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 ##
-## Ends in an error in state: 1087.
+## Ends in an error in state: 1093.
 ##
 ## _expr -> simple_expr DOT LBRACKET expr RBRACKET EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11448,7 +11420,7 @@ implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 
 implementation: TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 1084.
+## Ends in an error in state: 1090.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11485,21 +11457,21 @@ implementation: TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1083.
+## Ends in an error in state: 1089.
 ##
 ## _expr -> simple_expr DOT LBRACKET . expr RBRACKET EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11513,7 +11485,7 @@ implementation: TRUE DOT LBRACKET WITH
 
 implementation: TRUE DOT LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1095.
+## Ends in an error in state: 1101.
 ##
 ## _expr -> simple_expr DOT label_longident EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11525,7 +11497,7 @@ implementation: TRUE DOT LIDENT EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 ##
-## Ends in an error in state: 1081.
+## Ends in an error in state: 1087.
 ##
 ## _expr -> simple_expr DOT LPAREN expr RPAREN EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11537,7 +11509,7 @@ implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1078.
+## Ends in an error in state: 1084.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11574,21 +11546,21 @@ implementation: TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 848.
+## Ends in an error in state: 859.
 ##
 ## _expr -> simple_expr DOT LPAREN . expr RPAREN EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11602,7 +11574,7 @@ implementation: TRUE DOT LPAREN WITH
 
 implementation: TRUE DOT UIDENT DOT WITH
 ##
-## Ends in an error in state: 563.
+## Ends in an error in state: 471.
 ##
 ## label_longident -> mod_longident DOT . LIDENT [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident DOT . UIDENT [ DOT ]
@@ -11615,7 +11587,7 @@ implementation: TRUE DOT UIDENT DOT WITH
 
 implementation: TRUE DOT UIDENT WITH
 ##
-## Ends in an error in state: 562.
+## Ends in an error in state: 470.
 ##
 ## label_longident -> mod_longident . DOT LIDENT [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident . DOT UIDENT [ DOT ]
@@ -11628,7 +11600,7 @@ implementation: TRUE DOT UIDENT WITH
 
 implementation: TRUE DOT WITH
 ##
-## Ends in an error in state: 847.
+## Ends in an error in state: 858.
 ##
 ## _expr -> simple_expr DOT . label_longident EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> simple_expr DOT . LPAREN expr RPAREN EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -11649,7 +11621,7 @@ implementation: TRUE DOT WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER CHAR BAR WITH
 ##
-## Ends in an error in state: 1060.
+## Ends in an error in state: 727.
 ##
 ## pattern_with_bar -> BAR . pattern [ WHEN EQUALGREATER ]
 ##
@@ -11659,9 +11631,9 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER CHAR BAR WITH
 
 Expecting a match case
 
-implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT RBRACKET
+implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER MODULE UIDENT EQUAL UIDENT RBRACKET
 ##
-## Ends in an error in state: 790.
+## Ends in an error in state: 754.
 ##
 ## _simple_module_expr -> mod_longident . [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF DOT COLON AND ]
@@ -11672,45 +11644,45 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 <SYNTAX ERROR>
 
-implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT SEMI WITH
+implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2358.
+## Ends in an error in state: 2296.
 ##
-## _semi_terminated_seq_expr_row -> LET MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
+## _semi_terminated_seq_expr_row -> MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
 ## The known suffix of the stack is as follows:
-## LET MODULE UIDENT module_binding_body post_item_attributes SEMI
+## MODULE UIDENT module_binding_body post_item_attributes SEMI
 ##
 
 <SYNTAX ERROR>
 
-implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT WITH
+implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2355.
+## Ends in an error in state: 2293.
 ##
-## _semi_terminated_seq_expr_row -> LET MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
+## _semi_terminated_seq_expr_row -> MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
 ## The known suffix of the stack is as follows:
-## LET MODULE UIDENT
+## MODULE UIDENT
 ##
 
 <SYNTAX ERROR>
 
-implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
+implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER MODULE WITH
 ##
-## Ends in an error in state: 2354.
+## Ends in an error in state: 2292.
 ##
-## _semi_terminated_seq_expr_row -> LET MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
+## _semi_terminated_seq_expr_row -> MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
 ## The known suffix of the stack is as follows:
-## LET MODULE
+## MODULE
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 ##
-## Ends in an error in state: 2363.
+## Ends in an error in state: 2302.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11722,7 +11694,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2366.
+## Ends in an error in state: 2305.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11734,7 +11706,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2365.
+## Ends in an error in state: 2304.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11745,14 +11717,14 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2364, spurious reduction of production post_item_attributes ->
+## In state 2303, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 ##
-## Ends in an error in state: 2362.
+## Ends in an error in state: 2301.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11764,9 +11736,8 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 ##
-## Ends in an error in state: 2353.
+## Ends in an error in state: 2297.
 ##
-## _semi_terminated_seq_expr_row -> LET . MODULE UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI RBRACE BAR AND ]
 ## option(LET) -> LET . [ OPEN ]
 ##
@@ -11778,7 +11749,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 ##
-## Ends in an error in state: 2373.
+## Ends in an error in state: 2312.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ RBRACE BAR ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI RBRACE BAR AND ]
@@ -11798,7 +11769,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 2646.
+## Ends in an error in state: 2644.
 ##
 ## _expr -> TRY simple_expr LBRACE leading_bar_match_cases_to_sequence_body . RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## leading_bar_match_cases_to_sequence_body -> leading_bar_match_cases_to_sequence_body . leading_bar_match_case_to_sequence_body [ RBRACE BAR ]
@@ -11810,24 +11781,24 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2375, spurious reduction of production post_item_attributes ->
-## In state 2376, spurious reduction of production opt_semi ->
-## In state 2381, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
-## In state 2379, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
-## In state 2368, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
-## In state 2359, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
-## In state 2380, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2369, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
-## In state 2385, spurious reduction of production leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER semi_terminated_seq_expr
-## In state 2389, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 950, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2314, spurious reduction of production post_item_attributes ->
+## In state 2315, spurious reduction of production opt_semi ->
+## In state 2320, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
+## In state 2318, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
+## In state 2307, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
+## In state 2298, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
+## In state 2319, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2308, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2324, spurious reduction of production leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER semi_terminated_seq_expr
+## In state 2328, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
 ##
 
 Expecting one of the following:
@@ -11836,7 +11807,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2384.
+## Ends in an error in state: 2323.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11848,7 +11819,7 @@ Expecting the body of the matched pattern
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ##
-## Ends in an error in state: 1061.
+## Ends in an error in state: 728.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN EQUALGREATER BAR ]
 ## pattern_with_bar -> BAR pattern . [ WHEN EQUALGREATER ]
@@ -11860,7 +11831,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 692, spurious reduction of production pattern -> pattern_without_or
+## In state 610, spurious reduction of production pattern -> pattern_without_or
 ##
 
 Expecting one of the following:
@@ -11870,7 +11841,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2352.
+## Ends in an error in state: 2291.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar WHEN expr EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11882,7 +11853,7 @@ Expecting a sequence item
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2351.
+## Ends in an error in state: 2290.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11917,21 +11888,21 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 950, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2350.
+## Ends in an error in state: 730.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar WHEN . expr EQUALGREATER semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11943,7 +11914,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 
 implementation: TRY UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2645.
+## Ends in an error in state: 2643.
 ##
 ## _expr -> TRY simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11955,7 +11926,7 @@ implementation: TRY UIDENT LBRACE WITH
 
 implementation: TRY UIDENT UNDERSCORE
 ##
-## Ends in an error in state: 2642.
+## Ends in an error in state: 2640.
 ##
 ## _expr -> TRY simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> TRY simple_expr . WITH error [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -11975,17 +11946,17 @@ implementation: TRY UIDENT UNDERSCORE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 835, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 846, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT WITH WITH
 ##
-## Ends in an error in state: 2643.
+## Ends in an error in state: 2641.
 ##
 ## _expr -> TRY simple_expr WITH . error [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12010,7 +11981,7 @@ implementation: TRY WITH
 
 implementation: TYPE LIDENT AND LIDENT WITH
 ##
-## Ends in an error in state: 1807.
+## Ends in an error in state: 1808.
 ##
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -12021,14 +11992,14 @@ implementation: TYPE LIDENT AND LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1806, spurious reduction of production optional_type_parameters ->
+## In state 1807, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT AND WITH
 ##
-## Ends in an error in state: 1805.
+## Ends in an error in state: 1806.
 ##
 ## and_type_declaration -> AND . type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -12040,7 +12011,7 @@ implementation: TYPE LIDENT AND WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1812.
+## Ends in an error in state: 1813.
 ##
 ## constrain -> core_type EQUAL . core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -12052,7 +12023,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1811.
+## Ends in an error in state: 1812.
 ##
 ## constrain -> core_type . EQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -12075,7 +12046,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 
 implementation: TYPE LIDENT CONSTRAINT WITH
 ##
-## Ends in an error in state: 1810.
+## Ends in an error in state: 1811.
 ##
 ## constraints -> constraints CONSTRAINT . constrain [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -12087,7 +12058,7 @@ implementation: TYPE LIDENT CONSTRAINT WITH
 
 implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2595.
+## Ends in an error in state: 2593.
 ##
 ## constructor_declarations -> constructor_declarations_leading_bar . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations_leading_bar -> constructor_declarations_leading_bar . constructor_declaration_leading_bar [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
@@ -12099,17 +12070,17 @@ implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1382, spurious reduction of production attributes ->
-## In state 1383, spurious reduction of production attributes -> attribute attributes
-## In state 2580, spurious reduction of production constructor_declaration_leading_bar -> BAR UIDENT generalized_constructor_arguments attributes
-## In state 2600, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
+## In state 1388, spurious reduction of production attributes ->
+## In state 1389, spurious reduction of production attributes -> attribute attributes
+## In state 2578, spurious reduction of production constructor_declaration_leading_bar -> BAR UIDENT generalized_constructor_arguments attributes
+## In state 2598, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 ##
-## Ends in an error in state: 1809.
+## Ends in an error in state: 1810.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_declaration_details -> LIDENT optional_type_parameters type_kind constraints . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -12122,7 +12093,7 @@ implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 ##
-## Ends in an error in state: 1319.
+## Ends in an error in state: 1336.
 ##
 ## label_declarations -> label_declarations COMMA . label_declaration [ RBRACE COMMA ]
 ## opt_comma -> COMMA . [ RBRACE ]
@@ -12137,7 +12108,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2604.
+## Ends in an error in state: 2602.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12155,12 +12126,12 @@ implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1316, spurious reduction of production _poly_type -> core_type
-## In state 1317, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1315, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 1313, spurious reduction of production attributes ->
-## In state 1314, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 1323, spurious reduction of production label_declarations -> label_declaration
+## In state 1333, spurious reduction of production _poly_type -> core_type
+## In state 1334, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1332, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 1330, spurious reduction of production attributes ->
+## In state 1331, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 1340, spurious reduction of production label_declarations -> label_declaration
 ##
 
 Expecting one of the following:
@@ -12169,7 +12140,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1307.
+## Ends in an error in state: 1324.
 ##
 ## label_declaration -> mutable_flag LIDENT COLON . poly_type attributes [ RBRACE COMMA ]
 ##
@@ -12181,7 +12152,7 @@ Expecting a type name describing this field
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 1306.
+## Ends in an error in state: 1323.
 ##
 ## label_declaration -> mutable_flag LIDENT . COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -12194,7 +12165,7 @@ Expecting ":"
 
 implementation: TYPE LIDENT EQUAL LBRACE MUTABLE LET
 ##
-## Ends in an error in state: 1305.
+## Ends in an error in state: 1322.
 ##
 ## label_declaration -> mutable_flag . LIDENT COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -12207,7 +12178,7 @@ Expecting a type field definition in the form of:
 
 implementation: TYPE LIDENT EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2603.
+## Ends in an error in state: 2601.
 ##
 ## type_kind -> EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -12220,7 +12191,7 @@ Expecting at least one type field definition in the form of:
 
     implementation: TYPE LIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 2567.
+## Ends in an error in state: 2565.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
 ## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
@@ -12234,7 +12205,7 @@ Expecting at least one type field definition in the form of:
 
 implementation: TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 2566.
+## Ends in an error in state: 2564.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL PRIVATE . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12262,7 +12233,7 @@ implementation: TYPE LIDENT EQUAL UIDENT WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 ##
-## Ends in an error in state: 2577.
+## Ends in an error in state: 2575.
 ##
 ## constructor_declaration_leading_bar -> BAR . UIDENT generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
 ## constructor_declaration_leading_bar -> BAR . LPAREN RPAREN generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
@@ -12278,7 +12249,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 2616.
+## Ends in an error in state: 2614.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12290,17 +12261,17 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDO
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1261, spurious reduction of production attributes ->
-## In state 1262, spurious reduction of production attributes -> attribute attributes
-## In state 1314, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 1323, spurious reduction of production label_declarations -> label_declaration
+## In state 1278, spurious reduction of production attributes ->
+## In state 1279, spurious reduction of production attributes -> attribute attributes
+## In state 1331, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 1340, spurious reduction of production label_declarations -> label_declaration
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2615.
+## Ends in an error in state: 2613.
 ##
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -12312,7 +12283,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 ##
-## Ends in an error in state: 2610.
+## Ends in an error in state: 2608.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL core_type EQUAL PRIVATE . constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12325,7 +12296,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2598.
+## Ends in an error in state: 2596.
 ##
 ## constructor_declarations -> constructor_declaration_no_leading_bar . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations -> constructor_declaration_no_leading_bar . constructor_declarations_leading_bar [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12337,16 +12308,16 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1382, spurious reduction of production attributes ->
-## In state 1383, spurious reduction of production attributes -> attribute attributes
-## In state 2562, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
+## In state 1388, spurious reduction of production attributes ->
+## In state 1389, spurious reduction of production attributes -> attribute attributes
+## In state 2560, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2608.
+## Ends in an error in state: 2606.
 ##
 ## type_kind -> EQUAL core_type EQUAL . constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type EQUAL . PRIVATE constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12361,7 +12332,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 2607.
+## Ends in an error in state: 2605.
 ##
 ## type_kind -> EQUAL core_type . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type . EQUAL constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12377,11 +12348,11 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 728, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 722, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 724, spurious reduction of production _core_type -> core_type2
-## In state 735, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 723, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 643, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 637, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 639, spurious reduction of production _core_type -> core_type2
+## In state 650, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 638, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
@@ -12409,7 +12380,7 @@ implementation: TYPE LIDENT EQUAL WITH
 
 implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1804.
+## Ends in an error in state: 1805.
 ##
 ## _structure_item_without_item_extension_sugar -> many_type_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -12421,9 +12392,9 @@ implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1359, spurious reduction of production post_item_attributes ->
-## In state 1360, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2622, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 1379, spurious reduction of production post_item_attributes ->
+## In state 1380, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2620, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
@@ -12480,7 +12451,7 @@ implementation: TYPE LIDENT PLUS WITH
 
 implementation: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 2626.
+## Ends in an error in state: 2624.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12492,7 +12463,7 @@ implementation: TYPE LIDENT PLUSEQ BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 2625.
+## Ends in an error in state: 2623.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12504,7 +12475,7 @@ implementation: TYPE LIDENT PLUSEQ PRIVATE BANG
 
 implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 2628.
+## Ends in an error in state: 2626.
 ##
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_rebind [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -12517,7 +12488,7 @@ implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 2624.
+## Ends in an error in state: 2622.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12565,7 +12536,7 @@ Expecting one of the following:
 
 implementation: TYPE UIDENT DOT WITH
 ##
-## Ends in an error in state: 1922.
+## Ends in an error in state: 1894.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -12579,7 +12550,7 @@ implementation: TYPE UIDENT DOT WITH
 
 implementation: TYPE UIDENT WITH
 ##
-## Ends in an error in state: 1921.
+## Ends in an error in state: 1893.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -12618,7 +12589,7 @@ implementation: TYPE WITH
 
 implementation: UIDENT AMPERAMPER WITH
 ##
-## Ends in an error in state: 1031.
+## Ends in an error in state: 1039.
 ##
 ## _expr -> expr AMPERAMPER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12630,7 +12601,7 @@ implementation: UIDENT AMPERAMPER WITH
 
 implementation: UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 1029.
+## Ends in an error in state: 1037.
 ##
 ## _expr -> expr AMPERSAND . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12642,7 +12613,7 @@ implementation: UIDENT AMPERSAND WITH
 
 implementation: UIDENT BARBAR WITH
 ##
-## Ends in an error in state: 1027.
+## Ends in an error in state: 1035.
 ##
 ## _expr -> expr BARBAR . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12654,7 +12625,7 @@ implementation: UIDENT BARBAR WITH
 
 implementation: UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1033.
+## Ends in an error in state: 1041.
 ##
 ## _expr -> expr COLONEQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12666,7 +12637,7 @@ implementation: UIDENT COLONEQUAL WITH
 
 implementation: UIDENT DOT LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 1169.
+## Ends in an error in state: 1175.
 ##
 ## lbl_expr -> label_longident . COLON expr [ COMMA ]
 ## lbl_expr -> label_longident . [ COMMA ]
@@ -12680,7 +12651,7 @@ implementation: UIDENT DOT LBRACE LIDENT WITH
 
 implementation: UIDENT DOT LBRACE WITH
 ##
-## Ends in an error in state: 1149.
+## Ends in an error in state: 1155.
 ##
 ## _simple_expr -> mod_longident DOT LBRACE . RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12694,7 +12665,7 @@ implementation: UIDENT DOT LBRACE WITH
 
 implementation: UIDENT DOT LBRACELESS WITH
 ##
-## Ends in an error in state: 1144.
+## Ends in an error in state: 1150.
 ##
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12707,7 +12678,7 @@ implementation: UIDENT DOT LBRACELESS WITH
 
 implementation: UIDENT DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1134.
+## Ends in an error in state: 1140.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12719,7 +12690,7 @@ implementation: UIDENT DOT LBRACKET WITH
 
 implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 1119.
+## Ends in an error in state: 1125.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12732,23 +12703,23 @@ implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1122, spurious reduction of production expr_optional_constraint -> expr
-## In state 1118, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1128, spurious reduction of production expr_optional_constraint -> expr
+## In state 1124, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LBRACKETBAR WITH
 ##
-## Ends in an error in state: 1117.
+## Ends in an error in state: 1123.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12761,7 +12732,7 @@ implementation: UIDENT DOT LBRACKETBAR WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 816.
+## Ends in an error in state: 827.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12781,7 +12752,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 814.
+## Ends in an error in state: 825.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12794,7 +12765,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 813.
+## Ends in an error in state: 824.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -12809,19 +12780,19 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 790, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 794, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 791, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 777, spurious reduction of production _module_expr -> simple_module_expr
-## In state 796, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 795, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 754, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 758, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 755, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 736, spurious reduction of production _module_expr -> simple_module_expr
+## In state 760, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 759, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN MODULE WITH
 ##
-## Ends in an error in state: 812.
+## Ends in an error in state: 823.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON package_type RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12834,7 +12805,7 @@ implementation: UIDENT DOT LPAREN MODULE WITH
 
 implementation: UIDENT DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1098.
+## Ends in an error in state: 1104.
 ##
 ## expr_comma_list -> expr_optional_constraint . COMMA expr_optional_constraint [ RPAREN COMMA ]
 ##
@@ -12845,22 +12816,22 @@ implementation: UIDENT DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1114, spurious reduction of production expr_optional_constraint -> expr
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1120, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN WITH
 ##
-## Ends in an error in state: 811.
+## Ends in an error in state: 822.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN . expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12877,7 +12848,7 @@ implementation: UIDENT DOT LPAREN WITH
 
 implementation: UIDENT DOT WITH
 ##
-## Ends in an error in state: 810.
+## Ends in an error in state: 821.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12903,7 +12874,7 @@ implementation: UIDENT DOT WITH
 
 implementation: UIDENT GREATER WITH
 ##
-## Ends in an error in state: 1023.
+## Ends in an error in state: 1031.
 ##
 ## _expr -> expr GREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr GREATER . GREATER expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -12916,7 +12887,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP0 WITH
 ##
-## Ends in an error in state: 1021.
+## Ends in an error in state: 1029.
 ##
 ## _expr -> expr INFIXOP0 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12928,7 +12899,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP1 WITH
 ##
-## Ends in an error in state: 1017.
+## Ends in an error in state: 1025.
 ##
 ## _expr -> expr INFIXOP1 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12940,7 +12911,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP2 WITH
 ##
-## Ends in an error in state: 1015.
+## Ends in an error in state: 1023.
 ##
 ## _expr -> expr INFIXOP2 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12952,7 +12923,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP3 WITH
 ##
-## Ends in an error in state: 1001.
+## Ends in an error in state: 1009.
 ##
 ## _expr -> expr INFIXOP3 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12964,7 +12935,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP4 WITH
 ##
-## Ends in an error in state: 869.
+## Ends in an error in state: 880.
 ##
 ## _expr -> expr INFIXOP4 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12988,7 +12959,7 @@ Expecting an attribute id
 
 implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2440.
+## Ends in an error in state: 2438.
 ##
 ## attribute -> LBRACKETAT attr_id payload . RBRACKET [ error WITH UIDENT STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARRBRACKET BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12999,23 +12970,23 @@ implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1886, spurious reduction of production post_item_attributes ->
-## In state 1887, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1888, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1802, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1795, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1803, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1796, spurious reduction of production structure -> structure_item
-## In state 1892, spurious reduction of production payload -> structure
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1858, spurious reduction of production post_item_attributes ->
+## In state 1859, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1860, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1803, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1796, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1804, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1797, spurious reduction of production structure -> structure_item
+## In state 1864, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
@@ -13034,7 +13005,7 @@ Expecting an attributed id
 
 implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2437.
+## Ends in an error in state: 2435.
 ##
 ## item_attribute -> LBRACKETATAT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13045,30 +13016,30 @@ implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1886, spurious reduction of production post_item_attributes ->
-## In state 1887, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1888, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1802, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1795, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1803, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1796, spurious reduction of production structure -> structure_item
-## In state 1892, spurious reduction of production payload -> structure
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1858, spurious reduction of production post_item_attributes ->
+## In state 1859, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1860, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1803, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1796, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1804, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1797, spurious reduction of production structure -> structure_item
+## In state 1864, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
 
 implementation: UIDENT LESS WITH
 ##
-## Ends in an error in state: 1019.
+## Ends in an error in state: 1027.
 ##
 ## _expr -> expr LESS . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13080,7 +13051,7 @@ Expecting an expression
 
 implementation: UIDENT LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1013.
+## Ends in an error in state: 1021.
 ##
 ## _expr -> expr LESSDOTDOTGREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13129,7 +13100,7 @@ Expecting one of the following:
 
 implementation: UIDENT MINUS WITH
 ##
-## Ends in an error in state: 1011.
+## Ends in an error in state: 1019.
 ##
 ## _expr -> expr MINUS . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13141,7 +13112,7 @@ Expecting an expression
 
 implementation: UIDENT MINUSDOT WITH
 ##
-## Ends in an error in state: 1009.
+## Ends in an error in state: 1017.
 ##
 ## _expr -> expr MINUSDOT . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13153,7 +13124,7 @@ Expecting an expression
 
 implementation: UIDENT OR WITH
 ##
-## Ends in an error in state: 1007.
+## Ends in an error in state: 1015.
 ##
 ## _expr -> expr OR . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13165,7 +13136,7 @@ Expecting an expression
 
 implementation: UIDENT PERCENT WITH
 ##
-## Ends in an error in state: 999.
+## Ends in an error in state: 1007.
 ##
 ## _expr -> expr PERCENT . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13177,7 +13148,7 @@ Expecting an expression
 
 implementation: UIDENT PLUS WITH
 ##
-## Ends in an error in state: 1005.
+## Ends in an error in state: 1013.
 ##
 ## _expr -> expr PLUS . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13189,7 +13160,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSDOT WITH
 ##
-## Ends in an error in state: 1003.
+## Ends in an error in state: 1011.
 ##
 ## _expr -> expr PLUSDOT . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13201,7 +13172,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 997.
+## Ends in an error in state: 1005.
 ##
 ## _expr -> expr PLUSEQ . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13213,7 +13184,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1076.
+## Ends in an error in state: 1082.
 ##
 ## _expr -> expr QUESTION expr COLON . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13225,7 +13196,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT SEMI
 ##
-## Ends in an error in state: 1075.
+## Ends in an error in state: 1081.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -13260,14 +13231,14 @@ implementation: UIDENT QUESTION UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 950, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13276,7 +13247,7 @@ Expecting one of the following:
 
 implementation: UIDENT QUESTION WITH
 ##
-## Ends in an error in state: 884.
+## Ends in an error in state: 895.
 ##
 ## _expr -> expr QUESTION . expr COLON expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13288,7 +13259,7 @@ Expecting an expression
 
 implementation: UIDENT RBRACKET
 ##
-## Ends in an error in state: 2654.
+## Ends in an error in state: 2652.
 ##
 ## implementation -> structure . EOF [ # ]
 ##
@@ -13299,29 +13270,29 @@ implementation: UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1886, spurious reduction of production post_item_attributes ->
-## In state 1887, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1888, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1802, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1795, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1803, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1796, spurious reduction of production structure -> structure_item
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1858, spurious reduction of production post_item_attributes ->
+## In state 1859, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1860, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1803, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1796, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1804, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1797, spurious reduction of production structure -> structure_item
 ##
 
 Invalid token
 
 implementation: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 1890.
+## Ends in an error in state: 1862.
 ##
 ## structure -> structure_item SEMI . structure [ RBRACKET RBRACE EOF ]
 ##
@@ -13333,7 +13304,7 @@ Expecting a structure item
 
 implementation: UIDENT SHARP WITH
 ##
-## Ends in an error in state: 517.
+## Ends in an error in state: 796.
 ##
 ## _simple_expr -> simple_expr SHARP . label [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -13345,7 +13316,7 @@ Expecting an identifier
 
 implementation: UIDENT STAR WITH
 ##
-## Ends in an error in state: 867.
+## Ends in an error in state: 878.
 ##
 ## _expr -> expr STAR . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13357,7 +13328,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 2221.
+## Ends in an error in state: 1207.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13392,14 +13363,14 @@ implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 770, spurious reduction of production constr_longident -> mod_longident
-## In state 942, spurious reduction of production _simple_expr -> constr_longident
-## In state 837, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 827, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 912, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 922, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 951, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 921, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 744, spurious reduction of production constr_longident -> mod_longident
+## In state 950, spurious reduction of production _simple_expr -> constr_longident
+## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13408,7 +13379,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 2220.
+## Ends in an error in state: 1206.
 ##
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -13420,7 +13391,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2218.
+## Ends in an error in state: 1204.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13456,14 +13427,14 @@ implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13472,7 +13443,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2217.
+## Ends in an error in state: 1203.
 ##
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -13485,7 +13456,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2215.
+## Ends in an error in state: 1201.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13521,14 +13492,14 @@ implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 809, spurious reduction of production constr_longident -> mod_longident
-## In state 872, spurious reduction of production _simple_expr -> constr_longident
-## In state 842, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 819, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 852, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 881, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 851, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 820, spurious reduction of production constr_longident -> mod_longident
+## In state 883, spurious reduction of production _simple_expr -> constr_longident
+## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13537,7 +13508,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 511.
+## Ends in an error in state: 792.
 ##
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -13550,7 +13521,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT WITH
 ##
-## Ends in an error in state: 510.
+## Ends in an error in state: 791.
 ##
 ## _simple_expr -> simple_expr DOT . label_longident [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]

--- a/src/reason_parser.messages
+++ b/src/reason_parser.messages
@@ -42,7 +42,7 @@
 
 use_file: SHARP LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2847.
+## Ends in an error in state: 2853.
 ##
 ## _use_file -> toplevel_directive SEMI . use_file [ # ]
 ##
@@ -54,7 +54,7 @@ use_file: SHARP LIDENT SEMI WITH
 
 use_file: SHARP LIDENT TRUE WITH
 ##
-## Ends in an error in state: 2846.
+## Ends in an error in state: 2852.
 ##
 ## _use_file -> toplevel_directive . SEMI use_file [ # ]
 ## _use_file -> toplevel_directive . EOF [ # ]
@@ -67,7 +67,7 @@ use_file: SHARP LIDENT TRUE WITH
 
 use_file: UIDENT RPAREN
 ##
-## Ends in an error in state: 2849.
+## Ends in an error in state: 2855.
 ##
 ## _use_file -> structure_item . SEMI use_file [ # ]
 ## _use_file -> structure_item . EOF [ # ]
@@ -79,28 +79,28 @@ use_file: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 950, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2838, spurious reduction of production post_item_attributes ->
-## In state 2839, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 2840, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 2818, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 2812, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 2842, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 2819, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 940, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 861, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 949, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2844, spurious reduction of production post_item_attributes ->
+## In state 2845, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 2846, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 2824, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 2810, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 2848, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 2825, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 use_file: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2850.
+## Ends in an error in state: 2856.
 ##
 ## _use_file -> structure_item SEMI . use_file [ # ]
 ##
@@ -112,7 +112,7 @@ use_file: UIDENT SEMI WITH
 
 use_file: WITH
 ##
-## Ends in an error in state: 2843.
+## Ends in an error in state: 2849.
 ##
 ## use_file' -> . use_file [ # ]
 ##
@@ -124,7 +124,7 @@ use_file: WITH
 
 toplevel_phrase: SHARP UIDENT EOF
 ##
-## Ends in an error in state: 2810.
+## Ends in an error in state: 2808.
 ##
 ## _toplevel_phrase -> toplevel_directive . SEMI [ # ]
 ##
@@ -135,14 +135,14 @@ toplevel_phrase: SHARP UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2712, spurious reduction of production toplevel_directive -> SHARP ident
+## In state 2716, spurious reduction of production toplevel_directive -> SHARP ident
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 ##
-## Ends in an error in state: 2719.
+## Ends in an error in state: 2723.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ SEMI EOF DOT ]
 ## val_longident -> mod_longident DOT . val_ident [ SEMI EOF ]
@@ -155,7 +155,7 @@ toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 
 toplevel_phrase: SHARP UIDENT UIDENT WITH
 ##
-## Ends in an error in state: 2718.
+## Ends in an error in state: 2722.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ SEMI EOF DOT ]
 ## toplevel_directive -> SHARP ident mod_longident . [ SEMI EOF ]
@@ -169,7 +169,7 @@ toplevel_phrase: SHARP UIDENT UIDENT WITH
 
 toplevel_phrase: SHARP UIDENT WITH
 ##
-## Ends in an error in state: 2712.
+## Ends in an error in state: 2716.
 ##
 ## toplevel_directive -> SHARP ident . [ SEMI EOF ]
 ## toplevel_directive -> SHARP ident . STRING [ SEMI EOF ]
@@ -187,7 +187,7 @@ toplevel_phrase: SHARP UIDENT WITH
 
 toplevel_phrase: SHARP WITH
 ##
-## Ends in an error in state: 2711.
+## Ends in an error in state: 2715.
 ##
 ## toplevel_directive -> SHARP . ident [ SEMI EOF ]
 ## toplevel_directive -> SHARP . ident STRING [ SEMI EOF ]
@@ -205,7 +205,7 @@ toplevel_phrase: SHARP WITH
 
 toplevel_phrase: UIDENT RPAREN
 ##
-## Ends in an error in state: 2813.
+## Ends in an error in state: 2811.
 ##
 ## _toplevel_phrase -> structure_item . SEMI [ # ]
 ##
@@ -216,28 +216,28 @@ toplevel_phrase: UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 950, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2838, spurious reduction of production post_item_attributes ->
-## In state 2839, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 2840, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 2818, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 2812, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 2842, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 2819, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 940, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 861, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 949, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2844, spurious reduction of production post_item_attributes ->
+## In state 2845, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 2846, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 2824, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 2810, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 2848, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 2825, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: WITH
 ##
-## Ends in an error in state: 2674.
+## Ends in an error in state: 2678.
 ##
 ## toplevel_phrase' -> . toplevel_phrase [ # ]
 ##
@@ -249,7 +249,7 @@ toplevel_phrase: WITH
 
 parse_pattern: EXCEPTION WITH
 ##
-## Ends in an error in state: 582.
+## Ends in an error in state: 615.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -261,7 +261,7 @@ parse_pattern: EXCEPTION WITH
 
 parse_pattern: LAZY WITH
 ##
-## Ends in an error in state: 571.
+## Ends in an error in state: 609.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -273,7 +273,7 @@ parse_pattern: LAZY WITH
 
 parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ##
-## Ends in an error in state: 662.
+## Ends in an error in state: 693.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error RBRACE COMMA BAR ]
 ## lbl_pattern -> label_longident COLON pattern . [ error RBRACE COMMA ]
@@ -285,14 +285,14 @@ parse_pattern: LBRACE LIDENT COLON UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 534, spurious reduction of production pattern -> pattern_without_or
+## In state 572, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 483.
+## Ends in an error in state: 521.
 ##
 ## lbl_pattern -> label_longident COLON . pattern [ error RBRACE COMMA ]
 ##
@@ -304,7 +304,7 @@ parse_pattern: LBRACE LIDENT COLON WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 568.
+## Ends in an error in state: 606.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -317,7 +317,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 478.
+## Ends in an error in state: 516.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA UNDERSCORE . opt_comma [ error RBRACE ]
 ##
@@ -329,7 +329,7 @@ parse_pattern: LBRACE LIDENT COMMA UNDERSCORE WITH
 
 parse_pattern: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 477.
+## Ends in an error in state: 515.
 ##
 ## lbl_pattern_list -> lbl_pattern COMMA . [ error RBRACE ]
 ## lbl_pattern_list -> lbl_pattern COMMA . UNDERSCORE opt_comma [ error RBRACE ]
@@ -343,7 +343,7 @@ parse_pattern: LBRACE LIDENT COMMA WITH
 
 parse_pattern: LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 482.
+## Ends in an error in state: 520.
 ##
 ## lbl_pattern -> label_longident . COLON pattern [ error RBRACE COMMA ]
 ## lbl_pattern -> label_longident . [ error RBRACE COMMA ]
@@ -356,7 +356,7 @@ parse_pattern: LBRACE LIDENT WITH
 
 parse_pattern: LBRACE WITH
 ##
-## Ends in an error in state: 567.
+## Ends in an error in state: 605.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -369,7 +369,7 @@ parse_pattern: LBRACE WITH
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 559.
+## Ends in an error in state: 597.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET BAR ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT pattern . [ error SEMI RBRACKET ]
@@ -381,14 +381,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 534, spurious reduction of production pattern -> pattern_without_or
+## In state 572, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA DOTDOTDOT WITH
 ##
-## Ends in an error in state: 558.
+## Ends in an error in state: 596.
 ##
 ## pattern_comma_list_extension -> pattern_comma_list COMMA DOTDOTDOT . pattern [ error SEMI RBRACKET ]
 ##
@@ -400,7 +400,7 @@ Expecting a valid list identifier
 
 parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 565.
+## Ends in an error in state: 603.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ COMMA ]
@@ -413,14 +413,14 @@ parse_pattern: LBRACKET UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 534, spurious reduction of production pattern -> pattern_without_or
+## In state 572, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 557.
+## Ends in an error in state: 595.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ COMMA ]
 ## pattern_comma_list_extension -> pattern_comma_list COMMA . DOTDOTDOT pattern [ error SEMI RBRACKET ]
@@ -434,7 +434,7 @@ parse_pattern: LBRACKET UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKET UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 566.
+## Ends in an error in state: 604.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI RBRACKET COMMA BAR ]
 ## pattern_comma_list -> pattern . [ COMMA ]
@@ -447,14 +447,14 @@ parse_pattern: LBRACKET UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 534, spurious reduction of production pattern -> pattern_without_or
+## In state 572, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 553.
+## Ends in an error in state: 591.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -467,7 +467,7 @@ parse_pattern: LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LBRACKET WITH
 ##
-## Ends in an error in state: 549.
+## Ends in an error in state: 587.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -481,7 +481,7 @@ parse_pattern: LBRACKET WITH
 
 parse_pattern: LBRACKETBAR MINUS WITH
 ##
-## Ends in an error in state: 442.
+## Ends in an error in state: 480.
 ##
 ## signed_constant -> MINUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> MINUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -497,7 +497,7 @@ parse_pattern: LBRACKETBAR MINUS WITH
 
 parse_pattern: LBRACKETBAR PLUS WITH
 ##
-## Ends in an error in state: 441.
+## Ends in an error in state: 479.
 ##
 ## signed_constant -> PLUS . INT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## signed_constant -> PLUS . FLOAT [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE DOTDOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -513,7 +513,7 @@ parse_pattern: LBRACKETBAR PLUS WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 670.
+## Ends in an error in state: 701.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern_comma_list COMMA pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -525,14 +525,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 534, spurious reduction of production pattern -> pattern_without_or
+## In state 572, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 669.
+## Ends in an error in state: 700.
 ##
 ## pattern_comma_list -> pattern_comma_list COMMA . pattern [ error SEMI COMMA BARRBRACKET ]
 ##
@@ -544,7 +544,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE COMMA WITH
 
 parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ##
-## Ends in an error in state: 674.
+## Ends in an error in state: 705.
 ##
 ## _or_pattern -> pattern . BAR pattern [ error SEMI COMMA BARRBRACKET BAR ]
 ## pattern_comma_list -> pattern . [ error SEMI COMMA BARRBRACKET ]
@@ -556,14 +556,14 @@ parse_pattern: LBRACKETBAR UNDERSCORE RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 534, spurious reduction of production pattern -> pattern_without_or
+## In state 572, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 685.
+## Ends in an error in state: 716.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -576,7 +576,7 @@ parse_pattern: LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LBRACKETBAR WITH
 ##
-## Ends in an error in state: 440.
+## Ends in an error in state: 478.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -590,7 +590,7 @@ parse_pattern: LBRACKETBAR WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 2454.
+## Ends in an error in state: 2458.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -608,7 +608,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 2453.
+## Ends in an error in state: 2457.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -621,7 +621,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2452.
+## Ends in an error in state: 2456.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -639,7 +639,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2451.
+## Ends in an error in state: 2455.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -652,7 +652,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2450.
+## Ends in an error in state: 2454.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -665,7 +665,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2449.
+## Ends in an error in state: 2453.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -678,7 +678,7 @@ parse_pattern: LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN EXCEPTION WITH
 ##
-## Ends in an error in state: 498.
+## Ends in an error in state: 536.
 ##
 ## _pattern_without_or -> EXCEPTION . pattern_without_or [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -690,7 +690,7 @@ parse_pattern: LPAREN EXCEPTION WITH
 
 parse_pattern: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 484.
+## Ends in an error in state: 522.
 ##
 ## _pattern_without_or -> LAZY . simple_pattern [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ##
@@ -702,7 +702,7 @@ parse_pattern: LPAREN LAZY WITH
 
 parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 473.
+## Ends in an error in state: 511.
 ##
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE lbl_pattern_list . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -715,7 +715,7 @@ parse_pattern: LPAREN LBRACE LIDENT COMMA UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 468.
+## Ends in an error in state: 506.
 ##
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list RBRACE [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACE . lbl_pattern_list error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -728,7 +728,7 @@ parse_pattern: LPAREN LBRACE WITH
 
 parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 ##
-## Ends in an error in state: 664.
+## Ends in an error in state: 695.
 ##
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET pattern_comma_list_extension opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -741,7 +741,7 @@ parse_pattern: LPAREN LBRACKET UNDERSCORE SEMI RBRACE
 
 parse_pattern: LPAREN LBRACKET WITH
 ##
-## Ends in an error in state: 466.
+## Ends in an error in state: 504.
 ##
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi RBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKET . pattern_comma_list_extension opt_semi error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -755,7 +755,7 @@ parse_pattern: LPAREN LBRACKET WITH
 
 parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 ##
-## Ends in an error in state: 671.
+## Ends in an error in state: 702.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR pattern_comma_list opt_semi . error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -768,7 +768,7 @@ parse_pattern: LPAREN LBRACKETBAR UNDERSCORE SEMI BARBAR
 
 parse_pattern: LPAREN LBRACKETBAR WITH
 ##
-## Ends in an error in state: 465.
+## Ends in an error in state: 503.
 ##
 ## _simple_pattern_not_ident -> LBRACKETBAR . pattern_comma_list opt_semi BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LBRACKETBAR . BARRBRACKET [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -782,7 +782,7 @@ parse_pattern: LPAREN LBRACKETBAR WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 680.
+## Ends in an error in state: 711.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -800,7 +800,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCOR
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 679.
+## Ends in an error in state: 710.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -813,7 +813,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 678.
+## Ends in an error in state: 709.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -831,7 +831,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 677.
+## Ends in an error in state: 708.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -844,7 +844,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 676.
+## Ends in an error in state: 707.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -857,7 +857,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 675.
+## Ends in an error in state: 706.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -870,7 +870,7 @@ parse_pattern: LPAREN LPAREN COLONCOLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 452.
+## Ends in an error in state: 490.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT COLON . package_type error [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -883,7 +883,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT COLON WITH
 
 parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 450.
+## Ends in an error in state: 488.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE UIDENT . COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -897,7 +897,7 @@ parse_pattern: LPAREN LPAREN MODULE UIDENT WITH
 
 parse_pattern: LPAREN LPAREN MODULE WITH
 ##
-## Ends in an error in state: 449.
+## Ends in an error in state: 487.
 ##
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN MODULE . UIDENT COLON package_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -911,7 +911,7 @@ parse_pattern: LPAREN LPAREN MODULE WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 656.
+## Ends in an error in state: 687.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -926,7 +926,7 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 546.
+## Ends in an error in state: 584.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -944,17 +944,17 @@ parse_pattern: LPAREN LPAREN UNDERSCORE COMMA UNDERSCORE COLON LESSDOTDOTGREATER
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 623, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
-## In state 630, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 629, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 620, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 654, spurious reduction of production _pattern_optional_constraint -> pattern COLON core_type
+## In state 661, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 660, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 651, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 448.
+## Ends in an error in state: 486.
 ##
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## _pattern_without_or -> LPAREN . COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
@@ -978,7 +978,7 @@ parse_pattern: LPAREN LPAREN WITH
 
 parse_pattern: LPAREN MINUS WITH
 ##
-## Ends in an error in state: 462.
+## Ends in an error in state: 500.
 ##
 ## operator -> MINUS . [ RPAREN ]
 ## signed_constant -> MINUS . INT [ error RPAREN LBRACKETAT DOTDOT COMMA COLONCOLON COLON BAR AS ]
@@ -1008,7 +1008,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 260, spurious reduction of production ident -> UIDENT
-## In state 460, spurious reduction of production mty_longident -> ident
+## In state 498, spurious reduction of production mty_longident -> ident
 ##
 
 <SYNTAX ERROR>
@@ -1029,7 +1029,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WHILE
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2447.
+## Ends in an error in state: 2451.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ error RPAREN ]
 ##
@@ -1041,7 +1041,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2446.
+## Ends in an error in state: 2450.
 ##
 ## package_type_cstrs -> package_type_cstr . [ error RPAREN ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ error RPAREN ]
@@ -1054,12 +1054,12 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LESSDOTD
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 643, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 637, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 639, spurious reduction of production _core_type -> core_type2
-## In state 650, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 638, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2444, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 674, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 668, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 670, spurious reduction of production _core_type -> core_type2
+## In state 681, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 669, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 2448, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
@@ -1218,7 +1218,7 @@ parse_pattern: LPAREN SHARP WITH
 
 parse_pattern: LPAREN STRING DOTDOT WITH
 ##
-## Ends in an error in state: 506.
+## Ends in an error in state: 544.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ##
@@ -1230,7 +1230,7 @@ parse_pattern: LPAREN STRING DOTDOT WITH
 
 parse_pattern: LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 515.
+## Ends in an error in state: 553.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ error WITH UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER EOF DOT COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS AND ]
 ##
@@ -1242,7 +1242,7 @@ parse_pattern: LPAREN UIDENT DOT WITH
 
 parse_pattern: LPAREN UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 485.
+## Ends in an error in state: 523.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1264,7 +1264,7 @@ parse_pattern: LPAREN UIDENT LPAREN WITH
 
 parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 525.
+## Ends in an error in state: 563.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETAT COMMA COLONCOLON COLON BARRBRACKET BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ error UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET RBRACE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE COMMA COLONCOLON COLON CHAR BARRBRACKET BAR BACKQUOTE AS ]
@@ -1277,7 +1277,7 @@ parse_pattern: LPAREN UIDENT UNDERSCORE WITH
 
 parse_pattern: LPAREN UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 560.
+## Ends in an error in state: 598.
 ##
 ## _or_pattern -> pattern BAR . pattern [ error SEMI RPAREN RBRACKET RBRACE COMMA COLON BARRBRACKET BAR ]
 ##
@@ -1302,7 +1302,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LBRACKET BACKQUOTE LIDENT GREATER
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 179, spurious reduction of production attributes ->
-## In state 2527, spurious reduction of production tag_field -> name_tag attributes
+## In state 2531, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
@@ -1512,7 +1512,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LESS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2442.
+## Ends in an error in state: 2446.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1695,7 +1695,7 @@ parse_pattern: LPAREN UNDERSCORE COLON SHARP WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS QUOTE WITH
 ##
-## Ends in an error in state: 645.
+## Ends in an error in state: 676.
 ##
 ## _core_type -> core_type2 AS QUOTE . ident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AND ]
 ##
@@ -1707,7 +1707,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS QUOTE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS WITH
 ##
-## Ends in an error in state: 644.
+## Ends in an error in state: 675.
 ##
 ## _core_type -> core_type2 AS . QUOTE ident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AND ]
 ##
@@ -1719,7 +1719,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE AS WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 640.
+## Ends in an error in state: 671.
 ##
 ## _core_type2 -> core_type2 EQUALGREATER . core_type2 [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BARRBRACKET BAR AS AND ]
 ##
@@ -1731,7 +1731,7 @@ parse_pattern: LPAREN UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 634.
+## Ends in an error in state: 665.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ COMMA ]
 ## _simple_pattern_not_ident -> LPAREN pattern COLON . core_type RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1746,7 +1746,7 @@ parse_pattern: LPAREN UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 548.
+## Ends in an error in state: 586.
 ##
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1758,7 +1758,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA CHAR COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 622.
+## Ends in an error in state: 653.
 ##
 ## _pattern_optional_constraint -> pattern COLON . core_type [ RPAREN COMMA ]
 ##
@@ -1770,7 +1770,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE COLON WITH
 
 parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ##
-## Ends in an error in state: 573.
+## Ends in an error in state: 611.
 ##
 ## _simple_pattern_not_ident -> LPAREN pattern_two_or_more_comma_list . RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## pattern_two_or_more_comma_list -> pattern_two_or_more_comma_list . COMMA pattern_optional_constraint [ RPAREN COMMA ]
@@ -1782,18 +1782,18 @@ parse_pattern: LPAREN UNDERSCORE COMMA UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 610, spurious reduction of production pattern -> pattern_without_or
-## In state 621, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 630, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 629, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
-## In state 620, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
+## In state 641, spurious reduction of production pattern -> pattern_without_or
+## In state 652, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 661, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 660, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 651, spurious reduction of production pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA pattern_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 576.
+## Ends in an error in state: 614.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint COMMA . pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1805,7 +1805,7 @@ parse_pattern: LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 575.
+## Ends in an error in state: 613.
 ##
 ## pattern_two_or_more_comma_list -> pattern_optional_constraint . COMMA pattern_optional_constraint [ RPAREN COMMA ]
 ##
@@ -1816,10 +1816,10 @@ parse_pattern: LPAREN UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 534, spurious reduction of production pattern -> pattern_without_or
-## In state 631, spurious reduction of production _pattern_optional_constraint -> pattern
-## In state 630, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
-## In state 629, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
+## In state 572, spurious reduction of production pattern -> pattern_without_or
+## In state 662, spurious reduction of production _pattern_optional_constraint -> pattern
+## In state 661, spurious reduction of production mark_position_pat(_pattern_optional_constraint) -> _pattern_optional_constraint
+## In state 660, spurious reduction of production pattern_optional_constraint -> mark_position_pat(_pattern_optional_constraint)
 ##
 
 <SYNTAX ERROR>
@@ -1894,7 +1894,7 @@ parse_pattern: SHARP WITH
 
 parse_pattern: STRING DOTDOT WITH
 ##
-## Ends in an error in state: 588.
+## Ends in an error in state: 620.
 ##
 ## _simple_pattern_not_ident -> signed_constant DOTDOT . signed_constant [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ##
@@ -1906,7 +1906,7 @@ parse_pattern: STRING DOTDOT WITH
 
 parse_pattern: UIDENT DOT WITH
 ##
-## Ends in an error in state: 597.
+## Ends in an error in state: 436.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ WITH WHEN UNDERSCORE UIDENT TRUE STRING SLASHGREATER SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN GREATER FLOAT FALSE EQUALGREATER EQUAL EOF DOT COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS AND ]
 ##
@@ -1918,7 +1918,7 @@ parse_pattern: UIDENT DOT WITH
 
 parse_pattern: UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 572.
+## Ends in an error in state: 610.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS OPTIONAL_NO_DEFAULT NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1940,7 +1940,7 @@ parse_pattern: UIDENT LPAREN WITH
 
 parse_pattern: UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 606.
+## Ends in an error in state: 637.
 ##
 ## _pattern_without_or -> constr_longident simple_pattern_list . [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## simple_pattern_list -> simple_pattern_list . simple_pattern [ WHEN UNDERSCORE UIDENT TRUE STRING SHARP SEMI RPAREN RBRACKET PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKETAT LBRACKET LBRACE INT64 INT32 INT IN FLOAT FALSE EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON CHAR BAR BACKQUOTE AS ]
@@ -1953,7 +1953,7 @@ parse_pattern: UIDENT UNDERSCORE WITH
 
 parse_pattern: UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 624.
+## Ends in an error in state: 655.
 ##
 ## _or_pattern -> pattern BAR . pattern [ WHEN SEMI RPAREN RBRACKET IN EQUALGREATER EQUAL EOF COMMA COLON BAR ]
 ##
@@ -1965,7 +1965,7 @@ parse_pattern: UNDERSCORE BAR WITH
 
 parse_pattern: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2671.
+## Ends in an error in state: 2675.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EOF BAR ]
 ## parse_pattern -> pattern . EOF [ # ]
@@ -1977,14 +1977,14 @@ parse_pattern: UNDERSCORE WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 610, spurious reduction of production pattern -> pattern_without_or
+## In state 641, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 parse_pattern: WITH
 ##
-## Ends in an error in state: 2670.
+## Ends in an error in state: 2674.
 ##
 ## parse_pattern' -> . parse_pattern [ # ]
 ##
@@ -1996,7 +1996,7 @@ parse_pattern: WITH
 
 parse_expression: UIDENT SEMI
 ##
-## Ends in an error in state: 2668.
+## Ends in an error in state: 2672.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -2031,21 +2031,21 @@ parse_expression: UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 950, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 940, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 861, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 949, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 parse_expression: WITH
 ##
-## Ends in an error in state: 2666.
+## Ends in an error in state: 2670.
 ##
 ## parse_expression' -> . parse_expression [ # ]
 ##
@@ -2057,7 +2057,7 @@ parse_expression: WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 2521.
+## Ends in an error in state: 2525.
 ##
 ## tag_field -> name_tag opt_ampersand . amper_type_list attributes [ RBRACKET GREATER BAR ]
 ##
@@ -2069,7 +2069,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 ##
-## Ends in an error in state: 2524.
+## Ends in an error in state: 2528.
 ##
 ## amper_type_list -> amper_type_list AMPERSAND . core_type [ RBRACKET LBRACKETAT GREATER BAR AMPERSAND ]
 ##
@@ -2081,7 +2081,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ##
-## Ends in an error in state: 2528.
+## Ends in an error in state: 2532.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET tag_field . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field -> tag_field . [ BAR ]
@@ -2094,7 +2094,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 179, spurious reduction of production attributes ->
-## In state 2527, spurious reduction of production tag_field -> name_tag attributes
+## In state 2531, spurious reduction of production tag_field -> name_tag attributes
 ##
 
 <SYNTAX ERROR>
@@ -2126,7 +2126,7 @@ parse_core_type: LBRACKET BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 2532.
+## Ends in an error in state: 2536.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2139,7 +2139,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 2531.
+## Ends in an error in state: 2535.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2151,7 +2151,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE WITH
 ##
-## Ends in an error in state: 2530.
+## Ends in an error in state: 2534.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field . BAR row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2189,7 +2189,7 @@ parse_core_type: LBRACKETGREATER BAR ASSERT
 
 parse_core_type: LBRACKETGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 2534.
+## Ends in an error in state: 2538.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2240,7 +2240,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2539.
+## Ends in an error in state: 2543.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER name_tag_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## name_tag_list -> name_tag_list . name_tag [ RBRACKET BACKQUOTE ]
@@ -2253,7 +2253,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 ##
-## Ends in an error in state: 2538.
+## Ends in an error in state: 2542.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER . name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2265,7 +2265,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE WITH
 ##
-## Ends in an error in state: 2536.
+## Ends in an error in state: 2540.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . GREATER name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2317,7 +2317,7 @@ parse_core_type: LESS LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 ##
-## Ends in an error in state: 1328.
+## Ends in an error in state: 1254.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ##
@@ -2329,7 +2329,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT DOT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1325.
+## Ends in an error in state: 1251.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ RBRACE LBRACKETAT GREATER EQUAL COMMA ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -2342,7 +2342,7 @@ parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 
 parse_core_type: LESS LIDENT COLON QUOTE UIDENT QUOTE WITH
 ##
-## Ends in an error in state: 1326.
+## Ends in an error in state: 1252.
 ##
 ## typevar_list -> typevar_list QUOTE . ident [ QUOTE DOT ]
 ##
@@ -2385,11 +2385,11 @@ parse_core_type: LESS LIDENT COLON UNDERSCORE WITH
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1333, spurious reduction of production _poly_type -> core_type
-## In state 1334, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1332, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 2541, spurious reduction of production attributes ->
-## In state 2542, spurious reduction of production field -> label COLON poly_type attributes
+## In state 1259, spurious reduction of production _poly_type -> core_type
+## In state 1260, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1258, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 2545, spurious reduction of production attributes ->
+## In state 2546, spurious reduction of production field -> label COLON poly_type attributes
 ##
 
 <SYNTAX ERROR>
@@ -2432,7 +2432,7 @@ parse_core_type: LESS WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2551.
+## Ends in an error in state: 2555.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2444,7 +2444,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 ##
-## Ends in an error in state: 2549.
+## Ends in an error in state: 2553.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION EQUALGREATER . core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2456,7 +2456,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION EQUALGREATER WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 ##
-## Ends in an error in state: 2548.
+## Ends in an error in state: 2552.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type QUESTION . EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ##
@@ -2468,7 +2468,7 @@ parse_core_type: LIDENT COLONCOLON UNDERSCORE QUESTION WITH
 
 parse_core_type: LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2547.
+## Ends in an error in state: 2551.
 ##
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . QUESTION EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## _core_type2 -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER core_type2 [ WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2560,7 +2560,7 @@ parse_core_type: LPAREN MODULE UIDENT SEMI
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2556.
+## Ends in an error in state: 2560.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ RPAREN COLONGREATER ]
 ##
@@ -2572,7 +2572,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER A
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2555.
+## Ends in an error in state: 2559.
 ##
 ## package_type_cstrs -> package_type_cstr . [ RPAREN COLONGREATER ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ RPAREN COLONGREATER ]
@@ -2590,7 +2590,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LESSDOTDOTGREATER W
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2553, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 2557, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
@@ -2669,7 +2669,7 @@ parse_core_type: LPAREN UNDERSCORE COMMA WITH
 
 parse_core_type: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1269.
+## Ends in an error in state: 1195.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN core_type_comma_list . RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## core_type_comma_list -> core_type_comma_list . COMMA core_type [ RPAREN COMMA ]
@@ -2708,7 +2708,7 @@ parse_core_type: QUOTE WITH
 
 parse_core_type: SHARP LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 2558.
+## Ends in an error in state: 2562.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP class_longident non_arrowed_simple_core_type_list . [ WITH SEMI RPAREN RBRACKET RBRACE QUESTION LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2875,7 +2875,7 @@ parse_core_type: UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2664.
+## Ends in an error in state: 2668.
 ##
 ## parse_core_type -> core_type . EOF [ # ]
 ##
@@ -2898,7 +2898,7 @@ parse_core_type: UNDERSCORE WITH
 
 parse_core_type: WITH
 ##
-## Ends in an error in state: 2662.
+## Ends in an error in state: 2666.
 ##
 ## parse_core_type' -> . parse_core_type [ # ]
 ##
@@ -2910,7 +2910,7 @@ parse_core_type: WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 ##
-## Ends in an error in state: 2013.
+## Ends in an error in state: 2011.
 ##
 ## and_class_description -> AND . class_description_details post_item_attributes [ SEMI AND ]
 ##
@@ -2922,7 +2922,7 @@ interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ##
-## Ends in an error in state: 2012.
+## Ends in an error in state: 2010.
 ##
 ## _signature_item -> many_class_descriptions . [ SEMI ]
 ## many_class_descriptions -> many_class_descriptions . and_class_description [ SEMI AND ]
@@ -2934,22 +2934,22 @@ interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1751, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1755, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1749, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1753, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1764, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1762, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
-## In state 1982, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
-## In state 1983, spurious reduction of production post_item_attributes ->
-## In state 1984, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
+## In state 1677, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1681, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1675, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1679, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1690, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1688, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1958, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
+## In state 1959, spurious reduction of production post_item_attributes ->
+## In state 1960, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 1981.
+## Ends in an error in state: 1957.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters COLON . class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -2961,7 +2961,7 @@ interface: CLASS LIDENT COLON WITH
 
 interface: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1510.
+## Ends in an error in state: 1436.
 ##
 ## type_parameter -> type_variance . type_variable [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLON CHAR BACKQUOTE ]
 ##
@@ -2973,7 +2973,7 @@ interface: CLASS LIDENT PLUS WITH
 
 interface: CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1980.
+## Ends in an error in state: 1956.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters . COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS COLON ]
@@ -2986,7 +2986,7 @@ interface: CLASS LIDENT WITH
 
 interface: CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 1978.
+## Ends in an error in state: 1954.
 ##
 ## class_description_details -> virtual_flag . LIDENT class_type_parameters COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -2998,7 +2998,7 @@ interface: CLASS VIRTUAL LET
 
 interface: CLASS WITH
 ##
-## Ends in an error in state: 1969.
+## Ends in an error in state: 1945.
 ##
 ## many_class_descriptions -> CLASS . class_description_details post_item_attributes [ SEMI AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ SEMI AND ]
@@ -3011,7 +3011,7 @@ interface: CLASS WITH
 
 interface: EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1872.
+## Ends in an error in state: 1927.
 ##
 ## extension_constructor_declaration -> UIDENT . generalized_constructor_arguments attributes [ SEMI LBRACKETATAT BAR ]
 ##
@@ -3023,7 +3023,7 @@ interface: EXCEPTION UIDENT WITH
 
 interface: EXCEPTION WITH
 ##
-## Ends in an error in state: 1966.
+## Ends in an error in state: 1926.
 ##
 ## sig_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ SEMI ]
 ##
@@ -3035,7 +3035,7 @@ interface: EXCEPTION WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1961.
+## Ends in an error in state: 1921.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3047,7 +3047,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1960.
+## Ends in an error in state: 1920.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3070,7 +3070,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 interface: EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1959.
+## Ends in an error in state: 1919.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3082,7 +3082,7 @@ interface: EXTERNAL LIDENT COLON WITH
 
 interface: EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 1958.
+## Ends in an error in state: 1918.
 ##
 ## _signature_item -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3094,7 +3094,7 @@ interface: EXTERNAL LIDENT WITH
 
 interface: EXTERNAL WITH
 ##
-## Ends in an error in state: 1957.
+## Ends in an error in state: 1917.
 ##
 ## _signature_item -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -3106,7 +3106,7 @@ interface: EXTERNAL WITH
 
 interface: INCLUDE LBRACE OPEN UIDENT WITH
 ##
-## Ends in an error in state: 1985.
+## Ends in an error in state: 1961.
 ##
 ## signature -> signature_item . SEMI signature [ error RBRACE ]
 ##
@@ -3117,18 +3117,18 @@ interface: INCLUDE LBRACE OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1898, spurious reduction of production post_item_attributes ->
-## In state 1899, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 1990, spurious reduction of production _signature_item -> open_statement
-## In state 2020, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 1991, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 1803, spurious reduction of production post_item_attributes ->
+## In state 1804, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 1991, spurious reduction of production _signature_item -> open_statement
+## In state 2018, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 1992, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 1986.
+## Ends in an error in state: 1962.
 ##
 ## signature -> signature_item SEMI . signature [ error RBRACE ]
 ##
@@ -3140,7 +3140,7 @@ interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 
 interface: INCLUDE LBRACE WITH
 ##
-## Ends in an error in state: 1905.
+## Ends in an error in state: 1800.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LBRACE . signature error [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3153,7 +3153,7 @@ interface: INCLUDE LBRACE WITH
 
 interface: INCLUDE LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 1247.
+## Ends in an error in state: 1173.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _simple_module_type -> LBRACE . signature error [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3166,7 +3166,7 @@ interface: INCLUDE LPAREN LBRACE WITH
 
 interface: INCLUDE LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 2129.
+## Ends in an error in state: 1745.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3182,7 +3182,7 @@ interface: INCLUDE LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 2053.
+## Ends in an error in state: 2069.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3198,7 +3198,7 @@ interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 2104.
+## Ends in an error in state: 2077.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3213,7 +3213,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LID
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2103.
+## Ends in an error in state: 2076.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3225,7 +3225,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WIT
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2102.
+## Ends in an error in state: 2075.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3237,7 +3237,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2101.
+## Ends in an error in state: 2074.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3253,22 +3253,22 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1811, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1840, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1836, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1809, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1841, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1837, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1810, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1842, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1838, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2100.
+## Ends in an error in state: 2073.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3280,7 +3280,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2099.
+## Ends in an error in state: 2072.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3292,7 +3292,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 1246.
+## Ends in an error in state: 1171.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3306,7 +3306,7 @@ interface: INCLUDE LPAREN LPAREN WITH
 
 interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2128.
+## Ends in an error in state: 2435.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF ]
@@ -3320,19 +3320,19 @@ interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2109, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2113, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2110, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1235, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2115, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2114, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1733, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1737, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1734, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1151, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1739, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1738, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN MODULE TYPE WITH
 ##
-## Ends in an error in state: 781.
+## Ends in an error in state: 431.
 ##
 ## _non_arrowed_module_type -> MODULE TYPE . module_expr [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3344,7 +3344,7 @@ interface: INCLUDE LPAREN MODULE TYPE WITH
 
 interface: INCLUDE LPAREN MODULE WITH
 ##
-## Ends in an error in state: 780.
+## Ends in an error in state: 430.
 ##
 ## _non_arrowed_module_type -> MODULE . TYPE module_expr [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3356,7 +3356,7 @@ interface: INCLUDE LPAREN MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 ##
-## Ends in an error in state: 458.
+## Ends in an error in state: 496.
 ##
 ## ident -> UIDENT . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## mod_ext2 -> mod_ext_longident DOT UIDENT . LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -3370,7 +3370,7 @@ interface: INCLUDE LPAREN UIDENT DOT UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT DOT WITH
 ##
-## Ends in an error in state: 457.
+## Ends in an error in state: 495.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -3384,7 +3384,7 @@ interface: INCLUDE LPAREN UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 2090.
+## Ends in an error in state: 1789.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3399,7 +3399,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2089.
+## Ends in an error in state: 1788.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3411,7 +3411,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 456.
+## Ends in an error in state: 494.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -3431,7 +3431,7 @@ interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UIDENT WHILE
 ##
-## Ends in an error in state: 779.
+## Ends in an error in state: 1172.
 ##
 ## functor_arg_name -> UIDENT . [ COLON ]
 ## ident -> UIDENT . [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3446,7 +3446,7 @@ interface: INCLUDE LPAREN UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 ##
-## Ends in an error in state: 2072.
+## Ends in an error in state: 1771.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3459,7 +3459,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2069.
+## Ends in an error in state: 1768.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ RPAREN LPAREN DOT ]
 ## mod_ext2 -> UIDENT LPAREN mod_ext_longident . RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3479,7 +3479,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UID
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 2068.
+## Ends in an error in state: 1767.
 ##
 ## mod_ext2 -> UIDENT LPAREN . mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ##
@@ -3504,7 +3504,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WIT
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 2066.
+## Ends in an error in state: 1765.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3516,7 +3516,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 2081.
+## Ends in an error in state: 1780.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3529,7 +3529,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 ##
-## Ends in an error in state: 2067.
+## Ends in an error in state: 1766.
 ##
 ## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ## mod_ext_longident -> UIDENT . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3542,7 +3542,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2082.
+## Ends in an error in state: 1781.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3554,7 +3554,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2065.
+## Ends in an error in state: 1764.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3567,7 +3567,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 2064.
+## Ends in an error in state: 1763.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3580,7 +3580,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 2085.
+## Ends in an error in state: 1784.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3592,7 +3592,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER A
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER EQUAL
 ##
-## Ends in an error in state: 2084.
+## Ends in an error in state: 1783.
 ##
 ## _module_type -> module_type WITH with_constraints . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## with_constraints -> with_constraints . AND with_constraint [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3605,20 +3605,20 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER E
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 643, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 637, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 639, spurious reduction of production _core_type -> core_type2
-## In state 650, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 638, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2060, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 2087, spurious reduction of production with_constraints -> with_constraint
+## In state 674, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 668, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 670, spurious reduction of production _core_type -> core_type2
+## In state 681, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 669, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1754, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1786, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 2059.
+## Ends in an error in state: 1753.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3630,7 +3630,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 2061.
+## Ends in an error in state: 1755.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3642,7 +3642,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ##
-## Ends in an error in state: 2063.
+## Ends in an error in state: 1757.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3655,19 +3655,19 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 643, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 637, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 639, spurious reduction of production _core_type -> core_type2
-## In state 650, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 638, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 2062, spurious reduction of production constraints ->
+## In state 674, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 668, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 670, spurious reduction of production _core_type -> core_type2
+## In state 681, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 669, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 1756, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ##
-## Ends in an error in state: 2058.
+## Ends in an error in state: 1750.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3679,14 +3679,14 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1362, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 1288, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 2056.
+## Ends in an error in state: 1748.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3699,7 +3699,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH WITH
 ##
-## Ends in an error in state: 2055.
+## Ends in an error in state: 1747.
 ##
 ## _module_type -> module_type WITH . with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3711,7 +3711,7 @@ interface: INCLUDE LPAREN UIDENT WITH WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2137.
+## Ends in an error in state: 2025.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3727,22 +3727,22 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COL
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1811, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1840, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1836, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1809, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1841, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1837, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1810, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1842, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1838, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2136.
+## Ends in an error in state: 2024.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3754,7 +3754,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2135.
+## Ends in an error in state: 2023.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3766,7 +3766,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2134.
+## Ends in an error in state: 2022.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3782,22 +3782,22 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1811, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1840, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1836, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1809, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1841, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1837, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1810, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1842, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1838, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2133.
+## Ends in an error in state: 1799.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3809,7 +3809,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2132.
+## Ends in an error in state: 1798.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3821,7 +3821,7 @@ interface: INCLUDE LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN WITH
 ##
-## Ends in an error in state: 778.
+## Ends in an error in state: 1741.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3835,7 +3835,7 @@ interface: INCLUDE LPAREN WITH
 
 interface: INCLUDE MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2403.
+## Ends in an error in state: 797.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF AND ]
@@ -3849,19 +3849,19 @@ interface: INCLUDE MODULE TYPE UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 754, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 758, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 755, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 736, spurious reduction of production _module_expr -> simple_module_expr
-## In state 760, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 759, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 809, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 813, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 810, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 796, spurious reduction of production _module_expr -> simple_module_expr
+## In state 815, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 814, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE MODULE TYPE WITH
 ##
-## Ends in an error in state: 435.
+## Ends in an error in state: 795.
 ##
 ## _non_arrowed_module_type -> MODULE TYPE . module_expr [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3873,7 +3873,7 @@ interface: INCLUDE MODULE TYPE WITH
 
 interface: INCLUDE MODULE WITH
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 794.
 ##
 ## _non_arrowed_module_type -> MODULE . TYPE module_expr [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3913,7 +3913,7 @@ interface: INCLUDE UIDENT DOT WITH
 
 interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1947.
+## Ends in an error in state: 1834.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3929,22 +3929,22 @@ interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1811, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1840, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1836, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1809, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1841, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1837, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1810, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1842, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1838, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1946.
+## Ends in an error in state: 1833.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4004,7 +4004,7 @@ interface: INCLUDE UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1937.
+## Ends in an error in state: 1824.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4016,7 +4016,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 1939.
+## Ends in an error in state: 1826.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4042,7 +4042,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1940.
+## Ends in an error in state: 1827.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4054,7 +4054,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1936.
+## Ends in an error in state: 1823.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4067,7 +4067,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 1935.
+## Ends in an error in state: 1822.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4080,7 +4080,7 @@ interface: INCLUDE UIDENT WITH MODULE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 ##
-## Ends in an error in state: 1943.
+## Ends in an error in state: 1830.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4092,7 +4092,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER AND WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ##
-## Ends in an error in state: 1942.
+## Ends in an error in state: 1829.
 ##
 ## _module_type -> module_type WITH with_constraints . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraints -> with_constraints . AND with_constraint [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4110,15 +4110,15 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER GREATER
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1931, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1945, spurious reduction of production with_constraints -> with_constraint
+## In state 1818, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1832, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1930.
+## Ends in an error in state: 1817.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4130,7 +4130,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1932.
+## Ends in an error in state: 1819.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4142,7 +4142,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ##
-## Ends in an error in state: 1934.
+## Ends in an error in state: 1821.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4160,14 +4160,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1933, spurious reduction of production constraints ->
+## In state 1820, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1928.
+## Ends in an error in state: 1751.
 ##
 ## with_type_binder -> EQUAL . [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
 ## with_type_binder -> EQUAL . PRIVATE [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET ]
@@ -4180,7 +4180,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1927.
+## Ends in an error in state: 1816.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4192,14 +4192,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1926, spurious reduction of production optional_type_parameters ->
+## In state 1815, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 1925.
+## Ends in an error in state: 1814.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4212,7 +4212,7 @@ interface: INCLUDE UIDENT WITH TYPE WITH
 
 interface: INCLUDE UIDENT WITH WITH
 ##
-## Ends in an error in state: 1924.
+## Ends in an error in state: 1813.
 ##
 ## _module_type -> module_type WITH . with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4224,7 +4224,7 @@ interface: INCLUDE UIDENT WITH WITH
 
 interface: INCLUDE WITH
 ##
-## Ends in an error in state: 1919.
+## Ends in an error in state: 1914.
 ##
 ## _signature_item -> INCLUDE . module_type post_item_attributes [ SEMI ]
 ##
@@ -4236,7 +4236,7 @@ interface: INCLUDE WITH
 
 interface: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 1908.
+## Ends in an error in state: 1847.
 ##
 ## _signature_item -> LET val_ident COLON . core_type post_item_attributes [ SEMI ]
 ##
@@ -4248,7 +4248,7 @@ interface: LET LIDENT COLON WITH
 
 interface: LET LIDENT WITH
 ##
-## Ends in an error in state: 1907.
+## Ends in an error in state: 1846.
 ##
 ## _signature_item -> LET val_ident . COLON core_type post_item_attributes [ SEMI ]
 ##
@@ -4260,7 +4260,7 @@ interface: LET LIDENT WITH
 
 interface: LET LPAREN WITH
 ##
-## Ends in an error in state: 616.
+## Ends in an error in state: 647.
 ##
 ## val_ident -> LPAREN . operator RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ##
@@ -4272,7 +4272,7 @@ interface: LET LPAREN WITH
 
 interface: MODULE REC UIDENT COLON LIDENT AND WITH
 ##
-## Ends in an error in state: 2000.
+## Ends in an error in state: 2001.
 ##
 ## and_module_rec_declaration -> AND . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4284,7 +4284,7 @@ interface: MODULE REC UIDENT COLON LIDENT AND WITH
 
 interface: MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1999.
+## Ends in an error in state: 2000.
 ##
 ## _signature_item -> many_module_rec_declarations . [ SEMI ]
 ## many_module_rec_declarations -> many_module_rec_declarations . and_module_rec_declaration [ SEMI AND ]
@@ -4296,16 +4296,16 @@ interface: MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1584, spurious reduction of production post_item_attributes ->
-## In state 1585, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2046, spurious reduction of production many_module_rec_declarations -> MODULE REC module_rec_declaration_details post_item_attributes
+## In state 1510, spurious reduction of production post_item_attributes ->
+## In state 1511, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1990, spurious reduction of production many_module_rec_declarations -> opt_let_module REC module_rec_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: MODULE REC UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 2003.
+## Ends in an error in state: 1988.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -4321,22 +4321,22 @@ interface: MODULE REC UIDENT COLON UIDENT RPAREN
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1811, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1840, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1836, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1809, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1841, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1837, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1810, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1842, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1838, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: MODULE REC UIDENT COLON WITH
 ##
-## Ends in an error in state: 2002.
+## Ends in an error in state: 1987.
 ##
 ## module_rec_declaration_details -> UIDENT COLON . module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4348,7 +4348,7 @@ interface: MODULE REC UIDENT COLON WITH
 
 interface: MODULE REC UIDENT WITH
 ##
-## Ends in an error in state: 2001.
+## Ends in an error in state: 1986.
 ##
 ## module_rec_declaration_details -> UIDENT . COLON module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4360,19 +4360,19 @@ interface: MODULE REC UIDENT WITH
 
 interface: MODULE REC WITH
 ##
-## Ends in an error in state: 2044.
+## Ends in an error in state: 1985.
 ##
-## many_module_rec_declarations -> MODULE REC . module_rec_declaration_details post_item_attributes [ SEMI AND ]
+## many_module_rec_declarations -> opt_let_module REC . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
 ## The known suffix of the stack is as follows:
-## MODULE REC
+## opt_let_module REC
 ##
 
 <SYNTAX ERROR>
 
 interface: MODULE UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 2027.
+## Ends in an error in state: 1974.
 ##
 ## _module_declaration -> COLON module_type . [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -4388,22 +4388,22 @@ interface: MODULE UIDENT COLON UIDENT RPAREN
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1811, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1840, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1836, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1809, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1841, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1837, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1810, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1842, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1838, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2026.
+## Ends in an error in state: 1973.
 ##
 ## _module_declaration -> COLON . module_type [ SEMI LBRACKETATAT ]
 ##
@@ -4415,19 +4415,19 @@ interface: MODULE UIDENT COLON WITH
 
 interface: MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2033.
+## Ends in an error in state: 1980.
 ##
-## _signature_item -> MODULE UIDENT EQUAL . mod_longident post_item_attributes [ SEMI ]
+## _signature_item -> opt_let_module UIDENT EQUAL . mod_longident post_item_attributes [ SEMI ]
 ##
 ## The known suffix of the stack is as follows:
-## MODULE UIDENT EQUAL
+## opt_let_module UIDENT EQUAL
 ##
 
 <SYNTAX ERROR>
 
 interface: MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2031.
+## Ends in an error in state: 1978.
 ##
 ## _module_declaration -> LPAREN RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4439,7 +4439,7 @@ interface: MODULE UIDENT LPAREN RPAREN WITH
 
 interface: MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2025.
+## Ends in an error in state: 1972.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4451,7 +4451,7 @@ interface: MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 
 interface: MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2024.
+## Ends in an error in state: 1971.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type . RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -4467,22 +4467,22 @@ interface: MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1811, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1840, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1836, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1809, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1841, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1837, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1810, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1842, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1838, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: MODULE UIDENT LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1904.
+## Ends in an error in state: 1970.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON . module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4494,7 +4494,7 @@ interface: MODULE UIDENT LPAREN UIDENT COLON WITH
 
 interface: MODULE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1903.
+## Ends in an error in state: 1969.
 ##
 ## _module_declaration -> LPAREN UIDENT . COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4506,7 +4506,7 @@ interface: MODULE UIDENT LPAREN UIDENT WITH
 
 interface: MODULE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1902.
+## Ends in an error in state: 1968.
 ##
 ## _module_declaration -> LPAREN . UIDENT COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_declaration -> LPAREN . RPAREN module_declaration [ SEMI LBRACKETATAT ]
@@ -4519,22 +4519,23 @@ interface: MODULE UIDENT LPAREN WITH
 
 interface: MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1901.
+## Ends in an error in state: 1967.
 ##
-## _signature_item -> MODULE UIDENT . module_declaration post_item_attributes [ SEMI ]
-## _signature_item -> MODULE UIDENT . EQUAL mod_longident post_item_attributes [ SEMI ]
+## _signature_item -> opt_let_module UIDENT . module_declaration post_item_attributes [ SEMI ]
+## _signature_item -> opt_let_module UIDENT . EQUAL mod_longident post_item_attributes [ SEMI ]
 ##
 ## The known suffix of the stack is as follows:
-## MODULE UIDENT
+## opt_let_module UIDENT
 ##
 
 <SYNTAX ERROR>
 
 interface: LET WITH
 ##
-## Ends in an error in state: 1906.
+## Ends in an error in state: 1845.
 ##
 ## _signature_item -> LET . val_ident COLON core_type post_item_attributes [ SEMI ]
+## opt_let_module -> LET . MODULE [ UIDENT REC ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET
@@ -4544,7 +4545,7 @@ interface: LET WITH
 
 interface: MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2040.
+## Ends in an error in state: 1808.
 ##
 ## _signature_item -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ SEMI ]
 ##
@@ -4556,7 +4557,7 @@ interface: MODULE TYPE UIDENT EQUAL WITH
 
 interface: MODULE TYPE WITH
 ##
-## Ends in an error in state: 2038.
+## Ends in an error in state: 1806.
 ##
 ## _signature_item -> MODULE TYPE . ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4569,13 +4570,11 @@ interface: MODULE TYPE WITH
 
 interface: MODULE WITH
 ##
-## Ends in an error in state: 1900.
+## Ends in an error in state: 1805.
 ##
-## _signature_item -> MODULE . UIDENT module_declaration post_item_attributes [ SEMI ]
-## _signature_item -> MODULE . UIDENT EQUAL mod_longident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE . TYPE ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ SEMI ]
-## many_module_rec_declarations -> MODULE . REC module_rec_declaration_details post_item_attributes [ SEMI AND ]
+## opt_let_module -> MODULE . [ UIDENT REC ]
 ##
 ## The known suffix of the stack is as follows:
 ## MODULE
@@ -4585,7 +4584,7 @@ interface: MODULE WITH
 
 interface: OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2656.
+## Ends in an error in state: 2660.
 ##
 ## signature -> signature_item . SEMI signature [ EOF ]
 ##
@@ -4596,18 +4595,18 @@ interface: OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1898, spurious reduction of production post_item_attributes ->
-## In state 1899, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 1990, spurious reduction of production _signature_item -> open_statement
-## In state 2020, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 1991, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 1803, spurious reduction of production post_item_attributes ->
+## In state 1804, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 1991, spurious reduction of production _signature_item -> open_statement
+## In state 2018, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 1992, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 1871.
+## Ends in an error in state: 2057.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4619,7 +4618,7 @@ interface: TYPE LIDENT PLUSEQ BAR WITH
 
 interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 1870.
+## Ends in an error in state: 2056.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4631,7 +4630,7 @@ interface: TYPE LIDENT PLUSEQ PRIVATE BANG
 
 interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 1889.
+## Ends in an error in state: 2059.
 ##
 ## sig_extension_constructors -> sig_extension_constructors BAR . extension_constructor_declaration [ SEMI LBRACKETATAT BAR ]
 ##
@@ -4643,7 +4642,7 @@ interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 interface: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 1869.
+## Ends in an error in state: 2055.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4655,7 +4654,7 @@ interface: TYPE LIDENT PLUSEQ WITH
 
 interface: TYPE LIDENT RBRACKET
 ##
-## Ends in an error in state: 1263.
+## Ends in an error in state: 1189.
 ##
 ## potentially_long_ident_and_optional_type_parameters -> LIDENT optional_type_parameters . [ PLUSEQ ]
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ SEMI LBRACKETATAT EOF AND ]
@@ -4667,14 +4666,14 @@ interface: TYPE LIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1250, spurious reduction of production optional_type_parameters ->
+## In state 1176, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2657.
+## Ends in an error in state: 2661.
 ##
 ## signature -> signature_item SEMI . signature [ EOF ]
 ##
@@ -4686,7 +4685,7 @@ interface: TYPE LIDENT SEMI WITH
 
 interface: TYPE NONREC LET
 ##
-## Ends in an error in state: 1249.
+## Ends in an error in state: 1175.
 ##
 ## many_type_declarations -> TYPE nonrec_flag . type_declaration_details post_item_attributes [ SEMI AND ]
 ## sig_type_extension -> TYPE nonrec_flag . potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
@@ -4699,7 +4698,7 @@ interface: TYPE NONREC LET
 
 interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ##
-## Ends in an error in state: 1868.
+## Ends in an error in state: 2054.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters . PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4710,15 +4709,15 @@ interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1362, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
-## In state 1366, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
+## In state 1288, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 1292, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
 ##
 
 <SYNTAX ERROR>
 
 interface: WITH
 ##
-## Ends in an error in state: 2655.
+## Ends in an error in state: 2659.
 ##
 ## interface' -> . interface [ # ]
 ##
@@ -4730,7 +4729,7 @@ interface: WITH
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1768.
+## Ends in an error in state: 1694.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4742,7 +4741,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WIT
 
 implementation: CLASS LIDENT COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1766.
+## Ends in an error in state: 1692.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4754,7 +4753,7 @@ implementation: CLASS LIDENT COLON LIDENT COLONCOLON WITH
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1759.
+## Ends in an error in state: 1685.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4766,7 +4765,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE 
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 1758.
+## Ends in an error in state: 1684.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4779,7 +4778,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE 
 
 implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1757.
+## Ends in an error in state: 1683.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4791,7 +4790,7 @@ implementation: CLASS LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: CLASS LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1760.
+## Ends in an error in state: 1686.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4803,7 +4802,7 @@ implementation: CLASS LIDENT COLON LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1756, spurious reduction of production type_longident -> LIDENT
+## In state 1682, spurious reduction of production type_longident -> LIDENT
 ## In state 280, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
 ## In state 287, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
 ## In state 285, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
@@ -4814,7 +4813,7 @@ implementation: CLASS LIDENT COLON LIDENT WITH
 
 implementation: CLASS LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1740.
+## Ends in an error in state: 1666.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4826,7 +4825,7 @@ implementation: CLASS LIDENT COLON NEW WITH
 
 implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1761.
+## Ends in an error in state: 1687.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4838,7 +4837,7 @@ implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT MINUS WITH
 ##
-## Ends in an error in state: 1523.
+## Ends in an error in state: 1449.
 ##
 ## signed_constant -> MINUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> MINUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -4855,7 +4854,7 @@ implementation: CLASS LIDENT MINUS WITH
 
 implementation: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1522.
+## Ends in an error in state: 1448.
 ##
 ## signed_constant -> PLUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
 ## signed_constant -> PLUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLON CHAR BACKQUOTE ]
@@ -4872,7 +4871,7 @@ implementation: CLASS LIDENT PLUS WITH
 
 implementation: CLASS LIDENT QUOTE WITH
 ##
-## Ends in an error in state: 1511.
+## Ends in an error in state: 1437.
 ##
 ## _type_variable -> QUOTE . ident [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLON CHAR BACKQUOTE ]
 ##
@@ -4884,7 +4883,7 @@ implementation: CLASS LIDENT QUOTE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1445.
+## Ends in an error in state: 1371.
 ##
 ## class_sig_body -> class_self_type . class_sig_fields opt_semi [ error RBRACE ]
 ##
@@ -4896,7 +4895,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 ##
-## Ends in an error in state: 1440.
+## Ends in an error in state: 1366.
 ##
 ## class_self_type -> AS core_type . SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -4919,7 +4918,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 ##
-## Ends in an error in state: 1439.
+## Ends in an error in state: 1365.
 ##
 ## class_self_type -> AS . core_type SEMI [ error VAL SEMI RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -4931,7 +4930,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1493.
+## Ends in an error in state: 1419.
 ##
 ## _class_sig_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4943,7 +4942,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1488.
+## Ends in an error in state: 1414.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT ]
 ## _class_sig_field -> INHERIT class_instance_type . [ error SEMI RBRACE ]
@@ -4956,16 +4955,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1486, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1492, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1484, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1412, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1418, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1410, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1480.
+## Ends in an error in state: 1406.
 ##
 ## _class_sig_field -> INHERIT . class_instance_type [ error SEMI RBRACE ]
 ## _class_sig_field -> INHERIT . class_instance_type item_attribute post_item_attributes [ error SEMI RBRACE ]
@@ -4978,7 +4977,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH RBRACKET WITH
 ##
-## Ends in an error in state: 1743.
+## Ends in an error in state: 1669.
 ##
 ## _class_instance_type -> LBRACE class_sig_body . RBRACE [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE class_sig_body . error [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4990,20 +4989,20 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1500, spurious reduction of production post_item_attributes ->
-## In state 1501, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
-## In state 1506, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
-## In state 1499, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
-## In state 1508, spurious reduction of production class_sig_fields -> class_sig_field
-## In state 1503, spurious reduction of production opt_semi ->
-## In state 1507, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
+## In state 1426, spurious reduction of production post_item_attributes ->
+## In state 1427, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
+## In state 1432, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
+## In state 1425, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
+## In state 1434, spurious reduction of production class_sig_fields -> class_sig_field
+## In state 1429, spurious reduction of production opt_semi ->
+## In state 1433, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 ##
-## Ends in an error in state: 1469.
+## Ends in an error in state: 1395.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label COLON . poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5015,7 +5014,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 ##
-## Ends in an error in state: 1468.
+## Ends in an error in state: 1394.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags label . COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5027,7 +5026,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 ##
-## Ends in an error in state: 1465.
+## Ends in an error in state: 1391.
 ##
 ## private_virtual_flags -> PRIVATE . [ LIDENT ]
 ## private_virtual_flags -> PRIVATE . VIRTUAL [ LIDENT ]
@@ -5040,7 +5039,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 ##
-## Ends in an error in state: 1467.
+## Ends in an error in state: 1393.
 ##
 ## _class_sig_field -> METHOD private_virtual_flags . label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5052,7 +5051,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL PRIVATE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 ##
-## Ends in an error in state: 1463.
+## Ends in an error in state: 1389.
 ##
 ## private_virtual_flags -> VIRTUAL . [ LIDENT ]
 ## private_virtual_flags -> VIRTUAL . PRIVATE [ LIDENT ]
@@ -5065,7 +5064,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 ##
-## Ends in an error in state: 1462.
+## Ends in an error in state: 1388.
 ##
 ## _class_sig_field -> METHOD . private_virtual_flags label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5077,7 +5076,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE METHOD WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1460.
+## Ends in an error in state: 1386.
 ##
 ## value_type -> label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5089,7 +5088,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1459.
+## Ends in an error in state: 1385.
 ##
 ## value_type -> label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5101,7 +5100,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1455.
+## Ends in an error in state: 1381.
 ##
 ## value_type -> MUTABLE virtual_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5113,7 +5112,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 ##
-## Ends in an error in state: 1454.
+## Ends in an error in state: 1380.
 ##
 ## value_type -> MUTABLE virtual_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5125,7 +5124,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 ##
-## Ends in an error in state: 1453.
+## Ends in an error in state: 1379.
 ##
 ## value_type -> MUTABLE virtual_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5137,7 +5136,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1452.
+## Ends in an error in state: 1378.
 ##
 ## value_type -> MUTABLE . virtual_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5149,7 +5148,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1450.
+## Ends in an error in state: 1376.
 ##
 ## value_type -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5161,7 +5160,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1449.
+## Ends in an error in state: 1375.
 ##
 ## value_type -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5173,7 +5172,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1448.
+## Ends in an error in state: 1374.
 ##
 ## value_type -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5185,7 +5184,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1447.
+## Ends in an error in state: 1373.
 ##
 ## value_type -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5197,7 +5196,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 ##
-## Ends in an error in state: 1446.
+## Ends in an error in state: 1372.
 ##
 ## _class_sig_field -> VAL . value_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5209,7 +5208,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 ##
-## Ends in an error in state: 1742.
+## Ends in an error in state: 1668.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5222,7 +5221,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ##
-## Ends in an error in state: 1786.
+## Ends in an error in state: 1712.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## _non_arrowed_class_constructor_type -> class_instance_type . [ EQUALGREATER ]
@@ -5234,16 +5233,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1751, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1755, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1749, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1677, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1681, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1675, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1752.
+## Ends in an error in state: 1678.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
@@ -5256,7 +5255,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 ##
-## Ends in an error in state: 1751.
+## Ends in an error in state: 1677.
 ##
 ## _class_instance_type -> clty_longident . [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5269,7 +5268,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1780.
+## Ends in an error in state: 1706.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN class_constructor_type . RPAREN [ EQUALGREATER ]
 ##
@@ -5280,19 +5279,19 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1751, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1755, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1749, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1753, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1764, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1762, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1677, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1681, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1675, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1679, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1690, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1688, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 ##
-## Ends in an error in state: 1779.
+## Ends in an error in state: 1705.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN . class_constructor_type RPAREN [ EQUALGREATER ]
 ##
@@ -5304,7 +5303,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 ##
-## Ends in an error in state: 1747.
+## Ends in an error in state: 1673.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5318,7 +5317,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 ##
-## Ends in an error in state: 1746.
+## Ends in an error in state: 1672.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5338,7 +5337,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 
 implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ##
-## Ends in an error in state: 817.
+## Ends in an error in state: 780.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag simple_expr . simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ UIDENT TRUE STRING SHARPOP SHARP PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE DOT CHAR BANG BACKQUOTE ]
@@ -5357,17 +5356,17 @@ implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 846, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 834, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FOR UNDERSCORE WHEN
 ##
-## Ends in an error in state: 811.
+## Ends in an error in state: 774.
 ##
 ## _expr -> FOR pattern . IN simple_expr direction_flag simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _or_pattern -> pattern . BAR pattern [ IN BAR ]
@@ -5379,14 +5378,14 @@ implementation: FOR UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 610, spurious reduction of production pattern -> pattern_without_or
+## In state 641, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2373.
+## Ends in an error in state: 733.
 ##
 ## _simple_expr -> simple_expr . DOT label_longident [ UNDERSCORE UIDENT TRUE STRING SHARPOP SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
 ## _simple_expr -> simple_expr . DOT LPAREN expr RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARPOP SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOT COLON CHAR BACKQUOTE ]
@@ -5405,17 +5404,17 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 846, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 834, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 701.
+## Ends in an error in state: 732.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern EQUAL . simple_expr [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ##
@@ -5427,7 +5426,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE EQUAL WITH
 
 implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 699.
+## Ends in an error in state: 730.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON simple_pattern . OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -5441,7 +5440,7 @@ implementation: FUN LIDENT COLONCOLON UNDERSCORE WITH
 
 implementation: FUN LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 698.
+## Ends in an error in state: 729.
 ##
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## labeled_simple_pattern -> LIDENT COLONCOLON . simple_pattern OPTIONAL_NO_DEFAULT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -5455,7 +5454,7 @@ implementation: FUN LIDENT COLONCOLON WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2404.
+## Ends in an error in state: 2092.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -5471,22 +5470,22 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1811, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1840, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1836, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1809, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1841, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1837, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1810, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1842, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1838, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 433.
+## Ends in an error in state: 793.
 ##
 ## functor_arg -> LPAREN functor_arg_name COLON . module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -5498,7 +5497,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 432.
+## Ends in an error in state: 792.
 ##
 ## functor_arg -> LPAREN functor_arg_name . COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
 ##
@@ -5510,7 +5509,7 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE WITH
 
 implementation: INCLUDE FUN LPAREN WITH
 ##
-## Ends in an error in state: 428.
+## Ends in an error in state: 788.
 ##
 ## functor_arg -> LPAREN . RPAREN [ LPAREN EQUALGREATER COLON ]
 ## functor_arg -> LPAREN . functor_arg_name COLON module_type RPAREN [ LPAREN EQUALGREATER COLON ]
@@ -5523,7 +5522,7 @@ implementation: INCLUDE FUN LPAREN WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1772.
+## Ends in an error in state: 1698.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5535,16 +5534,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1596, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1602, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1594, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1522, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1528, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1520, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1771.
+## Ends in an error in state: 1697.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5556,7 +5555,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1770.
+## Ends in an error in state: 1696.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type . EQUAL class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5567,19 +5566,19 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1751, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1755, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1749, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1753, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1764, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1762, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1677, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1681, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1675, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1679, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1690, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1688, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 1739.
+## Ends in an error in state: 1665.
 ##
 ## _constrained_class_declaration -> COLON . class_constructor_type EQUAL class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5591,7 +5590,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1833.
+## Ends in an error in state: 1881.
 ##
 ## and_class_declaration -> AND . class_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5603,7 +5602,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1832.
+## Ends in an error in state: 1880.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_class_declarations -> many_class_declarations . and_class_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5615,16 +5614,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1379, spurious reduction of production post_item_attributes ->
-## In state 1380, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1795, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
+## In state 1305, spurious reduction of production post_item_attributes ->
+## In state 1306, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1721, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1738.
+## Ends in an error in state: 1664.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5636,16 +5635,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1596, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1602, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1594, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1522, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1528, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1520, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1524.
+## Ends in an error in state: 1450.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5657,7 +5656,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 1784.
+## Ends in an error in state: 1710.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5669,16 +5668,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1596, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1602, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1594, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1522, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1528, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1520, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1783.
+## Ends in an error in state: 1709.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5690,7 +5689,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1782.
+## Ends in an error in state: 1708.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type . EQUALGREATER class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5702,7 +5701,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT R
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1778.
+## Ends in an error in state: 1704.
 ##
 ## class_fun_return -> COLON . non_arrowed_class_constructor_type EQUALGREATER class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5714,7 +5713,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 1777.
+## Ends in an error in state: 1703.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> EQUALGREATER class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5726,16 +5725,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1596, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1602, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1594, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1522, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1528, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1520, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1776.
+## Ends in an error in state: 1702.
 ##
 ## class_fun_return -> EQUALGREATER . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5747,7 +5746,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1775.
+## Ends in an error in state: 1701.
 ##
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_return [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5760,7 +5759,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1521.
+## Ends in an error in state: 1447.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . constrained_class_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5775,7 +5774,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1828.
+## Ends in an error in state: 1876.
 ##
 ## and_class_type_declaration -> AND . class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5787,7 +5786,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1827.
+## Ends in an error in state: 1875.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_type_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5799,16 +5798,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND R
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1379, spurious reduction of production post_item_attributes ->
-## In state 1380, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1518, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
+## In state 1305, spurious reduction of production post_item_attributes ->
+## In state 1306, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1444, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1509.
+## Ends in an error in state: 1435.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5820,16 +5819,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1486, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1492, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1484, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1412, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1418, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1410, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1436.
+## Ends in an error in state: 1362.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5841,7 +5840,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1433.
+## Ends in an error in state: 1359.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters . EQUAL class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS EQUAL ]
@@ -5854,7 +5853,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 ##
-## Ends in an error in state: 1431.
+## Ends in an error in state: 1357.
 ##
 ## class_type_declaration_details -> virtual_flag . LIDENT class_type_parameters EQUAL class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5866,7 +5865,7 @@ implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE WITH
 ##
-## Ends in an error in state: 1430.
+## Ends in an error in state: 1356.
 ##
 ## many_class_type_declarations -> CLASS TYPE . class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5878,7 +5877,7 @@ implementation: INCLUDE LBRACE CLASS TYPE WITH
 
 implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 1519.
+## Ends in an error in state: 1445.
 ##
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters constrained_class_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5892,7 +5891,7 @@ implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 
 implementation: INCLUDE LBRACE CLASS WITH
 ##
-## Ends in an error in state: 1428.
+## Ends in an error in state: 1354.
 ##
 ## many_class_declarations -> CLASS . class_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5905,7 +5904,7 @@ implementation: INCLUDE LBRACE CLASS WITH
 
 implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 ##
-## Ends in an error in state: 1403.
+## Ends in an error in state: 1329.
 ##
 ## extension_constructor_declaration -> LPAREN . RPAREN generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## extension_constructor_rebind -> LPAREN . RPAREN EQUAL constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -5918,7 +5917,7 @@ implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1390.
+## Ends in an error in state: 1316.
 ##
 ## generalized_constructor_arguments -> COLON . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -5930,7 +5929,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 ##
-## Ends in an error in state: 1385.
+## Ends in an error in state: 1311.
 ##
 ## constr_longident -> LBRACKET . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -5942,7 +5941,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 1384.
+## Ends in an error in state: 1310.
 ##
 ## constr_longident -> LPAREN . RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -5954,7 +5953,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1383.
+## Ends in an error in state: 1309.
 ##
 ## extension_constructor_rebind -> UIDENT EQUAL . constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ##
@@ -5966,7 +5965,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1393.
+## Ends in an error in state: 1319.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list COLON . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -5978,7 +5977,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1392.
+## Ends in an error in state: 1318.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . COLON core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
@@ -5992,7 +5991,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1382.
+## Ends in an error in state: 1308.
 ##
 ## extension_constructor_declaration -> UIDENT . generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## extension_constructor_rebind -> UIDENT . EQUAL constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -6005,7 +6004,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 
 implementation: INCLUDE LBRACE EXCEPTION WITH
 ##
-## Ends in an error in state: 1381.
+## Ends in an error in state: 1307.
 ##
 ## str_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## str_exception_declaration -> EXCEPTION . extension_constructor_rebind post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
@@ -6018,7 +6017,7 @@ implementation: INCLUDE LBRACE EXCEPTION WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 ##
-## Ends in an error in state: 1375.
+## Ends in an error in state: 1301.
 ##
 ## primitive_declaration -> STRING . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ## primitive_declaration -> STRING . primitive_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
@@ -6031,7 +6030,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WIT
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1374.
+## Ends in an error in state: 1300.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6043,7 +6042,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1373.
+## Ends in an error in state: 1299.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6066,7 +6065,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1372.
+## Ends in an error in state: 1298.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6078,7 +6077,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 1371.
+## Ends in an error in state: 1297.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6090,7 +6089,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 
 implementation: INCLUDE LBRACE EXTERNAL WITH
 ##
-## Ends in an error in state: 1370.
+## Ends in an error in state: 1296.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6102,7 +6101,7 @@ implementation: INCLUDE LBRACE EXTERNAL WITH
 
 implementation: INCLUDE LBRACE MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2426.
+## Ends in an error in state: 429.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6114,7 +6113,7 @@ implementation: INCLUDE LBRACE MODULE TYPE UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE MODULE TYPE WITH
 ##
-## Ends in an error in state: 2424.
+## Ends in an error in state: 427.
 ##
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE . ident post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## _structure_item_without_item_extension_sugar -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
@@ -6127,7 +6126,7 @@ implementation: INCLUDE LBRACE MODULE TYPE WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1236.
+## Ends in an error in state: 1152.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER module_expr . [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6142,7 +6141,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHIL
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1234.
+## Ends in an error in state: 1150.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER . module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6154,7 +6153,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1233.
+## Ends in an error in state: 1149.
 ##
 ## _module_expr -> FUN functor_args . EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## functor_args -> functor_args . functor_arg [ LPAREN EQUALGREATER ]
@@ -6167,7 +6166,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 
 implementation: INCLUDE LPAREN FUN WITH
 ##
-## Ends in an error in state: 1232.
+## Ends in an error in state: 1148.
 ##
 ## _module_expr -> FUN . functor_args EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6179,7 +6178,7 @@ implementation: INCLUDE LPAREN FUN WITH
 
 implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2105.
+## Ends in an error in state: 2078.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -6195,23 +6194,23 @@ implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 260, spurious reduction of production ident -> UIDENT
-## In state 460, spurious reduction of production mty_longident -> ident
-## In state 2052, spurious reduction of production _simple_module_type -> mty_longident
-## In state 2096, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 2092, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 2050, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 2097, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 2093, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 2051, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 2098, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 2094, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 498, spurious reduction of production mty_longident -> ident
+## In state 1744, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1795, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1791, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1742, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1796, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1792, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1743, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1797, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1793, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1245.
+## Ends in an error in state: 1170.
 ##
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6224,7 +6223,7 @@ implementation: INCLUDE LPAREN UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2126.
+## Ends in an error in state: 2433.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -6241,19 +6240,19 @@ implementation: INCLUDE LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2109, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2113, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2110, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1235, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2115, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2114, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1733, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1737, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1734, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1151, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1739, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1738, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1223.
+## Ends in an error in state: 1164.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6273,7 +6272,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLON
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1222.
+## Ends in an error in state: 1163.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6285,7 +6284,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 1218.
+## Ends in an error in state: 2431.
 ##
 ## _module_expr -> LPAREN VAL expr COLON . error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6299,7 +6298,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1216.
+## Ends in an error in state: 1158.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6319,7 +6318,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1214.
+## Ends in an error in state: 2429.
 ##
 ## _module_expr -> LPAREN VAL expr COLONGREATER . error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6332,7 +6331,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 1211.
+## Ends in an error in state: 2427.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -6373,21 +6372,21 @@ implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN VAL WITH
 ##
-## Ends in an error in state: 783.
+## Ends in an error in state: 433.
 ##
 ## _module_expr -> LPAREN VAL . expr COLON error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _module_expr -> LPAREN VAL . expr COLONGREATER error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6405,7 +6404,7 @@ implementation: INCLUDE LPAREN VAL WITH
 
 implementation: INCLUDE LPAREN WITH
 ##
-## Ends in an error in state: 782.
+## Ends in an error in state: 432.
 ##
 ## _module_expr -> LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _module_expr -> LPAREN . VAL expr COLON error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6428,7 +6427,7 @@ implementation: INCLUDE LPAREN WITH
 
 implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ##
-## Ends in an error in state: 2124.
+## Ends in an error in state: 2083.
 ##
 ## _simple_module_expr -> LBRACE structure . RBRACE [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6439,29 +6438,29 @@ implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1858, spurious reduction of production post_item_attributes ->
-## In state 1859, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1860, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1803, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1796, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1804, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1797, spurious reduction of production structure -> structure_item
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1906, spurious reduction of production post_item_attributes ->
+## In state 1907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1856, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1722, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1909, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1857, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1723, spurious reduction of production structure -> structure_item
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 1226.
+## Ends in an error in state: 1146.
 ##
 ## _simple_module_expr -> LBRACE . structure RBRACE [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6473,7 +6472,7 @@ implementation: INCLUDE UIDENT LBRACE WITH
 
 implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1242.
+## Ends in an error in state: 1167.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -6490,19 +6489,19 @@ implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2109, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2113, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2110, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1235, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2115, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2114, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1733, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1737, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1734, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1151, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1739, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1738, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 1241.
+## Ends in an error in state: 1160.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type COLONGREATER package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6515,7 +6514,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1240.
+## Ends in an error in state: 1157.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6527,7 +6526,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 1239.
+## Ends in an error in state: 1155.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -6565,21 +6564,21 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 950, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 940, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 861, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 949, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL WITH
 ##
-## Ends in an error in state: 1238.
+## Ends in an error in state: 1154.
 ##
 ## _simple_module_expr -> LPAREN VAL . expr RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL . expr COLON package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6594,7 +6593,7 @@ implementation: INCLUDE UIDENT LPAREN VAL WITH
 
 implementation: INCLUDE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1237.
+## Ends in an error in state: 1153.
 ##
 ## _module_expr -> module_expr LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN . module_expr COLON module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6614,7 +6613,7 @@ implementation: INCLUDE UIDENT LPAREN WITH
 
 implementation: INCLUDE UIDENT WHILE
 ##
-## Ends in an error in state: 2109.
+## Ends in an error in state: 1733.
 ##
 ## _simple_module_expr -> mod_longident . [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF DOT COLON AND ]
@@ -6627,7 +6626,7 @@ implementation: INCLUDE UIDENT WHILE
 
 implementation: INCLUDE WITH
 ##
-## Ends in an error in state: 1231.
+## Ends in an error in state: 1147.
 ##
 ## _structure_item_without_item_extension_sugar -> INCLUDE . module_expr post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6639,7 +6638,7 @@ implementation: INCLUDE WITH
 
 implementation: LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1618.
+## Ends in an error in state: 1544.
 ##
 ## class_self_pattern_and_structure -> class_self_pattern . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -6651,7 +6650,7 @@ implementation: LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: LBRACE AS UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1607.
+## Ends in an error in state: 1533.
 ##
 ## _class_self_pattern -> AS pattern . SEMI [ error VAL RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ## _or_pattern -> pattern . BAR pattern [ SEMI BAR ]
@@ -6663,14 +6662,14 @@ implementation: LBRACE AS UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 610, spurious reduction of production pattern -> pattern_without_or
+## In state 641, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE AS WITH
 ##
-## Ends in an error in state: 1606.
+## Ends in an error in state: 1532.
 ##
 ## _class_self_pattern -> AS . pattern SEMI [ error VAL RBRACE METHOD LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ##
@@ -6682,7 +6681,7 @@ implementation: LBRACE AS WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1495.
+## Ends in an error in state: 1421.
 ##
 ## constrain_field -> core_type EQUAL . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -6694,7 +6693,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1494.
+## Ends in an error in state: 1420.
 ##
 ## constrain_field -> core_type . EQUAL core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -6717,7 +6716,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 
 implementation: LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1692.
+## Ends in an error in state: 1618.
 ##
 ## _class_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -6729,7 +6728,7 @@ implementation: LBRACE CONSTRAINT WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2184.
+## Ends in an error in state: 2264.
 ##
 ## opt_comma -> COMMA . [ RBRACE ]
 ## record_expr -> DOTDOTDOT expr_optional_constraint COMMA . lbl_expr_list [ error RBRACE ]
@@ -6743,7 +6742,7 @@ implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ##
-## Ends in an error in state: 2183.
+## Ends in an error in state: 2263.
 ##
 ## _simple_expr -> LBRACE DOTDOTDOT expr_optional_constraint . opt_comma RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## record_expr -> DOTDOTDOT expr_optional_constraint . COMMA lbl_expr_list [ error RBRACE ]
@@ -6756,22 +6755,22 @@ implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 950, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1107, spurious reduction of production expr_optional_constraint -> expr
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 940, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 861, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 949, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2105, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE DOTDOTDOT WITH
 ##
-## Ends in an error in state: 2182.
+## Ends in an error in state: 2262.
 ##
 ## _simple_expr -> LBRACE DOTDOTDOT . expr_optional_constraint opt_comma RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## record_expr -> DOTDOTDOT . expr_optional_constraint COMMA lbl_expr_list [ error RBRACE ]
@@ -6785,7 +6784,7 @@ implementation: LBRACE DOTDOTDOT WITH
 
 implementation: LBRACE INHERIT BANG WITH
 ##
-## Ends in an error in state: 1686.
+## Ends in an error in state: 1612.
 ##
 ## _class_field -> INHERIT override_flag . class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -6797,7 +6796,7 @@ implementation: LBRACE INHERIT BANG WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1592.
+## Ends in an error in state: 1518.
 ##
 ## _class_expr -> CLASS class_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF COLON AS AND ]
@@ -6810,7 +6809,7 @@ implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1591.
+## Ends in an error in state: 1517.
 ##
 ## _class_expr -> CLASS class_longident . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> CLASS class_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6823,7 +6822,7 @@ implementation: LBRACE INHERIT CLASS LIDENT WITH
 
 implementation: LBRACE INHERIT CLASS WITH
 ##
-## Ends in an error in state: 1590.
+## Ends in an error in state: 1516.
 ##
 ## _class_expr -> CLASS . class_longident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> CLASS . class_longident non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6836,7 +6835,7 @@ implementation: LBRACE INHERIT CLASS WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1599.
+## Ends in an error in state: 1525.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER class_expr . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6849,7 +6848,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND R
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1589.
+## Ends in an error in state: 1515.
 ##
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER . class_expr [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ##
@@ -6861,7 +6860,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1588.
+## Ends in an error in state: 1514.
 ##
 ## _class_fun_def -> labeled_simple_pattern . EQUALGREATER class_expr [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern . class_fun_def [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6874,7 +6873,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 
 implementation: LBRACE INHERIT FUN WITH
 ##
-## Ends in an error in state: 1586.
+## Ends in an error in state: 1512.
 ##
 ## _class_expr -> FUN . class_fun_def [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ##
@@ -6886,7 +6885,7 @@ implementation: LBRACE INHERIT FUN WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 1612.
+## Ends in an error in state: 1538.
 ##
 ## _class_expr_lets_and_rest -> let_bindings SEMI . class_expr_lets_and_rest [ error RBRACE ]
 ##
@@ -6898,7 +6897,7 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ##
-## Ends in an error in state: 1611.
+## Ends in an error in state: 1537.
 ##
 ## _class_expr_lets_and_rest -> let_bindings . SEMI class_expr_lets_and_rest [ error RBRACE ]
 ## let_bindings -> let_bindings . and_let_binding [ SEMI AND ]
@@ -6910,24 +6909,24 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1581, spurious reduction of production let_binding_body -> pattern EQUAL expr
-## In state 1582, spurious reduction of production post_item_attributes ->
-## In state 1583, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
-## In state 1613, spurious reduction of production let_binding -> let_binding_impl
-## In state 1614, spurious reduction of production let_bindings -> let_binding
+## In state 861, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 949, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1507, spurious reduction of production let_binding_body -> pattern EQUAL expr
+## In state 1508, spurious reduction of production post_item_attributes ->
+## In state 1509, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
+## In state 1539, spurious reduction of production let_binding -> let_binding_impl
+## In state 1540, spurious reduction of production let_bindings -> let_binding
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE LET WITH
 ##
-## Ends in an error in state: 1527.
+## Ends in an error in state: 1453.
 ##
-## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI EOF AND ]
+## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET
@@ -6937,7 +6936,7 @@ implementation: LBRACE INHERIT LBRACE LET WITH
 
 implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ##
-## Ends in an error in state: 1705.
+## Ends in an error in state: 1631.
 ##
 ## _class_expr -> class_expr . attribute [ error RBRACE LBRACKETAT ]
 ## _class_expr_lets_and_rest -> class_expr . [ error RBRACE ]
@@ -6949,16 +6948,16 @@ implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1596, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1602, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1594, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1522, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1528, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1520, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 ##
-## Ends in an error in state: 1615.
+## Ends in an error in state: 1541.
 ##
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI AND ]
 ##
@@ -6977,7 +6976,7 @@ implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 
 implementation: LBRACE INHERIT LBRACE WITH
 ##
-## Ends in an error in state: 1526.
+## Ends in an error in state: 1452.
 ##
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest RBRACE [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -6990,7 +6989,7 @@ implementation: LBRACE INHERIT LBRACE WITH
 
 implementation: LBRACE INHERIT LIDENT AS WITH
 ##
-## Ends in an error in state: 1688.
+## Ends in an error in state: 1614.
 ##
 ## parent_binder -> AS . LIDENT [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7002,7 +7001,7 @@ implementation: LBRACE INHERIT LIDENT AS WITH
 
 implementation: LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1687.
+## Ends in an error in state: 1613.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AS ]
 ## _class_field -> INHERIT override_flag class_expr . parent_binder post_item_attributes [ error SEMI RBRACE ]
@@ -7014,16 +7013,16 @@ implementation: LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1596, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1602, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1594, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1522, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1528, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1520, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT SEMI WITH
 ##
-## Ends in an error in state: 1701.
+## Ends in an error in state: 1627.
 ##
 ## semi_terminated_class_fields -> class_field SEMI . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -7035,7 +7034,7 @@ implementation: LBRACE INHERIT LIDENT SEMI WITH
 
 implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ##
-## Ends in an error in state: 1597.
+## Ends in an error in state: 1523.
 ##
 ## _class_expr -> class_simple_expr simple_labeled_expr_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## simple_labeled_expr_list -> simple_labeled_expr_list . labeled_simple_expr [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7047,20 +7046,20 @@ implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 851, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 866, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 871, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
-## In state 874, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 874, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 887, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 892, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
+## In state 895, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT WITH
 ##
-## Ends in an error in state: 1596.
+## Ends in an error in state: 1522.
 ##
 ## _class_expr -> class_simple_expr . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> class_simple_expr . simple_labeled_expr_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -7073,7 +7072,7 @@ implementation: LBRACE INHERIT LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1733.
+## Ends in an error in state: 1659.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -7085,7 +7084,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE 
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1732.
+## Ends in an error in state: 1658.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -7098,7 +7097,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON UNDERSCORE 
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 1731.
+## Ends in an error in state: 1657.
 ##
 ## _class_constructor_type -> LIDENT COLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -7110,7 +7109,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT COLONCOLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1724.
+## Ends in an error in state: 1650.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -7122,7 +7121,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 1723.
+## Ends in an error in state: 1649.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -7135,7 +7134,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 1722.
+## Ends in an error in state: 1648.
 ##
 ## _class_constructor_type -> LIDENT EXPLICITLY_PASSED_OPTIONAL . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -7147,7 +7146,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT EXPLICITLY_PASSED_OPTI
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1725.
+## Ends in an error in state: 1651.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -7159,7 +7158,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1721, spurious reduction of production type_longident -> LIDENT
+## In state 1647, spurious reduction of production type_longident -> LIDENT
 ## In state 280, spurious reduction of production _non_arrowed_simple_core_type -> type_longident
 ## In state 287, spurious reduction of production mark_position_typ(_non_arrowed_simple_core_type) -> _non_arrowed_simple_core_type
 ## In state 285, spurious reduction of production non_arrowed_simple_core_type -> mark_position_typ(_non_arrowed_simple_core_type)
@@ -7170,7 +7169,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 ##
-## Ends in an error in state: 1438.
+## Ends in an error in state: 1364.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -7183,7 +7182,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1720.
+## Ends in an error in state: 1646.
 ##
 ## _class_constructor_type -> NEW class_instance_type . [ error RPAREN ]
 ## _class_instance_type -> class_instance_type . attribute [ error RPAREN LBRACKETAT ]
@@ -7195,16 +7194,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1486, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1492, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1484, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1412, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1418, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1410, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1487.
+## Ends in an error in state: 1413.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
@@ -7217,7 +7216,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 ##
-## Ends in an error in state: 1486.
+## Ends in an error in state: 1412.
 ##
 ## _class_instance_type -> clty_longident . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -7230,7 +7229,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 ##
-## Ends in an error in state: 1482.
+## Ends in an error in state: 1408.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -7244,7 +7243,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 ##
-## Ends in an error in state: 1481.
+## Ends in an error in state: 1407.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET EOF AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -7264,7 +7263,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1719.
+## Ends in an error in state: 1645.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ error RPAREN ]
 ##
@@ -7276,7 +7275,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1726.
+## Ends in an error in state: 1652.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -7288,7 +7287,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 ##
-## Ends in an error in state: 1718.
+## Ends in an error in state: 1644.
 ##
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7301,7 +7300,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ##
-## Ends in an error in state: 1715.
+## Ends in an error in state: 1641.
 ##
 ## _class_expr -> class_expr . attribute [ error RPAREN LBRACKETAT COLON ]
 ## _class_simple_expr -> LPAREN class_expr . COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7316,16 +7315,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1596, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1602, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1594, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1522, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1528, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1520, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN WITH
 ##
-## Ends in an error in state: 1525.
+## Ends in an error in state: 1451.
 ##
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7340,7 +7339,7 @@ implementation: LBRACE INHERIT LPAREN WITH
 
 implementation: LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1685.
+## Ends in an error in state: 1611.
 ##
 ## _class_field -> INHERIT . override_flag class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7352,7 +7351,7 @@ implementation: LBRACE INHERIT WITH
 
 implementation: LBRACE INITIALIZER EQUALGREATER WITH
 ##
-## Ends in an error in state: 1682.
+## Ends in an error in state: 1608.
 ##
 ## _class_field -> INITIALIZER EQUALGREATER . expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7364,7 +7363,7 @@ implementation: LBRACE INITIALIZER EQUALGREATER WITH
 
 implementation: LBRACE INITIALIZER WITH
 ##
-## Ends in an error in state: 1681.
+## Ends in an error in state: 1607.
 ##
 ## _class_field -> INITIALIZER . EQUALGREATER expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7376,7 +7375,7 @@ implementation: LBRACE INITIALIZER WITH
 
 implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 2198.
+## Ends in an error in state: 2279.
 ##
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -7388,53 +7387,53 @@ implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2159, spurious reduction of production opt_semi -> SEMI
-## In state 2170, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
-## In state 2168, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2157, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2312, spurious reduction of production opt_semi -> SEMI
+## In state 2323, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
+## In state 2321, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2310, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
 ##
 
 Expecting "}" to finish the block
 
 implementation: LBRACE MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2145.
+## Ends in an error in state: 2307.
 ##
-## _semi_terminated_seq_expr_row -> MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
+## _semi_terminated_seq_expr_row -> opt_let_module UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
 ## The known suffix of the stack is as follows:
-## MODULE UIDENT module_binding_body post_item_attributes SEMI
+## opt_let_module UIDENT module_binding_body post_item_attributes SEMI
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE MODULE UIDENT WITH
 ##
-## Ends in an error in state: 774.
+## Ends in an error in state: 2296.
 ##
-## _semi_terminated_seq_expr_row -> MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
+## _semi_terminated_seq_expr_row -> opt_let_module UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
 ## The known suffix of the stack is as follows:
-## MODULE UIDENT
+## opt_let_module UIDENT
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE MODULE WITH
 ##
-## Ends in an error in state: 773.
+## Ends in an error in state: 2295.
 ##
-## _semi_terminated_seq_expr_row -> MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
+## _semi_terminated_seq_expr_row -> opt_let_module . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
 ## The known suffix of the stack is as follows:
-## MODULE
+## opt_let_module
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET OPEN BANG WITH
 ##
-## Ends in an error in state: 2151.
+## Ends in an error in state: 2290.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7446,7 +7445,7 @@ implementation: LBRACE LET OPEN BANG WITH
 
 implementation: LBRACE LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2154.
+## Ends in an error in state: 2293.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7458,7 +7457,7 @@ implementation: LBRACE LET OPEN UIDENT SEMI WITH
 
 implementation: LBRACE LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2153.
+## Ends in an error in state: 2292.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7469,14 +7468,14 @@ implementation: LBRACE LET OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2152, spurious reduction of production post_item_attributes ->
+## In state 2291, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET OPEN WITH
 ##
-## Ends in an error in state: 2150.
+## Ends in an error in state: 2289.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7488,9 +7487,10 @@ implementation: LBRACE LET OPEN WITH
 
 implementation: LBRACE LET WITH
 ##
-## Ends in an error in state: 2146.
+## Ends in an error in state: 474.
 ##
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ error SEMI RBRACE AND ]
+## opt_let_module -> LET . MODULE [ UIDENT ]
 ## option(LET) -> LET . [ OPEN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -7501,7 +7501,7 @@ implementation: LBRACE LET WITH
 
 implementation: LBRACE LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1177.
+## Ends in an error in state: 2159.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7537,21 +7537,21 @@ implementation: LBRACE LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1176.
+## Ends in an error in state: 2158.
 ##
 ## lbl_expr -> label_longident COLON . expr [ COMMA ]
 ## non_punned_lbl_expression -> label_longident COLON . expr [ error RBRACE ]
@@ -7564,7 +7564,7 @@ implementation: LBRACE LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1166.
+## Ends in an error in state: 2148.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7599,21 +7599,21 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 ##
-## Ends in an error in state: 1165.
+## Ends in an error in state: 2147.
 ##
 ## lbl_expr -> label_longident COLON . expr [ error RBRACE COMMA ]
 ##
@@ -7625,7 +7625,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 ##
-## Ends in an error in state: 1162.
+## Ends in an error in state: 2144.
 ##
 ## lbl_expr_list -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ## lbl_expr_list -> lbl_expr COMMA . [ error RBRACE ]
@@ -7638,7 +7638,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT WITH
 ##
-## Ends in an error in state: 1164.
+## Ends in an error in state: 2146.
 ##
 ## lbl_expr -> label_longident . COLON expr [ error RBRACE COMMA ]
 ## lbl_expr -> label_longident . [ error RBRACE COMMA ]
@@ -7651,7 +7651,7 @@ implementation: LBRACE LIDENT COMMA LIDENT WITH
 
 implementation: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 1173.
+## Ends in an error in state: 2155.
 ##
 ## lbl_expr_list_that_is_not_a_single_punned_field -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ##
@@ -7663,7 +7663,7 @@ implementation: LBRACE LIDENT COMMA WITH
 
 implementation: LBRACE METHOD BANG WITH
 ##
-## Ends in an error in state: 1643.
+## Ends in an error in state: 1569.
 ##
 ## method_ -> override_flag . PRIVATE VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag . VIRTUAL private_flag label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -7680,7 +7680,7 @@ implementation: LBRACE METHOD BANG WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1667.
+## Ends in an error in state: 1593.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7715,21 +7715,21 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1666.
+## Ends in an error in state: 1592.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT core_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7741,7 +7741,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1665.
+## Ends in an error in state: 1591.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT core_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7764,7 +7764,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1664.
+## Ends in an error in state: 1590.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE lident_list DOT . core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7776,7 +7776,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LBRACE METHOD LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 1662.
+## Ends in an error in state: 1588.
 ##
 ## method_ -> override_flag private_flag label COLON TYPE . lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7788,7 +7788,7 @@ implementation: LBRACE METHOD LIDENT COLON TYPE WITH
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1670.
+## Ends in an error in state: 1596.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7823,21 +7823,21 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1669.
+## Ends in an error in state: 1595.
 ##
 ## method_ -> override_flag private_flag label COLON poly_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7849,7 +7849,7 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1668.
+## Ends in an error in state: 1594.
 ##
 ## method_ -> override_flag private_flag label COLON poly_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7866,16 +7866,16 @@ implementation: LBRACE METHOD LIDENT COLON UNDERSCORE WITH
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1333, spurious reduction of production _poly_type -> core_type
-## In state 1334, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1332, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 1259, spurious reduction of production _poly_type -> core_type
+## In state 1260, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1258, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT COLON WITH
 ##
-## Ends in an error in state: 1661.
+## Ends in an error in state: 1587.
 ##
 ## method_ -> override_flag private_flag label COLON . poly_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag private_flag label COLON . TYPE lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -7888,7 +7888,7 @@ implementation: LBRACE METHOD LIDENT COLON WITH
 
 implementation: LBRACE METHOD LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1660.
+## Ends in an error in state: 1586.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7923,21 +7923,21 @@ implementation: LBRACE METHOD LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1659.
+## Ends in an error in state: 1585.
 ##
 ## method_ -> override_flag private_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7949,7 +7949,7 @@ implementation: LBRACE METHOD LIDENT EQUAL WITH
 
 implementation: LBRACE METHOD LIDENT EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1700.
+## Ends in an error in state: 1626.
 ##
 ## semi_terminated_class_fields -> class_field . [ error RBRACE ]
 ## semi_terminated_class_fields -> class_field . SEMI semi_terminated_class_fields [ error RBRACE ]
@@ -7961,27 +7961,27 @@ implementation: LBRACE METHOD LIDENT EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1658, spurious reduction of production curried_binding -> EQUALGREATER expr
-## In state 1678, spurious reduction of production method_ -> override_flag private_flag label curried_binding
-## In state 1679, spurious reduction of production post_item_attributes ->
-## In state 1680, spurious reduction of production _class_field -> METHOD method_ post_item_attributes
-## In state 1703, spurious reduction of production mark_position_cf(_class_field) -> _class_field
-## In state 1696, spurious reduction of production class_field -> mark_position_cf(_class_field)
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1584, spurious reduction of production curried_binding -> EQUALGREATER expr
+## In state 1604, spurious reduction of production method_ -> override_flag private_flag label curried_binding
+## In state 1605, spurious reduction of production post_item_attributes ->
+## In state 1606, spurious reduction of production _class_field -> METHOD method_ post_item_attributes
+## In state 1629, spurious reduction of production mark_position_cf(_class_field) -> _class_field
+## In state 1622, spurious reduction of production class_field -> mark_position_cf(_class_field)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1653.
+## Ends in an error in state: 1579.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7993,7 +7993,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1652.
+## Ends in an error in state: 1578.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8005,7 +8005,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL LIDENT WITH
 
 implementation: LBRACE METHOD PRIVATE VIRTUAL WITH
 ##
-## Ends in an error in state: 1651.
+## Ends in an error in state: 1577.
 ##
 ## method_ -> override_flag PRIVATE VIRTUAL . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8017,7 +8017,7 @@ implementation: LBRACE METHOD PRIVATE VIRTUAL WITH
 
 implementation: LBRACE METHOD PRIVATE WITH
 ##
-## Ends in an error in state: 1650.
+## Ends in an error in state: 1576.
 ##
 ## method_ -> override_flag PRIVATE . VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## private_flag -> PRIVATE . [ LIDENT ]
@@ -8030,7 +8030,7 @@ implementation: LBRACE METHOD PRIVATE WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1473.
+## Ends in an error in state: 1399.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8042,7 +8042,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1472.
+## Ends in an error in state: 1398.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -8055,7 +8055,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WIT
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE WITH
 ##
-## Ends in an error in state: 1470.
+## Ends in an error in state: 1396.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ error SEMI RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AS ]
 ## typevar_list -> QUOTE . ident [ QUOTE DOT ]
@@ -8068,7 +8068,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON QUOTE WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1648.
+## Ends in an error in state: 1574.
 ##
 ## method_ -> override_flag VIRTUAL private_flag label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8080,7 +8080,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE METHOD VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1647.
+## Ends in an error in state: 1573.
 ##
 ## method_ -> override_flag VIRTUAL private_flag label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8092,7 +8092,7 @@ implementation: LBRACE METHOD VIRTUAL LIDENT WITH
 
 implementation: LBRACE METHOD VIRTUAL PRIVATE LET
 ##
-## Ends in an error in state: 1646.
+## Ends in an error in state: 1572.
 ##
 ## method_ -> override_flag VIRTUAL private_flag . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8104,7 +8104,7 @@ implementation: LBRACE METHOD VIRTUAL PRIVATE LET
 
 implementation: LBRACE METHOD VIRTUAL WITH
 ##
-## Ends in an error in state: 1644.
+## Ends in an error in state: 1570.
 ##
 ## method_ -> override_flag VIRTUAL . private_flag label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8116,7 +8116,7 @@ implementation: LBRACE METHOD VIRTUAL WITH
 
 implementation: LBRACE METHOD WITH
 ##
-## Ends in an error in state: 1642.
+## Ends in an error in state: 1568.
 ##
 ## _class_field -> METHOD . method_ post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8128,7 +8128,7 @@ implementation: LBRACE METHOD WITH
 
 implementation: LBRACE PERCENT WITH TYPE
 ##
-## Ends in an error in state: 2161.
+## Ends in an error in state: 2314.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ error RBRACE ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ error SEMI RBRACE AND ]
@@ -8148,7 +8148,7 @@ implementation: LBRACE PERCENT WITH TYPE
 
 implementation: LBRACE UIDENT DOT WITH
 ##
-## Ends in an error in state: 2209.
+## Ends in an error in state: 2335.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
@@ -8175,7 +8175,7 @@ implementation: LBRACE UIDENT DOT WITH
 
 implementation: LBRACE VAL BANG WITH
 ##
-## Ends in an error in state: 1628.
+## Ends in an error in state: 1554.
 ##
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8190,7 +8190,7 @@ implementation: LBRACE VAL BANG WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1641.
+## Ends in an error in state: 1567.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8225,21 +8225,21 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL UIDENT RP
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 ##
-## Ends in an error in state: 1640.
+## Ends in an error in state: 1566.
 ##
 ## value -> override_flag mutable_flag label type_constraint EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8251,7 +8251,7 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER EQUAL WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1639.
+## Ends in an error in state: 1565.
 ##
 ## value -> override_flag mutable_flag label type_constraint . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8268,14 +8268,14 @@ implementation: LBRACE VAL LIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1109, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1126, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1638.
+## Ends in an error in state: 1564.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8310,21 +8310,21 @@ implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1637.
+## Ends in an error in state: 1563.
 ##
 ## value -> override_flag mutable_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8336,7 +8336,7 @@ implementation: LBRACE VAL LIDENT EQUAL WITH
 
 implementation: LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1636.
+## Ends in an error in state: 1562.
 ##
 ## value -> override_flag mutable_flag label . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag mutable_flag label . type_constraint EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -8349,7 +8349,7 @@ implementation: LBRACE VAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1633.
+## Ends in an error in state: 1559.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8362,18 +8362,18 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 643, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 637, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 639, spurious reduction of production _core_type -> core_type2
-## In state 650, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 638, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 674, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 668, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 670, spurious reduction of production _core_type -> core_type2
+## In state 681, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 669, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1632.
+## Ends in an error in state: 1558.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8386,7 +8386,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1631.
+## Ends in an error in state: 1557.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8399,7 +8399,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 ##
-## Ends in an error in state: 1630.
+## Ends in an error in state: 1556.
 ##
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8412,7 +8412,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 
 implementation: LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1629.
+## Ends in an error in state: 1555.
 ##
 ## mutable_flag -> MUTABLE . [ LIDENT ]
 ## value -> override_flag MUTABLE . VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -8426,7 +8426,7 @@ implementation: LBRACE VAL MUTABLE WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1624.
+## Ends in an error in state: 1550.
 ##
 ## value -> VIRTUAL mutable_flag label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8439,18 +8439,18 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 643, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 637, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 639, spurious reduction of production _core_type -> core_type2
-## In state 650, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 638, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 674, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 668, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 670, spurious reduction of production _core_type -> core_type2
+## In state 681, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 669, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1623.
+## Ends in an error in state: 1549.
 ##
 ## value -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8463,7 +8463,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1622.
+## Ends in an error in state: 1548.
 ##
 ## value -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8476,7 +8476,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1621.
+## Ends in an error in state: 1547.
 ##
 ## value -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8489,7 +8489,7 @@ implementation: LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1620.
+## Ends in an error in state: 1546.
 ##
 ## value -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL . mutable_flag label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8502,7 +8502,7 @@ implementation: LBRACE VAL VIRTUAL WITH
 
 implementation: LBRACE VAL WITH
 ##
-## Ends in an error in state: 1619.
+## Ends in an error in state: 1545.
 ##
 ## _class_field -> VAL . value post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8514,7 +8514,7 @@ implementation: LBRACE VAL WITH
 
 implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2491.
+## Ends in an error in state: 2495.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8549,14 +8549,14 @@ implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -8575,7 +8575,7 @@ implementation: LBRACELESS LIDENT COLON WITH
 
 implementation: LBRACELESS LIDENT COMMA WITH
 ##
-## Ends in an error in state: 766.
+## Ends in an error in state: 465.
 ##
 ## field_expr_list -> field_expr_list COMMA . field_expr [ error GREATERRBRACE COMMA ]
 ## opt_comma -> COMMA . [ error GREATERRBRACE ]
@@ -8601,7 +8601,7 @@ implementation: LBRACELESS LIDENT WITH
 
 implementation: LBRACKET DOTDOTDOT WITH
 ##
-## Ends in an error in state: 1141.
+## Ends in an error in state: 2123.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT . expr_optional_constraint RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -8613,7 +8613,7 @@ implementation: LBRACKET DOTDOTDOT WITH
 
 implementation: LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 1144.
+## Ends in an error in state: 2126.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint . opt_comma RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## expr_comma_seq_extension -> expr_optional_constraint . COMMA expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -8625,15 +8625,15 @@ implementation: LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 950, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1107, spurious reduction of production expr_optional_constraint -> expr
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 940, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 861, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 949, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2105, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 Expecting one of the following:
@@ -8642,7 +8642,7 @@ Expecting one of the following:
 
 implementation: LBRACKET WITH
 ##
-## Ends in an error in state: 721.
+## Ends in an error in state: 446.
 ##
 ## _simple_expr -> LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## constr_longident -> LBRACKET . RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -8658,7 +8658,7 @@ Expecting one of the following:
 
 implementation: LBRACKETATATAT UNDERSCORE
 ##
-## Ends in an error in state: 1229.
+## Ends in an error in state: 745.
 ##
 ## floating_attribute -> LBRACKETATATAT . attr_id payload RBRACKET [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -8670,7 +8670,7 @@ implementation: LBRACKETATATAT UNDERSCORE
 
 implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2120.
+## Ends in an error in state: 2193.
 ##
 ## floating_attribute -> LBRACKETATATAT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -8681,30 +8681,30 @@ implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1858, spurious reduction of production post_item_attributes ->
-## In state 1859, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1860, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1803, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1796, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1804, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1797, spurious reduction of production structure -> structure_item
-## In state 1864, spurious reduction of production payload -> structure
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1906, spurious reduction of production post_item_attributes ->
+## In state 1907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1856, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1722, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1909, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1857, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1723, spurious reduction of production structure -> structure_item
+## In state 1852, spurious reduction of production payload -> structure
 ##
 
 Expecting "]" to finish current floating attribute
 
 implementation: LBRACKETBAR BANG WITH
 ##
-## Ends in an error in state: 785.
+## Ends in an error in state: 748.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -8716,7 +8716,7 @@ implementation: LBRACKETBAR BANG WITH
 
 implementation: LBRACKETBAR MINUSDOT WITH
 ##
-## Ends in an error in state: 856.
+## Ends in an error in state: 877.
 ##
 ## _expr -> subtractive . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -8728,7 +8728,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR PLUSDOT WITH
 ##
-## Ends in an error in state: 890.
+## Ends in an error in state: 911.
 ##
 ## _expr -> additive . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -8752,7 +8752,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1134.
+## Ends in an error in state: 1114.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8764,7 +8764,7 @@ Expecting a type name
 
 implementation: LBRACKETBAR UIDENT COLON WITH
 ##
-## Ends in an error in state: 1131.
+## Ends in an error in state: 1111.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8776,7 +8776,7 @@ implementation: LBRACKETBAR UIDENT COLON WITH
 
 implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1129.
+## Ends in an error in state: 1109.
 ##
 ## type_constraint -> COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8788,7 +8788,7 @@ implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 
 implementation: LBRACKETBAR UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1126.
+## Ends in an error in state: 2117.
 ##
 ## expr_comma_seq -> expr_comma_seq COMMA . expr_optional_constraint [ error COMMA BARRBRACKET ]
 ## opt_comma -> COMMA . [ error BARRBRACKET ]
@@ -8801,7 +8801,7 @@ implementation: LBRACKETBAR UIDENT COMMA WITH
 
 implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 ##
-## Ends in an error in state: 1227.
+## Ends in an error in state: 743.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT . attr_id payload RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -8813,7 +8813,7 @@ implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH COLON WITH
 ##
-## Ends in an error in state: 1426.
+## Ends in an error in state: 1352.
 ##
 ## payload -> COLON . core_type [ RBRACKET ]
 ##
@@ -8837,7 +8837,7 @@ implementation: LBRACKETPERCENTPERCENT WITH DOT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ##
-## Ends in an error in state: 2457.
+## Ends in an error in state: 2461.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN RBRACKET BAR ]
 ## payload -> QUESTION pattern . [ RBRACKET ]
@@ -8850,14 +8850,14 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 610, spurious reduction of production pattern -> pattern_without_or
+## In state 641, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2459.
+## Ends in an error in state: 2463.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8892,21 +8892,21 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 950, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 940, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 861, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 949, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2458.
+## Ends in an error in state: 2462.
 ##
 ## payload -> QUESTION pattern WHEN . expr [ RBRACKET ]
 ##
@@ -8931,7 +8931,7 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION WITH
 
 implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2122.
+## Ends in an error in state: 2195.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -8942,23 +8942,23 @@ implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1858, spurious reduction of production post_item_attributes ->
-## In state 1859, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1860, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1803, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1796, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1804, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1797, spurious reduction of production structure -> structure_item
-## In state 1864, spurious reduction of production payload -> structure
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1906, spurious reduction of production post_item_attributes ->
+## In state 1907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1856, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1722, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1909, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1857, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1723, spurious reduction of production structure -> structure_item
+## In state 1852, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
@@ -8978,7 +8978,7 @@ implementation: LBRACKETPERCENTPERCENT WITH WITH
 
 implementation: LET CHAR EQUAL CHAR AND WITH
 ##
-## Ends in an error in state: 1838.
+## Ends in an error in state: 1886.
 ##
 ## and_let_binding -> AND . let_binding_body post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -8990,7 +8990,7 @@ implementation: LET CHAR EQUAL CHAR AND WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 2385.
+## Ends in an error in state: 2246.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -9025,21 +9025,21 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2389.
+## Ends in an error in state: 2250.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9051,7 +9051,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2388.
+## Ends in an error in state: 2249.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9074,7 +9074,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 2387.
+## Ends in an error in state: 2248.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9086,7 +9086,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2386.
+## Ends in an error in state: 2247.
 ##
 ## let_binding_body -> val_ident COLON typevar_list . DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -9099,7 +9099,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2383.
+## Ends in an error in state: 2244.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9111,7 +9111,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2382.
+## Ends in an error in state: 2243.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9134,7 +9134,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 2381.
+## Ends in an error in state: 2242.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9146,7 +9146,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1553.
+## Ends in an error in state: 1479.
 ##
 ## lident_list -> LIDENT . [ DOT ]
 ## lident_list -> LIDENT . lident_list [ DOT ]
@@ -9159,7 +9159,7 @@ implementation: LET LIDENT COLON TYPE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 2379.
+## Ends in an error in state: 2240.
 ##
 ## let_binding_body -> val_ident COLON TYPE . lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9171,7 +9171,7 @@ implementation: LET LIDENT COLON TYPE WITH
 
 implementation: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 2378.
+## Ends in an error in state: 2239.
 ##
 ## let_binding_body -> val_ident COLON . typevar_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## let_binding_body -> val_ident COLON . TYPE lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9185,7 +9185,7 @@ implementation: LET LIDENT COLON WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2392.
+## Ends in an error in state: 2253.
 ##
 ## let_binding_body -> val_ident type_constraint EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9197,7 +9197,7 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 2391.
+## Ends in an error in state: 2252.
 ##
 ## let_binding_body -> val_ident type_constraint . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9214,14 +9214,14 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1109, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1126, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2376.
+## Ends in an error in state: 2237.
 ##
 ## _curried_binding_return_typed -> EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9233,7 +9233,7 @@ implementation: LET LIDENT EQUALGREATER WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 692.
+## Ends in an error in state: 723.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9245,7 +9245,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 691.
+## Ends in an error in state: 722.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9257,7 +9257,7 @@ implementation: LET LIDENT LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT LPAREN TYPE WITH
 ##
-## Ends in an error in state: 690.
+## Ends in an error in state: 721.
 ##
 ## _curried_binding_return_typed -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9269,7 +9269,7 @@ implementation: LET LIDENT LPAREN TYPE WITH
 
 implementation: LET LIDENT LPAREN WITH
 ##
-## Ends in an error in state: 689.
+## Ends in an error in state: 720.
 ##
 ## _curried_binding_return_typed -> LPAREN . TYPE LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -9292,7 +9292,7 @@ implementation: LET LIDENT LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1675.
+## Ends in an error in state: 1601.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -9327,21 +9327,21 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1674.
+## Ends in an error in state: 1600.
 ##
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9353,7 +9353,7 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1673.
+## Ends in an error in state: 1599.
 ##
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type . EQUALGREATER expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9367,7 +9367,7 @@ Expecting "=>" to start the function body
 
 implementation: LET LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1672.
+## Ends in an error in state: 1598.
 ##
 ## curried_binding_return_typed_ -> COLON . non_arrowed_core_type EQUALGREATER expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9379,7 +9379,7 @@ implementation: LET LIDENT UNDERSCORE COLON WITH
 
 implementation: LET LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1657.
+## Ends in an error in state: 1583.
 ##
 ## curried_binding -> EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9391,7 +9391,7 @@ Expecting an expression as function body
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 696.
+## Ends in an error in state: 727.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT RPAREN . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9403,7 +9403,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 695.
+## Ends in an error in state: 726.
 ##
 ## curried_binding -> LPAREN TYPE LIDENT . RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9415,7 +9415,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 694.
+## Ends in an error in state: 725.
 ##
 ## curried_binding -> LPAREN TYPE . LIDENT RPAREN curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9427,7 +9427,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN TYPE WITH
 
 implementation: LET LIDENT UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 693.
+## Ends in an error in state: 724.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -9450,7 +9450,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 1671.
+## Ends in an error in state: 1597.
 ##
 ## curried_binding -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9462,7 +9462,7 @@ implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 
 implementation: LET LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2395.
+## Ends in an error in state: 2256.
 ##
 ## _curried_binding_return_typed -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9478,7 +9478,7 @@ Expecting one of the following:
 
 implementation: LET LIDENT WITH
 ##
-## Ends in an error in state: 688.
+## Ends in an error in state: 719.
 ##
 ## _simple_pattern -> val_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> val_ident . type_constraint EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9494,7 +9494,7 @@ implementation: LET LIDENT WITH
 
 implementation: MODULE REC UIDENT EQUAL UIDENT AND WITH
 ##
-## Ends in an error in state: 1823.
+## Ends in an error in state: 1871.
 ##
 ## and_nonlocal_module_bindings -> AND . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9506,7 +9506,7 @@ implementation: MODULE REC UIDENT EQUAL UIDENT AND WITH
 
 implementation: MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1822.
+## Ends in an error in state: 1870.
 ##
 ## _structure_item_without_item_extension_sugar -> many_nonlocal_module_bindings . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> many_nonlocal_module_bindings . and_nonlocal_module_bindings [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -9518,28 +9518,28 @@ implementation: MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1379, spurious reduction of production post_item_attributes ->
-## In state 1380, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2432, spurious reduction of production many_nonlocal_module_bindings -> MODULE REC nonlocal_module_binding_details post_item_attributes
+## In state 1305, spurious reduction of production post_item_attributes ->
+## In state 1306, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2046, spurious reduction of production many_nonlocal_module_bindings -> opt_let_module REC nonlocal_module_binding_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: MODULE REC WITH
 ##
-## Ends in an error in state: 2430.
+## Ends in an error in state: 2044.
 ##
-## many_nonlocal_module_bindings -> MODULE REC . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
+## many_nonlocal_module_bindings -> opt_let_module REC . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
 ## The known suffix of the stack is as follows:
-## MODULE REC
+## opt_let_module REC
 ##
 
 <SYNTAX ERROR>
 
 implementation: MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2411.
+## Ends in an error in state: 2028.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9553,19 +9553,19 @@ implementation: MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2109, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2113, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2110, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1235, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2115, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2114, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1733, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1737, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1734, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1151, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1739, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1738, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: MODULE UIDENT COLON UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2410.
+## Ends in an error in state: 2027.
 ##
 ## module_binding_body_expr -> COLON module_type EQUAL . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9577,7 +9577,7 @@ implementation: MODULE UIDENT COLON UIDENT EQUAL WITH
 
 implementation: MODULE UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2409.
+## Ends in an error in state: 2026.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER EQUAL ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER EQUAL ]
@@ -9593,22 +9593,22 @@ implementation: MODULE UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1921, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1811, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1840, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1836, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1809, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1841, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1837, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1810, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1842, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1838, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2408.
+## Ends in an error in state: 1740.
 ##
 ## module_binding_body_expr -> COLON . module_type EQUAL module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9620,7 +9620,7 @@ implementation: MODULE UIDENT COLON WITH
 
 implementation: MODULE UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2407.
+## Ends in an error in state: 1731.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9634,19 +9634,19 @@ implementation: MODULE UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2109, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2113, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2110, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1235, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2115, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2114, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1733, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1737, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1734, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1151, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1739, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1738, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2406.
+## Ends in an error in state: 1730.
 ##
 ## module_binding_body_expr -> EQUAL . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9658,7 +9658,7 @@ implementation: MODULE UIDENT EQUAL WITH
 
 implementation: MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2422.
+## Ends in an error in state: 2039.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER module_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9672,19 +9672,19 @@ implementation: MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT WIT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2109, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2113, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2110, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1235, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2115, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2114, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1733, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1737, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1734, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1151, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1739, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1738, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2421.
+## Ends in an error in state: 2038.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9696,7 +9696,7 @@ implementation: MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 
 implementation: MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2420.
+## Ends in an error in state: 2037.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type . EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_type -> non_arrowed_module_type . [ WITH LBRACKETAT EQUALGREATER ]
@@ -9710,19 +9710,19 @@ implementation: MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 279, spurious reduction of production mty_longident -> ident
-## In state 1922, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1953, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1949, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1920, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1954, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1950, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1811, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1840, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1836, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1809, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1841, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1837, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT COLONEQUAL LESSDOTDOTGREATER SEMI
 ##
-## Ends in an error in state: 2179.
+## Ends in an error in state: 2040.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER ]
@@ -9741,18 +9741,18 @@ implementation: MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT COLONE
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1931, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1945, spurious reduction of production with_constraints -> with_constraint
-## In state 1942, spurious reduction of production _module_type -> module_type WITH with_constraints
-## In state 1955, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1951, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1818, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1832, spurious reduction of production with_constraints -> with_constraint
+## In state 1829, spurious reduction of production _module_type -> module_type WITH with_constraints
+## In state 1842, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1838, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: MODULE UIDENT LPAREN RPAREN COLON WITH
 ##
-## Ends in an error in state: 2419.
+## Ends in an error in state: 2036.
 ##
 ## _module_binding_body_functor -> functor_args COLON . non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9764,7 +9764,7 @@ implementation: MODULE UIDENT LPAREN RPAREN COLON WITH
 
 implementation: MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2418.
+## Ends in an error in state: 2035.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER module_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9778,19 +9778,19 @@ implementation: MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2109, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 2113, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 2110, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1235, spurious reduction of production _module_expr -> simple_module_expr
-## In state 2115, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 2114, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1733, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1737, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1734, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1151, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1739, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1738, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2417.
+## Ends in an error in state: 2034.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9802,7 +9802,7 @@ implementation: MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 
 implementation: MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2416.
+## Ends in an error in state: 2033.
 ##
 ## _module_binding_body_functor -> functor_args . EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_binding_body_functor -> functor_args . COLON non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9816,7 +9816,7 @@ implementation: MODULE UIDENT LPAREN RPAREN WITH
 
 implementation: MODULE UIDENT WITH
 ##
-## Ends in an error in state: 427.
+## Ends in an error in state: 1729.
 ##
 ## nonlocal_module_binding_details -> UIDENT . module_binding_body [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9830,10 +9830,9 @@ implementation: MODULE WITH
 ##
 ## Ends in an error in state: 426.
 ##
-## _structure_item_without_item_extension_sugar -> MODULE . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## _structure_item_without_item_extension_sugar -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
-## many_nonlocal_module_bindings -> MODULE . REC nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
+## opt_let_module -> MODULE . [ UIDENT REC ]
 ##
 ## The known suffix of the stack is as follows:
 ## MODULE
@@ -9843,7 +9842,7 @@ implementation: MODULE WITH
 
 implementation: LET REC ASSERT
 ##
-## Ends in an error in state: 439.
+## Ends in an error in state: 477.
 ##
 ## let_binding_impl -> LET rec_flag . let_binding_body post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9855,7 +9854,7 @@ implementation: LET REC ASSERT
 
 implementation: LET UIDENT UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1844.
+## Ends in an error in state: 1892.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EQUAL BAR ]
 ## let_binding_body -> pattern . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9867,17 +9866,17 @@ implementation: LET UIDENT UNDERSCORE WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 606, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
-## In state 609, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
-## In state 604, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
-## In state 610, spurious reduction of production pattern -> pattern_without_or
+## In state 637, spurious reduction of production _pattern_without_or -> constr_longident simple_pattern_list
+## In state 640, spurious reduction of production mark_position_pat(_pattern_without_or) -> _pattern_without_or
+## In state 635, spurious reduction of production pattern_without_or -> mark_position_pat(_pattern_without_or)
+## In state 641, spurious reduction of production pattern -> pattern_without_or
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1842.
+## Ends in an error in state: 1890.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9889,7 +9888,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1841.
+## Ends in an error in state: 1889.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9912,7 +9911,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 
 implementation: LET UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1840.
+## Ends in an error in state: 1888.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON . core_type EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9924,7 +9923,7 @@ implementation: LET UNDERSCORE COLON WITH
 
 implementation: LET UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1845.
+## Ends in an error in state: 1893.
 ##
 ## let_binding_body -> pattern EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9936,7 +9935,7 @@ implementation: LET UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE WITH
 ##
-## Ends in an error in state: 1839.
+## Ends in an error in state: 1887.
 ##
 ## _simple_pattern -> simple_pattern_not_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> simple_pattern_not_ident . COLON core_type EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9949,9 +9948,10 @@ implementation: LET UNDERSCORE WITH
 
 implementation: LET WITH
 ##
-## Ends in an error in state: 437.
+## Ends in an error in state: 742.
 ##
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
+## opt_let_module -> LET . MODULE [ UIDENT REC ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET
@@ -9961,7 +9961,7 @@ Incomplete let binding
 
 implementation: LPAREN ASSERT WITH
 ##
-## Ends in an error in state: 854.
+## Ends in an error in state: 864.
 ##
 ## _expr -> ASSERT . simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -9973,7 +9973,7 @@ implementation: LPAREN ASSERT WITH
 
 implementation: LPAREN BACKQUOTE WITH
 ##
-## Ends in an error in state: 500.
+## Ends in an error in state: 538.
 ##
 ## name_tag -> BACKQUOTE . ident [ error UNDERSCORE UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -9985,7 +9985,7 @@ implementation: LPAREN BACKQUOTE WITH
 
 implementation: LPAREN BANG WITH
 ##
-## Ends in an error in state: 829.
+## Ends in an error in state: 1104.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP RPAREN QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## operator -> BANG . [ RPAREN ]
@@ -9998,7 +9998,7 @@ implementation: LPAREN BANG WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 ##
-## Ends in an error in state: 816.
+## Ends in an error in state: 779.
 ##
 ## _expr -> FOR pattern IN simple_expr direction_flag . simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10010,7 +10010,7 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT TO WITH
 
 implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ##
-## Ends in an error in state: 813.
+## Ends in an error in state: 776.
 ##
 ## _expr -> FOR pattern IN simple_expr . direction_flag simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ TO SHARPOP SHARP DOWNTO DOT ]
@@ -10029,17 +10029,17 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 846, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 834, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FOR UNDERSCORE IN WITH
 ##
-## Ends in an error in state: 812.
+## Ends in an error in state: 775.
 ##
 ## _expr -> FOR pattern IN . simple_expr direction_flag simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10051,7 +10051,7 @@ implementation: LPAREN FOR UNDERSCORE IN WITH
 
 implementation: LPAREN FOR WITH
 ##
-## Ends in an error in state: 810.
+## Ends in an error in state: 773.
 ##
 ## _expr -> FOR . pattern IN simple_expr direction_flag simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10063,7 +10063,7 @@ implementation: LPAREN FOR WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 1194.
+## Ends in an error in state: 2176.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10098,17 +10098,17 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1193.
+## Ends in an error in state: 2175.
 ##
 ## leading_bar_match_case -> pattern_with_bar EQUALGREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10120,7 +10120,7 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 1192.
+## Ends in an error in state: 2174.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10155,17 +10155,17 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1191.
+## Ends in an error in state: 2173.
 ##
 ## leading_bar_match_case -> pattern_with_bar WHEN expr EQUALGREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10177,7 +10177,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 1190.
+## Ends in an error in state: 2172.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10212,21 +10212,21 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 950, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 940, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 861, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 949, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 1189.
+## Ends in an error in state: 2171.
 ##
 ## leading_bar_match_case -> pattern_with_bar WHEN . expr EQUALGREATER expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10238,7 +10238,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 804.
+## Ends in an error in state: 767.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10250,7 +10250,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 803.
+## Ends in an error in state: 766.
 ##
 ## _expr -> FUN LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10262,7 +10262,7 @@ implementation: LPAREN FUN LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN LPAREN TYPE WITH
 ##
-## Ends in an error in state: 802.
+## Ends in an error in state: 765.
 ##
 ## _expr -> FUN LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10274,7 +10274,7 @@ implementation: LPAREN FUN LPAREN TYPE WITH
 
 implementation: LPAREN FUN LPAREN WITH
 ##
-## Ends in an error in state: 801.
+## Ends in an error in state: 764.
 ##
 ## _expr -> FUN LPAREN . TYPE LIDENT RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -10297,7 +10297,7 @@ implementation: LPAREN FUN LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 1179.
+## Ends in an error in state: 2161.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10332,17 +10332,17 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 809.
+## Ends in an error in state: 772.
 ##
 ## fun_def -> EQUALGREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10354,7 +10354,7 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 808.
+## Ends in an error in state: 771.
 ##
 ## fun_def -> LPAREN TYPE LIDENT RPAREN . fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10366,7 +10366,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 ##
-## Ends in an error in state: 807.
+## Ends in an error in state: 770.
 ##
 ## fun_def -> LPAREN TYPE LIDENT . RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10378,7 +10378,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE LIDENT WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 ##
-## Ends in an error in state: 806.
+## Ends in an error in state: 769.
 ##
 ## fun_def -> LPAREN TYPE . LIDENT RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10390,7 +10390,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN TYPE WITH
 
 implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 ##
-## Ends in an error in state: 805.
+## Ends in an error in state: 768.
 ##
 ## _simple_pattern_not_ident -> LPAREN . pattern RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
 ## _simple_pattern_not_ident -> LPAREN . pattern_two_or_more_comma_list RPAREN [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER COLON CHAR BACKQUOTE ]
@@ -10413,7 +10413,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 1184.
+## Ends in an error in state: 2166.
 ##
 ## fun_def -> labeled_simple_pattern . fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10425,7 +10425,7 @@ implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 
 implementation: LPAREN FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1198.
+## Ends in an error in state: 2180.
 ##
 ## _expr -> FUN labeled_simple_pattern . fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10437,7 +10437,7 @@ implementation: LPAREN FUN UNDERSCORE WITH
 
 implementation: LPAREN FUN WITH
 ##
-## Ends in an error in state: 800.
+## Ends in an error in state: 763.
 ##
 ## _expr -> FUN . labeled_simple_pattern fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> FUN . LPAREN TYPE LIDENT RPAREN fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10451,7 +10451,7 @@ implementation: LPAREN FUN WITH
 
 implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 ##
-## Ends in an error in state: 799.
+## Ends in an error in state: 762.
 ##
 ## _expr -> IF simple_expr simple_expr ELSE . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10463,7 +10463,7 @@ implementation: LPAREN IF UIDENT UIDENT ELSE WITH
 
 implementation: LPAREN IF UIDENT WITH
 ##
-## Ends in an error in state: 794.
+## Ends in an error in state: 757.
 ##
 ## _expr -> IF simple_expr . simple_expr ELSE expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF simple_expr . simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10483,17 +10483,17 @@ implementation: LPAREN IF UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 846, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 834, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN IF WITH
 ##
-## Ends in an error in state: 793.
+## Ends in an error in state: 756.
 ##
 ## _expr -> IF . simple_expr simple_expr ELSE expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> IF . simple_expr simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10506,7 +10506,7 @@ implementation: LPAREN IF WITH
 
 implementation: LPAREN LAZY WITH
 ##
-## Ends in an error in state: 784.
+## Ends in an error in state: 747.
 ##
 ## _expr -> LAZY . simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10518,7 +10518,7 @@ implementation: LPAREN LAZY WITH
 
 implementation: LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 772.
+## Ends in an error in state: 471.
 ##
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE . semi_terminated_seq_expr error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10538,7 +10538,7 @@ implementation: LPAREN LBRACE WITH
 
 implementation: LPAREN LBRACELESS WITH
 ##
-## Ends in an error in state: 763.
+## Ends in an error in state: 462.
 ##
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10552,7 +10552,7 @@ implementation: LPAREN LBRACELESS WITH
 
 implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ##
-## Ends in an error in state: 1142.
+## Ends in an error in state: 2124.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT expr_optional_constraint . RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10563,22 +10563,22 @@ implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 950, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1107, spurious reduction of production expr_optional_constraint -> expr
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 940, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 861, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 949, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2105, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKET UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1145.
+## Ends in an error in state: 2127.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint COMMA . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## opt_comma -> COMMA . [ RBRACKET ]
@@ -10591,7 +10591,7 @@ implementation: LPAREN LBRACKET UIDENT COMMA WITH
 
 implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2331.
+## Ends in an error in state: 2394.
 ##
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10604,23 +10604,23 @@ implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1128, spurious reduction of production expr_optional_constraint -> expr
-## In state 1124, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1108, spurious reduction of production expr_optional_constraint -> expr
+## In state 2115, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKETBAR WITH
 ##
-## Ends in an error in state: 720.
+## Ends in an error in state: 445.
 ##
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10646,7 +10646,7 @@ implementation: LPAREN LBRACKETPERCENT UNDERSCORE
 
 implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2460.
+## Ends in an error in state: 2464.
 ##
 ## extension -> LBRACKETPERCENT attr_id payload . RBRACKET [ error WITH UNDERSCORE UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10657,30 +10657,30 @@ implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1858, spurious reduction of production post_item_attributes ->
-## In state 1859, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1860, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1803, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1796, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1804, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1797, spurious reduction of production structure -> structure_item
-## In state 1864, spurious reduction of production payload -> structure
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1906, spurious reduction of production post_item_attributes ->
+## In state 1907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1856, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1722, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1909, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1857, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1723, spurious reduction of production structure -> structure_item
+## In state 1852, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 876.
+## Ends in an error in state: 897.
 ##
 ## _expr -> label EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10692,7 +10692,7 @@ implementation: LPAREN LIDENT EQUAL WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ##
-## Ends in an error in state: 2481.
+## Ends in an error in state: 2485.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr . RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10727,21 +10727,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 950, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 940, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 861, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 949, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2480.
+## Ends in an error in state: 2484.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA . expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10753,7 +10753,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2479.
+## Ends in an error in state: 2483.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr . COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10788,21 +10788,21 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 950, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 940, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 861, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 949, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2478.
+## Ends in an error in state: 2482.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN . expr COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10814,7 +10814,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2477.
+## Ends in an error in state: 2481.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN . LPAREN expr COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10826,7 +10826,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2476.
+## Ends in an error in state: 2480.
 ##
 ## _expr -> LPAREN COLONCOLON . RPAREN LPAREN expr COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10838,7 +10838,7 @@ implementation: LPAREN LPAREN COLONCOLON WITH
 
 implementation: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2470.
+## Ends in an error in state: 2474.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -10854,12 +10854,12 @@ implementation: LPAREN LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 754, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 758, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 755, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 736, spurious reduction of production _module_expr -> simple_module_expr
-## In state 760, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 759, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 809, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 813, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 810, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 796, spurious reduction of production _module_expr -> simple_module_expr
+## In state 815, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 814, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
@@ -10880,7 +10880,7 @@ Expecting a module expression
 
 implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ##
-## Ends in an error in state: 2483.
+## Ends in an error in state: 2487.
 ##
 ## _simple_expr -> LPAREN expr_comma_list . RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN expr_comma_list . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10893,12 +10893,12 @@ implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1128, spurious reduction of production expr_optional_constraint -> expr
-## In state 2279, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1108, spurious reduction of production expr_optional_constraint -> expr
+## In state 1107, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
@@ -10932,7 +10932,7 @@ Expecting one of the following:
 
 implementation: LPAREN MINUS WITH
 ##
-## Ends in an error in state: 762.
+## Ends in an error in state: 817.
 ##
 ## operator -> MINUS . [ RPAREN ]
 ## subtractive -> MINUS . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
@@ -10945,7 +10945,7 @@ implementation: LPAREN MINUS WITH
 
 implementation: LPAREN MINUSDOT WITH
 ##
-## Ends in an error in state: 761.
+## Ends in an error in state: 816.
 ##
 ## operator -> MINUSDOT . [ RPAREN ]
 ## subtractive -> MINUSDOT . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT64 INT32 INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
@@ -10958,7 +10958,7 @@ implementation: LPAREN MINUSDOT WITH
 
 implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2474.
+## Ends in an error in state: 2478.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10978,7 +10978,7 @@ implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2472.
+## Ends in an error in state: 2476.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -11068,7 +11068,7 @@ implementation: LPAREN PREFIXOP WITH
 
 implementation: LPAREN STAR WITH
 ##
-## Ends in an error in state: 543.
+## Ends in an error in state: 581.
 ##
 ## val_ident -> LPAREN operator . RPAREN [ error UNDERSCORE UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11080,7 +11080,7 @@ implementation: LPAREN STAR WITH
 
 implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1113.
+## Ends in an error in state: 1130.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -11092,7 +11092,7 @@ implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 
 implementation: LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1110.
+## Ends in an error in state: 1127.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -11104,7 +11104,7 @@ implementation: LPAREN UIDENT COLON WITH
 
 implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 2277.
+## Ends in an error in state: 1105.
 ##
 ## expr_comma_list -> expr_optional_constraint . COMMA expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -11121,15 +11121,15 @@ implementation: LPAREN UIDENT COLONGREATER LESSDOTDOTGREATER WITH
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1109, spurious reduction of production type_constraint -> COLONGREATER core_type
-## In state 2489, spurious reduction of production expr_optional_constraint -> expr type_constraint
+## In state 1126, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 2493, spurious reduction of production expr_optional_constraint -> expr type_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1108.
+## Ends in an error in state: 1125.
 ##
 ## type_constraint -> COLONGREATER . core_type [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -11141,7 +11141,7 @@ implementation: LPAREN UIDENT COLONGREATER WITH
 
 implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 2283.
+## Ends in an error in state: 1120.
 ##
 ## expr_comma_list -> expr_comma_list COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -11153,7 +11153,7 @@ implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 
 implementation: LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2278.
+## Ends in an error in state: 1106.
 ##
 ## expr_comma_list -> expr_optional_constraint COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -11226,7 +11226,7 @@ implementation: PERCENT WITH WITH
 
 implementation: STRING LIDENT COLONCOLON WITH
 ##
-## Ends in an error in state: 868.
+## Ends in an error in state: 889.
 ##
 ## label_expr -> LIDENT COLONCOLON . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11238,7 +11238,7 @@ implementation: STRING LIDENT COLONCOLON WITH
 
 implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 ##
-## Ends in an error in state: 865.
+## Ends in an error in state: 886.
 ##
 ## label_expr -> LIDENT EXPLICITLY_PASSED_OPTIONAL . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -11250,7 +11250,7 @@ implementation: STRING LIDENT EXPLICITLY_PASSED_OPTIONAL WITH
 
 implementation: STRING WITH
 ##
-## Ends in an error in state: 1797.
+## Ends in an error in state: 1723.
 ##
 ## structure -> structure_item . [ RBRACKET RBRACE EOF ]
 ## structure -> structure_item . error structure [ RBRACKET RBRACE EOF ]
@@ -11263,24 +11263,24 @@ implementation: STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1858, spurious reduction of production post_item_attributes ->
-## In state 1859, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1860, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1803, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1796, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1804, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1906, spurious reduction of production post_item_attributes ->
+## In state 1907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1856, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1722, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1909, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1857, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 Incomplete statement. Did you forget a ";"?
 
 implementation: SWITCH UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2515.
+## Ends in an error in state: 2519.
 ##
 ## _expr -> SWITCH simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11292,7 +11292,7 @@ implementation: SWITCH UIDENT LBRACE WITH
 
 implementation: SWITCH UIDENT WITH
 ##
-## Ends in an error in state: 2514.
+## Ends in an error in state: 2518.
 ##
 ## _expr -> SWITCH simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ SHARPOP SHARP LBRACE DOT ]
@@ -11311,10 +11311,10 @@ implementation: SWITCH UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 846, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 834, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -11333,7 +11333,7 @@ implementation: SWITCH WITH
 
 implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 ##
-## Ends in an error in state: 1098.
+## Ends in an error in state: 1049.
 ##
 ## _expr -> simple_expr DOT LBRACE expr RBRACE EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11345,7 +11345,7 @@ implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 
 implementation: TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 1096.
+## Ends in an error in state: 1047.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11381,21 +11381,21 @@ implementation: TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 950, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 940, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 861, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 949, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 1095.
+## Ends in an error in state: 1046.
 ##
 ## _expr -> simple_expr DOT LBRACE . expr RBRACE EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11408,7 +11408,7 @@ implementation: TRUE DOT LBRACE WITH
 
 implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 ##
-## Ends in an error in state: 1093.
+## Ends in an error in state: 1044.
 ##
 ## _expr -> simple_expr DOT LBRACKET expr RBRACKET EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11420,7 +11420,7 @@ implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 
 implementation: TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 1090.
+## Ends in an error in state: 1041.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11457,21 +11457,21 @@ implementation: TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1089.
+## Ends in an error in state: 1040.
 ##
 ## _expr -> simple_expr DOT LBRACKET . expr RBRACKET EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11485,7 +11485,7 @@ implementation: TRUE DOT LBRACKET WITH
 
 implementation: TRUE DOT LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1101.
+## Ends in an error in state: 1052.
 ##
 ## _expr -> simple_expr DOT label_longident EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11497,7 +11497,7 @@ implementation: TRUE DOT LIDENT EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 ##
-## Ends in an error in state: 1087.
+## Ends in an error in state: 1038.
 ##
 ## _expr -> simple_expr DOT LPAREN expr RPAREN EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11509,7 +11509,7 @@ implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1084.
+## Ends in an error in state: 1035.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11546,21 +11546,21 @@ implementation: TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 859.
+## Ends in an error in state: 880.
 ##
 ## _expr -> simple_expr DOT LPAREN . expr RPAREN EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11574,7 +11574,7 @@ implementation: TRUE DOT LPAREN WITH
 
 implementation: TRUE DOT UIDENT DOT WITH
 ##
-## Ends in an error in state: 471.
+## Ends in an error in state: 509.
 ##
 ## label_longident -> mod_longident DOT . LIDENT [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident DOT . UIDENT [ DOT ]
@@ -11587,7 +11587,7 @@ implementation: TRUE DOT UIDENT DOT WITH
 
 implementation: TRUE DOT UIDENT WITH
 ##
-## Ends in an error in state: 470.
+## Ends in an error in state: 508.
 ##
 ## label_longident -> mod_longident . DOT LIDENT [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUAL EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## mod_longident -> mod_longident . DOT UIDENT [ DOT ]
@@ -11600,7 +11600,7 @@ implementation: TRUE DOT UIDENT WITH
 
 implementation: TRUE DOT WITH
 ##
-## Ends in an error in state: 858.
+## Ends in an error in state: 879.
 ##
 ## _expr -> simple_expr DOT . label_longident EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> simple_expr DOT . LPAREN expr RPAREN EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -11621,7 +11621,7 @@ implementation: TRUE DOT WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER CHAR BAR WITH
 ##
-## Ends in an error in state: 727.
+## Ends in an error in state: 1085.
 ##
 ## pattern_with_bar -> BAR . pattern [ WHEN EQUALGREATER ]
 ##
@@ -11633,7 +11633,7 @@ Expecting a match case
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER MODULE UIDENT EQUAL UIDENT RBRACKET
 ##
-## Ends in an error in state: 754.
+## Ends in an error in state: 809.
 ##
 ## _simple_module_expr -> mod_longident . [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ WITH UIDENT SEMI RPAREN LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EQUAL EOF DOT COLON AND ]
@@ -11646,43 +11646,43 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER MODULE UIDENT EQUA
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2296.
+## Ends in an error in state: 2369.
 ##
-## _semi_terminated_seq_expr_row -> MODULE UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
+## _semi_terminated_seq_expr_row -> opt_let_module UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
 ## The known suffix of the stack is as follows:
-## MODULE UIDENT module_binding_body post_item_attributes SEMI
+## opt_let_module UIDENT module_binding_body post_item_attributes SEMI
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2293.
+## Ends in an error in state: 2366.
 ##
-## _semi_terminated_seq_expr_row -> MODULE UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
+## _semi_terminated_seq_expr_row -> opt_let_module UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
 ## The known suffix of the stack is as follows:
-## MODULE UIDENT
+## opt_let_module UIDENT
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER MODULE WITH
 ##
-## Ends in an error in state: 2292.
+## Ends in an error in state: 2365.
 ##
-## _semi_terminated_seq_expr_row -> MODULE . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
+## _semi_terminated_seq_expr_row -> opt_let_module . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
 ## The known suffix of the stack is as follows:
-## MODULE
+## opt_let_module
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 ##
-## Ends in an error in state: 2302.
+## Ends in an error in state: 2360.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11694,7 +11694,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2305.
+## Ends in an error in state: 2363.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11706,7 +11706,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2304.
+## Ends in an error in state: 2362.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11717,14 +11717,14 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2303, spurious reduction of production post_item_attributes ->
+## In state 2361, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 ##
-## Ends in an error in state: 2301.
+## Ends in an error in state: 2359.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11736,9 +11736,10 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 ##
-## Ends in an error in state: 2297.
+## Ends in an error in state: 2355.
 ##
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI RBRACE BAR AND ]
+## opt_let_module -> LET . MODULE [ UIDENT ]
 ## option(LET) -> LET . [ OPEN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -11749,7 +11750,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 ##
-## Ends in an error in state: 2312.
+## Ends in an error in state: 2376.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ RBRACE BAR ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI RBRACE BAR AND ]
@@ -11769,7 +11770,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 2644.
+## Ends in an error in state: 2648.
 ##
 ## _expr -> TRY simple_expr LBRACE leading_bar_match_cases_to_sequence_body . RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## leading_bar_match_cases_to_sequence_body -> leading_bar_match_cases_to_sequence_body . leading_bar_match_case_to_sequence_body [ RBRACE BAR ]
@@ -11781,24 +11782,24 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 950, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2314, spurious reduction of production post_item_attributes ->
-## In state 2315, spurious reduction of production opt_semi ->
-## In state 2320, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
-## In state 2318, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
-## In state 2307, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
-## In state 2298, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
-## In state 2319, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2308, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
-## In state 2324, spurious reduction of production leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER semi_terminated_seq_expr
-## In state 2328, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 940, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 861, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 949, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2378, spurious reduction of production post_item_attributes ->
+## In state 2379, spurious reduction of production opt_semi ->
+## In state 2384, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
+## In state 2382, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
+## In state 2371, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
+## In state 2356, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
+## In state 2383, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2372, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2387, spurious reduction of production leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER semi_terminated_seq_expr
+## In state 2391, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
 ##
 
 Expecting one of the following:
@@ -11807,7 +11808,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2323.
+## Ends in an error in state: 2386.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11819,7 +11820,7 @@ Expecting the body of the matched pattern
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ##
-## Ends in an error in state: 728.
+## Ends in an error in state: 1086.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN EQUALGREATER BAR ]
 ## pattern_with_bar -> BAR pattern . [ WHEN EQUALGREATER ]
@@ -11831,7 +11832,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 610, spurious reduction of production pattern -> pattern_without_or
+## In state 641, spurious reduction of production pattern -> pattern_without_or
 ##
 
 Expecting one of the following:
@@ -11841,7 +11842,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2291.
+## Ends in an error in state: 2354.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar WHEN expr EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11853,7 +11854,7 @@ Expecting a sequence item
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2290.
+## Ends in an error in state: 2353.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11888,21 +11889,21 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 950, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 940, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 861, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 949, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 730.
+## Ends in an error in state: 2352.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar WHEN . expr EQUALGREATER semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11914,7 +11915,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 
 implementation: TRY UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2643.
+## Ends in an error in state: 2647.
 ##
 ## _expr -> TRY simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11926,7 +11927,7 @@ implementation: TRY UIDENT LBRACE WITH
 
 implementation: TRY UIDENT UNDERSCORE
 ##
-## Ends in an error in state: 2640.
+## Ends in an error in state: 2644.
 ##
 ## _expr -> TRY simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> TRY simple_expr . WITH error [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -11946,17 +11947,17 @@ implementation: TRY UIDENT UNDERSCORE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 846, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 834, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT WITH WITH
 ##
-## Ends in an error in state: 2641.
+## Ends in an error in state: 2645.
 ##
 ## _expr -> TRY simple_expr WITH . error [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11981,7 +11982,7 @@ implementation: TRY WITH
 
 implementation: TYPE LIDENT AND LIDENT WITH
 ##
-## Ends in an error in state: 1808.
+## Ends in an error in state: 1861.
 ##
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -11992,14 +11993,14 @@ implementation: TYPE LIDENT AND LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1807, spurious reduction of production optional_type_parameters ->
+## In state 1860, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT AND WITH
 ##
-## Ends in an error in state: 1806.
+## Ends in an error in state: 1859.
 ##
 ## and_type_declaration -> AND . type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -12011,7 +12012,7 @@ implementation: TYPE LIDENT AND WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1813.
+## Ends in an error in state: 1760.
 ##
 ## constrain -> core_type EQUAL . core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -12023,7 +12024,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1812.
+## Ends in an error in state: 1759.
 ##
 ## constrain -> core_type . EQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -12046,7 +12047,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 
 implementation: TYPE LIDENT CONSTRAINT WITH
 ##
-## Ends in an error in state: 1811.
+## Ends in an error in state: 1758.
 ##
 ## constraints -> constraints CONSTRAINT . constrain [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -12058,7 +12059,7 @@ implementation: TYPE LIDENT CONSTRAINT WITH
 
 implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2593.
+## Ends in an error in state: 2597.
 ##
 ## constructor_declarations -> constructor_declarations_leading_bar . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations_leading_bar -> constructor_declarations_leading_bar . constructor_declaration_leading_bar [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
@@ -12070,17 +12071,17 @@ implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1388, spurious reduction of production attributes ->
-## In state 1389, spurious reduction of production attributes -> attribute attributes
-## In state 2578, spurious reduction of production constructor_declaration_leading_bar -> BAR UIDENT generalized_constructor_arguments attributes
-## In state 2598, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
+## In state 1314, spurious reduction of production attributes ->
+## In state 1315, spurious reduction of production attributes -> attribute attributes
+## In state 2582, spurious reduction of production constructor_declaration_leading_bar -> BAR UIDENT generalized_constructor_arguments attributes
+## In state 2602, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 ##
-## Ends in an error in state: 1810.
+## Ends in an error in state: 1863.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_declaration_details -> LIDENT optional_type_parameters type_kind constraints . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -12093,7 +12094,7 @@ implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER COMMA WITH
 ##
-## Ends in an error in state: 1336.
+## Ends in an error in state: 1262.
 ##
 ## label_declarations -> label_declarations COMMA . label_declaration [ RBRACE COMMA ]
 ## opt_comma -> COMMA . [ RBRACE ]
@@ -12108,7 +12109,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2602.
+## Ends in an error in state: 2606.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12126,12 +12127,12 @@ implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ## In state 299, spurious reduction of production _core_type -> core_type2
 ## In state 308, spurious reduction of production mark_position_typ(_core_type) -> _core_type
 ## In state 295, spurious reduction of production core_type -> mark_position_typ(_core_type)
-## In state 1333, spurious reduction of production _poly_type -> core_type
-## In state 1334, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1332, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 1330, spurious reduction of production attributes ->
-## In state 1331, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 1340, spurious reduction of production label_declarations -> label_declaration
+## In state 1259, spurious reduction of production _poly_type -> core_type
+## In state 1260, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1258, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 1256, spurious reduction of production attributes ->
+## In state 1257, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 1266, spurious reduction of production label_declarations -> label_declaration
 ##
 
 Expecting one of the following:
@@ -12140,7 +12141,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1324.
+## Ends in an error in state: 1250.
 ##
 ## label_declaration -> mutable_flag LIDENT COLON . poly_type attributes [ RBRACE COMMA ]
 ##
@@ -12152,7 +12153,7 @@ Expecting a type name describing this field
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 1323.
+## Ends in an error in state: 1249.
 ##
 ## label_declaration -> mutable_flag LIDENT . COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -12165,7 +12166,7 @@ Expecting ":"
 
 implementation: TYPE LIDENT EQUAL LBRACE MUTABLE LET
 ##
-## Ends in an error in state: 1322.
+## Ends in an error in state: 1248.
 ##
 ## label_declaration -> mutable_flag . LIDENT COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -12178,7 +12179,7 @@ Expecting a type field definition in the form of:
 
 implementation: TYPE LIDENT EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2601.
+## Ends in an error in state: 2605.
 ##
 ## type_kind -> EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -12191,7 +12192,7 @@ Expecting at least one type field definition in the form of:
 
     implementation: TYPE LIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 2565.
+## Ends in an error in state: 2569.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
 ## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
@@ -12205,7 +12206,7 @@ Expecting at least one type field definition in the form of:
 
 implementation: TYPE LIDENT EQUAL PRIVATE WITH
 ##
-## Ends in an error in state: 2564.
+## Ends in an error in state: 2568.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL PRIVATE . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12233,7 +12234,7 @@ implementation: TYPE LIDENT EQUAL UIDENT WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 ##
-## Ends in an error in state: 2575.
+## Ends in an error in state: 2579.
 ##
 ## constructor_declaration_leading_bar -> BAR . UIDENT generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
 ## constructor_declaration_leading_bar -> BAR . LPAREN RPAREN generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
@@ -12249,7 +12250,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDOTGREATER AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 2614.
+## Ends in an error in state: 2618.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12261,17 +12262,17 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LESSDOTDO
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1278, spurious reduction of production attributes ->
-## In state 1279, spurious reduction of production attributes -> attribute attributes
-## In state 1331, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
-## In state 1340, spurious reduction of production label_declarations -> label_declaration
+## In state 1204, spurious reduction of production attributes ->
+## In state 1205, spurious reduction of production attributes -> attribute attributes
+## In state 1257, spurious reduction of production label_declaration -> mutable_flag LIDENT COLON poly_type attributes
+## In state 1266, spurious reduction of production label_declarations -> label_declaration
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2613.
+## Ends in an error in state: 2617.
 ##
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -12283,7 +12284,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 ##
-## Ends in an error in state: 2608.
+## Ends in an error in state: 2612.
 ##
 ## private_flag -> PRIVATE . [ LBRACE ]
 ## type_kind -> EQUAL core_type EQUAL PRIVATE . constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12296,7 +12297,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE BANG
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2596.
+## Ends in an error in state: 2600.
 ##
 ## constructor_declarations -> constructor_declaration_no_leading_bar . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations -> constructor_declaration_no_leading_bar . constructor_declarations_leading_bar [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12308,16 +12309,16 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1388, spurious reduction of production attributes ->
-## In state 1389, spurious reduction of production attributes -> attribute attributes
-## In state 2560, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
+## In state 1314, spurious reduction of production attributes ->
+## In state 1315, spurious reduction of production attributes -> attribute attributes
+## In state 2564, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2606.
+## Ends in an error in state: 2610.
 ##
 ## type_kind -> EQUAL core_type EQUAL . constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type EQUAL . PRIVATE constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12332,7 +12333,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 2605.
+## Ends in an error in state: 2609.
 ##
 ## type_kind -> EQUAL core_type . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type . EQUAL constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12348,11 +12349,11 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 362, spurious reduction of production _core_type2 -> non_arrowed_core_type
-## In state 643, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
-## In state 637, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
-## In state 639, spurious reduction of production _core_type -> core_type2
-## In state 650, spurious reduction of production mark_position_typ(_core_type) -> _core_type
-## In state 638, spurious reduction of production core_type -> mark_position_typ(_core_type)
+## In state 674, spurious reduction of production mark_position_typ(_core_type2) -> _core_type2
+## In state 668, spurious reduction of production core_type2 -> mark_position_typ(_core_type2)
+## In state 670, spurious reduction of production _core_type -> core_type2
+## In state 681, spurious reduction of production mark_position_typ(_core_type) -> _core_type
+## In state 669, spurious reduction of production core_type -> mark_position_typ(_core_type)
 ##
 
 <SYNTAX ERROR>
@@ -12380,7 +12381,7 @@ implementation: TYPE LIDENT EQUAL WITH
 
 implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1805.
+## Ends in an error in state: 1858.
 ##
 ## _structure_item_without_item_extension_sugar -> many_type_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -12392,9 +12393,9 @@ implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1379, spurious reduction of production post_item_attributes ->
-## In state 1380, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2620, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 1305, spurious reduction of production post_item_attributes ->
+## In state 1306, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2624, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
@@ -12451,7 +12452,7 @@ implementation: TYPE LIDENT PLUS WITH
 
 implementation: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 2624.
+## Ends in an error in state: 2628.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12463,7 +12464,7 @@ implementation: TYPE LIDENT PLUSEQ BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ PRIVATE BANG
 ##
-## Ends in an error in state: 2623.
+## Ends in an error in state: 2627.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12475,7 +12476,7 @@ implementation: TYPE LIDENT PLUSEQ PRIVATE BANG
 
 implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 2626.
+## Ends in an error in state: 2630.
 ##
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_rebind [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -12488,7 +12489,7 @@ implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 2622.
+## Ends in an error in state: 2626.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12536,7 +12537,7 @@ Expecting one of the following:
 
 implementation: TYPE UIDENT DOT WITH
 ##
-## Ends in an error in state: 1894.
+## Ends in an error in state: 2064.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -12550,7 +12551,7 @@ implementation: TYPE UIDENT DOT WITH
 
 implementation: TYPE UIDENT WITH
 ##
-## Ends in an error in state: 1893.
+## Ends in an error in state: 2063.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -12589,7 +12590,7 @@ implementation: TYPE WITH
 
 implementation: UIDENT AMPERAMPER WITH
 ##
-## Ends in an error in state: 1039.
+## Ends in an error in state: 1031.
 ##
 ## _expr -> expr AMPERAMPER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12601,7 +12602,7 @@ implementation: UIDENT AMPERAMPER WITH
 
 implementation: UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 1037.
+## Ends in an error in state: 1029.
 ##
 ## _expr -> expr AMPERSAND . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12613,7 +12614,7 @@ implementation: UIDENT AMPERSAND WITH
 
 implementation: UIDENT BARBAR WITH
 ##
-## Ends in an error in state: 1035.
+## Ends in an error in state: 1027.
 ##
 ## _expr -> expr BARBAR . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12625,7 +12626,7 @@ implementation: UIDENT BARBAR WITH
 
 implementation: UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1041.
+## Ends in an error in state: 1033.
 ##
 ## _expr -> expr COLONEQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12637,7 +12638,7 @@ implementation: UIDENT COLONEQUAL WITH
 
 implementation: UIDENT DOT LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 1175.
+## Ends in an error in state: 2157.
 ##
 ## lbl_expr -> label_longident . COLON expr [ COMMA ]
 ## lbl_expr -> label_longident . [ COMMA ]
@@ -12651,7 +12652,7 @@ implementation: UIDENT DOT LBRACE LIDENT WITH
 
 implementation: UIDENT DOT LBRACE WITH
 ##
-## Ends in an error in state: 1155.
+## Ends in an error in state: 2137.
 ##
 ## _simple_expr -> mod_longident DOT LBRACE . RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12665,7 +12666,7 @@ implementation: UIDENT DOT LBRACE WITH
 
 implementation: UIDENT DOT LBRACELESS WITH
 ##
-## Ends in an error in state: 1150.
+## Ends in an error in state: 2132.
 ##
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12678,7 +12679,7 @@ implementation: UIDENT DOT LBRACELESS WITH
 
 implementation: UIDENT DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1140.
+## Ends in an error in state: 2122.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12690,7 +12691,7 @@ implementation: UIDENT DOT LBRACKET WITH
 
 implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 1125.
+## Ends in an error in state: 2116.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12703,23 +12704,23 @@ implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1128, spurious reduction of production expr_optional_constraint -> expr
-## In state 1124, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1108, spurious reduction of production expr_optional_constraint -> expr
+## In state 2115, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LBRACKETBAR WITH
 ##
-## Ends in an error in state: 1123.
+## Ends in an error in state: 2114.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12732,7 +12733,7 @@ implementation: UIDENT DOT LBRACKETBAR WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 827.
+## Ends in an error in state: 2100.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12752,7 +12753,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 825.
+## Ends in an error in state: 2098.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12765,7 +12766,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 824.
+## Ends in an error in state: 2097.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -12780,19 +12781,19 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 754, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 758, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 755, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 736, spurious reduction of production _module_expr -> simple_module_expr
-## In state 760, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 759, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 809, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 813, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 810, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 796, spurious reduction of production _module_expr -> simple_module_expr
+## In state 815, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 814, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN MODULE WITH
 ##
-## Ends in an error in state: 823.
+## Ends in an error in state: 786.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON package_type RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE . module_expr COLON error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12805,7 +12806,7 @@ implementation: UIDENT DOT LPAREN MODULE WITH
 
 implementation: UIDENT DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1104.
+## Ends in an error in state: 2102.
 ##
 ## expr_comma_list -> expr_optional_constraint . COMMA expr_optional_constraint [ RPAREN COMMA ]
 ##
@@ -12816,22 +12817,22 @@ implementation: UIDENT DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1120, spurious reduction of production expr_optional_constraint -> expr
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2111, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LPAREN WITH
 ##
-## Ends in an error in state: 822.
+## Ends in an error in state: 785.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN . expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12848,7 +12849,7 @@ implementation: UIDENT DOT LPAREN WITH
 
 implementation: UIDENT DOT WITH
 ##
-## Ends in an error in state: 821.
+## Ends in an error in state: 784.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12874,7 +12875,7 @@ implementation: UIDENT DOT WITH
 
 implementation: UIDENT GREATER WITH
 ##
-## Ends in an error in state: 1031.
+## Ends in an error in state: 1023.
 ##
 ## _expr -> expr GREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr GREATER . GREATER expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -12887,7 +12888,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP0 WITH
 ##
-## Ends in an error in state: 1029.
+## Ends in an error in state: 1021.
 ##
 ## _expr -> expr INFIXOP0 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12899,7 +12900,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP1 WITH
 ##
-## Ends in an error in state: 1025.
+## Ends in an error in state: 1017.
 ##
 ## _expr -> expr INFIXOP1 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12911,7 +12912,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP2 WITH
 ##
-## Ends in an error in state: 1023.
+## Ends in an error in state: 1015.
 ##
 ## _expr -> expr INFIXOP2 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12923,7 +12924,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP3 WITH
 ##
-## Ends in an error in state: 1009.
+## Ends in an error in state: 1001.
 ##
 ## _expr -> expr INFIXOP3 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12935,7 +12936,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP4 WITH
 ##
-## Ends in an error in state: 880.
+## Ends in an error in state: 901.
 ##
 ## _expr -> expr INFIXOP4 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12959,7 +12960,7 @@ Expecting an attribute id
 
 implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2438.
+## Ends in an error in state: 2442.
 ##
 ## attribute -> LBRACKETAT attr_id payload . RBRACKET [ error WITH UIDENT STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARRBRACKET BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12970,23 +12971,23 @@ implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1858, spurious reduction of production post_item_attributes ->
-## In state 1859, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1860, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1803, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1796, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1804, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1797, spurious reduction of production structure -> structure_item
-## In state 1864, spurious reduction of production payload -> structure
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1906, spurious reduction of production post_item_attributes ->
+## In state 1907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1856, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1722, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1909, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1857, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1723, spurious reduction of production structure -> structure_item
+## In state 1852, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
@@ -13005,7 +13006,7 @@ Expecting an attributed id
 
 implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2435.
+## Ends in an error in state: 2439.
 ##
 ## item_attribute -> LBRACKETATAT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -13016,30 +13017,30 @@ implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1858, spurious reduction of production post_item_attributes ->
-## In state 1859, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1860, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1803, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1796, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1804, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1797, spurious reduction of production structure -> structure_item
-## In state 1864, spurious reduction of production payload -> structure
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1906, spurious reduction of production post_item_attributes ->
+## In state 1907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1856, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1722, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1909, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1857, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1723, spurious reduction of production structure -> structure_item
+## In state 1852, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
 
 implementation: UIDENT LESS WITH
 ##
-## Ends in an error in state: 1027.
+## Ends in an error in state: 1019.
 ##
 ## _expr -> expr LESS . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13051,7 +13052,7 @@ Expecting an expression
 
 implementation: UIDENT LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1021.
+## Ends in an error in state: 1013.
 ##
 ## _expr -> expr LESSDOTDOTGREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13100,7 +13101,7 @@ Expecting one of the following:
 
 implementation: UIDENT MINUS WITH
 ##
-## Ends in an error in state: 1019.
+## Ends in an error in state: 1011.
 ##
 ## _expr -> expr MINUS . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13112,7 +13113,7 @@ Expecting an expression
 
 implementation: UIDENT MINUSDOT WITH
 ##
-## Ends in an error in state: 1017.
+## Ends in an error in state: 1009.
 ##
 ## _expr -> expr MINUSDOT . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13124,7 +13125,7 @@ Expecting an expression
 
 implementation: UIDENT OR WITH
 ##
-## Ends in an error in state: 1015.
+## Ends in an error in state: 1007.
 ##
 ## _expr -> expr OR . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13136,7 +13137,7 @@ Expecting an expression
 
 implementation: UIDENT PERCENT WITH
 ##
-## Ends in an error in state: 1007.
+## Ends in an error in state: 999.
 ##
 ## _expr -> expr PERCENT . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13148,7 +13149,7 @@ Expecting an expression
 
 implementation: UIDENT PLUS WITH
 ##
-## Ends in an error in state: 1013.
+## Ends in an error in state: 1005.
 ##
 ## _expr -> expr PLUS . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13160,7 +13161,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSDOT WITH
 ##
-## Ends in an error in state: 1011.
+## Ends in an error in state: 1003.
 ##
 ## _expr -> expr PLUSDOT . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13172,7 +13173,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 1005.
+## Ends in an error in state: 997.
 ##
 ## _expr -> expr PLUSEQ . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13184,7 +13185,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1082.
+## Ends in an error in state: 995.
 ##
 ## _expr -> expr QUESTION expr COLON . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13196,7 +13197,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT SEMI
 ##
-## Ends in an error in state: 1081.
+## Ends in an error in state: 994.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -13231,14 +13232,14 @@ implementation: UIDENT QUESTION UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 950, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 940, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 861, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 949, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13247,7 +13248,7 @@ Expecting one of the following:
 
 implementation: UIDENT QUESTION WITH
 ##
-## Ends in an error in state: 895.
+## Ends in an error in state: 916.
 ##
 ## _expr -> expr QUESTION . expr COLON expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13259,7 +13260,7 @@ Expecting an expression
 
 implementation: UIDENT RBRACKET
 ##
-## Ends in an error in state: 2652.
+## Ends in an error in state: 2656.
 ##
 ## implementation -> structure . EOF [ # ]
 ##
@@ -13270,29 +13271,29 @@ implementation: UIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1858, spurious reduction of production post_item_attributes ->
-## In state 1859, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1860, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1803, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1796, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1804, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1797, spurious reduction of production structure -> structure_item
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1906, spurious reduction of production post_item_attributes ->
+## In state 1907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1856, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1722, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1909, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1857, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1723, spurious reduction of production structure -> structure_item
 ##
 
 Invalid token
 
 implementation: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 1862.
+## Ends in an error in state: 2049.
 ##
 ## structure -> structure_item SEMI . structure [ RBRACKET RBRACE EOF ]
 ##
@@ -13304,7 +13305,7 @@ Expecting a structure item
 
 implementation: UIDENT SHARP WITH
 ##
-## Ends in an error in state: 796.
+## Ends in an error in state: 759.
 ##
 ## _simple_expr -> simple_expr SHARP . label [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -13316,7 +13317,7 @@ Expecting an identifier
 
 implementation: UIDENT STAR WITH
 ##
-## Ends in an error in state: 878.
+## Ends in an error in state: 899.
 ##
 ## _expr -> expr STAR . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13328,7 +13329,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 1207.
+## Ends in an error in state: 2189.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13363,14 +13364,14 @@ implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 744, spurious reduction of production constr_longident -> mod_longident
-## In state 950, spurious reduction of production _simple_expr -> constr_longident
-## In state 848, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 838, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 920, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 930, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 959, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 929, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 737, spurious reduction of production constr_longident -> mod_longident
+## In state 940, spurious reduction of production _simple_expr -> constr_longident
+## In state 836, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 824, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 861, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 949, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13379,7 +13380,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 1206.
+## Ends in an error in state: 2188.
 ##
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -13391,7 +13392,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 1204.
+## Ends in an error in state: 2186.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13427,14 +13428,14 @@ implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13443,7 +13444,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1203.
+## Ends in an error in state: 2185.
 ##
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -13456,7 +13457,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1201.
+## Ends in an error in state: 2183.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13492,14 +13493,14 @@ implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 820, spurious reduction of production constr_longident -> mod_longident
-## In state 883, spurious reduction of production _simple_expr -> constr_longident
-## In state 853, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 830, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 857, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 863, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 892, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 862, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 783, spurious reduction of production constr_longident -> mod_longident
+## In state 904, spurious reduction of production _simple_expr -> constr_longident
+## In state 876, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 866, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 878, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 884, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 913, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 883, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13508,7 +13509,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 792.
+## Ends in an error in state: 755.
 ##
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -13521,7 +13522,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT WITH
 ##
-## Ends in an error in state: 791.
+## Ends in an error in state: 754.
 ##
 ## _simple_expr -> simple_expr DOT . label_longident [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -1448,7 +1448,7 @@ _structure_item_without_item_extension_sugar:
   | str_exception_declaration {
       mkstr(Pstr_exception $1)
     }
-  | MODULE nonlocal_module_binding_details post_item_attributes {
+  | opt_let_module nonlocal_module_binding_details post_item_attributes {
       let (ident, body) = $2 in
       let loc = mklocation $symbolstartpos $endpos in
       mkstr(Pstr_module (Mb.mk ident body ~attrs:$3 ~loc))
@@ -1517,7 +1517,7 @@ module_binding_body:
   | module_binding_body_functor { $1 }
 
 many_nonlocal_module_bindings:
-  | MODULE REC nonlocal_module_binding_details post_item_attributes {
+  | opt_let_module REC nonlocal_module_binding_details post_item_attributes {
     let (ident, body) = $3 in
     let loc = mklocation $symbolstartpos $endpos in
     [Mb.mk ident body ~attrs:$4 ~loc]
@@ -1715,11 +1715,11 @@ _signature_item:
   | sig_exception_declaration {
       mksig(Psig_exception $1)
     }
-  | MODULE as_loc(UIDENT) module_declaration post_item_attributes {
+  | opt_let_module as_loc(UIDENT) module_declaration post_item_attributes {
       let loc = mklocation $symbolstartpos $endpos in
       mksig(Psig_module (Md.mk $2 $3 ~attrs:$4 ~loc))
     }
-  | MODULE as_loc(UIDENT) EQUAL as_loc(mod_longident) post_item_attributes {
+  | opt_let_module as_loc(UIDENT) EQUAL as_loc(mod_longident) post_item_attributes {
       let loc = mklocation $symbolstartpos $endpos in
       let loc_mod = mklocation $startpos($4) $endpos($4) in
       mksig(
@@ -1787,7 +1787,7 @@ module_rec_declaration_details:
 ;
 
 many_module_rec_declarations:
-  | MODULE REC module_rec_declaration_details post_item_attributes {
+  | opt_let_module REC module_rec_declaration_details post_item_attributes {
       let (ident, body) = $3 in
       let loc = mklocation $symbolstartpos $endpos in
       [Md.mk ident body ~attrs:$4 ~loc]
@@ -2426,7 +2426,7 @@ _semi_terminated_seq_expr_row:
        * expression attributes *)
       {expr with pexp_attributes = item_attrs @ expr.pexp_attributes}
     }
-  | MODULE as_loc(UIDENT) module_binding_body post_item_attributes SEMI semi_terminated_seq_expr {
+  | opt_let_module as_loc(UIDENT) module_binding_body post_item_attributes SEMI semi_terminated_seq_expr {
       let item_attrs = $4 in
       mkexp ~attrs:item_attrs (Pexp_letmodule($2, $3, $6))
     }
@@ -4402,6 +4402,11 @@ toplevel_directive:
 ;
 
 /* Miscellaneous */
+
+opt_let_module:
+    | LET MODULE { () }
+    | MODULE { () }
+;
 
 name_tag:
     BACKQUOTE ident                             { $2 }

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -1448,10 +1448,10 @@ _structure_item_without_item_extension_sugar:
   | str_exception_declaration {
       mkstr(Pstr_exception $1)
     }
-  | LET MODULE nonlocal_module_binding_details post_item_attributes {
-      let (ident, body) = $3 in
+  | MODULE nonlocal_module_binding_details post_item_attributes {
+      let (ident, body) = $2 in
       let loc = mklocation $symbolstartpos $endpos in
-      mkstr(Pstr_module (Mb.mk ident body ~attrs:$4 ~loc))
+      mkstr(Pstr_module (Mb.mk ident body ~attrs:$3 ~loc))
     }
   | many_nonlocal_module_bindings {
       mkstr(Pstr_recmodule(List.rev $1))
@@ -1517,10 +1517,10 @@ module_binding_body:
   | module_binding_body_functor { $1 }
 
 many_nonlocal_module_bindings:
-  | LET MODULE REC nonlocal_module_binding_details post_item_attributes {
-    let (ident, body) = $4 in
+  | MODULE REC nonlocal_module_binding_details post_item_attributes {
+    let (ident, body) = $3 in
     let loc = mklocation $symbolstartpos $endpos in
-    [Mb.mk ident body ~attrs:$5 ~loc]
+    [Mb.mk ident body ~attrs:$4 ~loc]
   }
   | many_nonlocal_module_bindings and_nonlocal_module_bindings {
     $2::$1
@@ -1715,19 +1715,19 @@ _signature_item:
   | sig_exception_declaration {
       mksig(Psig_exception $1)
     }
-  | LET MODULE as_loc(UIDENT) module_declaration post_item_attributes {
+  | MODULE as_loc(UIDENT) module_declaration post_item_attributes {
       let loc = mklocation $symbolstartpos $endpos in
-      mksig(Psig_module (Md.mk $3 $4 ~attrs:$5 ~loc))
+      mksig(Psig_module (Md.mk $2 $3 ~attrs:$4 ~loc))
     }
-  | LET MODULE as_loc(UIDENT) EQUAL as_loc(mod_longident) post_item_attributes {
+  | MODULE as_loc(UIDENT) EQUAL as_loc(mod_longident) post_item_attributes {
       let loc = mklocation $symbolstartpos $endpos in
-      let loc_mod = mklocation $startpos($5) $endpos($5) in
+      let loc_mod = mklocation $startpos($4) $endpos($4) in
       mksig(
         Psig_module (
           Md.mk
-            $3
-            (Mty.alias ~loc:loc_mod $5)
-            ~attrs:$6
+            $2
+            (Mty.alias ~loc:loc_mod $4)
+            ~attrs:$5
             ~loc
         )
       )
@@ -1787,10 +1787,10 @@ module_rec_declaration_details:
 ;
 
 many_module_rec_declarations:
-  | LET MODULE REC module_rec_declaration_details post_item_attributes {
-      let (ident, body) = $4 in
+  | MODULE REC module_rec_declaration_details post_item_attributes {
+      let (ident, body) = $3 in
       let loc = mklocation $symbolstartpos $endpos in
-      [Md.mk ident body ~attrs:$5 ~loc]
+      [Md.mk ident body ~attrs:$4 ~loc]
     }
   | many_module_rec_declarations and_module_rec_declaration  {
       $2::$1
@@ -2426,9 +2426,9 @@ _semi_terminated_seq_expr_row:
        * expression attributes *)
       {expr with pexp_attributes = item_attrs @ expr.pexp_attributes}
     }
-  | LET MODULE as_loc(UIDENT) module_binding_body post_item_attributes SEMI semi_terminated_seq_expr {
-      let item_attrs = $5 in
-      mkexp ~attrs:item_attrs (Pexp_letmodule($3, $4, $7))
+  | MODULE as_loc(UIDENT) module_binding_body post_item_attributes SEMI semi_terminated_seq_expr {
+      let item_attrs = $4 in
+      mkexp ~attrs:item_attrs (Pexp_letmodule($2, $3, $6))
     }
   | LET? OPEN override_flag as_loc(mod_longident) post_item_attributes SEMI semi_terminated_seq_expr {
       let item_attrs = $5 in

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -4173,7 +4173,7 @@ class printer  ()= object(self:'self)
             let openSourceMapped = SourceMap (lid.loc, openLayout) in
             openSourceMapped::listItems
       | ([], Pexp_letmodule (s, me, e)) ->
-          let prefixText = "let module" in
+          let prefixText = "module" in
           let bindingName = atom ~loc:s.loc s.txt in
           let moduleExpr = me in
           let letModuleLayout =
@@ -5349,14 +5349,14 @@ class printer  ()= object(self:'self)
         | Psig_module {pmd_name; pmd_type={pmty_desc=Pmty_alias alias}} ->
             label ~space:true
               (makeList ~postSpace:true [
-                 atom "let module";
+                 atom "module";
                  atom pmd_name.txt;
                  atom "="
                ])
               (self#longident_loc alias)
         | Psig_module pmd ->
             self#formatSimpleSignatureBinding
-              "let module"
+              "module"
               (atom pmd.pmd_name.txt)
               (self#module_type pmd.pmd_type);
         | Psig_open od ->
@@ -5379,7 +5379,7 @@ class printer  ()= object(self:'self)
         | Psig_recmodule decls ->
             let first xx =
               self#formatSimpleSignatureBinding
-                "let module rec"
+                "module rec"
                 (atom xx.pmd_name.txt)
                 (self#module_type xx.pmd_type)
             in
@@ -5658,7 +5658,7 @@ class printer  ()= object(self:'self)
         | Pstr_typext te -> (self#type_extension te)
         | Pstr_exception ed -> (self#exception_declaration ed)
         | Pstr_module x ->
-            let prefixText = "let module" in
+            let prefixText = "module" in
             let bindingName = atom ~loc:x.pmb_name.loc x.pmb_name.txt in
             let moduleExpr = x.pmb_expr in
             self#let_module_binding prefixText bindingName moduleExpr
@@ -5698,7 +5698,7 @@ class printer  ()= object(self:'self)
 
         | Pstr_recmodule decls -> (* 3.07 *)
             let first xx =
-              let prefixText = "let module rec" in
+              let prefixText = "module rec" in
               self#let_module_binding prefixText (atom xx.pmb_name.txt) xx.pmb_expr in
             let notFirst xx =
               let prefixText = "and" in


### PR DESCRIPTION
Related to #26.

Note that I chose to use `module` instead of the proposed `mod` keyword as I think it's more descriptive and clear. Of course if we want to use `mod` anyway I can still change it into that.
