### PR TITLE
Github Highlighting for tests and table formatting 

### DIFF
--- a/docs/mlCompared.html
+++ b/docs/mlCompared.html
@@ -156,27 +156,27 @@ optional. `{}` braces are only needed if you have more than one item to chain
 together via `;`.
 
 > <table>
-  <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      <pre>
-let \_ =
-  let msg = "Hello" in
-  print\_string msg;
-  let msg2 = "Goodbye" in
-  print\_string msg2</pre>
-    </td>
-    <td>
-      <pre>
-{
-  let msg = "Hello";
-  print\_string msg;
-  let msg2 = "Goodbye";
-  print\_string msg2
-};</pre>
-    </td>
-  </tr>
-</table>
+>   <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
+>   <tr>
+>     <td>
+>       <pre>
+> let \_ =
+>   let msg = "Hello" in
+>   print\_string msg;
+>   let msg2 = "Goodbye" in
+>   print\_string msg2</pre>
+>     </td>
+>     <td>
+>       <pre>
+> {
+>   let msg = "Hello";
+>   print\_string msg;
+>   let msg2 = "Goodbye";
+>   print\_string msg2
+> };</pre>
+>     </td>
+>   </tr>
+> </table>
 
 `Reason`'s `{}` syntax removes many commonly reported pain points in `OCaml`'s
 syntax:
@@ -266,64 +266,64 @@ In `Reason`, tuples always require parentheses. This requirement makes `Reason` 
 read and also removes the need for type annotations inside of tuple members
 to be wrapped in *additional* parentheses.
 > <table>
-  <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      <pre>let tup = 4, 5</pre>
-    </td>
-    <td>
-      <pre>let tup = (4, 5);</pre>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <pre>let tup = ((1: int), (2:int))</pre>
-    </td>
-    <td>
-      <pre>let tup = (1: int, 2:int);</pre>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <pre>fun ((a:int), (b:int)) -> a </pre>
-    </td>
-    <td>
-      <pre>fun (a:int, b:int) => a</pre>
-    </td>
-  </tr>
-</table>
+>  <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
+>  <tr>
+>    <td>
+>      <pre>let tup = 4, 5</pre>
+>    </td>
+>    <td>
+>      <pre>let tup = (4, 5);</pre>
+>    </td>
+>  </tr>
+>  <tr>
+>    <td>
+>      <pre>let tup = ((1: int), (2:int))</pre>
+>    </td>
+>    <td>
+>      <pre>let tup = (1: int, 2:int);</pre>
+>    </td>
+>  </tr>
+>  <tr>
+>    <td>
+>      <pre>fun ((a:int), (b:int)) -> a </pre>
+>    </td>
+>    <td>
+>      <pre>fun (a:int, b:int) => a</pre>
+>    </td>
+>  </tr>
+></table>
 
 In `Reason`, records resemble JavaScript, using `:` instead of `=`. Because
 `Reason` tuples always require wrapping parens, records may contain lambdas as values
 without needing extra parens.
 > <table>
-  <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      <pre>
-let myRec = {x = 0; y = 10}</pre>
-    </td>
-    <td>
-      <pre>
-let myRec = {x: 0, y: 10};</pre>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <pre>
-let myFuncs = {
-  myFun = (fun x -> x + 1);
-  your = (fun a b -> a + b);
-}</pre>
-    </td>
-    <td>
-      <pre>
-let myFuncs = {
-  myFun: fun x => x + 1,
-  your: fun a b => a + b
-};</pre>
-    </td>
-</table>
+>   <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
+>   <tr>
+>     <td>
+>       <pre>
+> let myRec = {x = 0; y = 10}</pre>
+>     </td>
+>     <td>
+>       <pre>
+> let myRec = {x: 0, y: 10};</pre>
+>     </td>
+>   </tr>
+>   <tr>
+>     <td>
+>       <pre>
+> let myFuncs = {
+>   myFun = (fun x -> x + 1);
+>   your = (fun a b -> a + b);
+> }</pre>
+>     </td>
+>     <td>
+>       <pre>
+> let myFuncs = {
+>   myFun: fun x => x + 1,
+>   your: fun a b => a + b
+> };</pre>
+>     </td>
+> </table>
 
 ### Lists
 
@@ -420,49 +420,49 @@ function. The single case match is a natural extension of the simple lambda,
 and the multicase lambda is a natural extension of the single case lambda.
 
 > <table>
-  <thead><tr> <th scope="col"><p>Form</p></th><th scope="col"><p>Ocaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      lambda
-    </td>
-    <td>
-      <pre>
-fun pat -> e</pre>
-    </td>
-    <td>
-      <pre>
-fun pat => e</pre>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      one match case
-    </td>
-    <td>
-      <pre>
-function | pat -> e</pre>
-    </td>
-    <td>
-      <pre>
-fun | pat => e</pre>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      many cases
-    </td>
-    <td>
-      <pre>
-function | pat -> e
-         | pat2 -> e</pre>
-    </td>
-    <td>
-      <pre>
-fun | pat => e
-    | pat2 => e</pre>
-    </td>
-  </tr>
-</table>
+>   <thead><tr> <th scope="col"><p>Form</p></th><th scope="col"><p>Ocaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
+>   <tr>
+>     <td>
+>       lambda
+>     </td>
+>     <td>
+>       <pre>
+> fun pat -> e</pre>
+>     </td>
+>     <td>
+>       <pre>
+> fun pat => e</pre>
+>     </td>
+>   </tr>
+>   <tr>
+>     <td>
+>       one match case
+>     </td>
+>     <td>
+>       <pre>
+> function | pat -> e</pre>
+>     </td>
+>     <td>
+>       <pre>
+> fun | pat => e</pre>
+>     </td>
+>   </tr>
+>   <tr>
+>     <td>
+>       many cases
+>     </td>
+>     <td>
+>       <pre>
+> function | pat -> e
+>          | pat2 -> e</pre>
+>     </td>
+>     <td>
+>       <pre>
+> fun | pat => e
+>     | pat2 => e</pre>
+>     </td>
+>   </tr>
+> </table>
 
 ###### Let binding for curried functions
 
@@ -471,38 +471,38 @@ functions. The following table shows three equivalent definitions which are
 identical once parsed. As always, all `Reason` functions include an `=>` arrow.
 
 > <table> <thead><tr><th scope="col"><p>Ocaml</p></th><th
-        scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      <pre>
-let x = fun a -> fun b -> e</pre>
-    </td>
-    <td>
-      <pre>
-let x = fun a => fun b => e;</pre>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <pre>
-let x = fun a b -> e</pre>
-    </td>
-    <td>
-      <pre>
-let x = fun a b => e;</pre>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <pre>
-let x a b = e</pre>
-    </td>
-    <td>
-      <pre>
-let x a b => e;</pre>
-    </td>
-  </tr>
-</table>
+>         scope="col"><p>Reason</p></th></tr></thead>
+>   <tr>
+>     <td>
+>       <pre>
+> let x = fun a -> fun b -> e</pre>
+>     </td>
+>     <td>
+>       <pre>
+> let x = fun a => fun b => e;</pre>
+>     </td>
+>   </tr>
+>   <tr>
+>     <td>
+>       <pre>
+> let x = fun a b -> e</pre>
+>     </td>
+>     <td>
+>       <pre>
+> let x = fun a b => e;</pre>
+>     </td>
+>   </tr>
+>   <tr>
+>     <td>
+>       <pre>
+> let x a b = e</pre>
+>     </td>
+>     <td>
+>       <pre>
+> let x a b => e;</pre>
+>     </td>
+>   </tr>
+> </table>
 
 
 ### Annotating Function Arguments
@@ -556,26 +556,26 @@ scope/function bodies) is exactly the same as defining top level modules. The
 module definition is local/top level.
 
 > <table>
-  <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      <pre>
-(\*Top level \*)
-module X = ..
-(\*Local \*)
-module X = ..
-module type Y = ...</pre>
-    </td>
-    <td>
-      <pre>
-/\* Top level \*/
-module X = ..
-/\* Local \*/
-module X = ..
-module type Y = ..</pre>
-    </td>
-  </tr>
-</table>
+>   <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
+>   <tr>
+>     <td>
+>       <pre>
+> (\*Top level \*)
+> module X = ..
+> (\*Local \*)
+> module X = ..
+> module type Y = ...</pre>
+>     </td>
+>     <td>
+>       <pre>
+> /\* Top level \*/
+> module X = ..
+> /\* Local \*/
+> module X = ..
+> module type Y = ..</pre>
+>     </td>
+>   </tr>
+> </table>
 
 
 ### Type Parameters
@@ -626,29 +626,29 @@ patterns to learn.
 For example, you can imagine `list` being a "function" for types that accepts a
 type and returns a new type.
 
-<table>
-  <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      <pre>
-let x: int list = [2]
-type listOfListOfInts =
-  int list list
-type ('a, 'b) tup = ('a \* 'b)
-type pairs = (int, int) tup list
-let tuples: pairs = [(2, 3)]</pre>
-    </td>
-    <td>
-      <pre>
-let x: list int = [2];
-type listOfListOfInts =
-  list (list int);
-type tup 'a 'b = ('a, 'b);
-type pairs = list (tup int int)
-let tuples: pairs = [(2, 3)]</pre>
-    </td>
-  </tr>
-</table>
+> <table>
+>   <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
+>   <tr>
+>     <td>
+>       <pre>
+> let x: int list = [2]
+> type listOfListOfInts =
+>   int list list
+> type ('a, 'b) tup = ('a \* 'b)
+> type pairs = (int, int) tup list
+> let tuples: pairs = [(2, 3)]</pre>
+>     </td>
+>     <td>
+>       <pre>
+> let x: list int = [2];
+> type listOfListOfInts =
+>   list (list int);
+> type tup 'a 'b = ('a, 'b);
+> type pairs = list (tup int int)
+> let tuples: pairs = [(2, 3)]</pre>
+>     </td>
+>   </tr>
+> </table>
 
 
 
@@ -662,21 +662,24 @@ a single argument which happens to be a tuple.
 
 The following examples shows the difference between passing *two* type
 parameters to `pair`, and a *single* type parameter that happens to be a tuple.
-<table>
-  <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      <pre>
-type intPair = (int, int) pair
-type pairList = (int \* int) list</pre>
-    </td>
-    <td>
-      <pre>
-type intPair = pair int int;
-type pairList = list (int, int);</pre>
-    </td>
-  </tr>
-</table>
+
+> <table>
+>   <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
+>   <tr>
+>     <td>
+>       <pre>
+> type intPair = (int, int) pair
+> type pairList = (int \* int) list</pre>
+>     </td>
+>     <td>
+>       <pre>
+> type intPair = pair int int;
+> type pairList = list (int, int);</pre>
+>     </td>
+>   </tr>
+> </table>
+
+
 
 - In `Reason`, syntax that represent tuple or tuple types, always looks like
   tuples.
@@ -709,67 +712,68 @@ type pairList = list (int, int);</pre>
 - Tuples **always** *look* like tuples, and anything that looks like a tuple
   *is* a tuple.
 
-<table>
-  <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      <pre>
-type myVariant =
-   | HasNothing
-   | HasSingleInt of int
-   | HasSingleTuple of (int \* int)
-   | HasMultipleInts of int \* int
-   | HasMultipleTuples
-      of (int \* int) \* (int\* int)
+> <table>
+>   <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
+>   <tr>
+>     <td>
+>       <pre>
+> type myVariant =
+>    | HasNothing
+>    | HasSingleInt of int
+>    | HasSingleTuple of (int \* int)
+>    | HasMultipleInts of int \* int
+>    | HasMultipleTuples
+>       of (int \* int) \* (int\* int)
+>
+> let a = HasSingleInt 10
+> let a = HasSingleTuple (10, 10)
+> let a = HasMultipleInts (10, 10)
+> let a =
+>   HasMultipleTuples (
+>     (10, 10),
+>     (10, 10)
+>   )
+>
+> let res = match x with
+>    | HasNothing -> 0
+>    | HasSingleInt x -> 0
+>    | HasSingleTuple (x, y) -> 0
+>    | HasMultipleInts (x, y) -> 0
+>    | HasMultipleTuples
+>       ((x, y),
+>        (q, r)) -> 0</pre>
+>     </td>
+>     <td>
+>       <pre>
+> type myVariant =
+>    | HasNothing
+>    | HasSingleInt int
+>    | HasSingleTuple (int, int)
+>    | HasMultipleInts int int
+>    | HasMultipleTuples
+>       (int, int) (int, int);
+>
+> let a = HasSingleInt 10;
+> let a = HasSingleTuple (10, 10);
+> let a = HasMultipleInts 10 10;
+> let a =
+>   HasMultipleTuples
+>     (10, 10)
+>     (10, 10);
+>
+> let res = switch x {
+>    | HasNothing => 0
+>    | HasSingleInt x => 0
+>    | HasSingleTuple (x, y) => 0
+>    | HasMultipleInts x y => 0
+>    | HasMultipleTuples
+>       (x, y)
+>       (q, r) => 0
+> };</pre>
+>     </td>
+>   </tr>
+> </table>
 
-let a = HasSingleInt 10
-let a = HasSingleTuple (10, 10)
-let a = HasMultipleInts (10, 10)
-let a =
-  HasMultipleTuples (
-    (10, 10),
-    (10, 10)
-  )
-
-let res = match x with
-   | HasNothing -> 0
-   | HasSingleInt x -> 0
-   | HasSingleTuple (x, y) -> 0
-   | HasMultipleInts (x, y) -> 0
-   | HasMultipleTuples
-      ((x, y),
-       (q, r)) -> 0</pre>
-    </td>
-    <td>
-      <pre>
-type myVariant =
-   | HasNothing
-   | HasSingleInt int
-   | HasSingleTuple (int, int)
-   | HasMultipleInts int int
-   | HasMultipleTuples
-      (int, int) (int, int);
-
-let a = HasSingleInt 10;
-let a = HasSingleTuple (10, 10);
-let a = HasMultipleInts 10 10;
-let a =
-  HasMultipleTuples
-    (10, 10)
-    (10, 10);
-
-let res = switch x {
-   | HasNothing => 0
-   | HasSingleInt x => 0
-   | HasSingleTuple (x, y) => 0
-   | HasMultipleInts x y => 0
-   | HasMultipleTuples
-      (x, y)
-      (q, r) => 0
-};</pre>
-    </td>
-  </tr>
-</table>
 
 
 ### Pattern Matching
@@ -795,72 +799,73 @@ parentheses, otherwise the `Some` case is parsed as belonging to the outer
 issue.
 
 > <table>
-  <thead><tr> <th scope="col"><p>OCaml (BROKEN)</p></th><th scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      <pre>
-let res = match x with
-  | A (x, y) -> match y with
-    | None -> 0
-    | Some i -> 10
-  | B (x, y) -> 0</pre>
-    </td>
-    <td>
-      <pre>
-let res = switch x {
-  | A (x, y) => switch y {
-    | None => 0
-    | Some i => 10
-  }
-  | B x y => 0
-};</pre>
-    </td>
-  </tr>
-</table>
+>   <thead><tr> <th scope="col"><p>OCaml (BROKEN)</p></th><th scope="col"><p>Reason</p></th></tr></thead>
+>   <tr>
+>     <td>
+>       <pre>
+> let res = match x with
+>   | A (x, y) -> match y with
+>     | None -> 0
+ >    | Some i -> 10
+>   | B (x, y) -> 0</pre>
+>     </td>
+>     <td>
+>       <pre>
+> let res = switch x {
+>   | A (x, y) => switch y {
+>     | None => 0
+>     | Some i => 10
+>   }
+>   | B x y => 0
+> };</pre>
+>     </td>
+>   </tr>
+> </table>
 
 ### Modules and Signatures
 
 ###### Defining Modules/Signatures
 
-<table>
-  <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      <pre>
-module type MySig = sig
-  type t = int
-  val x: int
-end
-module MyModule: MySig = struct
-  type t = int
-  let x = 10
-end
-module MyModule = struct
-  module NestedModule = struct
-     let msg = "hello";
-  end
-end
-      </pre>
-    </td>
-    <td>
-      <pre>
-module type MySig = {
-  type t = int;
-  let x: int;
-};
-module MyModule: MySig = {
-  type t = int;
-  let x = 10;
-};
-module MyModule = {
-  module NestedModule = {
-     let msg = "hello";
-  };
-};
-      </pre>
-    </td>
-  </tr>
-</table>
+> <table>
+>  <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
+>  <tr>
+>    <td>
+>      <pre>
+>module type MySig = sig
+>  type t = int
+>  val x: int
+>end
+>module MyModule: MySig = struct
+>  type t = int
+>  let x = 10
+>end
+>module MyModule = struct
+>  module NestedModule = struct
+>     let msg = "hello";
+>  end
+>end
+>      </pre>
+>    </td>
+>    <td>
+>      <pre>
+>module type MySig = {
+>  type t = int;
+>  let x: int;
+>};
+>module MyModule: MySig = {
+>  type t = int;
+>  let x = 10;
+>};
+>module MyModule = {
+>  module NestedModule = {
+>     let msg = "hello";
+>  };
+>};
+>      </pre>
+>    </td>
+>  </tr>
+></table>
+
 
 
 ##### Functors Types
@@ -872,24 +877,26 @@ In `Reason`, functor parsing rules are almost identical to the function
   parsing rules, using `=>` to represent curried application.
 
 > <table>
-  <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      <pre>
-module type FType =
-    functor (A: ASig) ->
-    functor (B:BSig) -> Result
-      </pre>
-    </td>
-    <td>
-      <pre>
-module type FType =
-    (A: ASig) =>
-    (B:BSig) => Result;
-      </pre>
-    </td>
-  </tr>
-</table>
+>   <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
+>   <tr>
+>     <td>
+>       <pre>
+> module type FType =
+>     functor (A: ASig) ->
+>     functor (B:BSig) -> Result
+>       </pre>
+>     </td>
+>     <td>
+>       <pre>
+> module type FType =
+>     (A: ASig) =>
+>     (B:BSig) => Result;
+>       </pre>
+>     </td>
+>   </tr>
+> </table>
+
+
 
 ### Functors
 
@@ -897,67 +904,66 @@ In `Reason`, the syntax for creating and applying functors is nearly identical
 to the syntax for creating/applying functions. Also, functor *application* is
 consistent with function application (again, space separated lists).
 
-
 > <table>
-  <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      <pre>
-module F =
-  functor (A:ASig) ->
-  functor (B:BSig) ->
-    struct end</pre>
-    </td>
-    <td>
-      <pre>
-module F =
-  fun (A:ASig) =>
-  fun (B:BSig) =>
-    {};</pre>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <pre>
-module F =
-  functor
-    (A:ASig)
-    (B:BSig) -> struct end</pre>
-    </td>
-    <td>
-      <pre>
-module F =
-  fun (A:ASig)
-      (B:BSig) => {};</pre>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <pre>
-module F
-       (A:ASig)
-       (B:BSig) =
-         struct end</pre>
-    </td>
-    <td>
-      <pre>
-module F
-           (A:ASig)
-           (B:BSig) =>
-             {};</pre>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <pre>
-module Res = F(A)(B)</pre>
-    </td>
-    <td>
-      <pre>
-module Res = F A B;</pre>
-    </td>
-  </tr>
-</table>
+>   <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
+>   <tr>
+>     <td>
+>       <pre>
+> module F =
+>   functor (A:ASig) ->
+>   functor (B:BSig) ->
+>     struct end</pre>
+>     </td>
+>     <td>
+>       <pre>
+> module F =
+>   fun (A:ASig) =>
+>   fun (B:BSig) =>
+>     {};</pre>
+>     </td>
+>   </tr>
+>   <tr>
+>     <td>
+>       <pre>
+> module F =
+>   functor
+>     (A:ASig)
+>     (B:BSig) -> struct end</pre>
+>     </td>
+>     <td>
+>       <pre>
+> module F =
+>   fun (A:ASig)
+>       (B:BSig) => {};</pre>
+>     </td>
+>   </tr>
+>   <tr>
+>     <td>
+>       <pre>
+> module F
+>        (A:ASig)
+>        (B:BSig) =
+>          struct end</pre>
+>     </td>
+>     <td>
+>       <pre>
+> module F
+>            (A:ASig)
+>            (B:BSig) =>
+>              {};</pre>
+>     </td>
+>   </tr>
+>   <tr>
+>     <td>
+>       <pre>
+> module Res = F(A)(B)</pre>
+>     </td>
+>     <td>
+>       <pre>
+> module Res = F A B;</pre>
+>     </td>
+>   </tr>
+> </table>
 
 > \* *Note: There is currently a known inconsistency where functors do not
 conform to function application syntax when in type annotation position - see
@@ -981,72 +987,76 @@ see were very confusing when it would believe the function's return value
 was a tuple with infix `,` comma.
 
 > <table>
-  <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      <pre>
-let myFuncs = {
-  myFun = (fun x -> x + 1);
-  your = (fun a b -> a + b);
-}</pre>
-    </td>
-    <td>
-      <pre>
-let myFuncs = {
-  myFun: fun x => x + 1,
-  your: fun a b => a + b
-}</pre>
-    </td>
-  </tr>
-</table>
+>   <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
+>   <tr>
+>     <td>
+>       <pre>
+> let myFuncs = {
+>   myFun = (fun x -> x + 1);
+>   your = (fun a b -> a + b);
+> }</pre>
+>     </td>
+>     <td>
+>       <pre>
+> let myFuncs = {
+>   myFun: fun x => x + 1,
+>   your: fun a b => a + b
+> }</pre>
+>     </td>
+>   </tr>
+> </table>
+
 
 
 ###### Lambdas as match results no longer need extra parens
 > <table>
-  <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      <pre>
-let x = match prnt with
-  | None -> fun a -> blah
-  (\* Extra () required ! \*)
-  | Some "\_" -> (fun a -> ())
-  | Some "ml" -> blah
-      </pre>
-    </td>
-    <td>
-      <pre>
-let x = switch prnt {
-| None => fun a => blah
-| Some "_" => fun a => ()
-| Some "ml" => blah
-};</pre>
-    </td>
-  </tr>
-</table>
+>   <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
+>   <tr>
+>     <td>
+>       <pre>
+> let x = match prnt with
+>   | None -> fun a -> blah
+>   (\* Extra () required ! \*)
+>   | Some "\_" -> (fun a -> ())
+>   | Some "ml" -> blah
+>       </pre>
+>     </td>
+>     <td>
+>       <pre>
+> let x = switch prnt {
+> | None => fun a => blah
+> | Some "_" => fun a => ()
+> | Some "ml" => blah
+> };</pre>
+>     </td>
+>   </tr>
+> </table>
+
+
 
 ###### Lambdas and type annotations in tuples no longer require extra parens
 > <table>
-  <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      <pre>
-let tuple =
-  ((fun x -> x), 20)
-let tuple =
-  (("hi": string), (20: int))
-      </pre>
-    </td>
-    <td>
-      <pre>
-let tuple =
-  (fun x => x, 20);
-let tuple =
-  ("hi": string, 20: int);
-      </pre>
-    </td>
-  </tr>
-</table>
+>   <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
+>   <tr>
+>     <td>
+>       <pre>
+> let tuple =
+>   ((fun x -> x), 20)
+> let tuple =
+>   (("hi": string), (20: int))
+>       </pre>
+>     </td>
+>     <td>
+>       <pre>
+> let tuple =
+>   (fun x => x, 20);
+> let tuple =
+>   ("hi": string, 20: int);
+>       </pre>
+>     </td>
+>   </tr>
+> </table>
+
 
 
 ### Various Differences
@@ -1056,56 +1066,61 @@ let tuple =
 With `Reason`, `as` has a higher precedence than `|` bar. This allows creating `as` aliases
 for entire rows in pattern matching.
 
-<table>
-  <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      <pre>
-let ppp = match MyThing 20 with
-  | (MyThing x as ppp)
-  | (YourThing x as ppp) -> ppp;
-      </pre>
-    </td>
-    <td>
-      <pre>
-let ppp = switch (MyThing 20) {
-| MyThing x as ppp
-| YourThing x as ppp => ppp;
-};
-      </pre>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <pre>
-let | (MyThing \_ as ppp)
-    | (YourThing \_ as ppp) = ppp;</pre>
-    </td>
-    <td>
-      <pre>
-let | MyThing \_ as ppp
-    | YourThing \_ as ppp = ppp;</pre>
-    </td>
-  </tr>
-</table>
+> <table>
+>   <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
+>   <tr>
+>     <td>
+>       <pre>
+> let ppp = match MyThing 20 with
+>   | (MyThing x as ppp)
+>   | (YourThing x as ppp) -> ppp;
+>       </pre>
+>     </td>
+>     <td>
+>       <pre>
+> let ppp = switch (MyThing 20) {
+> | MyThing x as ppp
+> | YourThing x as ppp => ppp;
+> };
+>       </pre>
+>     </td>
+>   </tr>
+>   <tr>
+>     <td>
+>       <pre>
+> let | (MyThing \_ as ppp)
+>     | (YourThing \_ as ppp) = ppp;</pre>
+>     </td>
+>     <td>
+>       <pre>
+> let | MyThing \_ as ppp
+>     | YourThing \_ as ppp = ppp;</pre>
+>     </td>
+>   </tr>
+> </table>
+
+
 
 ###Mutable Record Field Updates
 
 Because equalities and their negations have been made more consistent in `Reason`,
 the `=` operator is available for mutable field update.
+
 > <table>
-  <thead><tr> <th scope="col"><p >OCaml</p></th> <th scope="col"><p>Reason</p></th></tr></thead>
-  <tr>
-    <td>
-      <pre>
-myRec.field <- "next"</pre>
-    </td>
-    <td>
-      <pre>
-myRec.field = "next"</pre>
-    </td>
-  </tr>
-</table>
+>   <thead><tr> <th scope="col"><p >OCaml</p></th> <th scope="col"><p>Reason</p></th></tr></thead>
+>   <tr>
+>     <td>
+>       <pre>
+> myRec.field <- "next"</pre>
+>     </td>
+>     <td>
+>       <pre>
+> myRec.field = "next"</pre>
+>     </td>
+>   </tr>
+> </table>
+
+
 
 ##### Prefix operators
 
@@ -1157,27 +1172,27 @@ uses `===` to represent `OCaml`'s `==`, then how would `Reason` represent `OCaml
 equals symbol!
 
 > <table>
-  <thead><tr> <th scope="col"><p>Identifier</p></th><th scope="col"><p>Meaning</p></th> <th scope="col"><p>Expressed in OCaml via</p></th> <th scope="col"><p>Expressed in Reason via</p></th></tr></thead>
-  <tr>
-  <tr>
-    <td>
-      <pre>
-"==="</pre>
-    </td>
-    <td>
-      <pre>
-Custom value</pre>
-    </td>
-    <td>
-      <pre>
-x === y</pre>
-    </td>
-    <td>
-      <pre>
-x \=== y</pre>
-    </td>
-  </tr>
-</table>
+>   <thead><tr> <th scope="col"><p>Identifier</p></th><th scope="col"><p>Meaning</p></th> <th scope="col"><p>Expressed in OCaml via</p></th> <th scope="col"><p>Expressed in Reason via</p></th></tr></thead>
+>   <tr>
+>   <tr>
+>     <td>
+>       <pre>
+> "==="</pre>
+>     </td>
+>     <td>
+>       <pre>
+> Custom value</pre>
+>     </td>
+>     <td>
+>       <pre>
+> x === y</pre>
+>     </td>
+>     <td>
+>       <pre>
+> x \=== y</pre>
+>     </td>
+>   </tr>
+> </table>
 
 
 

--- a/formatTest/typeCheckedTests/expected_output/arityConversion.re
+++ b/formatTest/typeCheckedTests/expected_output/arityConversion.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 Some (1, 2, 3);
 
 type bcd =

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -1,5 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /**
  * Generally, dangling attributes [@..] apply to everything to the left of it,
  * up until a comma, equals asignment, arrow, bar, or infix symbol (+/-) or

--- a/formatTest/typeCheckedTests/expected_output/attributes.rei
+++ b/formatTest/typeCheckedTests/expected_output/attributes.rei
@@ -1,4 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 let test: int;
 /**
  * Attributes with doc/text attributes should be stripped. They're left over from a

--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -1,4 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 type reasonXyz =
   | X
   | Y int int int

--- a/formatTest/typeCheckedTests/expected_output/comments.re
+++ b/formatTest/typeCheckedTests/expected_output/comments.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /* **** comment */
 
 /*** comment */

--- a/formatTest/typeCheckedTests/expected_output/comments.rei
+++ b/formatTest/typeCheckedTests/expected_output/comments.rei
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /* **** comment */
 /*** comment */
 /** docstring */

--- a/formatTest/typeCheckedTests/expected_output/imperative.re
+++ b/formatTest/typeCheckedTests/expected_output/imperative.re
@@ -1,4 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /*
  * Syntax and fallback syntax.
 

--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 type component = {displayName: string};
 
 module Bar = {

--- a/formatTest/typeCheckedTests/expected_output/knownMlIssues.re
+++ b/formatTest/typeCheckedTests/expected_output/knownMlIssues.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /* [x] fixed */
 type t2 =
   (int, int) /* attributed to entire type not binding */;

--- a/formatTest/typeCheckedTests/expected_output/lazy.re
+++ b/formatTest/typeCheckedTests/expected_output/lazy.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 let myComputation =
   lazy {
     let tmp = 10;

--- a/formatTest/typeCheckedTests/expected_output/mlSyntax.re
+++ b/formatTest/typeCheckedTests/expected_output/mlSyntax.re
@@ -1,5 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /**
  * Testing pattern matching using ml syntax to exercise nesting of cases.
  */

--- a/formatTest/typeCheckedTests/expected_output/mlVariants.re
+++ b/formatTest/typeCheckedTests/expected_output/mlVariants.re
@@ -1,4 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 type polyVariantsInMl = [
   | `IntTuple (int, int)
   | `StillAnIntTuple (int, int)

--- a/formatTest/typeCheckedTests/expected_output/mutation.re
+++ b/formatTest/typeCheckedTests/expected_output/mutation.re
@@ -1,5 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /**
  * Testing mutations.
  */

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 class virtual stack 'a init => {
   /*

--- a/formatTest/typeCheckedTests/expected_output/patternMatching.re
+++ b/formatTest/typeCheckedTests/expected_output/patternMatching.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 type point = {x: int, y: int};
 
 let id x => x;

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 3; /* - */
 
 3; /*-*/

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.rei
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.rei
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 module JustString: {
   include Map.S; /* Comment eol include */
 };

--- a/formatTest/typeCheckedTests/expected_output/sequences.re
+++ b/formatTest/typeCheckedTests/expected_output/sequences.re
@@ -1,5 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /**
  * Testing Sequences.
  */

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -1,4 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 let run () =>
   TestUtils.printSection "Basic Structures";
 

--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 bla#=10;
 
 bla#=(Some 10);

--- a/formatTest/unit_tests/expected_output/escapesInStrings.re
+++ b/formatTest/unit_tests/expected_output/escapesInStrings.re
@@ -1,4 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /*
     let str = "@[.... some formatting ....@\n\010@.";
  */

--- a/formatTest/unit_tests/expected_output/fixme.re
+++ b/formatTest/unit_tests/expected_output/fixme.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /**
  * Problem: In thise example, the comment should have a space after it.
  */

--- a/formatTest/unit_tests/expected_output/functionInfix.re
+++ b/formatTest/unit_tests/expected_output/functionInfix.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 let entries = ref [];
 
 let all = ref 0;

--- a/formatTest/unit_tests/expected_output/if.re
+++ b/formatTest/unit_tests/expected_output/if.re
@@ -1,4 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 let logTSuccess self =>
   if (self > other) {
     print_string "Did T";

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -1,4 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /* - A good way to test if formatting of infix operators groups precedences
    correctly, is to write an expression twice. Once in a form where parenthesis
    explicitly group according to the parse tree and write it another time

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -1,4 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 let run () => TestUtils.printSection "Modules";
 
 

--- a/formatTest/unit_tests/expected_output/object.re
+++ b/formatTest/unit_tests/expected_output/object.re
@@ -1,4 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 type t = {.};
 
 type t = {. u : int, v : int};

--- a/formatTest/unit_tests/expected_output/polymorphism.re
+++ b/formatTest/unit_tests/expected_output/polymorphism.re
@@ -1,4 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 let run () =>
   TestUtils.printSection "Polymorphism";
 

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1,4 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 [@@@autoFormat let wrap = 80; let shift = 2];
 
 Modules.run ();

--- a/formatTest/unit_tests/expected_output/syntax.rei
+++ b/formatTest/unit_tests/expected_output/syntax.rei
@@ -1,5 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /**
  * Typically the "interface file" is where you would write a ton of
  * comments/documentation.

--- a/formatTest/unit_tests/expected_output/testUtils.re
+++ b/formatTest/unit_tests/expected_output/testUtils.re
@@ -1,4 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 let printSection s => {
   print_string "\n";
   print_string s;

--- a/formatTest/unit_tests/expected_output/trailingSpaces.re
+++ b/formatTest/unit_tests/expected_output/trailingSpaces.re
@@ -1,4 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 module M =
   Something.Create {
     type resource1 = MyModule.MySubmodule.t;

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -1,4 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 module LocalModule = {
   type accessedThroughModule =
     | AccessedThroughModule;

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -1,4 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /* Run the formatting pretty printer with width 50 */
 /*
  * Testing infix wrapping

--- a/formatTest/unit_tests/expected_output/wrappingTest.rei
+++ b/formatTest/unit_tests/expected_output/wrappingTest.rei
@@ -1,4 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 let named: a::int => b::int => int;
 
 let namedAlias: a::int => b::int => int;

--- a/formatTest/unit_tests/input/basicStructures.re
+++ b/formatTest/unit_tests/input/basicStructures.re
@@ -1,5 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 let run = fun () => {TestUtils.printSection "Basic Structures";};
 
 while something {

--- a/formatTest/unit_tests/input/bucklescript.re
+++ b/formatTest/unit_tests/input/bucklescript.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 bla#=10;
 
 bla#=(Some 10);

--- a/formatTest/unit_tests/input/escapesInStrings.re
+++ b/formatTest/unit_tests/input/escapesInStrings.re
@@ -1,6 +1,11 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
 /*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
+/*
     let str = "@[.... some formatting ....@\n\010@.";
  */
 

--- a/formatTest/unit_tests/input/fixme.re
+++ b/formatTest/unit_tests/input/fixme.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /**
  * Problem: In thise example, the comment should have a space after it.
  */

--- a/formatTest/unit_tests/input/functionInfix.re
+++ b/formatTest/unit_tests/input/functionInfix.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 let entries = ref [];
 
 let all = ref 0;

--- a/formatTest/unit_tests/input/if.re
+++ b/formatTest/unit_tests/input/if.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
 let logTSuccess = fun self => if (self > other) {
@@ -181,4 +186,3 @@ let pngSuffix =
   pixRation > 1 ?
     "@" ^ string_of_int pixRation ^ "x.png"
     : ".png";
-

--- a/formatTest/unit_tests/input/infix.re
+++ b/formatTest/unit_tests/input/infix.re
@@ -1,5 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /* - A good way to test if formatting of infix operators groups precedences
    correctly, is to write an expression twice. Once in a form where parenthesis
    explicitly group according to the parse tree and write it another time

--- a/formatTest/unit_tests/input/modules.re
+++ b/formatTest/unit_tests/input/modules.re
@@ -1,5 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 let run = fun () => {
   TestUtils.printSection "Modules";
 };

--- a/formatTest/unit_tests/input/object.re
+++ b/formatTest/unit_tests/input/object.re
@@ -1,5 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+ 
 type t = {.};
 
 type t = {

--- a/formatTest/unit_tests/input/polymorphism.re
+++ b/formatTest/unit_tests/input/polymorphism.re
@@ -1,5 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 let run = fun () => {
   TestUtils.printSection "Polymorphism";
 };

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -1,5 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 [@@@autoFormat let wrap=80; let shift=2;];
 Modules.run ();
 Polymorphism.run ();

--- a/formatTest/unit_tests/input/syntax.rei
+++ b/formatTest/unit_tests/input/syntax.rei
@@ -1,5 +1,15 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /**
  * Typically the "interface file" is where you would write a ton of
  * comments/documentation.

--- a/formatTest/unit_tests/input/testUtils.re
+++ b/formatTest/unit_tests/input/testUtils.re
@@ -1,5 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 let printSection s => {
   print_string "\n";
   print_string s;

--- a/formatTest/unit_tests/input/trailingSpaces.re
+++ b/formatTest/unit_tests/input/trailingSpaces.re
@@ -1,5 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 module M = Something.Create {
   type resource1 = MyModule.MySubmodule.t;
   type resource2 = MyModule.MySubmodule.t;

--- a/formatTest/unit_tests/input/variants.re
+++ b/formatTest/unit_tests/input/variants.re
@@ -1,5 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 module LocalModule = {
   type accessedThroughModule = | AccessedThroughModule;
   type accessedThroughModuleWithArg =

--- a/formatTest/unit_tests/input/wrappingTest.re
+++ b/formatTest/unit_tests/input/wrappingTest.re
@@ -1,5 +1,9 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
 
 /* Run the formatting pretty printer with width 50 */
 

--- a/formatTest/unit_tests/input/wrappingTest.rei
+++ b/formatTest/unit_tests/input/wrappingTest.rei
@@ -1,5 +1,10 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 let named : a::int => b::int => int;
 
 let namedAlias : a::int => b::int => int;

--- a/miscTests/reactjs_jsx_ppx_tests/test1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test1.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /* dont touch these; no annotation */
 type dom = {createElement: unit => unit};
 

--- a/miscTests/reactjs_jsx_ppx_tests/test2.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test2.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /* hello comments */
 
        (createElement [||])[@JSX]

--- a/miscTests/reactjs_jsx_ppx_tests/test3.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test3.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /* hello comments */
 
        (Foo.createElement ())[@JSX]

--- a/miscTests/reactjs_jsx_ppx_tests/test4.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test4.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /* hello comments */
 
        (Foo.createElementLol ())[@JSX]

--- a/miscTests/reactjs_jsx_ppx_tests/test5.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test5.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /* hello comments */
 
         let div children => 1;

--- a/miscTests/reactjs_jsx_ppx_tests/test6.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test6.re
@@ -1,3 +1,8 @@
+/*
+ * vim: set ft=rust:
+ * vim: set ft=reason:
+ */
+
 /* hello comments */
 
         let div children => 1;


### PR DESCRIPTION
I added to all test files so that syntax highlighting on github works:
```
/*
 * vim: set ft=rust:
 * vim: set ft=reason:
 */
```

Also fixed formatting of tables in the OCaml Reason comparison html. Some tables weren't appearing on the opposite side of the description text. 
