### PR TITLE
add merlin pin commands before `make`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,11 @@ opam init
 opam update
 opam switch 4.02.3
 eval $(opam config env)
+opam pin add -y merlin 'https://github.com/the-lambda-church/merlin.git'
+opam pin add -y merlin_extend 'https://github.com/let-def/merlin-extend.git'
 git clone git@github.com:facebook/reason.git
 cd reason
+make
 opam pin add -y reason .
 ```
 


### PR DESCRIPTION
So I followed the "contribution guide" but got stuck on this error, while trying to `make` the forked version of Reason:

![](https://images.discordapp.net/.eJwdyEsOhCAMANC7cABakZ_ehiBBo7YEalxM5u6TzFu-j3r6pVa1i7SxAmzHyNw3PYR7qkVX5nqV1I6hM9-QRFLe70IywDgTrEcXFozGWMTpX3H23s1mid4GtPDQSfySblTV9wcGlSLb.jB5sAesvUNhrZDEDhsYQXjxzB94)

Running these two commands solved the problem:

```
opam pin add -y merlin 'https://github.com/the-lambda-church/merlin.git'
opam pin add -y merlin_extend 'https://github.com/let-def/merlin-extend.git'
```

![](https://images.discordapp.net/.eJwdyEEOhCAMAMC_8ADKIgj6G4IEzWpLaI0H49_d7G0ytzr7rma1ijSeAZaNM_VFs1BPtehKVPeS2sY60wFJJOX1KCgM1tvgRuPDZKK1zpjPv-IUhuhdiMNPI5z4RbpQN6zqeQEIPSLw.HbBOknJMQBSh06vNcfyc8O-zto4)

Also the docs [here](http://facebook.github.io/reason/#community) mention the `make` step which is missing here.