### PR TITLE
Put function name and arguments into the same tuple

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/lazy.re
+++ b/formatTest/typeCheckedTests/expected_output/lazy.re
@@ -12,9 +12,8 @@ let operateOnLazyValue (lazy {myRecordField}) => {
   tmp + tmp
 };
 
-let result = operateOnLazyValue (
-  lazy {myRecordField: 100}
-);
+let result =
+  operateOnLazyValue (lazy {myRecordField: 100});
 
 type box 'a =
   | Box 'a;

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -157,21 +157,24 @@ let acceptsClosedAnonObjAsArg
     (o: < x : int, y : int >) =>
   o#x + o#y;
 
-let res = acceptsOpenAnonObjAsArg {
-  method x = 0;
-  method y = 10
-};
+let res =
+  acceptsOpenAnonObjAsArg {
+    method x = 0;
+    method y = 10
+  };
 
-let res = acceptsOpenAnonObjAsArg {
-  method x = 0;
-  method y = 10;
-  method z = 10
-};
+let res =
+  acceptsOpenAnonObjAsArg {
+    method x = 0;
+    method y = 10;
+    method z = 10
+  };
 
-let res = acceptsClosedAnonObjAsArg {
-  method x = 0;
-  method y = 10
-};
+let res =
+  acceptsClosedAnonObjAsArg {
+    method x = 0;
+    method y = 10
+  };
 
 /* TODO: Unify class constructor return values with function return values */
 class myClassWithAnnotatedReturnType
@@ -284,12 +287,8 @@ let module HasTupleClasses: {
 
 class intTuples = class tupleClass int int;
 
-class intTuplesHardcoded = (
-  class tupleClass int int
-) (
-  8,
-  8
-);
+class intTuplesHardcoded =
+  (class tupleClass int int) (8, 8);
 
 
 /**

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -364,3 +364,9 @@ let equal i1 i2 =>
   compare
     (compare 0 0)
     (compare 1 1); /* END OF LINE HERE */
+
+let tuple_equal (i1, i2) => i1 == i2;
+
+let tuple_equal (csu, mgd) =>
+  /* Some really long comments, see https://github.com/facebook/reason/issues/811 */
+  tuple_equal (csu, mgd);

--- a/formatTest/typeCheckedTests/input/reasonComments.re
+++ b/formatTest/typeCheckedTests/input/reasonComments.re
@@ -348,3 +348,9 @@ let equal i1 i2 =>
 
 let equal i1 i2 =>
   compare (compare 0 0) (compare 1 1); /* END OF LINE HERE */
+
+let tuple_equal (i1, i2) => i1 == i2;
+
+let tuple_equal (csu, mgd) =>
+  /* Some really long comments, see https://github.com/facebook/reason/issues/811 */
+  tuple_equal (csu, mgd);

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -1,5 +1,6 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
-let run () => TestUtils.printSection "Basic Structures";
+let run () =>
+  TestUtils.printSection "Basic Structures";
 
 while something {
   print_string "You're in a while loop";
@@ -312,7 +313,8 @@ let annotatingFuncApplication = (
 );
 
 /* Pretty printer might stick the [int] at the label. */
-let annotatingSingleFuncApplication: int = _dummyFunc "a";
+let annotatingSingleFuncApplication: int =
+  _dummyFunc "a";
 
 /* So lets try a place where it won't */
 let annotatingSingleFuncApplication = {
@@ -604,10 +606,11 @@ let anotherRecord = {
 };
 
 let anotherRecord = {
-  ...SomeReally.longFunctionCall {
-    passingRecordField: 0,
-    andThisOtherRecordField: 10
-  },
+  ...
+    SomeReally.longFunctionCall {
+      passingRecordField: 0,
+      andThisOtherRecordField: 10
+    },
   name: "joe++",
   age: testRecord.age + 10
 };

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -188,13 +188,15 @@ let module MyFunctor (M: HasTT) => {
    bottom of this file. [Actually, forgiving the trailing SEMI might not be
    such a great idea].
    */
-let module MyFunctorResult = MyFunctor {
-  type tt = string;
-};
+let module MyFunctorResult =
+  MyFunctor {
+    type tt = string;
+  };
 
-let module LookNoParensNeeded = MyFunctor {
-  type tt = string;
-};
+let module LookNoParensNeeded =
+  MyFunctor {
+    type tt = string;
+  };
 
 module type SigResult = {let result: int;};
 
@@ -445,9 +447,8 @@ let module Id (X: Type) => X;
 let module Compose
            (F: Type => Type)
            (G: Type => Type)
-           (X: Type) => F (
-  G X
-);
+           (X: Type) =>
+  F (G X);
 
 let l: Compose(List)(Maybe)(Char).t = [Some 'a'];
 
@@ -482,12 +483,13 @@ Printf.printf
  </div>;
  };
  */
-include YourLib.CreateComponent {
-  type thing = blahblahblah;
-  type state = unit;
-  let getInitialState _ => ();
-  let myValue = {recordField: "hello"};
-};
+include
+  YourLib.CreateComponent {
+    type thing = blahblahblah;
+    type state = unit;
+    let getInitialState _ => ();
+    let myValue = {recordField: "hello"};
+  };
 
 module type HasInt = {let x: int;};
 

--- a/formatTest/unit_tests/expected_output/polymorphism.re
+++ b/formatTest/unit_tests/expected_output/polymorphism.re
@@ -1,5 +1,6 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
-let run () => TestUtils.printSection "Polymorphism";
+let run () =>
+  TestUtils.printSection "Polymorphism";
 
 type myType 'a = list 'a;
 

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -284,10 +284,8 @@ let addPoints (p1: point, p2: point) => {
 
 let res1 = printPoint point2D;
 
-let res2 = printPoint {
-  x: point3D.x,
-  y: point3D.y
-};
+let res2 =
+  printPoint {x: point3D.x, y: point3D.y};
 
 /*
     When () were used to indicate sequences, the parser used seq_expr not only
@@ -311,12 +309,13 @@ let res2 = printPoint {
         let x = {a};    /* Record {a:a} */
         let x = {a;};   /* Single item sequence returning identifier {a} */
  */
-let res3 = printPoint (
-  addPoints (
-    point2D,
-    {x: point3D.x, y: point3D.y}
-  )
-);
+let res3 =
+  printPoint (
+    addPoints (
+      point2D,
+      {x: point3D.x, y: point3D.y}
+    )
+  );
 
 type person = {age: int, name: string};
 
@@ -592,10 +591,10 @@ let result =
 
 let result =
   myRecordWithFunctions.addThreeNumbersTupled (
-  10,
-  20,
-  30
-);
+    10,
+    20,
+    30
+  );
 
 let lookTuplesRequireParens = (1, 2);
 

--- a/formatTest/unit_tests/expected_output/trailingSpaces.re
+++ b/formatTest/unit_tests/expected_output/trailingSpaces.re
@@ -1,5 +1,6 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
-let module M = Something.Create {
-  type resource1 = MyModule.MySubmodule.t;
-  type resource2 = MyModule.MySubmodule.t;
-};
+let module M =
+  Something.Create {
+    type resource1 = MyModule.MySubmodule.t;
+    type resource2 = MyModule.MySubmodule.t;
+  };

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -487,7 +487,8 @@ let secondArgShouldWrap
 /* Now check that one and two args both indent the same when applying */
 let reallyReallyLongVarName = "hello";
 
-let result = oneArgShouldWrapToAlignWith reallyReallyLongVarName;
+let result =
+  oneArgShouldWrapToAlignWith reallyReallyLongVarName;
 
 let result =
   twoArgsShouldWrapToAlignWith
@@ -500,7 +501,8 @@ let justReturn x => x;
    function application "justReturn hasABunch" */
 let acceptsTwoThings
     (nameAge: nameAge)
-    (hasABunch: hasABunch) => justReturn hasABunch;
+    (hasABunch: hasABunch) =>
+  justReturn hasABunch;
 
 /*
   Ideally, we'd allow "acceptsTwoThings {age, name}" on the first line, then
@@ -546,15 +548,16 @@ let reallyLongFunctionNameThatJustConcats a =>
 
 let seeHowLongValuesWrap = {
   age: 30,
-  name: reallyLongFunctionNameThatJustConcats [
-    "one",
-    "two",
-    "two",
-    "two",
-    "two",
-    "two",
-    "two"
-  ]
+  name:
+    reallyLongFunctionNameThatJustConcats [
+      "one",
+      "two",
+      "two",
+      "two",
+      "two",
+      "two",
+      "two"
+    ]
 };
 
 /*
@@ -581,14 +584,8 @@ let bothArgsWrapAndIndent
   f
 );
 
-let result = onlyReturnWraps (
-  10,
-  11,
-  12,
-  13,
-  14,
-  15
-);
+let result =
+  onlyReturnWraps (10, 11, 12, 13, 14, 15);
 
 let result =
   bothArgsWrapAndIndent
@@ -954,24 +951,25 @@ let (
   n,
   o,
   p
-) = echoTuple (
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0
-);
+) =
+  echoTuple (
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  );
 
 /* Annotated version */
 let (
@@ -991,24 +989,25 @@ let (
   n,
   o,
   p
-): sixteenTuple = echoTuple (
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0
-);
+): sixteenTuple =
+  echoTuple (
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  );
 
 /* Annotated inline */
 let x: (
@@ -1028,24 +1027,25 @@ let x: (
   int,
   int,
   int
-) = echoTuple (
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0
-);
+) =
+  echoTuple (
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  );
 
 /* Desired formatting if pattern does not fit, arguments do (margin 70) */
 /* Destructured */
@@ -1181,24 +1181,25 @@ let (
   nxx,
   oxx,
   pxx
-) = echoTuple (
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0
-);
+) =
+  echoTuple (
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  );
 
 /* Annotated */
 let (
@@ -1218,24 +1219,25 @@ let (
   nxx,
   oxx,
   pxx
-): sixteenTuple = echoTuple (
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0
-);
+): sixteenTuple =
+  echoTuple (
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  );
 
 /* Annotated Inline */
 let (
@@ -1272,65 +1274,68 @@ let (
   int,
   int,
   int
-) = echoTuple (
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0
-);
+) =
+  echoTuple (
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  );
 
 /* Not-Destructured */
-let someResult = echoTuple (
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0
-);
+let someResult =
+  echoTuple (
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  );
 
 /* Annotated */
 /* Not-Destructured */
-let someResult: sixteenTuple = echoTuple (
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0
-);
+let someResult: sixteenTuple =
+  echoTuple (
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  );
 
 /* Annotated Inline */
 /* Not-Destructured */
@@ -1351,24 +1356,25 @@ let someResult: (
   int,
   int,
   int
-) = echoTuple (
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0
-);
+) =
+  echoTuple (
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  );
 
 /* Desired formatting if neither fit on one line (margin 70) */
 /* Destructured */
@@ -1597,24 +1603,25 @@ let (
   nxx,
   oxx,
   pxx
-) = echoTuple (
-  1000,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10
-);
+) =
+  echoTuple (
+    1000,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10
+  );
 
 /* Annoted */
 /* Destructured */
@@ -1635,24 +1642,25 @@ let (
   nxx,
   oxx,
   pxx
-): sixteenTuple = echoTuple (
-  1000,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10
-);
+): sixteenTuple =
+  echoTuple (
+    1000,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10
+  );
 
 /* Annoted Inline */
 /* Destructured */
@@ -1690,66 +1698,69 @@ let (
   int,
   int,
   int
-) = echoTuple (
-  1000,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10
-);
+) =
+  echoTuple (
+    1000,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10
+  );
 
 /* Desired formatting if neither fit on one line (margin 70) */
 /* Not-Destructured */
-let someResult = echoTuple (
-  1000,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10
-);
+let someResult =
+  echoTuple (
+    1000,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10
+  );
 
 /* Annoted */
 /* Not-Destructured */
-let someResult: sixteenTuple = echoTuple (
-  1000,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10
-);
+let someResult: sixteenTuple =
+  echoTuple (
+    1000,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10
+  );
 
 /* Annoted Inline */
 /* Not-Destructured */
@@ -1770,24 +1781,25 @@ let someResult: (
   int,
   int,
   int
-) = echoTuple (
-  1000,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10,
-  10
-);
+) =
+  echoTuple (
+    1000,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10,
+    10
+  );
 
 /* The rhs of = shouldn't be broken onto its own newline: @see ensureSingleTokenSticksToLabel */
 let someResult: (
@@ -2031,9 +2043,8 @@ let theTupleTypeAnnotationShouldWrap: (
   "now these tuple values should wrap"
 );
 
-let rec mutuallyRecursiveOne x => mutuallyRecursiveTwo (
-  x + x
-)
+let rec mutuallyRecursiveOne x =>
+  mutuallyRecursiveTwo (x + x)
 and mutuallyRecursiveTwo y => print_int y;
 
 /* The only downside to this is that now you can't redeclare a binding. */
@@ -2044,8 +2055,8 @@ type x = private int;
 
 type myType 'a 'b 'c = private ('a, 'b, 'c);
 
-type privateVariant = private
-  | BigSize int | SmallSize int;
+type privateVariant =
+  private | BigSize int | SmallSize int;
 
 type doubleEqualsDoublePrivateVariant =
   privateVariant =

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2218,10 +2218,9 @@ let formatAttachmentApplication finalWrapping (attachTo: (bool * layoutNode) opt
           | (hd::tl, Some (useSpace, toThis)) ->
             (* TODO: Can't attach location to this - maybe rewrite anyways *)
             let attachedArgs = makeAppList attachedList in
-            label
-              ~space:true
-              (label ~space:useSpace toThis attachedArgs)
-              wrappedListy
+              (label ~space:useSpace toThis (label
+              ~space:true attachedArgs wrappedListy))
+
           | (hd::tl, None) ->
             (* Args that are "attached to nothing" *)
             let appList = makeAppList attachedList in


### PR DESCRIPTION
#811

Currently in a function application, the function name and the arguments are not in the same label (see screenshot I put up in #811). This creates weird formatting, especially when we add comments on top of it. This diff put them under the same label. 

cc @jordwalke 