### PR TITLE
Minor doc fix "argument clearly one unit" -> "argument is clearly one unit"

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -417,7 +417,7 @@ let six = increment(5);
 let thirteen = increment(double(6));
 ```
 Just like with function definitions, you can omit the parenthesis around the
-argument when you call the function, if the argument clearly "one unit". In
+argument when you call the function, if the argument is clearly "one unit". In
 this example, the `5` is clearly one unit so the `()` were omitted. The
 parenthesis around `double 6`, could _not_ be omitted because `double 6` is not
 "one unit".


### PR DESCRIPTION
Spotted this when reading docs.