### PR TITLE
New JSX PPX logic

### DIFF
--- a/miscTests/reactjs_jsx_ppx_tests/expected1.txt
+++ b/miscTests/reactjs_jsx_ppx_tests/expected1.txt
@@ -5,18 +5,19 @@ let _ = div.createElement ()
 module Gah = struct let createElement () = () end
 let _ = Gah.createElement ()
 let asd = ((Bar.createElement ~foo:1 ~bar:2 ["a"; "b"])[@jsxa ][@foo ])
-let asd = ((Bar.createElement ~foo:1 ~bar:2 ["a"; "b"])[@foo ])
-let _ = Baz.Beee.createElement ~baz:2 ["a"; "b"]
-let _ = Bar.createElement [foo]
-let _ = Bar.createElement ~foo:1 ~bar:2 []
-let _ =
-  Bar.createElement ~foo:(Baz.createElement ~baz:(Baaz.createElement []) [])
-    []
-let _ = Div.createElement ~foo:1 ~bar:2 []
+let asd = ((Bar.createElement ~foo:1 ~bar:2 ["a"; "b"] ())[@foo ])
+let _ = Baz.Beee.createElement ~baz:2 ["a"; "b"] ()
+let _ = Bar.createElement [foo] ()
+let _ = Bar.createElement ~foo:1 ~bar:2 [] ()
 let _ =
   Bar.createElement
-    [Baz.Beee.createElement ~baz:2 ~kek:(Foo.createElement []) ["a"; "b"];
-    Bar.createElement []]
+    ~foo:(Baz.createElement ~baz:(Baaz.createElement [] ()) [] ()) [] ()
+let _ = Div.createElement ~foo:1 ~bar:2 [] ()
+let _ =
+  Bar.createElement
+    [Baz.Beee.createElement ~baz:2 ~kek:(Foo.createElement [] ()) ["a"; "b"]
+       ();
+    Bar.createElement [] ()] ()
 let _ =
   ReactRe.createDOMElement "bar"
     (Js.Null.return

--- a/miscTests/reactjs_jsx_ppx_tests/expected3.txt
+++ b/miscTests/reactjs_jsx_ppx_tests/expected3.txt
@@ -1,1 +1,1 @@
-let _ = Foo.createElement ()
+let _ = Foo.createElement () ()


### PR DESCRIPTION
This changes `Foo.createElement bar::1 [][@JSX]` from the previous logic (a no-op when the JSX element is upper-cased) to `Foo.createElement bar::1 [] ()`. This way we don't have to forward `ref` and `key` for each component's boilerplate `createElement` call. For more info, see the super duper secret library.