### PR TITLE
Improve auto-mode-alist configuration

### DIFF
--- a/editorSupport/emacs/reason-mode.el
+++ b/editorSupport/emacs/reason-mode.el
@@ -1141,8 +1141,7 @@ This is written mainly to be used as `end-of-defun-function' for Reason."
   )
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.re\\'" . reason-mode))
-(add-to-list 'auto-mode-alist '("\\.rei\\'" . reason-mode))
+(add-to-list 'auto-mode-alist '("\\.rei?\\'" . reason-mode))
 
 
 (defun reason-mode-reload ()


### PR DESCRIPTION
`autoload` cookie affects only one s-expression. So original code should be written as bellow.

```lisp
;;;###autoload
(progn
  (add-to-list 'auto-mode-alist '("\\.re\\'" . reason-mode))
  (add-to-list 'auto-mode-alist '("\\.rei\\'" . reason-mode)))
```

However this is enough to improve regular expression of file extension.