### PR TITLE
Expose reason.cma

### DIFF
--- a/pkg/META.in
+++ b/pkg/META.in
@@ -16,6 +16,9 @@ archive(byte, toploop) += "@menhirLib/menhirLib.cmo"
 archive(byte, toploop, -pkg_utop) += "reason_toploop.cmo"
 archive(byte, toploop, pkg_utop) += "reason_utop.cmo"
 
+archive(byte) = "reason.cma"
+archive(native) = "reason.cmxa"
+
 package "lib" (
   version = "%{version}%"
   description = "Library version of reason"


### PR DESCRIPTION
so that people can just add "-package reason" in their ocamlfind