### PR TITLE
[atom-reason] highlight `as`; jsx improvements

### DIFF
--- a/editorSupport/language-reason/grammars/reason.json
+++ b/editorSupport/language-reason/grammars/reason.json
@@ -162,25 +162,30 @@
         {
           "begin": "\\b([[:lower:]][[:word:]]*)\\b[[:space:]]*(=)",
           "end": "(?<![=])(?=[/>[:lower:]])",
+          "comment": "meta.separator",
           "beginCaptures": {
-            "1": { "name": "constant.language support.property-value entity.name.filename variable.interpolation" },
-            "2": { "name": "markup.inserted keyword.control.less message.error" }
+            "1": { "name": "constant.language support.property-value entity.name.filename markup.inserted" },
+            "2": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
           },
           "patterns": [
             { "include": "#value-expression-atomic-with-paths" }
           ]
         },
         {
-          "match": "\\b([[:lower:]][[:word:]]*)\\b",
-          "name": "constant.language support.property-value entity.name.filename variable.interpolation"
+          "match": "(\\b([[:lower:]][[:word:]]*)\\b[[:space:]]*+)",
+          "captures": {
+            "1": { "comment": "meta.separator" },
+            "2": { "name": "constant.language support.property-value entity.name.filename markup.inserted" }
+          }
         }
       ]
     },
     "jsx-body": {
-      "begin": "(>)",
+      "begin": "((>))",
       "end": "(?=</)",
       "beginCaptures": {
-        "1": { "name": "keyword.other" }
+        "1": { "comment": "meta.separator" },
+        "2": { "name": "punctuation.definition.tag.end.js" }
       },
       "patterns": [
         {
@@ -191,22 +196,27 @@
       ]
     },
     "jsx-head": {
-      "begin": "(<)(?=[_[:alpha:]])",
-      "end": "(?=(/>)|(</))",
+      "begin": "((<))(?=[_[:alpha:]])",
+      "end": "((/>))|(?=</)",
       "applyEndPatternLast": true,
       "beginCaptures": {
-        "1": { "name": "keyword.other" },
-        "2": { "name": "entity.name.function" }
+        "1": { "comment": "meta.separator" },
+        "2": { "name": "punctuation.definition.tag.begin.js" }
+      },
+      "endCaptures": {
+        "1": { "comment": "meta.separator" },
+        "2": { "name": "punctuation.definition.tag.end.js" }
       },
       "patterns": [
         {
           "begin": "\\G",
-          "end": "(?=[[:space:]/>])",
+          "end": "(?=[[:space:]/>])[[:space:]]*+",
+          "comment": "meta.separator",
           "patterns": [
             { "include": "#module-path-simple" },
             {
               "match": "\\b[[:lower:]][[:word:]]*\\b",
-              "name": "entity.name.function"
+              "name": "entity.name.tag.inline.any.html"
             }
           ]
         },
@@ -218,18 +228,19 @@
       "begin": "\\G(/>)|(</)",
       "end": "(>)",
       "applyEndPatternLast": true,
+      "comment": "meta.separator",
       "beginCaptures": {
-        "1": { "name": "keyword.other" },
-        "2": { "name": "keyword.other" }
+        "1": { "name": "punctuation.definition.tag.end.js" },
+        "2": { "name": "punctuation.definition.tag.begin.js" }
       },
       "endCaptures": {
-        "1": { "name": "keyword.other" }
+        "1": { "name": "punctuation.definition.tag.end.js" }
       },
       "patterns": [
         { "include": "#module-path-simple" },
         {
           "match": "\\b[[:lower:]][[:word:]]*\\b",
-          "name": "entity.name.function"
+          "name": "entity.name.tag.inline.any.html"
         }
       ]
     },
@@ -1002,10 +1013,11 @@
       "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control.less message.error"
     },
     "operator-infix-custom": {
-      "match": "(?:(?<![#\\-:!?.@*/&%^+<=>|~$\\\\])([</]>)(?![#\\-:!?.@*/&%^+<=>|~$\\\\]))|([#\\-@*/&%^+<=>|$\\\\][#\\-:!?.@*/&%^+<=>|~$\\\\]*)",
+      "match": "(?:(?<![#\\-:!?.@*/&%^+<=>|~$\\\\])((<>))(?![#\\-:!?.@*/&%^+<=>|~$\\\\]))|([#\\-@*/&%^+<=>|$\\\\][#\\-:!?.@*/&%^+<=>|~$\\\\]*)",
       "captures": {
-        "1": { "name": "keyword.control" },
-        "2": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+        "1": { "comment": "meta.separator" },
+        "2": { "name": "punctuation.definition.tag.begin.js" },
+        "3": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
       }
     },
     "operator-infix-custom-hash": {
@@ -1402,6 +1414,10 @@
         { "include": "#comment" },
         { "include": "#module-path-extended-prefix" },
         { "include": "#type-expression-label" },
+        {
+          "match": "\\b(as)\\b",
+          "name": "variable.other.class.js variable.interpolation storage.modifier message.error"
+        },
         { "include": "#type-expression-constructor" },
         { "include": "#type-expression-object" },
         { "include": "#type-expression-parens" },
@@ -1920,7 +1936,7 @@
             {
               "begin": "({)([_[:lower:]]*)?(\\|)",
               "end": "(?=\\|\\2})",
-              "contentName": "meta.separator",
+              "comment": "meta.separator",
               "beginCaptures": {
                 "1": { "name": "keyword.control.flow message.error" },
                 "2": { "name": "constant.language" },
@@ -1933,7 +1949,7 @@
             {
               "begin": "\"",
               "end": "\"",
-              "contentName": "meta.separator",
+              "comment": "meta.separator",
               "patterns": [
                 { "include": "source.js" }
               ]

--- a/editorSupport/language-reason/grammars/reason.json
+++ b/editorSupport/language-reason/grammars/reason.json
@@ -165,7 +165,7 @@
           "comment": "meta.separator",
           "beginCaptures": {
             "1": { "name": "constant.language support.property-value entity.name.filename markup.inserted" },
-            "2": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+            "2": { "name": "keyword.control.less" }
           },
           "patterns": [
             { "include": "#value-expression-atomic-with-paths" }


### PR DESCRIPTION
This PR fixes a bug with `as` in type expressions and improves highlighting for JSX. @jordwalke @chenglou 

Based on the discussion on discord, I investigated some alternatives for highlighting the JSX. There is a [react plugin](https://orktes.github.io/atom-react/) that shows highlighting using the "atom dark" theme where the tag delimiters and the tag name have the same colors. However, this is because the colors for those tokens for that theme happen to coincide. For other themes it can look differently.

I put together a comparison of some of the more common themes to show how JSX is highlighted with that plugin:

![comparison](https://cloud.githubusercontent.com/assets/151197/20234514/d9ebeed6-a839-11e6-9171-665374d144ae.png)

So what I've done is gone through and changed the highlighting for this plugin to use the usual theme tag highlighting scopes for lowercase names as well as the tag delimiters. For module paths, the module prefix is still highlighted as a module but if the last path component is a lowercase identifier, it is highlighted with the scope for tag names.

I think this is a okay trade off for a few reasons. For one, with the default "One Dark theme", if the module path prefixes use the theme tag scope, the paths will consist of light red next to dark red, which is something I've tried to minimize with the most recent changes @chenglou requested. I also think it's generally a good idea to try and maintain the invariant that syntactic entities have (for the most part) the same color consistently throughout the document.

But also for practical purposes, for a few themes it ends up looking worse than others to use the same scope for the tag name and the delimiters. For the "Dracula" theme (the one I personally use the most), for instance, it would either be the keyword pink (for lowercase) or the italic, underlined green (for module names), both of which look kind of bad for large blocks.

Currently I'm trying to get pretty good results across Dracula, Monokai, Dark+ [on vscode], One Dark, and Oceanic Next. So it's also a bit tricky to make adjustments to help one theme (e.g., Dracula, as above) without negatively impact the others too much.

~~But one other change I made is to lighten the background for JSX in the One Dark and a few others that have a similar scope. It's a bit subtle but maybe it helps a little bit.~~

We could try to improve things further still and maybe look at using some custom styles in the plugin itself but in the meantime this should be a little better.

Here are some previews:

#### Atom Dark
![atom-dark](https://cloud.githubusercontent.com/assets/151197/20234855/60520d88-a840-11e6-8940-e54705b9dd14.png)
#### One Dark
![dark-one](https://cloud.githubusercontent.com/assets/151197/20234856/65187104-a840-11e6-853a-20336e35b5cf.png)
#### Oceanic Next
![oceanic](https://cloud.githubusercontent.com/assets/151197/20234859/6a57ce6c-a840-11e6-83e4-d33ef384612c.png)
#### Base16 Tomorrow Night
![tomorrow](https://cloud.githubusercontent.com/assets/151197/20234860/6eb21bde-a840-11e6-81ce-0426981036f9.png)
