### PR TITLE
Add spaces after "<" and before ">" for obj type declaration.

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -336,4 +336,4 @@ type classAttributesOnKeys = <
   key2 [@bs.get null] : (Js.t int) [@onType2],
   key3 [@bs.get null] : (Js.t int) [@onType2],
   key4 : Js.t (int [@justOnInt])
->;
+ >;

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -106,33 +106,33 @@ let (<..>) a b => a + b;
 
 let five = 2 <..> 3;
 
-type nestedObj = <bar : <a : int>>;
+type nestedObj = < bar : < a : int > >;
 
 let (>>) a b => a > b;
 
 let bigger = 3 >> 2;
 
-type typeDefForClosedObj = <x : int, y : int>;
+type typeDefForClosedObj = < x : int, y : int >;
 
 type typeDefForOpenObj 'a =
-  <x : int, y : int, ..> as 'a;
+  < x : int, y : int, .. > as 'a;
 
-let anonClosedObject: <x : int, y : int> = {
+let anonClosedObject: < x : int, y : int > = {
   method x = 0;
   method y = 0
 };
 
 let onlyHasX = {method x = 0};
 
-let xs: list <x : int> = [
+let xs: list < x : int > = [
   onlyHasX,
-  (anonClosedObject :> <x : int>)
+  (anonClosedObject :> < x : int >)
 ];
 
 let constrainedAndCoerced = (
   [anonClosedObject, anonClosedObject]:
-    list <x : int, y : int> :>
-    list <x : int>
+    list < x : int, y : int > :>
+    list < x : int >
 );
 
 /* If one day, unparenthesized type constraints are allowed on the RHS of a
@@ -140,21 +140,21 @@ let constrainedAndCoerced = (
  * a separate kind of token (for now). Any issues would likely be caught in the
  * idempotent test case.
  */
-let xs: ref <x : int> = {
-  contents: (anonClosedObject :> <x : int>)
+let xs: ref < x : int > = {
+  contents: (anonClosedObject :> < x : int >)
 };
 
 let coercedReturn = {
   let tmp = anonClosedObject;
-  (tmp :> <x : int>)
+  (tmp :> < x : int >)
 };
 
 let acceptsOpenAnonObjAsArg
-    (o: <x : int, y : int, ..>) =>
+    (o: < x : int, y : int, .. >) =>
   o#x + o#y;
 
 let acceptsClosedAnonObjAsArg
-    (o: <x : int, y : int>) =>
+    (o: < x : int, y : int >) =>
   o#x + o#y;
 
 let res = acceptsOpenAnonObjAsArg {

--- a/formatTest/unit_tests/expected_output/object.re
+++ b/formatTest/unit_tests/expected_output/object.re
@@ -1,15 +1,15 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 type t = <>;
 
-type t = <u : int, v : int>;
+type t = < u : int, v : int >;
 
-type t = <u : int, ..>;
+type t = < u : int, .. >;
 
-type t = <u : int, ..>;
+type t = < u : int, .. >;
 
-type t = <..>;
+type t = < .. >;
 
-type t = <..>;
+type t = < .. >;
 
 let (<..>) a b => a + b;
 

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2718,7 +2718,10 @@ class printer  ()= object(self:'self)
             | Open -> [atom ".."]
           in
           let rows = List.concat [(List.map core_field_type l); openness] in
-          makeList ~break:IfNeed ~postSpace:true ~wrap:("<", ">") ~sep:"," rows
+          if List.length rows = 0 then
+            atom "<>"
+          else
+            makeList ~break:IfNeed ~postSpace:true ~wrap:("< ", " >") ~sep:"," rows
         | Ptyp_package (lid, cstrs) ->
           let typeConstraint (s, ct) =
             label


### PR DESCRIPTION
This is to avoid conflicting with the JSX syntax. It's a quick fix
intended to be temporary until the JSX stuff is more mature.

`refmt` is broken without this because `type a = < x : int >` becomes `type a = <x : int>` which then doesn't parse because `refmt` think it's some malformed JSX.