### PR TITLE
Fix printing of extensible variants

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -338,3 +338,20 @@ type classAttributesOnKeys = {
   key3 [@bs.get null] : (Js.t int) [@onType2],
   key4 : Js.t (int [@justOnInt])
 };
+
+type attr = ..;
+
+type attr +=
+  | Str [@tag1] [@tag2]
+  | Float [@tag3]
+[@@block];
+
+type reconciler 'props = ..;
+
+type reconciler 'props +=
+  | Foo int :(reconciler int) [@onFirstRow]
+  | Bar (int [@onInt]) :(reconciler unit)
+                        [@onSecondRow]
+  | Baz :(reconciler (unit [@onUnit]))
+         [@onThirdRow]
+[@@onVariantType];

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -265,3 +265,17 @@ type classAttributesOnKeys = {
 
   key4 : Js.t (int [@justOnInt])
 };
+
+type attr = ..;
+
+type attr +=
+  | Str [@tag1] [@tag2]
+  | Float [@tag3]
+[@@block];
+
+type reconciler 'props = ..;
+
+type reconciler 'props +=
+ | Foo int : reconciler int [@onFirstRow]
+ | Bar (int [@onInt]) : reconciler unit [@onSecondRow]
+ | Baz: reconciler (unit [@onUnit]) [@onThirdRow] [@@onVariantType];

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -483,3 +483,34 @@ let listPatternMayEvenIncludeAliases x =>
     ()
   | _ => ()
   };
+
+/*
+ * Testing extensible variants
+ */
+type attr = ..;
+
+/* `of` is optional */
+type attr +=
+  | Str string;
+
+type attr +=
+  | Point int int;
+
+type attr +=
+  | Float float
+  | Char char;
+
+type tag 'props = ..;
+
+type titleProps = {title: string};
+
+type tag 'props +=
+  | Title :tag titleProps
+  | Count int :tag int;
+
+module Graph = {
+  type node = ..;
+};
+
+type Graph.node +=
+  | Str = Graph.Str;

--- a/formatTest/unit_tests/input/variants.re
+++ b/formatTest/unit_tests/input/variants.re
@@ -339,3 +339,32 @@ let listPatternMayEvenIncludeAliases x => switch x {
   | [Blah x y as head, Foo a b as head2, ...Something x as tail] => ()
   | _ => ()
 };
+
+/*
+ * Testing extensible variants
+ */
+type attr = ..;
+
+/* `of` is optional */
+type attr += Str of string;
+
+type attr += | Point int int;
+
+type attr +=
+ | Float float
+ | Char char;
+
+type tag 'props = ..;
+
+type titleProps = { title: string };
+
+type tag 'props +=
+  | Title: tag titleProps
+  | Count int :tag int;
+
+module Graph = {
+  type node = ..;
+};
+
+type Graph.node +=
+  | Str = Graph.Str;


### PR DESCRIPTION
The printer defaulted to the default (Ocaml) printer when pretty printing extensible variants.
See https://github.com/facebook/reason/issues/918

This PR tries to fix the problem & intends to make Extensible Variants great again.

