### PR TITLE
[Reason] JSX: Breaking Bad 🚌 

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -92,6 +92,7 @@ let module Namespace = {
   let module Foo = {
     let createElement
         intended::intended=?
+        anotherOptional::x=100
         children => {
       displayName: "test"
     };
@@ -167,7 +168,8 @@ let a3 = <So> <Much> <Nesting /> </Much> </So>;
 
 let a4 =
   <Sibling>
-    <One test=true foo=b /> <Two foo=b />
+    <One test=true foo=b />
+    <Two foo=b />
   </Sibling>;
 
 let a5 = <Foo> "testing a string here" </Foo>;
@@ -415,3 +417,67 @@ let asd2 = video test::false 10 [@JSX] [@foo];
 let div children => 1;
 
 ((fun () => div) ()) [] [@JSX];
+
+let myFun () =>
+  <>
+    <Namespace.Foo
+      intended=true
+      anotherOptional=200
+    />
+    <Namespace.Foo
+      intended=true
+      anotherOptional=200
+    />
+    <Namespace.Foo
+      intended=true anotherOptional=200>
+      <Foo />
+      <Foo />
+      <Foo />
+      <Foo />
+      <Foo />
+      <Foo />
+      <Foo />
+    </Namespace.Foo>
+  </>;
+
+let myFun () => <> </>;
+
+let myFun () =>
+  <>
+    <Namespace.Foo
+      intended=true
+      anotherOptional=200
+    />
+    <Namespace.Foo
+      intended=true
+      anotherOptional=200
+    />
+    <Namespace.Foo
+      intended=true anotherOptional=200>
+      <Foo />
+      <Foo />
+      <Foo />
+      <Foo />
+      <Foo />
+      <Foo />
+      <Foo />
+    </Namespace.Foo>
+  </>;
+
+
+/**
+ * Children should wrap without forcing attributes to.
+ */
+<Foo a=10 b=0>
+  <Bar />
+  <Bar />
+  <Bar />
+  <Bar />
+</Foo>;
+/**
+ * Failing test cases:
+ */
+/* let res = <Foo a=10 b=(<Foo a=200 />) > */
+/*   <Bar /> */
+/* </Foo>; */
+/* let res = <Foo a=10 b=(<Foo a=200 />) />; */

--- a/formatTest/typeCheckedTests/input/jsx.re
+++ b/formatTest/typeCheckedTests/input/jsx.re
@@ -16,6 +16,7 @@ let module Foo = {
     let createElement a::a=? b::b=? children => {displayName: "test"};
 };
 
+
 let module One = {
     let createElement test::test=? foo::foo=? children => {displayName: "test"};
     let createElementobvioustypo test::test children => {displayName: "test"};
@@ -55,7 +56,7 @@ let module Pun = {
 
 let module Namespace = {
     let module Foo = {
-        let createElement intended::intended=? children => {displayName: "test"};
+        let createElement intended::intended=? anotherOptional::x=100 children => {displayName: "test"};
     };
 };
 
@@ -243,3 +244,61 @@ let asd2 = video test::false 10 [@JSX] [@foo];
 
 let div children => 1;
 (((fun () => div) ()) [])[@JSX];
+
+let myFun () => {
+  <>
+        <Namespace.Foo intended=(true) anotherOptional=200 />
+        <Namespace.Foo intended=(true) anotherOptional=200 />
+        <Namespace.Foo intended=(true) anotherOptional=200>
+          <Foo />
+          <Foo />
+          <Foo />
+          <Foo />
+          <Foo />
+          <Foo />
+          <Foo />
+        </Namespace.Foo>
+  </>;
+
+};
+
+let myFun () => {
+<>
+</>;
+};
+
+let myFun () => {
+  <>
+        <Namespace.Foo intended=(true) anotherOptional=200 />
+        <Namespace.Foo intended=(true) anotherOptional=200 />
+        <Namespace.Foo intended=(true) anotherOptional=200>
+          <Foo />
+          <Foo />
+          <Foo />
+          <Foo />
+          <Foo />
+          <Foo />
+          <Foo />
+        </Namespace.Foo>
+  </>;
+};
+
+/**
+ * Children should wrap without forcing attributes to.
+ */
+<Foo a=10 b=0>
+  <Bar />
+  <Bar />
+  <Bar />
+  <Bar />
+</Foo>;
+
+/**
+ * Failing test cases:
+ */
+/* let res = <Foo a=10 b=(<Foo a=200 />) > */
+/*   <Bar /> */
+/* </Foo>; */
+
+/* let res = <Foo a=10 b=(<Foo a=200 />) />; */
+

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,8 +1,0 @@
-{
-  "name": "reason",
-  "dependencies": {
-    "@opam-alpha/camlp4": {
-      "version": "4.4.27"
-    }
-  }
-}

--- a/package.json
+++ b/package.json
@@ -64,8 +64,12 @@
     "scripts": {
         "editor": "eval $(dependencyEnv) && eval $EDITOR",
         "postinstall": "eval $(dependencyEnv) && nopam && substs pkg/META.in && make compile_error && ocaml pkg/build.ml native=true native-dynlink=true utop=${utop_installed:-false} && (opam-installer --prefix=$opam_prefix || true)",
+        "clean": "eval $(dependencyEnv) && nopam && make clean",
         "env": "eval $(dependencyEnv) && env",
         "formatTest": "eval $(dependencyEnv) && cd formatTest; ./test.sh",
         "whereisrefmt": "eval $(dependencyEnv) && which refmt"
+    },
+    "engines" : {
+      "npm" : ">=3.10.0"
     }
 }


### PR DESCRIPTION
[Reason] JSX: Breaking Bad 🚌
Summary: Fix the bad breaking of JSX tags.

Two improvements here:

- Attributes now break independently of children (fixes https://github.com/facebook/reason/issues/794)
- Fix wonky incorrect breaking (fixes https://github.com/facebook/reason/issues/787)
