### PR TITLE
Fix 861

### DIFF
--- a/src/syntax_util.ml
+++ b/src/syntax_util.ml
@@ -142,29 +142,25 @@ let identifier_mapper f =
 
 (** unescape_stars_slashes_mapper unescapes all stars and slashes in an AST *)
 let unescape_stars_slashes_mapper =
-  let unescape_stars_slashes str =
-    let len = String.length str in
-    if len < 2 then
-      str
-    else
-      let ending = String.sub str 1 (len - 1) in
-    String.sub str 0 1 ^
+  let unescape_stars_slashes = function
+    | str when String.length str <= 1 -> str
+    | "/\\*" -> "/*"
+    | "*\\/" -> "*/"
+    | str ->
       replace_string "\\*" "*"
-        (replace_string ("\\/") "/" ending)
+        (replace_string "\\/" "/" str)
   in
   identifier_mapper unescape_stars_slashes
 
 (** escape_stars_slashes_mapper escapes all stars and slashes in an AST *)
 let escape_stars_slashes_mapper =
-  let escape_stars_slashes str =
-    let len = String.length str in
-    if len < 2 then
-      str
-    else
-      let ending = String.sub str 1 (len -1) in
-      String.sub str 0 1 ^
-        replace_string "*" "\\*"
-          (replace_string "/" "\\/" ending)
+  let escape_stars_slashes = function
+    | str when String.length str <= 1 -> str
+    | "/*" -> "/\\*"
+    | "*/" -> "*\\/"
+    | str ->
+      replace_string "/*" "/\\*"
+        (replace_string "*/" "*\\/" str)
   in
   identifier_mapper escape_stars_slashes
 

--- a/src/syntax_util.ml
+++ b/src/syntax_util.ml
@@ -3,18 +3,6 @@ open Asttypes
 open Parsetree
 open Longident
 
-(** [is_prefixed prefix i str] checks if prefix is the prefix of str
-  * starting from position i
-  *)
-let is_prefixed prefix str i =
-  let len = String.length prefix in
-  if i + len > String.length str then false else
-  let rec loop j =
-    if j >= len then true else
-      if String.unsafe_get prefix j <> String.unsafe_get str (i + j) then false else loop (j + 1)
-    in
-  loop 0
-
 (**
  * pick_while returns a tuple where first element is longest prefix (possibly empty) of the list of elements that satisfy p
  * and second element is the remainder of the list
@@ -26,28 +14,53 @@ let rec pick_while p = function
                   hd :: satisfied, not_satisfied
   | l -> ([], l)
 
+(** [is_prefixed prefix i str] checks if prefix is the prefix of str
+  * starting from position i
+  *)
+let is_prefixed prefix str i =
+  let len = String.length prefix in
+  let j = ref 0 in
+  while !j < len && String.unsafe_get prefix !j =
+                    String.unsafe_get str (i + !j) do
+    incr j
+  done;
+  (!j = len)
 
-let rec replace_string_ old_str new_str i str buffer =
-  if i >= String.length str then
-    ()
-  else
-    (* found match *)
-    if is_prefixed old_str str i then
-      (* split string *)
-      let old_str_len = String.length old_str in
-      Buffer.add_string buffer new_str;
-      replace_string_ old_str new_str (i + old_str_len) str buffer
+(** [find_substring sub str i]
+    returns the smallest [j >= i] such that [sub = str.[j..length sub - 1]]
+    raises [Not_found] if there is no such j
+    behavior is not defined if [sub] is the empty string
+*)
+let find_substring sub str i =
+  let len = String.length str - String.length sub in
+  let found = ref false and i = ref i in
+  while not !found && !i <= len do
+    if is_prefixed sub str !i then
+      found := true
     else
-      let start = String.sub str i 1 in
-      Buffer.add_string buffer start;
-      replace_string_ old_str new_str (i + 1) str buffer
-
+      incr i;
+  done;
+  if not !found then
+    raise Not_found;
+  !i
 
 (** [replace_string old_str new_str str] replaces old_str to new_str in str *)
 let replace_string old_str new_str str =
-  let buffer = Buffer.create (String.length old_str * 2) in
-  replace_string_ old_str new_str 0 str buffer;
-  Buffer.contents buffer
+  match find_substring old_str str 0 with
+  | exception Not_found -> str
+  | occurrence ->
+    let buffer = Buffer.create (String.length str + 15) in
+    let rec loop i j =
+      Buffer.add_substring buffer str i (j - i);
+      Buffer.add_string buffer new_str;
+      let i = j + String.length old_str in
+      match find_substring old_str str i with
+      | j -> loop i j
+      | exception Not_found ->
+        Buffer.add_substring buffer str i (String.length str - i)
+    in
+    loop 0 occurrence;
+    Buffer.contents buffer
 
 
 module StringMap = Map.Make (String)
@@ -127,8 +140,7 @@ let identifier_mapper f =
   end;
 }
 
-(** unescape_stars_slashes_mapper unescapes all stars and slases in an AST
-  *)
+(** unescape_stars_slashes_mapper unescapes all stars and slashes in an AST *)
 let unescape_stars_slashes_mapper =
   let unescape_stars_slashes str =
     let len = String.length str in
@@ -142,8 +154,7 @@ let unescape_stars_slashes_mapper =
   in
   identifier_mapper unescape_stars_slashes
 
-(** escape_stars_slashes_mapper escapes all stars and slases in an AST
-  *)
+(** escape_stars_slashes_mapper escapes all stars and slashes in an AST *)
 let escape_stars_slashes_mapper =
   let escape_stars_slashes str =
     let len = String.length str in

--- a/src/syntax_util.ml
+++ b/src/syntax_util.ml
@@ -140,27 +140,25 @@ let identifier_mapper f =
   end;
 }
 
-(** unescape_stars_slashes_mapper unescapes all stars and slashes in an AST *)
+(** escape special characters that conflicts with lexer tokens *)
+
+let mappings = [("/*", "/\\*"); ("*/", "*\\/")]
+
 let unescape_stars_slashes_mapper =
-  let unescape_stars_slashes = function
-    | str when String.length str <= 1 -> str
-    | "/\\*" -> "/*"
-    | "*\\/" -> "*/"
-    | str ->
-      replace_string "\\*" "*"
-        (replace_string "\\/" "/" str)
+  let unescape_stars_slashes str =
+    if String.length str < 2 then str else
+    List.fold_left
+      (fun str (unescaped, escaped) -> replace_string escaped unescaped str)
+      str mappings
   in
   identifier_mapper unescape_stars_slashes
 
-(** escape_stars_slashes_mapper escapes all stars and slashes in an AST *)
 let escape_stars_slashes_mapper =
-  let escape_stars_slashes = function
-    | str when String.length str <= 1 -> str
-    | "/*" -> "/\\*"
-    | "*/" -> "*\\/"
-    | str ->
-      replace_string "/*" "/\\*"
-        (replace_string "*/" "*\\/" str)
+  let escape_stars_slashes str =
+    if String.length str < 2 then str else
+    List.fold_left
+      (fun str (unescaped, escaped) -> replace_string unescaped escaped str)
+      str mappings
   in
   identifier_mapper escape_stars_slashes
 


### PR DESCRIPTION
The escaping scheme is now simply that all occurrences of `/*` and `*/` should be replaced by `/\*` and `*\/`.

The patch also replaces the implementation of `replace_string`. It no longer allocates any memory on the fast path (no match). Previous version would allocate ~8 words per character.