### PR TITLE
Add support for trailing commas in tuples

### DIFF
--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -345,6 +345,11 @@ let (tupleItem, withOutsideTypeConstraint): (
   20
 );
 
+/* Trailing commas */
+let trailingCommaAccepted = (1, 2);
+
+let moreTrailing = (1, 2, 3, 4, 5, 7);
+
 
 /**                        Immutable Lists
  * ============================================================================

--- a/formatTest/unit_tests/input/basicStructures.re
+++ b/formatTest/unit_tests/input/basicStructures.re
@@ -276,6 +276,10 @@ let annotatingSingleFuncApplication = {
 let (tupleItem:int, constrainedWithoutGrouping:int) = (10, 20);
 let (tupleItem, withOutsideTypeConstraint):(int,int) = (10, 20);
 
+/* Trailing commas */
+let trailingCommaAccepted = (1, 2,);
+let moreTrailing = (1, 2, 3, 4, 5, 7, );
+
 /**                        Immutable Lists
  * ============================================================================
  */

--- a/src/reason_parser.messages
+++ b/src/reason_parser.messages
@@ -42,7 +42,7 @@
 
 use_file: SHARP LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2864.
+## Ends in an error in state: 2866.
 ##
 ## _use_file -> toplevel_directive SEMI . use_file [ # ]
 ##
@@ -54,7 +54,7 @@ use_file: SHARP LIDENT SEMI WITH
 
 use_file: SHARP LIDENT TRUE WITH
 ##
-## Ends in an error in state: 2863.
+## Ends in an error in state: 2865.
 ##
 ## _use_file -> toplevel_directive . SEMI use_file [ # ]
 ## _use_file -> toplevel_directive . EOF [ # ]
@@ -67,7 +67,7 @@ use_file: SHARP LIDENT TRUE WITH
 
 use_file: UIDENT RPAREN
 ##
-## Ends in an error in state: 2866.
+## Ends in an error in state: 2868.
 ##
 ## _use_file -> structure_item . SEMI use_file [ # ]
 ## _use_file -> structure_item . EOF [ # ]
@@ -87,20 +87,20 @@ use_file: UIDENT RPAREN
 ## In state 925, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 960, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 924, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2855, spurious reduction of production post_item_attributes ->
-## In state 2856, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 2857, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 2835, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 2821, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 2859, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 2836, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 2857, spurious reduction of production post_item_attributes ->
+## In state 2858, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 2859, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 2837, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 2823, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 2861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 2838, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 use_file: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2867.
+## Ends in an error in state: 2869.
 ##
 ## _use_file -> structure_item SEMI . use_file [ # ]
 ##
@@ -112,7 +112,7 @@ use_file: UIDENT SEMI WITH
 
 use_file: WITH
 ##
-## Ends in an error in state: 2860.
+## Ends in an error in state: 2862.
 ##
 ## use_file' -> . use_file [ # ]
 ##
@@ -124,7 +124,7 @@ use_file: WITH
 
 toplevel_phrase: SHARP UIDENT EOF
 ##
-## Ends in an error in state: 2819.
+## Ends in an error in state: 2821.
 ##
 ## _toplevel_phrase -> toplevel_directive . SEMI [ # ]
 ##
@@ -135,7 +135,7 @@ toplevel_phrase: SHARP UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2727, spurious reduction of production toplevel_directive -> SHARP ident
+## In state 2729, spurious reduction of production toplevel_directive -> SHARP ident
 ##
 
 <SYNTAX ERROR>
@@ -155,7 +155,7 @@ toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 
 toplevel_phrase: SHARP UIDENT UIDENT WITH
 ##
-## Ends in an error in state: 2733.
+## Ends in an error in state: 2735.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ SEMI EOF DOT ]
 ## toplevel_directive -> SHARP ident mod_longident . [ SEMI EOF ]
@@ -169,7 +169,7 @@ toplevel_phrase: SHARP UIDENT UIDENT WITH
 
 toplevel_phrase: SHARP UIDENT WITH
 ##
-## Ends in an error in state: 2727.
+## Ends in an error in state: 2729.
 ##
 ## toplevel_directive -> SHARP ident . [ SEMI EOF ]
 ## toplevel_directive -> SHARP ident . STRING [ SEMI EOF ]
@@ -187,7 +187,7 @@ toplevel_phrase: SHARP UIDENT WITH
 
 toplevel_phrase: SHARP WITH
 ##
-## Ends in an error in state: 2726.
+## Ends in an error in state: 2728.
 ##
 ## toplevel_directive -> SHARP . ident [ SEMI EOF ]
 ## toplevel_directive -> SHARP . ident STRING [ SEMI EOF ]
@@ -205,7 +205,7 @@ toplevel_phrase: SHARP WITH
 
 toplevel_phrase: UIDENT RPAREN
 ##
-## Ends in an error in state: 2822.
+## Ends in an error in state: 2824.
 ##
 ## _toplevel_phrase -> structure_item . SEMI [ # ]
 ##
@@ -224,20 +224,20 @@ toplevel_phrase: UIDENT RPAREN
 ## In state 925, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 960, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 924, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2855, spurious reduction of production post_item_attributes ->
-## In state 2856, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 2857, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 2835, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 2821, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 2859, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 2836, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 2857, spurious reduction of production post_item_attributes ->
+## In state 2858, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 2859, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 2837, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 2823, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 2861, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 2838, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: WITH
 ##
-## Ends in an error in state: 2689.
+## Ends in an error in state: 2691.
 ##
 ## toplevel_phrase' -> . toplevel_phrase [ # ]
 ##
@@ -590,7 +590,7 @@ parse_pattern: LBRACKETBAR WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 2460.
+## Ends in an error in state: 2461.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -608,7 +608,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 2459.
+## Ends in an error in state: 2460.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -621,7 +621,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2458.
+## Ends in an error in state: 2459.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -639,7 +639,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2457.
+## Ends in an error in state: 2458.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -652,7 +652,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2456.
+## Ends in an error in state: 2457.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -665,7 +665,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2455.
+## Ends in an error in state: 2456.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -1029,7 +1029,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WHILE
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LBRACE DOTDOT RBRACE AND WITH
 ##
-## Ends in an error in state: 2453.
+## Ends in an error in state: 2454.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ error RPAREN ]
 ##
@@ -1041,7 +1041,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LBRACE D
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LBRACE DOTDOT RBRACE WITH
 ##
-## Ends in an error in state: 2452.
+## Ends in an error in state: 2453.
 ##
 ## package_type_cstrs -> package_type_cstr . [ error RPAREN ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ error RPAREN ]
@@ -1059,7 +1059,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LBRACE D
 ## In state 664, spurious reduction of production _core_type -> core_type2
 ## In state 675, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 663, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 2450, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 2451, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
@@ -1528,7 +1528,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT UNDERSCORE WHILE
 
 parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2568.
+## Ends in an error in state: 2570.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN MODULE package_type . RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1548,7 +1548,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE UIDENT COLONGREATER
 
 parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE WITH
 ##
-## Ends in an error in state: 2567.
+## Ends in an error in state: 2569.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN MODULE . package_type RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1560,7 +1560,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2570.
+## Ends in an error in state: 2572.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN core_type_comma_list . RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## core_type_comma_list -> core_type_comma_list . COMMA core_type [ RPAREN COMMA ]
@@ -1578,7 +1578,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LPAREN UNDERSCORE WITH
 ## In state 289, spurious reduction of production _core_type -> core_type2
 ## In state 301, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 288, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1217, spurious reduction of production core_type_comma_list -> core_type
+## In state 1218, spurious reduction of production core_type_comma_list -> core_type
 ##
 
 <SYNTAX ERROR>
@@ -1893,7 +1893,7 @@ parse_pattern: UNDERSCORE BAR WITH
 
 parse_pattern: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2686.
+## Ends in an error in state: 2688.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EOF BAR ]
 ## parse_pattern -> pattern . EOF [ # ]
@@ -1912,7 +1912,7 @@ parse_pattern: UNDERSCORE WITH
 
 parse_pattern: WITH
 ##
-## Ends in an error in state: 2685.
+## Ends in an error in state: 2687.
 ##
 ## parse_pattern' -> . parse_pattern [ # ]
 ##
@@ -1924,7 +1924,7 @@ parse_pattern: WITH
 
 parse_expression: UIDENT SEMI
 ##
-## Ends in an error in state: 2683.
+## Ends in an error in state: 2685.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -1973,7 +1973,7 @@ parse_expression: UIDENT SEMI
 
 parse_expression: WITH
 ##
-## Ends in an error in state: 2681.
+## Ends in an error in state: 2683.
 ##
 ## parse_expression' -> . parse_expression [ # ]
 ##
@@ -2009,7 +2009,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ##
-## Ends in an error in state: 2542.
+## Ends in an error in state: 2544.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET tag_field . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field -> tag_field . [ BAR ]
@@ -2029,7 +2029,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 
 parse_core_type: LBRACKET BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 2540.
+## Ends in an error in state: 2542.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET BAR row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2042,7 +2042,7 @@ parse_core_type: LBRACKET BAR UNDERSCORE WITH
 
 parse_core_type: LBRACKET BAR WITH
 ##
-## Ends in an error in state: 2539.
+## Ends in an error in state: 2541.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET BAR . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2054,7 +2054,7 @@ parse_core_type: LBRACKET BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 2546.
+## Ends in an error in state: 2548.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2067,7 +2067,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 2545.
+## Ends in an error in state: 2547.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2079,7 +2079,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE WITH
 ##
-## Ends in an error in state: 2544.
+## Ends in an error in state: 2546.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field . BAR row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2117,7 +2117,7 @@ parse_core_type: LBRACKETGREATER BAR ASSERT
 
 parse_core_type: LBRACKETGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 2548.
+## Ends in an error in state: 2550.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2168,7 +2168,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2553.
+## Ends in an error in state: 2555.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER name_tag_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## name_tag_list -> name_tag_list . name_tag [ RBRACKET BACKQUOTE ]
@@ -2181,7 +2181,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 ##
-## Ends in an error in state: 2552.
+## Ends in an error in state: 2554.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER . name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2193,7 +2193,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE WITH
 ##
-## Ends in an error in state: 2550.
+## Ends in an error in state: 2552.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . GREATER name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2246,7 +2246,7 @@ parse_core_type: LBRACE LIDENT COLON LBRACE DOTDOT RBRACE COMMA WITH
 
 parse_core_type: LBRACE LIDENT COLON QUOTE UIDENT DOT WITH
 ##
-## Ends in an error in state: 1591.
+## Ends in an error in state: 1592.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ RBRACE LBRACKETAT EQUAL COMMA ]
 ##
@@ -2258,7 +2258,7 @@ parse_core_type: LBRACE LIDENT COLON QUOTE UIDENT DOT WITH
 
 parse_core_type: LBRACE LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1590.
+## Ends in an error in state: 1591.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ RBRACE LBRACKETAT EQUAL COMMA ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -2271,7 +2271,7 @@ parse_core_type: LBRACE LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 
 parse_core_type: LBRACE LIDENT COLON QUOTE UIDENT QUOTE WITH
 ##
-## Ends in an error in state: 1393.
+## Ends in an error in state: 1394.
 ##
 ## typevar_list -> typevar_list QUOTE . ident [ QUOTE DOT ]
 ##
@@ -2283,7 +2283,7 @@ parse_core_type: LBRACE LIDENT COLON QUOTE UIDENT QUOTE WITH
 
 parse_core_type: LBRACE LIDENT COLON QUOTE WITH
 ##
-## Ends in an error in state: 1489.
+## Ends in an error in state: 1490.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ RBRACE LBRACKETAT EQUALGREATER EQUAL COMMA COLONGREATER AS ]
 ## typevar_list -> QUOTE . ident [ QUOTE DOT ]
@@ -2296,7 +2296,7 @@ parse_core_type: LBRACE LIDENT COLON QUOTE WITH
 
 parse_core_type: LBRACE LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2536.
+## Ends in an error in state: 2538.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## object_record_type -> LBRACE label_declarations . opt_comma RBRACE [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2314,11 +2314,11 @@ parse_core_type: LBRACE LIDENT COLON UNDERSCORE WITH
 ## In state 289, spurious reduction of production _core_type -> core_type2
 ## In state 301, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 288, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1597, spurious reduction of production _poly_type -> core_type
-## In state 1598, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1596, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 2528, spurious reduction of production attributes ->
-## In state 2529, spurious reduction of production label_declaration -> mutable_flag LIDENT attributes COLON poly_type attributes
+## In state 1598, spurious reduction of production _poly_type -> core_type
+## In state 1599, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1597, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 2530, spurious reduction of production attributes ->
+## In state 2531, spurious reduction of production label_declaration -> mutable_flag LIDENT attributes COLON poly_type attributes
 ## In state 330, spurious reduction of production label_declarations -> label_declaration
 ##
 
@@ -2408,7 +2408,7 @@ parse_core_type: LPAREN MODULE UIDENT SEMI
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LBRACE DOTDOT RBRACE AND WITH
 ##
-## Ends in an error in state: 2564.
+## Ends in an error in state: 2566.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ RPAREN COLONGREATER ]
 ##
@@ -2420,7 +2420,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LBRACE DOTDOT RBRAC
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LBRACE DOTDOT RBRACE WITH
 ##
-## Ends in an error in state: 2563.
+## Ends in an error in state: 2565.
 ##
 ## package_type_cstrs -> package_type_cstr . [ RPAREN COLONGREATER ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ RPAREN COLONGREATER ]
@@ -2438,7 +2438,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LBRACE DOTDOT RBRAC
 ## In state 289, spurious reduction of production _core_type -> core_type2
 ## In state 301, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 288, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 2561, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 2563, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
@@ -2505,7 +2505,7 @@ parse_core_type: LPAREN MODULE WITH
 
 parse_core_type: LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 1215.
+## Ends in an error in state: 1216.
 ##
 ## core_type_comma_list -> core_type_comma_list COMMA . core_type [ RPAREN COMMA ]
 ##
@@ -2517,7 +2517,7 @@ parse_core_type: LPAREN UNDERSCORE COMMA WITH
 
 parse_core_type: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1213.
+## Ends in an error in state: 1214.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN core_type_comma_list . RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## core_type_comma_list -> core_type_comma_list . COMMA core_type [ RPAREN COMMA ]
@@ -2535,7 +2535,7 @@ parse_core_type: LPAREN UNDERSCORE WITH
 ## In state 289, spurious reduction of production _core_type -> core_type2
 ## In state 301, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 288, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1217, spurious reduction of production core_type_comma_list -> core_type
+## In state 1218, spurious reduction of production core_type_comma_list -> core_type
 ##
 
 Expecting one of the following:
@@ -2556,7 +2556,7 @@ parse_core_type: QUOTE WITH
 
 parse_core_type: SHARP LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 2566.
+## Ends in an error in state: 2568.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP class_longident non_arrowed_simple_core_type_list . [ WITH SEMI RPAREN RBRACKET RBRACE QUESTION LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2723,7 +2723,7 @@ parse_core_type: UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2679.
+## Ends in an error in state: 2681.
 ##
 ## parse_core_type -> core_type . EOF [ # ]
 ##
@@ -2746,7 +2746,7 @@ parse_core_type: UNDERSCORE WITH
 
 parse_core_type: WITH
 ##
-## Ends in an error in state: 2677.
+## Ends in an error in state: 2679.
 ##
 ## parse_core_type' -> . parse_core_type [ # ]
 ##
@@ -2758,7 +2758,7 @@ parse_core_type: WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 ##
-## Ends in an error in state: 2014.
+## Ends in an error in state: 2015.
 ##
 ## and_class_description -> AND . class_description_details post_item_attributes [ SEMI AND ]
 ##
@@ -2770,7 +2770,7 @@ interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ##
-## Ends in an error in state: 2013.
+## Ends in an error in state: 2014.
 ##
 ## _signature_item -> many_class_descriptions . [ SEMI ]
 ## many_class_descriptions -> many_class_descriptions . and_class_description [ SEMI AND ]
@@ -2782,22 +2782,22 @@ interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1681, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1685, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1679, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1683, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1694, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1692, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
-## In state 1961, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
-## In state 1962, spurious reduction of production post_item_attributes ->
-## In state 1963, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
+## In state 1682, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1686, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1680, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1684, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1695, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1693, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1962, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
+## In state 1963, spurious reduction of production post_item_attributes ->
+## In state 1964, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 1960.
+## Ends in an error in state: 1961.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters COLON . class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -2809,7 +2809,7 @@ interface: CLASS LIDENT COLON WITH
 
 interface: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1438.
+## Ends in an error in state: 1439.
 ##
 ## type_parameter -> type_variance . type_variable [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENTCOLONCOLON LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLONCOLONLIDENT COLON CHAR BACKQUOTE ]
 ##
@@ -2821,7 +2821,7 @@ interface: CLASS LIDENT PLUS WITH
 
 interface: CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1959.
+## Ends in an error in state: 1960.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters . COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS COLON ]
@@ -2834,7 +2834,7 @@ interface: CLASS LIDENT WITH
 
 interface: CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 1957.
+## Ends in an error in state: 1958.
 ##
 ## class_description_details -> virtual_flag . LIDENT class_type_parameters COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -2846,7 +2846,7 @@ interface: CLASS VIRTUAL LET
 
 interface: CLASS WITH
 ##
-## Ends in an error in state: 1948.
+## Ends in an error in state: 1949.
 ##
 ## many_class_descriptions -> CLASS . class_description_details post_item_attributes [ SEMI AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ SEMI AND ]
@@ -2859,7 +2859,7 @@ interface: CLASS WITH
 
 interface: EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1930.
+## Ends in an error in state: 1931.
 ##
 ## extension_constructor_declaration -> UIDENT . generalized_constructor_arguments attributes [ SEMI LBRACKETATAT BAR ]
 ##
@@ -2871,7 +2871,7 @@ interface: EXCEPTION UIDENT WITH
 
 interface: EXCEPTION WITH
 ##
-## Ends in an error in state: 1929.
+## Ends in an error in state: 1930.
 ##
 ## sig_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ SEMI ]
 ##
@@ -2883,7 +2883,7 @@ interface: EXCEPTION WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1924.
+## Ends in an error in state: 1925.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -2895,7 +2895,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1923.
+## Ends in an error in state: 1924.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -2918,7 +2918,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 interface: EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1922.
+## Ends in an error in state: 1923.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -2930,7 +2930,7 @@ interface: EXTERNAL LIDENT COLON WITH
 
 interface: EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 1921.
+## Ends in an error in state: 1922.
 ##
 ## _signature_item -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -2942,7 +2942,7 @@ interface: EXTERNAL LIDENT WITH
 
 interface: EXTERNAL WITH
 ##
-## Ends in an error in state: 1920.
+## Ends in an error in state: 1921.
 ##
 ## _signature_item -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -2954,7 +2954,7 @@ interface: EXTERNAL WITH
 
 interface: INCLUDE LBRACE OPEN UIDENT WITH
 ##
-## Ends in an error in state: 1964.
+## Ends in an error in state: 1965.
 ##
 ## signature -> signature_item . SEMI signature [ error RBRACE ]
 ##
@@ -2965,18 +2965,18 @@ interface: INCLUDE LBRACE OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1806, spurious reduction of production post_item_attributes ->
-## In state 1807, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 1994, spurious reduction of production _signature_item -> open_statement
-## In state 2021, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 1995, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 1807, spurious reduction of production post_item_attributes ->
+## In state 1808, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 1995, spurious reduction of production _signature_item -> open_statement
+## In state 2022, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 1996, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 1965.
+## Ends in an error in state: 1966.
 ##
 ## signature -> signature_item SEMI . signature [ error RBRACE ]
 ##
@@ -2988,7 +2988,7 @@ interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 
 interface: INCLUDE LBRACE WITH
 ##
-## Ends in an error in state: 1803.
+## Ends in an error in state: 1804.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LBRACE . signature error [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3001,7 +3001,7 @@ interface: INCLUDE LBRACE WITH
 
 interface: INCLUDE LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 1188.
+## Ends in an error in state: 1189.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _simple_module_type -> LBRACE . signature error [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3014,7 +3014,7 @@ interface: INCLUDE LPAREN LBRACE WITH
 
 interface: INCLUDE LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 1748.
+## Ends in an error in state: 1749.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3030,7 +3030,7 @@ interface: INCLUDE LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 2073.
+## Ends in an error in state: 2074.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3046,7 +3046,7 @@ interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 2081.
+## Ends in an error in state: 2082.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3061,7 +3061,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LID
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2080.
+## Ends in an error in state: 2081.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3073,7 +3073,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WIT
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2079.
+## Ends in an error in state: 2080.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3085,7 +3085,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2078.
+## Ends in an error in state: 2079.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3101,22 +3101,22 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 806, spurious reduction of production mty_longident -> ident
-## In state 1814, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1843, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1839, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1812, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1844, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1840, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1813, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1845, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1841, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1815, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1844, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1840, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1813, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1845, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1841, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1814, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1846, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1842, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2077.
+## Ends in an error in state: 2078.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3128,7 +3128,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2076.
+## Ends in an error in state: 2077.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3140,7 +3140,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 1186.
+## Ends in an error in state: 1187.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3154,7 +3154,7 @@ interface: INCLUDE LPAREN LPAREN WITH
 
 interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ##
-## Ends in an error in state: 2437.
+## Ends in an error in state: 2438.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF ]
@@ -3168,12 +3168,12 @@ interface: INCLUDE LPAREN MODULE TYPE UIDENT COLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1736, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1740, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1737, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1166, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1742, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1741, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1737, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1741, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1738, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1167, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1743, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1742, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
@@ -3232,7 +3232,7 @@ interface: INCLUDE LPAREN UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 1792.
+## Ends in an error in state: 1793.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3247,7 +3247,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1791.
+## Ends in an error in state: 1792.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3279,7 +3279,7 @@ interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UIDENT WHILE
 ##
-## Ends in an error in state: 1187.
+## Ends in an error in state: 1188.
 ##
 ## functor_arg_name -> UIDENT . [ COLON ]
 ## ident -> UIDENT . [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3294,7 +3294,7 @@ interface: INCLUDE LPAREN UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 ##
-## Ends in an error in state: 1774.
+## Ends in an error in state: 1775.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3307,7 +3307,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1771.
+## Ends in an error in state: 1772.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ RPAREN LPAREN DOT ]
 ## mod_ext2 -> UIDENT LPAREN mod_ext_longident . RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3327,7 +3327,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UID
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1770.
+## Ends in an error in state: 1771.
 ##
 ## mod_ext2 -> UIDENT LPAREN . mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ##
@@ -3352,7 +3352,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WIT
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1768.
+## Ends in an error in state: 1769.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3364,7 +3364,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 1783.
+## Ends in an error in state: 1784.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3377,7 +3377,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 ##
-## Ends in an error in state: 1769.
+## Ends in an error in state: 1770.
 ##
 ## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ## mod_ext_longident -> UIDENT . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3390,7 +3390,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1784.
+## Ends in an error in state: 1785.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3402,7 +3402,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1767.
+## Ends in an error in state: 1768.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3415,7 +3415,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 1766.
+## Ends in an error in state: 1767.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3428,7 +3428,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRACE AND WITH
 ##
-## Ends in an error in state: 1787.
+## Ends in an error in state: 1788.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3440,7 +3440,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRAC
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRACE EQUAL
 ##
-## Ends in an error in state: 1786.
+## Ends in an error in state: 1787.
 ##
 ## _module_type -> module_type WITH with_constraints . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## with_constraints -> with_constraints . AND with_constraint [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3458,15 +3458,15 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRAC
 ## In state 664, spurious reduction of production _core_type -> core_type2
 ## In state 675, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 663, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1757, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1789, spurious reduction of production with_constraints -> with_constraint
+## In state 1758, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1790, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1756.
+## Ends in an error in state: 1757.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3478,7 +3478,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRI WITH
 ##
-## Ends in an error in state: 1758.
+## Ends in an error in state: 1759.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3490,7 +3490,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRI WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ##
-## Ends in an error in state: 1760.
+## Ends in an error in state: 1761.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3508,14 +3508,14 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ## In state 664, spurious reduction of production _core_type -> core_type2
 ## In state 675, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 663, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1759, spurious reduction of production constraints ->
+## In state 1760, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ##
-## Ends in an error in state: 1753.
+## Ends in an error in state: 1754.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3527,14 +3527,14 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1285, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 1286, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 1751.
+## Ends in an error in state: 1752.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3547,7 +3547,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH WITH
 ##
-## Ends in an error in state: 1750.
+## Ends in an error in state: 1751.
 ##
 ## _module_type -> module_type WITH . with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3559,7 +3559,7 @@ interface: INCLUDE LPAREN UIDENT WITH WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2028.
+## Ends in an error in state: 2029.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3575,22 +3575,22 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COL
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 806, spurious reduction of production mty_longident -> ident
-## In state 1814, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1843, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1839, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1812, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1844, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1840, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1813, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1845, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1841, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1815, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1844, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1840, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1813, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1845, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1841, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1814, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1846, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1842, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2027.
+## Ends in an error in state: 2028.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3602,7 +3602,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2026.
+## Ends in an error in state: 2027.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3614,7 +3614,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2025.
+## Ends in an error in state: 2026.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3630,22 +3630,22 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 806, spurious reduction of production mty_longident -> ident
-## In state 1814, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1843, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1839, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1812, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1844, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1840, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1813, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1845, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1841, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1815, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1844, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1840, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1813, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1845, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1841, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1814, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1846, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1842, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1802.
+## Ends in an error in state: 1803.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3657,7 +3657,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1801.
+## Ends in an error in state: 1802.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3669,7 +3669,7 @@ interface: INCLUDE LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN WITH
 ##
-## Ends in an error in state: 1744.
+## Ends in an error in state: 1745.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3761,7 +3761,7 @@ interface: INCLUDE UIDENT DOT WITH
 
 interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1837.
+## Ends in an error in state: 1838.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3777,22 +3777,22 @@ interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 806, spurious reduction of production mty_longident -> ident
-## In state 1814, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1843, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1839, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1812, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1844, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1840, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1813, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1845, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1841, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1815, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1844, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1840, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1813, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1845, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1841, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1814, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1846, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1842, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1836.
+## Ends in an error in state: 1837.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3852,7 +3852,7 @@ interface: INCLUDE UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1827.
+## Ends in an error in state: 1828.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3864,7 +3864,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 1829.
+## Ends in an error in state: 1830.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3890,7 +3890,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1830.
+## Ends in an error in state: 1831.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3902,7 +3902,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1826.
+## Ends in an error in state: 1827.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3915,7 +3915,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 1825.
+## Ends in an error in state: 1826.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3928,7 +3928,7 @@ interface: INCLUDE UIDENT WITH MODULE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRACE AND WITH
 ##
-## Ends in an error in state: 1833.
+## Ends in an error in state: 1834.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3940,7 +3940,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRACE AND W
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRACE GREATER
 ##
-## Ends in an error in state: 1832.
+## Ends in an error in state: 1833.
 ##
 ## _module_type -> module_type WITH with_constraints . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraints -> with_constraints . AND with_constraint [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3958,15 +3958,15 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRACE GREAT
 ## In state 289, spurious reduction of production _core_type -> core_type2
 ## In state 301, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 288, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1821, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1835, spurious reduction of production with_constraints -> with_constraint
+## In state 1822, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1836, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1820.
+## Ends in an error in state: 1821.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3978,7 +3978,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRI WITH
 ##
-## Ends in an error in state: 1822.
+## Ends in an error in state: 1823.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3990,7 +3990,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRI WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ##
-## Ends in an error in state: 1824.
+## Ends in an error in state: 1825.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4008,14 +4008,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ## In state 289, spurious reduction of production _core_type -> core_type2
 ## In state 301, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 288, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1823, spurious reduction of production constraints ->
+## In state 1824, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1754.
+## Ends in an error in state: 1755.
 ##
 ## with_type_binder -> EQUAL . [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENTCOLONCOLON LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET LBRACE ]
 ## with_type_binder -> EQUAL . PRI [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENTCOLONCOLON LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET LBRACE ]
@@ -4028,7 +4028,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1819.
+## Ends in an error in state: 1820.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4040,14 +4040,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1818, spurious reduction of production optional_type_parameters ->
+## In state 1819, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 1817.
+## Ends in an error in state: 1818.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4060,7 +4060,7 @@ interface: INCLUDE UIDENT WITH TYPE WITH
 
 interface: INCLUDE UIDENT WITH WITH
 ##
-## Ends in an error in state: 1816.
+## Ends in an error in state: 1817.
 ##
 ## _module_type -> module_type WITH . with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4072,7 +4072,7 @@ interface: INCLUDE UIDENT WITH WITH
 
 interface: INCLUDE WITH
 ##
-## Ends in an error in state: 1917.
+## Ends in an error in state: 1918.
 ##
 ## _signature_item -> INCLUDE . module_type post_item_attributes [ SEMI ]
 ##
@@ -4084,7 +4084,7 @@ interface: INCLUDE WITH
 
 interface: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 1850.
+## Ends in an error in state: 1851.
 ##
 ## _signature_item -> LET val_ident COLON . core_type post_item_attributes [ SEMI ]
 ##
@@ -4096,7 +4096,7 @@ interface: LET LIDENT COLON WITH
 
 interface: LET LIDENT WITH
 ##
-## Ends in an error in state: 1849.
+## Ends in an error in state: 1850.
 ##
 ## _signature_item -> LET val_ident . COLON core_type post_item_attributes [ SEMI ]
 ##
@@ -4120,7 +4120,7 @@ interface: LET LPAREN WITH
 
 interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
 ##
-## Ends in an error in state: 2004.
+## Ends in an error in state: 2005.
 ##
 ## and_module_rec_declaration -> AND . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4132,7 +4132,7 @@ interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
 
 interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2003.
+## Ends in an error in state: 2004.
 ##
 ## _signature_item -> many_module_rec_declarations . [ SEMI ]
 ## many_module_rec_declarations -> many_module_rec_declarations . and_module_rec_declaration [ SEMI AND ]
@@ -4144,16 +4144,16 @@ interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1514, spurious reduction of production post_item_attributes ->
-## In state 1515, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1993, spurious reduction of production many_module_rec_declarations -> opt_let_module REC module_rec_declaration_details post_item_attributes
+## In state 1515, spurious reduction of production post_item_attributes ->
+## In state 1516, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1994, spurious reduction of production many_module_rec_declarations -> opt_let_module REC module_rec_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 1991.
+## Ends in an error in state: 1992.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -4169,22 +4169,22 @@ interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 806, spurious reduction of production mty_longident -> ident
-## In state 1814, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1843, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1839, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1812, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1844, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1840, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1813, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1845, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1841, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1815, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1844, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1840, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1813, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1845, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1841, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1814, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1846, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1842, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON WITH
 ##
-## Ends in an error in state: 1990.
+## Ends in an error in state: 1991.
 ##
 ## module_rec_declaration_details -> UIDENT COLON . module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4196,7 +4196,7 @@ interface: LET MODULE REC UIDENT COLON WITH
 
 interface: LET MODULE REC UIDENT WITH
 ##
-## Ends in an error in state: 1989.
+## Ends in an error in state: 1990.
 ##
 ## module_rec_declaration_details -> UIDENT . COLON module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4208,7 +4208,7 @@ interface: LET MODULE REC UIDENT WITH
 
 interface: LET MODULE REC WITH
 ##
-## Ends in an error in state: 1988.
+## Ends in an error in state: 1989.
 ##
 ## many_module_rec_declarations -> opt_let_module REC . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4220,7 +4220,7 @@ interface: LET MODULE REC WITH
 
 interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 1977.
+## Ends in an error in state: 1978.
 ##
 ## _module_declaration -> COLON module_type . [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -4236,22 +4236,22 @@ interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 806, spurious reduction of production mty_longident -> ident
-## In state 1814, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1843, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1839, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1812, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1844, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1840, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1813, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1845, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1841, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1815, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1844, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1840, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1813, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1845, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1841, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1814, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1846, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1842, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 1976.
+## Ends in an error in state: 1977.
 ##
 ## _module_declaration -> COLON . module_type [ SEMI LBRACKETATAT ]
 ##
@@ -4263,7 +4263,7 @@ interface: LET MODULE UIDENT COLON WITH
 
 interface: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1983.
+## Ends in an error in state: 1984.
 ##
 ## _signature_item -> opt_let_module UIDENT EQUAL . mod_longident post_item_attributes [ SEMI ]
 ##
@@ -4275,7 +4275,7 @@ interface: LET MODULE UIDENT EQUAL WITH
 
 interface: LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1981.
+## Ends in an error in state: 1982.
 ##
 ## _module_declaration -> LPAREN RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4287,7 +4287,7 @@ interface: LET MODULE UIDENT LPAREN RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1975.
+## Ends in an error in state: 1976.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4299,7 +4299,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1974.
+## Ends in an error in state: 1975.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type . RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -4315,22 +4315,22 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 806, spurious reduction of production mty_longident -> ident
-## In state 1814, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1843, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1839, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1812, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1844, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1840, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1813, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1845, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1841, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1815, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1844, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1840, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1813, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1845, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1841, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1814, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1846, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1842, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1973.
+## Ends in an error in state: 1974.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON . module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4342,7 +4342,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1972.
+## Ends in an error in state: 1973.
 ##
 ## _module_declaration -> LPAREN UIDENT . COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4354,7 +4354,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT WITH
 
 interface: LET MODULE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1971.
+## Ends in an error in state: 1972.
 ##
 ## _module_declaration -> LPAREN . UIDENT COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_declaration -> LPAREN . RPAREN module_declaration [ SEMI LBRACKETATAT ]
@@ -4367,7 +4367,7 @@ interface: LET MODULE UIDENT LPAREN WITH
 
 interface: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1970.
+## Ends in an error in state: 1971.
 ##
 ## _signature_item -> opt_let_module UIDENT . module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> opt_let_module UIDENT . EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4380,7 +4380,7 @@ interface: LET MODULE UIDENT WITH
 
 interface: LET MODULE WITH
 ##
-## Ends in an error in state: 1969.
+## Ends in an error in state: 1970.
 ##
 ## _signature_item -> opt_let_module . UIDENT module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> opt_let_module . UIDENT EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4394,7 +4394,7 @@ interface: LET MODULE WITH
 
 interface: LET WITH
 ##
-## Ends in an error in state: 1848.
+## Ends in an error in state: 1849.
 ##
 ## _signature_item -> LET . val_ident COLON core_type post_item_attributes [ SEMI ]
 ## opt_let_module -> LET . MODULE [ UIDENT REC ]
@@ -4407,7 +4407,7 @@ interface: LET WITH
 
 interface: MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1811.
+## Ends in an error in state: 1812.
 ##
 ## _signature_item -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ SEMI ]
 ##
@@ -4419,7 +4419,7 @@ interface: MODULE TYPE UIDENT EQUAL WITH
 
 interface: MODULE TYPE WITH
 ##
-## Ends in an error in state: 1809.
+## Ends in an error in state: 1810.
 ##
 ## _signature_item -> MODULE TYPE . ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4432,7 +4432,7 @@ interface: MODULE TYPE WITH
 
 interface: MODULE WITH
 ##
-## Ends in an error in state: 1808.
+## Ends in an error in state: 1809.
 ##
 ## _signature_item -> MODULE . TYPE ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4446,7 +4446,7 @@ interface: MODULE WITH
 
 interface: OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2671.
+## Ends in an error in state: 2673.
 ##
 ## signature -> signature_item . SEMI signature [ EOF ]
 ##
@@ -4457,18 +4457,18 @@ interface: OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1806, spurious reduction of production post_item_attributes ->
-## In state 1807, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 1994, spurious reduction of production _signature_item -> open_statement
-## In state 2021, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 1995, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 1807, spurious reduction of production post_item_attributes ->
+## In state 1808, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 1995, spurious reduction of production _signature_item -> open_statement
+## In state 2022, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 1996, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 2061.
+## Ends in an error in state: 2062.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4480,7 +4480,7 @@ interface: TYPE LIDENT PLUSEQ BAR WITH
 
 interface: TYPE LIDENT PLUSEQ PRI BANG
 ##
-## Ends in an error in state: 2060.
+## Ends in an error in state: 2061.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4492,7 +4492,7 @@ interface: TYPE LIDENT PLUSEQ PRI BANG
 
 interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 2063.
+## Ends in an error in state: 2064.
 ##
 ## sig_extension_constructors -> sig_extension_constructors BAR . extension_constructor_declaration [ SEMI LBRACKETATAT BAR ]
 ##
@@ -4504,7 +4504,7 @@ interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 interface: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 2058.
+## Ends in an error in state: 2059.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4516,7 +4516,7 @@ interface: TYPE LIDENT PLUSEQ WITH
 
 interface: TYPE LIDENT RBRACKET
 ##
-## Ends in an error in state: 1204.
+## Ends in an error in state: 1205.
 ##
 ## potentially_long_ident_and_optional_type_parameters -> LIDENT optional_type_parameters . [ PLUSEQ ]
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ SEMI LBRACKETATAT EOF AND ]
@@ -4528,14 +4528,14 @@ interface: TYPE LIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1191, spurious reduction of production optional_type_parameters ->
+## In state 1192, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2672.
+## Ends in an error in state: 2674.
 ##
 ## signature -> signature_item SEMI . signature [ EOF ]
 ##
@@ -4547,7 +4547,7 @@ interface: TYPE LIDENT SEMI WITH
 
 interface: TYPE NONREC LET
 ##
-## Ends in an error in state: 1190.
+## Ends in an error in state: 1191.
 ##
 ## many_type_declarations -> TYPE nonrec_flag . type_declaration_details post_item_attributes [ SEMI AND ]
 ## sig_type_extension -> TYPE nonrec_flag . potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
@@ -4560,7 +4560,7 @@ interface: TYPE NONREC LET
 
 interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ##
-## Ends in an error in state: 2057.
+## Ends in an error in state: 2058.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters . PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4571,15 +4571,15 @@ interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1285, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
-## In state 1289, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
+## In state 1286, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 1290, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
 ##
 
 <SYNTAX ERROR>
 
 interface: WITH
 ##
-## Ends in an error in state: 2670.
+## Ends in an error in state: 2672.
 ##
 ## interface' -> . interface [ # ]
 ##
@@ -4591,7 +4591,7 @@ interface: WITH
 
 implementation: CLASS LIDENT COLON LIDENTCOLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1697.
+## Ends in an error in state: 1698.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4603,7 +4603,7 @@ implementation: CLASS LIDENT COLON LIDENTCOLONCOLON UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT COLON LIDENTCOLONCOLON WITH
 ##
-## Ends in an error in state: 1686.
+## Ends in an error in state: 1687.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON . QUESTION non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _class_constructor_type -> LIDENTCOLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
@@ -4616,7 +4616,7 @@ implementation: CLASS LIDENT COLON LIDENTCOLONCOLON WITH
 
 implementation: CLASS LIDENT COLON LIDENTCOLONCOLON QUESTION UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1689.
+## Ends in an error in state: 1690.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON QUESTION non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4628,7 +4628,7 @@ implementation: CLASS LIDENT COLON LIDENTCOLONCOLON QUESTION UNDERSCORE EQUALGRE
 
 implementation: CLASS LIDENT COLON LIDENTCOLONCOLON QUESTION UNDERSCORE WITH
 ##
-## Ends in an error in state: 1688.
+## Ends in an error in state: 1689.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON QUESTION non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4641,7 +4641,7 @@ implementation: CLASS LIDENT COLON LIDENTCOLONCOLON QUESTION UNDERSCORE WITH
 
 implementation: CLASS LIDENT COLON LIDENTCOLONCOLON QUESTION WITH
 ##
-## Ends in an error in state: 1687.
+## Ends in an error in state: 1688.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON QUESTION . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4653,7 +4653,7 @@ implementation: CLASS LIDENT COLON LIDENTCOLONCOLON QUESTION WITH
 
 implementation: CLASS LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1690.
+## Ends in an error in state: 1691.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4675,7 +4675,7 @@ implementation: CLASS LIDENT COLON LIDENT WITH
 
 implementation: CLASS LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1670.
+## Ends in an error in state: 1671.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4687,7 +4687,7 @@ implementation: CLASS LIDENT COLON NEW WITH
 
 implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1691.
+## Ends in an error in state: 1692.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4699,7 +4699,7 @@ implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT MINUS WITH
 ##
-## Ends in an error in state: 1451.
+## Ends in an error in state: 1452.
 ##
 ## signed_constant -> MINUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENTCOLONCOLON LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLONCOLONLIDENT COLON CHAR BACKQUOTE ]
 ## signed_constant -> MINUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENTCOLONCOLON LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLONCOLONLIDENT COLON CHAR BACKQUOTE ]
@@ -4716,7 +4716,7 @@ implementation: CLASS LIDENT MINUS WITH
 
 implementation: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1450.
+## Ends in an error in state: 1451.
 ##
 ## signed_constant -> PLUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENTCOLONCOLON LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLONCOLONLIDENT COLON CHAR BACKQUOTE ]
 ## signed_constant -> PLUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS NATIVEINT MINUS LPAREN LIDENTCOLONCOLON LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUALGREATER DOTDOT COLONCOLONLIDENT COLON CHAR BACKQUOTE ]
@@ -4733,7 +4733,7 @@ implementation: CLASS LIDENT PLUS WITH
 
 implementation: CLASS LIDENT QUOTE WITH
 ##
-## Ends in an error in state: 1439.
+## Ends in an error in state: 1440.
 ##
 ## _type_variable -> QUOTE . ident [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS NATIVEINT MINUS LPAREN LIDENTCOLONCOLON LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT64 INT32 INT FLOAT FALSE EQUAL COLONCOLONLIDENT COLON CHAR BACKQUOTE ]
 ##
@@ -4745,7 +4745,7 @@ implementation: CLASS LIDENT QUOTE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1368.
+## Ends in an error in state: 1369.
 ##
 ## class_sig_body -> class_self_type . class_sig_fields opt_semi [ error RBRACE ]
 ##
@@ -4757,7 +4757,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 ##
-## Ends in an error in state: 1363.
+## Ends in an error in state: 1364.
 ##
 ## class_self_type -> AS core_type . SEMI [ error VAL SEMI RBRACE PUB PRI LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -4780,7 +4780,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 ##
-## Ends in an error in state: 1362.
+## Ends in an error in state: 1363.
 ##
 ## class_self_type -> AS . core_type SEMI [ error VAL SEMI RBRACE PUB PRI LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -4792,7 +4792,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1421.
+## Ends in an error in state: 1422.
 ##
 ## _class_sig_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4804,7 +4804,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1416.
+## Ends in an error in state: 1417.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT ]
 ## _class_sig_field -> INHERIT class_instance_type . [ error SEMI RBRACE ]
@@ -4817,16 +4817,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1414, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1420, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1412, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1415, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1421, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1413, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1408.
+## Ends in an error in state: 1409.
 ##
 ## _class_sig_field -> INHERIT . class_instance_type [ error SEMI RBRACE ]
 ## _class_sig_field -> INHERIT . class_instance_type item_attribute post_item_attributes [ error SEMI RBRACE ]
@@ -4839,7 +4839,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH RBRACKET WITH
 ##
-## Ends in an error in state: 1673.
+## Ends in an error in state: 1674.
 ##
 ## _class_instance_type -> LBRACE class_sig_body . RBRACE [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE class_sig_body . error [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4851,20 +4851,20 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1428, spurious reduction of production post_item_attributes ->
-## In state 1429, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
-## In state 1434, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
-## In state 1427, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
-## In state 1436, spurious reduction of production class_sig_fields -> class_sig_field
-## In state 1431, spurious reduction of production opt_semi ->
-## In state 1435, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
+## In state 1429, spurious reduction of production post_item_attributes ->
+## In state 1430, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
+## In state 1435, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
+## In state 1428, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
+## In state 1437, spurious reduction of production class_sig_fields -> class_sig_field
+## In state 1432, spurious reduction of production opt_semi ->
+## In state 1436, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PUB LIDENT COLON WITH
 ##
-## Ends in an error in state: 1389.
+## Ends in an error in state: 1390.
 ##
 ## _class_sig_field -> PUB private_virtual_flags label COLON . poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4876,7 +4876,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PUB LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PUB LIDENT WITH
 ##
-## Ends in an error in state: 1388.
+## Ends in an error in state: 1389.
 ##
 ## _class_sig_field -> PUB private_virtual_flags label . COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4888,7 +4888,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PUB LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PRI WITH
 ##
-## Ends in an error in state: 1402.
+## Ends in an error in state: 1403.
 ##
 ## _class_sig_field -> PRI . private_virtual_flags label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4900,7 +4900,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PRI WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PRI VIRTUAL WITH
 ##
-## Ends in an error in state: 1403.
+## Ends in an error in state: 1404.
 ##
 ## _class_sig_field -> PRI private_virtual_flags . label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4912,7 +4912,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PRI VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PUB VIRTUAL WITH
 ##
-## Ends in an error in state: 1387.
+## Ends in an error in state: 1388.
 ##
 ## _class_sig_field -> PUB private_virtual_flags . label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4924,7 +4924,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PUB VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PUB WITH
 ##
-## Ends in an error in state: 1385.
+## Ends in an error in state: 1386.
 ##
 ## _class_sig_field -> PUB . private_virtual_flags label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4936,7 +4936,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PUB WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1383.
+## Ends in an error in state: 1384.
 ##
 ## value_type -> label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -4948,7 +4948,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1382.
+## Ends in an error in state: 1383.
 ##
 ## value_type -> label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -4960,7 +4960,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1378.
+## Ends in an error in state: 1379.
 ##
 ## value_type -> MUTABLE virtual_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -4972,7 +4972,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 ##
-## Ends in an error in state: 1377.
+## Ends in an error in state: 1378.
 ##
 ## value_type -> MUTABLE virtual_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -4984,7 +4984,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 ##
-## Ends in an error in state: 1376.
+## Ends in an error in state: 1377.
 ##
 ## value_type -> MUTABLE virtual_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -4996,7 +4996,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1375.
+## Ends in an error in state: 1376.
 ##
 ## value_type -> MUTABLE . virtual_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5008,7 +5008,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1373.
+## Ends in an error in state: 1374.
 ##
 ## value_type -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5020,7 +5020,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1372.
+## Ends in an error in state: 1373.
 ##
 ## value_type -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5032,7 +5032,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1371.
+## Ends in an error in state: 1372.
 ##
 ## value_type -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5044,7 +5044,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1370.
+## Ends in an error in state: 1371.
 ##
 ## value_type -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -5056,7 +5056,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 ##
-## Ends in an error in state: 1369.
+## Ends in an error in state: 1370.
 ##
 ## _class_sig_field -> VAL . value_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5068,7 +5068,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 ##
-## Ends in an error in state: 1672.
+## Ends in an error in state: 1673.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5081,7 +5081,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ##
-## Ends in an error in state: 1715.
+## Ends in an error in state: 1716.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## _non_arrowed_class_constructor_type -> class_instance_type . [ EQUALGREATER ]
@@ -5093,16 +5093,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1681, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1685, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1679, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1682, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1686, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1680, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1682.
+## Ends in an error in state: 1683.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EQUALGREATER EQUAL EOF AND ]
@@ -5115,7 +5115,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 ##
-## Ends in an error in state: 1681.
+## Ends in an error in state: 1682.
 ##
 ## _class_instance_type -> clty_longident . [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5128,7 +5128,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1709.
+## Ends in an error in state: 1710.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN class_constructor_type . RPAREN [ EQUALGREATER ]
 ##
@@ -5139,19 +5139,19 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1681, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1685, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1679, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1683, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1694, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1692, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1682, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1686, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1680, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1684, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1695, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1693, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 ##
-## Ends in an error in state: 1708.
+## Ends in an error in state: 1709.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN . class_constructor_type RPAREN [ EQUALGREATER ]
 ##
@@ -5163,7 +5163,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 ##
-## Ends in an error in state: 1677.
+## Ends in an error in state: 1678.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5177,7 +5177,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 ##
-## Ends in an error in state: 1676.
+## Ends in an error in state: 1677.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5314,7 +5314,7 @@ implementation: FUN LIDENTCOLONCOLON WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2096.
+## Ends in an error in state: 2097.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -5330,15 +5330,15 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 806, spurious reduction of production mty_longident -> ident
-## In state 1814, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1843, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1839, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1812, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1844, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1840, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1813, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1845, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1841, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1815, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1844, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1840, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1813, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1845, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1841, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1814, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1846, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1842, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
@@ -5382,7 +5382,7 @@ implementation: INCLUDE FUN LPAREN WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1701.
+## Ends in an error in state: 1702.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5394,16 +5394,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1526, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1532, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1524, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1527, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1533, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1525, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1700.
+## Ends in an error in state: 1701.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5415,7 +5415,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1699.
+## Ends in an error in state: 1700.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type . EQUAL class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5426,19 +5426,19 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1681, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1685, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1679, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1683, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1694, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1692, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1682, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1686, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1680, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1684, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1695, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1693, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 1669.
+## Ends in an error in state: 1670.
 ##
 ## _constrained_class_declaration -> COLON . class_constructor_type EQUAL class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5450,7 +5450,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1884.
+## Ends in an error in state: 1885.
 ##
 ## and_class_declaration -> AND . class_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5462,7 +5462,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1883.
+## Ends in an error in state: 1884.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_class_declarations -> many_class_declarations . and_class_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5474,16 +5474,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1302, spurious reduction of production post_item_attributes ->
-## In state 1303, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1724, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
+## In state 1303, spurious reduction of production post_item_attributes ->
+## In state 1304, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1725, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1668.
+## Ends in an error in state: 1669.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5495,16 +5495,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1526, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1532, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1524, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1527, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1533, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1525, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1452.
+## Ends in an error in state: 1453.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5516,7 +5516,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 1713.
+## Ends in an error in state: 1714.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5528,16 +5528,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1526, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1532, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1524, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1527, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1533, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1525, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1712.
+## Ends in an error in state: 1713.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5549,7 +5549,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1711.
+## Ends in an error in state: 1712.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type . EQUALGREATER class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5561,7 +5561,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT R
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1707.
+## Ends in an error in state: 1708.
 ##
 ## class_fun_return -> COLON . non_arrowed_class_constructor_type EQUALGREATER class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5573,7 +5573,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 1706.
+## Ends in an error in state: 1707.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> EQUALGREATER class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5585,16 +5585,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1526, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1532, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1524, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1527, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1533, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1525, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1705.
+## Ends in an error in state: 1706.
 ##
 ## class_fun_return -> EQUALGREATER . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5606,7 +5606,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1704.
+## Ends in an error in state: 1705.
 ##
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_return [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5619,7 +5619,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1449.
+## Ends in an error in state: 1450.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . constrained_class_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5634,7 +5634,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1879.
+## Ends in an error in state: 1880.
 ##
 ## and_class_type_declaration -> AND . class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5646,7 +5646,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1878.
+## Ends in an error in state: 1879.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_type_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5658,16 +5658,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND R
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1302, spurious reduction of production post_item_attributes ->
-## In state 1303, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1446, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
+## In state 1303, spurious reduction of production post_item_attributes ->
+## In state 1304, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1447, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1437.
+## Ends in an error in state: 1438.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5679,16 +5679,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1414, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1420, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1412, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1415, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1421, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1413, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1359.
+## Ends in an error in state: 1360.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5700,7 +5700,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1356.
+## Ends in an error in state: 1357.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters . EQUAL class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS EQUAL ]
@@ -5713,7 +5713,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 ##
-## Ends in an error in state: 1354.
+## Ends in an error in state: 1355.
 ##
 ## class_type_declaration_details -> virtual_flag . LIDENT class_type_parameters EQUAL class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5725,7 +5725,7 @@ implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE WITH
 ##
-## Ends in an error in state: 1353.
+## Ends in an error in state: 1354.
 ##
 ## many_class_type_declarations -> CLASS TYPE . class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5737,7 +5737,7 @@ implementation: INCLUDE LBRACE CLASS TYPE WITH
 
 implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 1447.
+## Ends in an error in state: 1448.
 ##
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters constrained_class_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5751,7 +5751,7 @@ implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 
 implementation: INCLUDE LBRACE CLASS WITH
 ##
-## Ends in an error in state: 1351.
+## Ends in an error in state: 1352.
 ##
 ## many_class_declarations -> CLASS . class_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5764,7 +5764,7 @@ implementation: INCLUDE LBRACE CLASS WITH
 
 implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 ##
-## Ends in an error in state: 1326.
+## Ends in an error in state: 1327.
 ##
 ## extension_constructor_declaration -> LPAREN . RPAREN generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## extension_constructor_rebind -> LPAREN . RPAREN EQUAL constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -5777,7 +5777,7 @@ implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1313.
+## Ends in an error in state: 1314.
 ##
 ## generalized_constructor_arguments -> COLON . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -5789,7 +5789,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 ##
-## Ends in an error in state: 1308.
+## Ends in an error in state: 1309.
 ##
 ## constr_longident -> LBRACKET . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -5801,7 +5801,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 1307.
+## Ends in an error in state: 1308.
 ##
 ## constr_longident -> LPAREN . RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -5813,7 +5813,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1306.
+## Ends in an error in state: 1307.
 ##
 ## extension_constructor_rebind -> UIDENT EQUAL . constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ##
@@ -5825,7 +5825,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1316.
+## Ends in an error in state: 1317.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list COLON . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -5837,7 +5837,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1315.
+## Ends in an error in state: 1316.
 ##
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ## generalized_constructor_arguments -> non_arrowed_simple_core_type_list . COLON core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
@@ -5851,7 +5851,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1305.
+## Ends in an error in state: 1306.
 ##
 ## extension_constructor_declaration -> UIDENT . generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## extension_constructor_rebind -> UIDENT . EQUAL constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -5864,7 +5864,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 
 implementation: INCLUDE LBRACE EXCEPTION WITH
 ##
-## Ends in an error in state: 1304.
+## Ends in an error in state: 1305.
 ##
 ## str_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## str_exception_declaration -> EXCEPTION . extension_constructor_rebind post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
@@ -5877,7 +5877,7 @@ implementation: INCLUDE LBRACE EXCEPTION WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 ##
-## Ends in an error in state: 1298.
+## Ends in an error in state: 1299.
 ##
 ## primitive_declaration -> STRING . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ## primitive_declaration -> STRING . primitive_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
@@ -5890,7 +5890,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WIT
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1297.
+## Ends in an error in state: 1298.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -5902,7 +5902,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1296.
+## Ends in an error in state: 1297.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -5925,7 +5925,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1295.
+## Ends in an error in state: 1296.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -5937,7 +5937,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 1294.
+## Ends in an error in state: 1295.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -5949,7 +5949,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 
 implementation: INCLUDE LBRACE EXTERNAL WITH
 ##
-## Ends in an error in state: 1293.
+## Ends in an error in state: 1294.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6000,7 +6000,7 @@ implementation: INCLUDE LBRACE MODULE WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1167.
+## Ends in an error in state: 1168.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER module_expr . [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6015,7 +6015,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHIL
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1165.
+## Ends in an error in state: 1166.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER . module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6027,7 +6027,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1164.
+## Ends in an error in state: 1165.
 ##
 ## _module_expr -> FUN functor_args . EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## functor_args -> functor_args . functor_arg [ LPAREN EQUALGREATER ]
@@ -6040,7 +6040,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 
 implementation: INCLUDE LPAREN FUN WITH
 ##
-## Ends in an error in state: 1163.
+## Ends in an error in state: 1164.
 ##
 ## _module_expr -> FUN . functor_args EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6052,7 +6052,7 @@ implementation: INCLUDE LPAREN FUN WITH
 
 implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2082.
+## Ends in an error in state: 2083.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -6069,22 +6069,22 @@ implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 242, spurious reduction of production ident -> UIDENT
 ## In state 492, spurious reduction of production mty_longident -> ident
-## In state 1747, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1798, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1794, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1745, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1799, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1795, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1746, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1800, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1796, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1748, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1799, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1795, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1746, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1800, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1796, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1747, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1801, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1797, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1185.
+## Ends in an error in state: 1186.
 ##
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6097,7 +6097,7 @@ implementation: INCLUDE LPAREN UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2435.
+## Ends in an error in state: 2436.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -6114,19 +6114,19 @@ implementation: INCLUDE LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1736, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1740, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1737, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1166, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1742, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1741, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1737, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1741, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1738, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1167, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1743, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1742, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1179.
+## Ends in an error in state: 1180.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6146,7 +6146,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLON
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1178.
+## Ends in an error in state: 1179.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6158,7 +6158,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 2433.
+## Ends in an error in state: 2434.
 ##
 ## _module_expr -> LPAREN VAL expr COLON . error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6172,7 +6172,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1173.
+## Ends in an error in state: 1174.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6192,7 +6192,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 2431.
+## Ends in an error in state: 2432.
 ##
 ## _module_expr -> LPAREN VAL expr COLONGREATER . error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6205,7 +6205,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 2429.
+## Ends in an error in state: 2430.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -6301,7 +6301,7 @@ implementation: INCLUDE LPAREN WITH
 
 implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ##
-## Ends in an error in state: 2087.
+## Ends in an error in state: 2088.
 ##
 ## _simple_module_expr -> LBRACE structure . RBRACE [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6320,21 +6320,21 @@ implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ## In state 883, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 918, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 882, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1909, spurious reduction of production post_item_attributes ->
-## In state 1910, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1911, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1859, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1725, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1912, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1860, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1726, spurious reduction of production structure -> structure_item
+## In state 1910, spurious reduction of production post_item_attributes ->
+## In state 1911, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1912, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1860, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1726, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1913, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1861, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1727, spurious reduction of production structure -> structure_item
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 1161.
+## Ends in an error in state: 1162.
 ##
 ## _simple_module_expr -> LBRACE . structure RBRACE [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6346,7 +6346,7 @@ implementation: INCLUDE UIDENT LBRACE WITH
 
 implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1182.
+## Ends in an error in state: 1183.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -6363,19 +6363,19 @@ implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1736, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1740, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1737, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1166, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1742, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1741, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1737, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1741, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1738, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1167, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1743, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1742, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 1175.
+## Ends in an error in state: 1176.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type COLONGREATER package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6388,7 +6388,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1172.
+## Ends in an error in state: 1173.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6400,7 +6400,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 1170.
+## Ends in an error in state: 1171.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -6452,7 +6452,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 
 implementation: INCLUDE UIDENT LPAREN VAL WITH
 ##
-## Ends in an error in state: 1169.
+## Ends in an error in state: 1170.
 ##
 ## _simple_module_expr -> LPAREN VAL . expr RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL . expr COLON package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6467,7 +6467,7 @@ implementation: INCLUDE UIDENT LPAREN VAL WITH
 
 implementation: INCLUDE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1168.
+## Ends in an error in state: 1169.
 ##
 ## _module_expr -> module_expr LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN . module_expr COLON module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6487,7 +6487,7 @@ implementation: INCLUDE UIDENT LPAREN WITH
 
 implementation: INCLUDE UIDENT WHILE
 ##
-## Ends in an error in state: 1736.
+## Ends in an error in state: 1737.
 ##
 ## _simple_module_expr -> mod_longident . [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF DOT COLON AND ]
@@ -6500,7 +6500,7 @@ implementation: INCLUDE UIDENT WHILE
 
 implementation: INCLUDE WITH
 ##
-## Ends in an error in state: 1162.
+## Ends in an error in state: 1163.
 ##
 ## _structure_item_without_item_extension_sugar -> INCLUDE . module_expr post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6512,7 +6512,7 @@ implementation: INCLUDE WITH
 
 implementation: LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1548.
+## Ends in an error in state: 1549.
 ##
 ## class_self_pattern_and_structure -> class_self_pattern . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -6524,7 +6524,7 @@ implementation: LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: LBRACE AS UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1537.
+## Ends in an error in state: 1538.
 ##
 ## _class_self_pattern -> AS pattern . SEMI [ error VAL RBRACE PUB PRI LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ## _or_pattern -> pattern . BAR pattern [ SEMI BAR ]
@@ -6543,7 +6543,7 @@ implementation: LBRACE AS UNDERSCORE WHEN
 
 implementation: LBRACE AS WITH
 ##
-## Ends in an error in state: 1536.
+## Ends in an error in state: 1537.
 ##
 ## _class_self_pattern -> AS . pattern SEMI [ error VAL RBRACE PUB PRI LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ##
@@ -6555,7 +6555,7 @@ implementation: LBRACE AS WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1423.
+## Ends in an error in state: 1424.
 ##
 ## constrain_field -> core_type EQUAL . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -6567,7 +6567,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1422.
+## Ends in an error in state: 1423.
 ##
 ## constrain_field -> core_type . EQUAL core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -6590,7 +6590,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 
 implementation: LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1623.
+## Ends in an error in state: 1624.
 ##
 ## _class_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -6602,7 +6602,7 @@ implementation: LBRACE CONSTRAINT WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2266.
+## Ends in an error in state: 2267.
 ##
 ## opt_comma -> COMMA . [ RBRACE ]
 ## record_expr -> DOTDOTDOT expr_optional_constraint COMMA . lbl_expr_list [ error RBRACE ]
@@ -6616,7 +6616,7 @@ implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ##
-## Ends in an error in state: 2265.
+## Ends in an error in state: 2266.
 ##
 ## _simple_expr -> LBRACE DOTDOTDOT expr_optional_constraint . opt_comma RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## record_expr -> DOTDOTDOT expr_optional_constraint . COMMA lbl_expr_list [ error RBRACE ]
@@ -6637,14 +6637,14 @@ implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ## In state 925, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 960, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 924, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2109, spurious reduction of production expr_optional_constraint -> expr
+## In state 2110, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE DOTDOTDOT WITH
 ##
-## Ends in an error in state: 2264.
+## Ends in an error in state: 2265.
 ##
 ## _simple_expr -> LBRACE DOTDOTDOT . expr_optional_constraint opt_comma RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## record_expr -> DOTDOTDOT . expr_optional_constraint COMMA lbl_expr_list [ error RBRACE ]
@@ -6658,7 +6658,7 @@ implementation: LBRACE DOTDOTDOT WITH
 
 implementation: LBRACE INHERIT BANG WITH
 ##
-## Ends in an error in state: 1617.
+## Ends in an error in state: 1618.
 ##
 ## _class_field -> INHERIT override_flag . class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -6670,7 +6670,7 @@ implementation: LBRACE INHERIT BANG WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1522.
+## Ends in an error in state: 1523.
 ##
 ## _class_expr -> CLASS class_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EOF COLON AS AND ]
@@ -6683,7 +6683,7 @@ implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1521.
+## Ends in an error in state: 1522.
 ##
 ## _class_expr -> CLASS class_longident . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> CLASS class_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6696,7 +6696,7 @@ implementation: LBRACE INHERIT CLASS LIDENT WITH
 
 implementation: LBRACE INHERIT CLASS WITH
 ##
-## Ends in an error in state: 1520.
+## Ends in an error in state: 1521.
 ##
 ## _class_expr -> CLASS . class_longident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> CLASS . class_longident non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6709,7 +6709,7 @@ implementation: LBRACE INHERIT CLASS WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1529.
+## Ends in an error in state: 1530.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER class_expr . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6722,7 +6722,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND R
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1519.
+## Ends in an error in state: 1520.
 ##
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER . class_expr [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ##
@@ -6734,7 +6734,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1518.
+## Ends in an error in state: 1519.
 ##
 ## _class_fun_def -> labeled_simple_pattern . EQUALGREATER class_expr [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern . class_fun_def [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6747,7 +6747,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 
 implementation: LBRACE INHERIT FUN WITH
 ##
-## Ends in an error in state: 1516.
+## Ends in an error in state: 1517.
 ##
 ## _class_expr -> FUN . class_fun_def [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ##
@@ -6759,7 +6759,7 @@ implementation: LBRACE INHERIT FUN WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 1542.
+## Ends in an error in state: 1543.
 ##
 ## _class_expr_lets_and_rest -> let_bindings SEMI . class_expr_lets_and_rest [ error RBRACE ]
 ##
@@ -6771,7 +6771,7 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ##
-## Ends in an error in state: 1541.
+## Ends in an error in state: 1542.
 ##
 ## _class_expr_lets_and_rest -> let_bindings . SEMI class_expr_lets_and_rest [ error RBRACE ]
 ## let_bindings -> let_bindings . and_let_binding [ SEMI AND ]
@@ -6787,18 +6787,18 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ## In state 925, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 960, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 924, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1511, spurious reduction of production let_binding_body -> pattern EQUAL expr
-## In state 1512, spurious reduction of production post_item_attributes ->
-## In state 1513, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
-## In state 1543, spurious reduction of production let_binding -> let_binding_impl
-## In state 1544, spurious reduction of production let_bindings -> let_binding
+## In state 1512, spurious reduction of production let_binding_body -> pattern EQUAL expr
+## In state 1513, spurious reduction of production post_item_attributes ->
+## In state 1514, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
+## In state 1544, spurious reduction of production let_binding -> let_binding_impl
+## In state 1545, spurious reduction of production let_bindings -> let_binding
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE LET WITH
 ##
-## Ends in an error in state: 1455.
+## Ends in an error in state: 1456.
 ##
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI AND ]
 ##
@@ -6810,7 +6810,7 @@ implementation: LBRACE INHERIT LBRACE LET WITH
 
 implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ##
-## Ends in an error in state: 1636.
+## Ends in an error in state: 1637.
 ##
 ## _class_expr -> class_expr . attribute [ error RBRACE LBRACKETAT ]
 ## _class_expr_lets_and_rest -> class_expr . [ error RBRACE ]
@@ -6822,16 +6822,16 @@ implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1526, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1532, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1524, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1527, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1533, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1525, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 ##
-## Ends in an error in state: 1545.
+## Ends in an error in state: 1546.
 ##
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI AND ]
 ##
@@ -6850,7 +6850,7 @@ implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 
 implementation: LBRACE INHERIT LBRACE WITH
 ##
-## Ends in an error in state: 1454.
+## Ends in an error in state: 1455.
 ##
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest RBRACE [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLONCOLONLIDENT COLONCOLON COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLONCOLONLIDENT COLONCOLON COLON CHAR BANG BACKQUOTE AS AND ]
@@ -6863,7 +6863,7 @@ implementation: LBRACE INHERIT LBRACE WITH
 
 implementation: LBRACE INHERIT LIDENT AS WITH
 ##
-## Ends in an error in state: 1619.
+## Ends in an error in state: 1620.
 ##
 ## parent_binder -> AS . LIDENT [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -6875,7 +6875,7 @@ implementation: LBRACE INHERIT LIDENT AS WITH
 
 implementation: LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1618.
+## Ends in an error in state: 1619.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AS ]
 ## _class_field -> INHERIT override_flag class_expr . parent_binder post_item_attributes [ error SEMI RBRACE ]
@@ -6887,16 +6887,16 @@ implementation: LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1526, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1532, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1524, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1527, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1533, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1525, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT SEMI WITH
 ##
-## Ends in an error in state: 1632.
+## Ends in an error in state: 1633.
 ##
 ## semi_terminated_class_fields -> class_field SEMI . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -6908,7 +6908,7 @@ implementation: LBRACE INHERIT LIDENT SEMI WITH
 
 implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ##
-## Ends in an error in state: 1527.
+## Ends in an error in state: 1528.
 ##
 ## _class_expr -> class_simple_expr simple_labeled_expr_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## simple_labeled_expr_list -> simple_labeled_expr_list . labeled_simple_expr [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLONCOLONLIDENT COLONCOLON COLON CHAR BANG BACKQUOTE AS AND ]
@@ -6933,7 +6933,7 @@ implementation: LBRACE INHERIT LIDENT UIDENT STAR
 
 implementation: LBRACE INHERIT LIDENT WITH
 ##
-## Ends in an error in state: 1526.
+## Ends in an error in state: 1527.
 ##
 ## _class_expr -> class_simple_expr . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> class_simple_expr . simple_labeled_expr_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6946,7 +6946,7 @@ implementation: LBRACE INHERIT LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1663.
+## Ends in an error in state: 1664.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -6958,7 +6958,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON UNDERSCORE E
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1662.
+## Ends in an error in state: 1663.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -6971,7 +6971,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON UNDERSCORE W
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON WITH
 ##
-## Ends in an error in state: 1652.
+## Ends in an error in state: 1653.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON . QUESTION non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _class_constructor_type -> LIDENTCOLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
@@ -6984,7 +6984,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON QUESTION UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1655.
+## Ends in an error in state: 1656.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON QUESTION non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -6996,7 +6996,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON QUESTION UND
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON QUESTION UNDERSCORE WITH
 ##
-## Ends in an error in state: 1654.
+## Ends in an error in state: 1655.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON QUESTION non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -7009,7 +7009,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON QUESTION UND
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON QUESTION WITH
 ##
-## Ends in an error in state: 1653.
+## Ends in an error in state: 1654.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON QUESTION . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -7021,7 +7021,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON QUESTION WIT
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1656.
+## Ends in an error in state: 1657.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -7043,7 +7043,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 ##
-## Ends in an error in state: 1361.
+## Ends in an error in state: 1362.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -7056,7 +7056,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1651.
+## Ends in an error in state: 1652.
 ##
 ## _class_constructor_type -> NEW class_instance_type . [ error RPAREN ]
 ## _class_instance_type -> class_instance_type . attribute [ error RPAREN LBRACKETAT ]
@@ -7068,16 +7068,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1414, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1420, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1412, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1415, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1421, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1413, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1415.
+## Ends in an error in state: 1416.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EOF AND ]
@@ -7090,7 +7090,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 ##
-## Ends in an error in state: 1414.
+## Ends in an error in state: 1415.
 ##
 ## _class_instance_type -> clty_longident . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -7103,7 +7103,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 ##
-## Ends in an error in state: 1410.
+## Ends in an error in state: 1411.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EOF AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -7117,7 +7117,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 ##
-## Ends in an error in state: 1409.
+## Ends in an error in state: 1410.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EOF AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -7137,7 +7137,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1650.
+## Ends in an error in state: 1651.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ error RPAREN ]
 ##
@@ -7149,7 +7149,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1657.
+## Ends in an error in state: 1658.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -7161,7 +7161,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 ##
-## Ends in an error in state: 1649.
+## Ends in an error in state: 1650.
 ##
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLONCOLONLIDENT COLONCOLON COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLONCOLONLIDENT COLONCOLON COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7174,7 +7174,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ##
-## Ends in an error in state: 1646.
+## Ends in an error in state: 1647.
 ##
 ## _class_expr -> class_expr . attribute [ error RPAREN LBRACKETAT COLON ]
 ## _class_simple_expr -> LPAREN class_expr . COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLONCOLONLIDENT COLONCOLON COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7189,16 +7189,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1526, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1532, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1524, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1527, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1533, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1525, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN WITH
 ##
-## Ends in an error in state: 1453.
+## Ends in an error in state: 1454.
 ##
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLONCOLONLIDENT COLONCOLON COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW NATIVEINT LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT FLOAT FALSE EOF COLONCOLONLIDENT COLONCOLON COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7213,7 +7213,7 @@ implementation: LBRACE INHERIT LPAREN WITH
 
 implementation: LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1616.
+## Ends in an error in state: 1617.
 ##
 ## _class_field -> INHERIT . override_flag class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7225,7 +7225,7 @@ implementation: LBRACE INHERIT WITH
 
 implementation: LBRACE INITIALIZER EQUALGREATER WITH
 ##
-## Ends in an error in state: 1613.
+## Ends in an error in state: 1614.
 ##
 ## _class_field -> INITIALIZER EQUALGREATER . expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7237,7 +7237,7 @@ implementation: LBRACE INITIALIZER EQUALGREATER WITH
 
 implementation: LBRACE INITIALIZER WITH
 ##
-## Ends in an error in state: 1612.
+## Ends in an error in state: 1613.
 ##
 ## _class_field -> INITIALIZER . EQUALGREATER expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7249,7 +7249,7 @@ implementation: LBRACE INITIALIZER WITH
 
 implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 2281.
+## Ends in an error in state: 2282.
 ##
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -7261,17 +7261,17 @@ implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2314, spurious reduction of production opt_semi -> SEMI
-## In state 2325, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
-## In state 2323, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2312, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2315, spurious reduction of production opt_semi -> SEMI
+## In state 2326, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
+## In state 2324, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2313, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
 ##
 
 Expecting "}" to finish the block
 
 implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2309.
+## Ends in an error in state: 2310.
 ##
 ## _semi_terminated_seq_expr_row -> opt_let_module UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7283,7 +7283,7 @@ implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 
 implementation: LBRACE LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2298.
+## Ends in an error in state: 2299.
 ##
 ## _semi_terminated_seq_expr_row -> opt_let_module UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7295,7 +7295,7 @@ implementation: LBRACE LET MODULE UIDENT WITH
 
 implementation: LBRACE LET MODULE WITH
 ##
-## Ends in an error in state: 2297.
+## Ends in an error in state: 2298.
 ##
 ## _semi_terminated_seq_expr_row -> opt_let_module . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7307,7 +7307,7 @@ implementation: LBRACE LET MODULE WITH
 
 implementation: LBRACE LET OPEN BANG WITH
 ##
-## Ends in an error in state: 2292.
+## Ends in an error in state: 2293.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7319,7 +7319,7 @@ implementation: LBRACE LET OPEN BANG WITH
 
 implementation: LBRACE LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2295.
+## Ends in an error in state: 2296.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7331,7 +7331,7 @@ implementation: LBRACE LET OPEN UIDENT SEMI WITH
 
 implementation: LBRACE LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2294.
+## Ends in an error in state: 2295.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7342,14 +7342,14 @@ implementation: LBRACE LET OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2293, spurious reduction of production post_item_attributes ->
+## In state 2294, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET OPEN WITH
 ##
-## Ends in an error in state: 2291.
+## Ends in an error in state: 2292.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7375,7 +7375,7 @@ implementation: LBRACE LET WITH
 
 implementation: LBRACE LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2163.
+## Ends in an error in state: 2164.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7425,7 +7425,7 @@ implementation: LBRACE LIDENT COLON UIDENT SEMI
 
 implementation: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 2162.
+## Ends in an error in state: 2163.
 ##
 ## lbl_expr -> label_longident COLON . expr [ COMMA ]
 ## non_punned_lbl_expression -> label_longident COLON . expr [ error RBRACE ]
@@ -7438,7 +7438,7 @@ implementation: LBRACE LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2152.
+## Ends in an error in state: 2153.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7487,7 +7487,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 ##
-## Ends in an error in state: 2151.
+## Ends in an error in state: 2152.
 ##
 ## lbl_expr -> label_longident COLON . expr [ error RBRACE COMMA ]
 ##
@@ -7499,7 +7499,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 ##
-## Ends in an error in state: 2148.
+## Ends in an error in state: 2149.
 ##
 ## lbl_expr_list -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ## lbl_expr_list -> lbl_expr COMMA . [ error RBRACE ]
@@ -7512,7 +7512,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT WITH
 ##
-## Ends in an error in state: 2150.
+## Ends in an error in state: 2151.
 ##
 ## lbl_expr -> label_longident . COLON expr [ error RBRACE COMMA ]
 ## lbl_expr -> label_longident . [ error RBRACE COMMA ]
@@ -7525,7 +7525,7 @@ implementation: LBRACE LIDENT COMMA LIDENT WITH
 
 implementation: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 2159.
+## Ends in an error in state: 2160.
 ##
 ## lbl_expr_list_that_is_not_a_single_punned_field -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ##
@@ -7537,7 +7537,7 @@ implementation: LBRACE LIDENT COMMA WITH
 
 implementation: LBRACE PUB BANG WITH
 ##
-## Ends in an error in state: 1573.
+## Ends in an error in state: 1574.
 ##
 ## method_ -> override_flag . VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag . label curried_binding [ error SEMI RBRACE LBRACKETATAT ]
@@ -7553,7 +7553,7 @@ implementation: LBRACE PUB BANG WITH
 
 implementation: LBRACE PUB LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1589.
+## Ends in an error in state: 1590.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7602,7 +7602,7 @@ implementation: LBRACE PUB LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDENT 
 
 implementation: LBRACE PUB LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1588.
+## Ends in an error in state: 1589.
 ##
 ## method_ -> override_flag label COLON TYPE lident_list DOT core_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7614,7 +7614,7 @@ implementation: LBRACE PUB LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE PUB LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1587.
+## Ends in an error in state: 1588.
 ##
 ## method_ -> override_flag label COLON TYPE lident_list DOT core_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7637,7 +7637,7 @@ implementation: LBRACE PUB LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LBRACE PUB LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1586.
+## Ends in an error in state: 1587.
 ##
 ## method_ -> override_flag label COLON TYPE lident_list DOT . core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7649,7 +7649,7 @@ implementation: LBRACE PUB LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LBRACE PUB LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 1584.
+## Ends in an error in state: 1585.
 ##
 ## method_ -> override_flag label COLON TYPE . lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7661,7 +7661,7 @@ implementation: LBRACE PUB LIDENT COLON TYPE WITH
 
 implementation: LBRACE PUB LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1595.
+## Ends in an error in state: 1596.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7710,7 +7710,7 @@ implementation: LBRACE PUB LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 
 implementation: LBRACE PUB LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1594.
+## Ends in an error in state: 1595.
 ##
 ## method_ -> override_flag label COLON poly_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7722,7 +7722,7 @@ implementation: LBRACE PUB LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: LBRACE PUB LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1593.
+## Ends in an error in state: 1594.
 ##
 ## method_ -> override_flag label COLON poly_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7739,16 +7739,16 @@ implementation: LBRACE PUB LIDENT COLON UNDERSCORE WITH
 ## In state 289, spurious reduction of production _core_type -> core_type2
 ## In state 301, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 288, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1597, spurious reduction of production _poly_type -> core_type
-## In state 1598, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1596, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 1598, spurious reduction of production _poly_type -> core_type
+## In state 1599, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1597, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE PUB LIDENT COLON WITH
 ##
-## Ends in an error in state: 1583.
+## Ends in an error in state: 1584.
 ##
 ## method_ -> override_flag label COLON . poly_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag label COLON . TYPE lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -7761,7 +7761,7 @@ implementation: LBRACE PUB LIDENT COLON WITH
 
 implementation: LBRACE PUB LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1582.
+## Ends in an error in state: 1583.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7810,7 +7810,7 @@ implementation: LBRACE PUB LIDENT EQUAL UIDENT RPAREN
 
 implementation: LBRACE PUB LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1581.
+## Ends in an error in state: 1582.
 ##
 ## method_ -> override_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7822,7 +7822,7 @@ implementation: LBRACE PUB LIDENT EQUAL WITH
 
 implementation: LBRACE PUB LIDENT EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1631.
+## Ends in an error in state: 1632.
 ##
 ## semi_terminated_class_fields -> class_field . [ error RBRACE ]
 ## semi_terminated_class_fields -> class_field . SEMI semi_terminated_class_fields [ error RBRACE ]
@@ -7842,19 +7842,19 @@ implementation: LBRACE PUB LIDENT EQUALGREATER UIDENT RPAREN
 ## In state 883, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 918, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 882, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1580, spurious reduction of production curried_binding -> EQUALGREATER expr
-## In state 1606, spurious reduction of production method_ -> override_flag label curried_binding
-## In state 1607, spurious reduction of production post_item_attributes ->
-## In state 1608, spurious reduction of production _class_field -> PUB method_ post_item_attributes
-## In state 1634, spurious reduction of production mark_position_cf(_class_field) -> _class_field
-## In state 1627, spurious reduction of production class_field -> mark_position_cf(_class_field)
+## In state 1581, spurious reduction of production curried_binding -> EQUALGREATER expr
+## In state 1607, spurious reduction of production method_ -> override_flag label curried_binding
+## In state 1608, spurious reduction of production post_item_attributes ->
+## In state 1609, spurious reduction of production _class_field -> PUB method_ post_item_attributes
+## In state 1635, spurious reduction of production mark_position_cf(_class_field) -> _class_field
+## In state 1628, spurious reduction of production class_field -> mark_position_cf(_class_field)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE PRI VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1576.
+## Ends in an error in state: 1577.
 ##
 ## method_ -> override_flag VIRTUAL label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7866,7 +7866,7 @@ implementation: LBRACE PRI VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE PRI VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1575.
+## Ends in an error in state: 1576.
 ##
 ## method_ -> override_flag VIRTUAL label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7878,7 +7878,7 @@ implementation: LBRACE PRI VIRTUAL LIDENT WITH
 
 implementation: LBRACE PRI VIRTUAL WITH
 ##
-## Ends in an error in state: 1574.
+## Ends in an error in state: 1575.
 ##
 ## method_ -> override_flag VIRTUAL . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7890,7 +7890,7 @@ implementation: LBRACE PRI VIRTUAL WITH
 
 implementation: LBRACE PRI WITH
 ##
-## Ends in an error in state: 1609.
+## Ends in an error in state: 1610.
 ##
 ## _class_field -> PRI . method_ post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7902,7 +7902,7 @@ implementation: LBRACE PRI WITH
 
 implementation: LBRACE PUB VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1395.
+## Ends in an error in state: 1396.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7914,7 +7914,7 @@ implementation: LBRACE PUB VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LBRACE PUB VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1392.
+## Ends in an error in state: 1393.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -7927,7 +7927,7 @@ implementation: LBRACE PUB VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 
 implementation: LBRACE PUB VIRTUAL LIDENT COLON QUOTE WITH
 ##
-## Ends in an error in state: 1390.
+## Ends in an error in state: 1391.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ error SEMI RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AS ]
 ## typevar_list -> QUOTE . ident [ QUOTE DOT ]
@@ -7940,7 +7940,7 @@ implementation: LBRACE PUB VIRTUAL LIDENT COLON QUOTE WITH
 
 implementation: LBRACE PUB WITH
 ##
-## Ends in an error in state: 1572.
+## Ends in an error in state: 1573.
 ##
 ## _class_field -> PUB . method_ post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7952,7 +7952,7 @@ implementation: LBRACE PUB WITH
 
 implementation: LBRACE PERCENT WITH TYPE
 ##
-## Ends in an error in state: 2316.
+## Ends in an error in state: 2317.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ error RBRACE ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ error SEMI RBRACE AND ]
@@ -7972,7 +7972,7 @@ implementation: LBRACE PERCENT WITH TYPE
 
 implementation: LBRACE UIDENT DOT WITH
 ##
-## Ends in an error in state: 2337.
+## Ends in an error in state: 2338.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL COLONCOLONLIDENT COLONCOLON CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL COLONCOLONLIDENT COLONCOLON CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
@@ -7999,7 +7999,7 @@ implementation: LBRACE UIDENT DOT WITH
 
 implementation: LBRACE VAL BANG WITH
 ##
-## Ends in an error in state: 1558.
+## Ends in an error in state: 1559.
 ##
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8014,7 +8014,7 @@ implementation: LBRACE VAL BANG WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LBRACE DOTDOT RBRACE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1571.
+## Ends in an error in state: 1572.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8063,7 +8063,7 @@ implementation: LBRACE VAL LIDENT COLONGREATER LBRACE DOTDOT RBRACE EQUAL UIDENT
 
 implementation: LBRACE VAL LIDENT COLONGREATER LBRACE DOTDOT RBRACE EQUAL WITH
 ##
-## Ends in an error in state: 1570.
+## Ends in an error in state: 1571.
 ##
 ## value -> override_flag mutable_flag label type_constraint EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8075,7 +8075,7 @@ implementation: LBRACE VAL LIDENT COLONGREATER LBRACE DOTDOT RBRACE EQUAL WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LBRACE DOTDOT RBRACE WITH
 ##
-## Ends in an error in state: 1569.
+## Ends in an error in state: 1570.
 ##
 ## value -> override_flag mutable_flag label type_constraint . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8092,14 +8092,14 @@ implementation: LBRACE VAL LIDENT COLONGREATER LBRACE DOTDOT RBRACE WITH
 ## In state 289, spurious reduction of production _core_type -> core_type2
 ## In state 301, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 288, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1141, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1142, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1568.
+## Ends in an error in state: 1569.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8148,7 +8148,7 @@ implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 
 implementation: LBRACE VAL LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1567.
+## Ends in an error in state: 1568.
 ##
 ## value -> override_flag mutable_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8160,7 +8160,7 @@ implementation: LBRACE VAL LIDENT EQUAL WITH
 
 implementation: LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1566.
+## Ends in an error in state: 1567.
 ##
 ## value -> override_flag mutable_flag label . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag mutable_flag label . type_constraint EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -8173,7 +8173,7 @@ implementation: LBRACE VAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1563.
+## Ends in an error in state: 1564.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8197,7 +8197,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1562.
+## Ends in an error in state: 1563.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8210,7 +8210,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1561.
+## Ends in an error in state: 1562.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8223,7 +8223,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 ##
-## Ends in an error in state: 1560.
+## Ends in an error in state: 1561.
 ##
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8236,7 +8236,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 
 implementation: LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1559.
+## Ends in an error in state: 1560.
 ##
 ## mutable_flag -> MUTABLE . [ LIDENT ]
 ## value -> override_flag MUTABLE . VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -8250,7 +8250,7 @@ implementation: LBRACE VAL MUTABLE WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1554.
+## Ends in an error in state: 1555.
 ##
 ## value -> VIRTUAL mutable_flag label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8274,7 +8274,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1553.
+## Ends in an error in state: 1554.
 ##
 ## value -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8287,7 +8287,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1552.
+## Ends in an error in state: 1553.
 ##
 ## value -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8300,7 +8300,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1551.
+## Ends in an error in state: 1552.
 ##
 ## value -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8313,7 +8313,7 @@ implementation: LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1550.
+## Ends in an error in state: 1551.
 ##
 ## value -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL . mutable_flag label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8326,7 +8326,7 @@ implementation: LBRACE VAL VIRTUAL WITH
 
 implementation: LBRACE VAL WITH
 ##
-## Ends in an error in state: 1549.
+## Ends in an error in state: 1550.
 ##
 ## _class_field -> VAL . value post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8338,7 +8338,7 @@ implementation: LBRACE VAL WITH
 
 implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2497.
+## Ends in an error in state: 2499.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8425,7 +8425,7 @@ implementation: LBRACELESS LIDENT WITH
 
 implementation: LBRACKET DOTDOTDOT WITH
 ##
-## Ends in an error in state: 2127.
+## Ends in an error in state: 2128.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT . expr_optional_constraint RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -8437,7 +8437,7 @@ implementation: LBRACKET DOTDOTDOT WITH
 
 implementation: LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2130.
+## Ends in an error in state: 2131.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint . opt_comma RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## expr_comma_seq_extension -> expr_optional_constraint . COMMA expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -8457,7 +8457,7 @@ implementation: LBRACKET UIDENT SEMI
 ## In state 925, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 960, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 924, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2109, spurious reduction of production expr_optional_constraint -> expr
+## In state 2110, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 Expecting one of the following:
@@ -8494,7 +8494,7 @@ implementation: LBRACKETATATAT UNDERSCORE
 
 implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2196.
+## Ends in an error in state: 2197.
 ##
 ## floating_attribute -> LBRACKETATATAT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -8513,15 +8513,15 @@ implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ## In state 883, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 918, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 882, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1909, spurious reduction of production post_item_attributes ->
-## In state 1910, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1911, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1859, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1725, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1912, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1860, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1726, spurious reduction of production structure -> structure_item
-## In state 1855, spurious reduction of production payload -> structure
+## In state 1910, spurious reduction of production post_item_attributes ->
+## In state 1911, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1912, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1860, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1726, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1913, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1861, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1727, spurious reduction of production structure -> structure_item
+## In state 1856, spurious reduction of production payload -> structure
 ##
 
 Expecting "]" to finish current floating attribute
@@ -8612,7 +8612,7 @@ implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 
 implementation: LBRACKETBAR UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2121.
+## Ends in an error in state: 2122.
 ##
 ## expr_comma_seq -> expr_comma_seq COMMA . expr_optional_constraint [ error COMMA BARRBRACKET ]
 ## opt_comma -> COMMA . [ error BARRBRACKET ]
@@ -8637,7 +8637,7 @@ implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH COLON WITH
 ##
-## Ends in an error in state: 1349.
+## Ends in an error in state: 1350.
 ##
 ## payload -> COLON . core_type [ RBRACKET ]
 ##
@@ -8661,7 +8661,7 @@ implementation: LBRACKETPERCENTPERCENT WITH DOT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ##
-## Ends in an error in state: 2463.
+## Ends in an error in state: 2464.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN RBRACKET BAR ]
 ## payload -> QUESTION pattern . [ RBRACKET ]
@@ -8681,7 +8681,7 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2465.
+## Ends in an error in state: 2466.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8730,7 +8730,7 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2464.
+## Ends in an error in state: 2465.
 ##
 ## payload -> QUESTION pattern WHEN . expr [ RBRACKET ]
 ##
@@ -8755,7 +8755,7 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION WITH
 
 implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2198.
+## Ends in an error in state: 2199.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -8774,15 +8774,15 @@ implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ## In state 883, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 918, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 882, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1909, spurious reduction of production post_item_attributes ->
-## In state 1910, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1911, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1859, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1725, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1912, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1860, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1726, spurious reduction of production structure -> structure_item
-## In state 1855, spurious reduction of production payload -> structure
+## In state 1910, spurious reduction of production post_item_attributes ->
+## In state 1911, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1912, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1860, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1726, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1913, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1861, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1727, spurious reduction of production structure -> structure_item
+## In state 1856, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
@@ -8802,7 +8802,7 @@ implementation: LBRACKETPERCENTPERCENT WITH WITH
 
 implementation: LET CHAR EQUAL CHAR AND WITH
 ##
-## Ends in an error in state: 1889.
+## Ends in an error in state: 1890.
 ##
 ## and_let_binding -> AND . let_binding_body post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -8814,7 +8814,7 @@ implementation: LET CHAR EQUAL CHAR AND WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 2248.
+## Ends in an error in state: 2249.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -8863,7 +8863,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2252.
+## Ends in an error in state: 2253.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -8875,7 +8875,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2251.
+## Ends in an error in state: 2252.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -8898,7 +8898,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 2250.
+## Ends in an error in state: 2251.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -8910,7 +8910,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2249.
+## Ends in an error in state: 2250.
 ##
 ## let_binding_body -> val_ident COLON typevar_list . DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -8923,7 +8923,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2246.
+## Ends in an error in state: 2247.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -8935,7 +8935,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2245.
+## Ends in an error in state: 2246.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -8958,7 +8958,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 2244.
+## Ends in an error in state: 2245.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -8970,7 +8970,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1481.
+## Ends in an error in state: 1482.
 ##
 ## lident_list -> LIDENT . [ DOT ]
 ## lident_list -> LIDENT . lident_list [ DOT ]
@@ -8983,7 +8983,7 @@ implementation: LET LIDENT COLON TYPE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 2242.
+## Ends in an error in state: 2243.
 ##
 ## let_binding_body -> val_ident COLON TYPE . lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -8995,7 +8995,7 @@ implementation: LET LIDENT COLON TYPE WITH
 
 implementation: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 2241.
+## Ends in an error in state: 2242.
 ##
 ## let_binding_body -> val_ident COLON . typevar_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## let_binding_body -> val_ident COLON . TYPE lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9009,7 +9009,7 @@ implementation: LET LIDENT COLON WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2255.
+## Ends in an error in state: 2256.
 ##
 ## let_binding_body -> val_ident type_constraint EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9021,7 +9021,7 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 2254.
+## Ends in an error in state: 2255.
 ##
 ## let_binding_body -> val_ident type_constraint . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9038,14 +9038,14 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ## In state 289, spurious reduction of production _core_type -> core_type2
 ## In state 301, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 288, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1141, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1142, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2239.
+## Ends in an error in state: 2240.
 ##
 ## _curried_binding_return_typed -> EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9116,7 +9116,7 @@ implementation: LET LIDENT LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1603.
+## Ends in an error in state: 1604.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -9165,7 +9165,7 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPARE
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1602.
+## Ends in an error in state: 1603.
 ##
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9177,7 +9177,7 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1601.
+## Ends in an error in state: 1602.
 ##
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type . EQUALGREATER expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9191,7 +9191,7 @@ Expecting "=>" to start the function body
 
 implementation: LET LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1600.
+## Ends in an error in state: 1601.
 ##
 ## curried_binding_return_typed_ -> COLON . non_arrowed_core_type EQUALGREATER expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9203,7 +9203,7 @@ implementation: LET LIDENT UNDERSCORE COLON WITH
 
 implementation: LET LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1579.
+## Ends in an error in state: 1580.
 ##
 ## curried_binding -> EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9274,7 +9274,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 1599.
+## Ends in an error in state: 1600.
 ##
 ## curried_binding -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9286,7 +9286,7 @@ implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 
 implementation: LET LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2258.
+## Ends in an error in state: 2259.
 ##
 ## _curried_binding_return_typed -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9318,7 +9318,7 @@ implementation: LET LIDENT WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 ##
-## Ends in an error in state: 1874.
+## Ends in an error in state: 1875.
 ##
 ## and_nonlocal_module_bindings -> AND . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9330,7 +9330,7 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1873.
+## Ends in an error in state: 1874.
 ##
 ## _structure_item_without_item_extension_sugar -> many_nonlocal_module_bindings . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> many_nonlocal_module_bindings . and_nonlocal_module_bindings [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -9342,16 +9342,16 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WIT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1302, spurious reduction of production post_item_attributes ->
-## In state 1303, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2049, spurious reduction of production many_nonlocal_module_bindings -> opt_let_module REC nonlocal_module_binding_details post_item_attributes
+## In state 1303, spurious reduction of production post_item_attributes ->
+## In state 1304, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2050, spurious reduction of production many_nonlocal_module_bindings -> opt_let_module REC nonlocal_module_binding_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE REC WITH
 ##
-## Ends in an error in state: 2047.
+## Ends in an error in state: 2048.
 ##
 ## many_nonlocal_module_bindings -> opt_let_module REC . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9363,7 +9363,7 @@ implementation: LET MODULE REC WITH
 
 implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2031.
+## Ends in an error in state: 2032.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9377,19 +9377,19 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1736, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1740, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1737, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1166, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1742, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1741, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1737, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1741, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1738, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1167, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1743, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1742, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2030.
+## Ends in an error in state: 2031.
 ##
 ## module_binding_body_expr -> COLON module_type EQUAL . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9401,7 +9401,7 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
 
 implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2029.
+## Ends in an error in state: 2030.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER EQUAL ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER EQUAL ]
@@ -9417,22 +9417,22 @@ implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 806, spurious reduction of production mty_longident -> ident
-## In state 1814, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1843, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1839, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1812, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1844, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1840, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1813, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1845, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1841, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1815, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1844, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1840, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1813, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1845, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1841, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1814, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1846, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1842, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 1743.
+## Ends in an error in state: 1744.
 ##
 ## module_binding_body_expr -> COLON . module_type EQUAL module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9444,7 +9444,7 @@ implementation: LET MODULE UIDENT COLON WITH
 
 implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 1734.
+## Ends in an error in state: 1735.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9458,19 +9458,19 @@ implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1736, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1740, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1737, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1166, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1742, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1741, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1737, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1741, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1738, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1167, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1743, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1742, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1733.
+## Ends in an error in state: 1734.
 ##
 ## module_binding_body_expr -> EQUAL . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9482,7 +9482,7 @@ implementation: LET MODULE UIDENT EQUAL WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2042.
+## Ends in an error in state: 2043.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER module_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9496,19 +9496,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1736, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1740, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1737, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1166, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1742, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1741, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1737, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1741, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1738, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1167, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1743, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1742, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2041.
+## Ends in an error in state: 2042.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9520,7 +9520,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2040.
+## Ends in an error in state: 2041.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type . EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_type -> non_arrowed_module_type . [ WITH LBRACKETAT EQUALGREATER ]
@@ -9534,19 +9534,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 134, spurious reduction of production ident -> UIDENT
 ## In state 806, spurious reduction of production mty_longident -> ident
-## In state 1814, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1843, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1839, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1812, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1844, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1840, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1815, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1844, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1840, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1813, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1845, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1841, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRACE SEMI
 ##
-## Ends in an error in state: 2043.
+## Ends in an error in state: 2044.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER ]
@@ -9565,18 +9565,18 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT CO
 ## In state 289, spurious reduction of production _core_type -> core_type2
 ## In state 301, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 288, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1821, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1835, spurious reduction of production with_constraints -> with_constraint
-## In state 1832, spurious reduction of production _module_type -> module_type WITH with_constraints
-## In state 1845, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1841, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1822, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1836, spurious reduction of production with_constraints -> with_constraint
+## In state 1833, spurious reduction of production _module_type -> module_type WITH with_constraints
+## In state 1846, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1842, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
 ##
-## Ends in an error in state: 2039.
+## Ends in an error in state: 2040.
 ##
 ## _module_binding_body_functor -> functor_args COLON . non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9588,7 +9588,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2038.
+## Ends in an error in state: 2039.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER module_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9602,19 +9602,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1736, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1740, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1737, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1166, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1742, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1741, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1737, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1741, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1738, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1167, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1743, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1742, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2037.
+## Ends in an error in state: 2038.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9626,7 +9626,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2036.
+## Ends in an error in state: 2037.
 ##
 ## _module_binding_body_functor -> functor_args . EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_binding_body_functor -> functor_args . COLON non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9640,7 +9640,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 
 implementation: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1732.
+## Ends in an error in state: 1733.
 ##
 ## nonlocal_module_binding_details -> UIDENT . module_binding_body [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9652,7 +9652,7 @@ implementation: LET MODULE UIDENT WITH
 
 implementation: LET MODULE WITH
 ##
-## Ends in an error in state: 1731.
+## Ends in an error in state: 1732.
 ##
 ## _structure_item_without_item_extension_sugar -> opt_let_module . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> opt_let_module . REC nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -9677,7 +9677,7 @@ implementation: LET REC ASSERT
 
 implementation: LET UIDENT UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1895.
+## Ends in an error in state: 1896.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EQUAL BAR ]
 ## let_binding_body -> pattern . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9699,7 +9699,7 @@ implementation: LET UIDENT UNDERSCORE WHEN
 
 implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1893.
+## Ends in an error in state: 1894.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9711,7 +9711,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1892.
+## Ends in an error in state: 1893.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9734,7 +9734,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 
 implementation: LET UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1891.
+## Ends in an error in state: 1892.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON . core_type EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9746,7 +9746,7 @@ implementation: LET UNDERSCORE COLON WITH
 
 implementation: LET UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1896.
+## Ends in an error in state: 1897.
 ##
 ## let_binding_body -> pattern EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9758,7 +9758,7 @@ implementation: LET UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE WITH
 ##
-## Ends in an error in state: 1890.
+## Ends in an error in state: 1891.
 ##
 ## _simple_pattern -> simple_pattern_not_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> simple_pattern_not_ident . COLON core_type EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9886,7 +9886,7 @@ implementation: LPAREN FOR WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2179.
+## Ends in an error in state: 2180.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -9931,7 +9931,7 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2178.
+## Ends in an error in state: 2179.
 ##
 ## leading_bar_match_case -> pattern_with_bar EQUALGREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -9943,7 +9943,7 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2177.
+## Ends in an error in state: 2178.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -9988,7 +9988,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2176.
+## Ends in an error in state: 2177.
 ##
 ## leading_bar_match_case -> pattern_with_bar WHEN expr EQUALGREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10000,7 +10000,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2175.
+## Ends in an error in state: 2176.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10049,7 +10049,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2174.
+## Ends in an error in state: 2175.
 ##
 ## leading_bar_match_case -> pattern_with_bar WHEN . expr EQUALGREATER expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10120,7 +10120,7 @@ implementation: LPAREN FUN LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2164.
+## Ends in an error in state: 2165.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10236,7 +10236,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 2169.
+## Ends in an error in state: 2170.
 ##
 ## fun_def -> labeled_simple_pattern . fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10248,7 +10248,7 @@ implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 
 implementation: LPAREN FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2183.
+## Ends in an error in state: 2184.
 ##
 ## _expr -> FUN labeled_simple_pattern . fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10375,7 +10375,7 @@ implementation: LPAREN LBRACELESS WITH
 
 implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ##
-## Ends in an error in state: 2128.
+## Ends in an error in state: 2129.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT expr_optional_constraint . RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10394,14 +10394,14 @@ implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ## In state 925, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 960, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 924, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2109, spurious reduction of production expr_optional_constraint -> expr
+## In state 2110, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKET UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2131.
+## Ends in an error in state: 2132.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint COMMA . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## opt_comma -> COMMA . [ RBRACKET ]
@@ -10414,7 +10414,7 @@ implementation: LPAREN LBRACKET UIDENT COMMA WITH
 
 implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2396.
+## Ends in an error in state: 2397.
 ##
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10436,7 +10436,7 @@ implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ## In state 918, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 882, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1123, spurious reduction of production expr_optional_constraint -> expr
-## In state 2119, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 2120, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
@@ -10469,7 +10469,7 @@ implementation: LPAREN LBRACKETPERCENT UNDERSCORE
 
 implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2466.
+## Ends in an error in state: 2467.
 ##
 ## extension -> LBRACKETPERCENT attr_id payload . RBRACKET [ error WITH UNDERSCORE UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10488,15 +10488,15 @@ implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ## In state 883, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 918, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 882, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1909, spurious reduction of production post_item_attributes ->
-## In state 1910, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1911, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1859, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1725, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1912, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1860, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1726, spurious reduction of production structure -> structure_item
-## In state 1855, spurious reduction of production payload -> structure
+## In state 1910, spurious reduction of production post_item_attributes ->
+## In state 1911, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1912, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1860, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1726, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1913, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1861, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1727, spurious reduction of production structure -> structure_item
+## In state 1856, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
@@ -10515,7 +10515,7 @@ implementation: LPAREN LIDENT EQUAL WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ##
-## Ends in an error in state: 2487.
+## Ends in an error in state: 2488.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr . RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10564,7 +10564,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2486.
+## Ends in an error in state: 2487.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA . expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10576,7 +10576,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2485.
+## Ends in an error in state: 2486.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr . COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10625,7 +10625,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2484.
+## Ends in an error in state: 2485.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN . expr COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10637,7 +10637,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2483.
+## Ends in an error in state: 2484.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN . LPAREN expr COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10649,7 +10649,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2482.
+## Ends in an error in state: 2483.
 ##
 ## _expr -> LPAREN COLONCOLON . RPAREN LPAREN expr COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10661,7 +10661,7 @@ implementation: LPAREN LPAREN COLONCOLON WITH
 
 implementation: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2476.
+## Ends in an error in state: 2477.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -10703,9 +10703,9 @@ Expecting a module expression
 
 implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ##
-## Ends in an error in state: 2489.
+## Ends in an error in state: 2490.
 ##
-## _simple_expr -> LPAREN expr_comma_list . RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
+## _simple_expr -> LPAREN expr_comma_list . opt_comma RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN expr_comma_list . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## expr_comma_list -> expr_comma_list . COMMA expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -10734,7 +10734,7 @@ implementation: LPAREN LPAREN WITH
 ## _simple_expr -> LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . expr error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . expr type_constraint RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
-## _simple_expr -> LPAREN . expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
+## _simple_expr -> LPAREN . expr_comma_list opt_comma RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . expr_comma_list error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . MODULE module_expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . MODULE module_expr COLON package_type RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -10781,7 +10781,7 @@ implementation: LPAREN MINUSDOT WITH
 
 implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2480.
+## Ends in an error in state: 2481.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10801,7 +10801,7 @@ implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2478.
+## Ends in an error in state: 2479.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10903,7 +10903,7 @@ implementation: LPAREN STAR WITH
 
 implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1145.
+## Ends in an error in state: 1146.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -10915,7 +10915,7 @@ implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 
 implementation: LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1142.
+## Ends in an error in state: 1143.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -10944,15 +10944,15 @@ implementation: LPAREN UIDENT COLONGREATER LBRACE DOTDOT RBRACE WITH
 ## In state 289, spurious reduction of production _core_type -> core_type2
 ## In state 301, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 288, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1141, spurious reduction of production type_constraint -> COLONGREATER core_type
-## In state 2495, spurious reduction of production expr_optional_constraint -> expr type_constraint
+## In state 1142, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 2497, spurious reduction of production expr_optional_constraint -> expr type_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1140.
+## Ends in an error in state: 1141.
 ##
 ## type_constraint -> COLONGREATER . core_type [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -10964,9 +10964,10 @@ implementation: LPAREN UIDENT COLONGREATER WITH
 
 implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 1135.
+## Ends in an error in state: 1134.
 ##
 ## expr_comma_list -> expr_comma_list COMMA . expr_optional_constraint [ error RPAREN COMMA ]
+## opt_comma -> COMMA . [ RPAREN ]
 ##
 ## The known suffix of the stack is as follows:
 ## expr_comma_list COMMA
@@ -11074,7 +11075,7 @@ implementation: STRING LIDENTCOLONCOLON QUESTION WITH
 
 implementation: STRING WITH
 ##
-## Ends in an error in state: 1726.
+## Ends in an error in state: 1727.
 ##
 ## structure -> structure_item . [ RBRACKET RBRACE EOF ]
 ## structure -> structure_item . error structure [ RBRACKET RBRACE EOF ]
@@ -11091,20 +11092,20 @@ implementation: STRING WITH
 ## In state 883, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 918, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 882, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1909, spurious reduction of production post_item_attributes ->
-## In state 1910, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1911, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1859, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1725, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1912, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1860, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1910, spurious reduction of production post_item_attributes ->
+## In state 1911, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1912, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1860, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1726, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1913, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1861, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 Incomplete statement. Did you forget a ";"?
 
 implementation: SWITCH UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2521.
+## Ends in an error in state: 2523.
 ##
 ## _expr -> SWITCH simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11116,7 +11117,7 @@ implementation: SWITCH UIDENT LBRACE WITH
 
 implementation: SWITCH UIDENT WITH
 ##
-## Ends in an error in state: 2520.
+## Ends in an error in state: 2522.
 ##
 ## _expr -> SWITCH simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ SHARPOP SHARP LBRACE DOT ]
@@ -11470,7 +11471,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2371.
+## Ends in an error in state: 2372.
 ##
 ## _semi_terminated_seq_expr_row -> opt_let_module UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11482,7 +11483,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2368.
+## Ends in an error in state: 2369.
 ##
 ## _semi_terminated_seq_expr_row -> opt_let_module UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11494,7 +11495,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 ##
-## Ends in an error in state: 2367.
+## Ends in an error in state: 2368.
 ##
 ## _semi_terminated_seq_expr_row -> opt_let_module . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11506,7 +11507,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 ##
-## Ends in an error in state: 2362.
+## Ends in an error in state: 2363.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11518,7 +11519,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2365.
+## Ends in an error in state: 2366.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11530,7 +11531,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2364.
+## Ends in an error in state: 2365.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11541,14 +11542,14 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2363, spurious reduction of production post_item_attributes ->
+## In state 2364, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 ##
-## Ends in an error in state: 2361.
+## Ends in an error in state: 2362.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11560,7 +11561,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 ##
-## Ends in an error in state: 2357.
+## Ends in an error in state: 2358.
 ##
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI RBRACE BAR AND ]
 ## opt_let_module -> LET . MODULE [ UIDENT ]
@@ -11574,7 +11575,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 ##
-## Ends in an error in state: 2378.
+## Ends in an error in state: 2379.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ RBRACE BAR ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI RBRACE BAR AND ]
@@ -11594,7 +11595,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 2659.
+## Ends in an error in state: 2661.
 ##
 ## _expr -> TRY simple_expr LBRACE leading_bar_match_cases_to_sequence_body . RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## leading_bar_match_cases_to_sequence_body -> leading_bar_match_cases_to_sequence_body . leading_bar_match_case_to_sequence_body [ RBRACE BAR ]
@@ -11614,16 +11615,16 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ## In state 925, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 960, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 924, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2380, spurious reduction of production post_item_attributes ->
-## In state 2381, spurious reduction of production opt_semi ->
-## In state 2386, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
-## In state 2384, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
-## In state 2373, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
-## In state 2358, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
-## In state 2385, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2374, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
-## In state 2389, spurious reduction of production leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER semi_terminated_seq_expr
-## In state 2393, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
+## In state 2381, spurious reduction of production post_item_attributes ->
+## In state 2382, spurious reduction of production opt_semi ->
+## In state 2387, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
+## In state 2385, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
+## In state 2374, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
+## In state 2359, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
+## In state 2386, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2375, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2390, spurious reduction of production leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER semi_terminated_seq_expr
+## In state 2394, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
 ##
 
 Expecting one of the following:
@@ -11632,7 +11633,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2388.
+## Ends in an error in state: 2389.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11666,7 +11667,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2356.
+## Ends in an error in state: 2357.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar WHEN expr EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11678,7 +11679,7 @@ Expecting a sequence item
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2355.
+## Ends in an error in state: 2356.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11727,7 +11728,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2354.
+## Ends in an error in state: 2355.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar WHEN . expr EQUALGREATER semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11739,7 +11740,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 
 implementation: TRY UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2658.
+## Ends in an error in state: 2660.
 ##
 ## _expr -> TRY simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11751,7 +11752,7 @@ implementation: TRY UIDENT LBRACE WITH
 
 implementation: TRY UIDENT UNDERSCORE
 ##
-## Ends in an error in state: 2655.
+## Ends in an error in state: 2657.
 ##
 ## _expr -> TRY simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> TRY simple_expr . WITH error [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -11781,7 +11782,7 @@ implementation: TRY UIDENT UNDERSCORE
 
 implementation: TRY UIDENT WITH WITH
 ##
-## Ends in an error in state: 2656.
+## Ends in an error in state: 2658.
 ##
 ## _expr -> TRY simple_expr WITH . error [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11806,7 +11807,7 @@ implementation: TRY WITH
 
 implementation: TYPE LIDENT AND LIDENT WITH
 ##
-## Ends in an error in state: 1864.
+## Ends in an error in state: 1865.
 ##
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -11817,14 +11818,14 @@ implementation: TYPE LIDENT AND LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1863, spurious reduction of production optional_type_parameters ->
+## In state 1864, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT AND WITH
 ##
-## Ends in an error in state: 1862.
+## Ends in an error in state: 1863.
 ##
 ## and_type_declaration -> AND . type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -11836,7 +11837,7 @@ implementation: TYPE LIDENT AND WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1763.
+## Ends in an error in state: 1764.
 ##
 ## constrain -> core_type EQUAL . core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -11848,7 +11849,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1762.
+## Ends in an error in state: 1763.
 ##
 ## constrain -> core_type . EQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -11871,7 +11872,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 
 implementation: TYPE LIDENT CONSTRAINT WITH
 ##
-## Ends in an error in state: 1761.
+## Ends in an error in state: 1762.
 ##
 ## constraints -> constraints CONSTRAINT . constrain [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -11883,7 +11884,7 @@ implementation: TYPE LIDENT CONSTRAINT WITH
 
 implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2610.
+## Ends in an error in state: 2612.
 ##
 ## constructor_declarations -> constructor_declarations_leading_bar . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations_leading_bar -> constructor_declarations_leading_bar . constructor_declaration_leading_bar [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
@@ -11895,17 +11896,17 @@ implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1311, spurious reduction of production attributes ->
-## In state 1312, spurious reduction of production attributes -> attribute attributes
-## In state 2595, spurious reduction of production constructor_declaration_leading_bar -> BAR UIDENT generalized_constructor_arguments attributes
-## In state 2615, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
+## In state 1312, spurious reduction of production attributes ->
+## In state 1313, spurious reduction of production attributes -> attribute attributes
+## In state 2597, spurious reduction of production constructor_declaration_leading_bar -> BAR UIDENT generalized_constructor_arguments attributes
+## In state 2617, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 ##
-## Ends in an error in state: 1866.
+## Ends in an error in state: 1867.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_declaration_details -> LIDENT optional_type_parameters type_kind constraints . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -11936,11 +11937,11 @@ implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ## In state 289, spurious reduction of production _core_type -> core_type2
 ## In state 301, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 288, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1597, spurious reduction of production _poly_type -> core_type
-## In state 1598, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1596, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 2528, spurious reduction of production attributes ->
-## In state 2529, spurious reduction of production label_declaration -> mutable_flag LIDENT attributes COLON poly_type attributes
+## In state 1598, spurious reduction of production _poly_type -> core_type
+## In state 1599, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1597, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 2530, spurious reduction of production attributes ->
+## In state 2531, spurious reduction of production label_declaration -> mutable_flag LIDENT attributes COLON poly_type attributes
 ## In state 330, spurious reduction of production label_declarations -> label_declaration
 ##
 
@@ -11950,7 +11951,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 2527.
+## Ends in an error in state: 2529.
 ##
 ## label_declaration -> mutable_flag LIDENT attributes COLON . poly_type attributes [ RBRACE COMMA ]
 ##
@@ -11962,7 +11963,7 @@ Expecting a type name describing this field
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 2526.
+## Ends in an error in state: 2528.
 ##
 ## label_declaration -> mutable_flag LIDENT attributes . COLON poly_type attributes [ RBRACE COMMA ]
 ##
@@ -12012,7 +12013,7 @@ Expecting at least one type field definition in the form of:
 
     implementation: TYPE LIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 2582.
+## Ends in an error in state: 2584.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
 ## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
@@ -12026,7 +12027,7 @@ Expecting at least one type field definition in the form of:
 
 implementation: TYPE LIDENT EQUAL PRI WITH
 ##
-## Ends in an error in state: 2581.
+## Ends in an error in state: 2583.
 ##
 ## type_kind -> EQUAL PRI . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL PRI . constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12053,7 +12054,7 @@ implementation: TYPE LIDENT EQUAL UIDENT WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 ##
-## Ends in an error in state: 2592.
+## Ends in an error in state: 2594.
 ##
 ## constructor_declaration_leading_bar -> BAR . UIDENT generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
 ## constructor_declaration_leading_bar -> BAR . LPAREN RPAREN generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
@@ -12069,7 +12070,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LBRACE DOTDOT RBRACE AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 2626.
+## Ends in an error in state: 2628.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12083,7 +12084,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LBRACE DO
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 303, spurious reduction of production attributes ->
 ## In state 304, spurious reduction of production attributes -> attribute attributes
-## In state 2529, spurious reduction of production label_declaration -> mutable_flag LIDENT attributes COLON poly_type attributes
+## In state 2531, spurious reduction of production label_declaration -> mutable_flag LIDENT attributes COLON poly_type attributes
 ## In state 330, spurious reduction of production label_declarations -> label_declaration
 ##
 
@@ -12091,7 +12092,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LBRACE DO
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2625.
+## Ends in an error in state: 2627.
 ##
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -12103,7 +12104,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRI BANG
 ##
-## Ends in an error in state: 2620.
+## Ends in an error in state: 2622.
 ##
 ## private_flag -> PRI . [ LBRACE ]
 ## type_kind -> EQUAL core_type EQUAL PRI . constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12116,7 +12117,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRI BANG
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2613.
+## Ends in an error in state: 2615.
 ##
 ## constructor_declarations -> constructor_declaration_no_leading_bar . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations -> constructor_declaration_no_leading_bar . constructor_declarations_leading_bar [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12128,16 +12129,16 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1311, spurious reduction of production attributes ->
-## In state 1312, spurious reduction of production attributes -> attribute attributes
-## In state 2577, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
+## In state 1312, spurious reduction of production attributes ->
+## In state 1313, spurious reduction of production attributes -> attribute attributes
+## In state 2579, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2618.
+## Ends in an error in state: 2620.
 ##
 ## type_kind -> EQUAL core_type EQUAL . constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type EQUAL . PRI constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12152,7 +12153,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 2617.
+## Ends in an error in state: 2619.
 ##
 ## type_kind -> EQUAL core_type . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type . EQUAL constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12199,7 +12200,7 @@ implementation: TYPE LIDENT EQUAL WITH
 
 implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1861.
+## Ends in an error in state: 1862.
 ##
 ## _structure_item_without_item_extension_sugar -> many_type_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -12211,9 +12212,9 @@ implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1302, spurious reduction of production post_item_attributes ->
-## In state 1303, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2632, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 1303, spurious reduction of production post_item_attributes ->
+## In state 1304, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2634, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
@@ -12270,7 +12271,7 @@ implementation: TYPE LIDENT PLUS WITH
 
 implementation: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 2636.
+## Ends in an error in state: 2638.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12282,7 +12283,7 @@ implementation: TYPE LIDENT PLUSEQ BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ PRI BANG
 ##
-## Ends in an error in state: 2635.
+## Ends in an error in state: 2637.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12294,7 +12295,7 @@ implementation: TYPE LIDENT PLUSEQ PRI BANG
 
 implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 2638.
+## Ends in an error in state: 2640.
 ##
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_rebind [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -12307,7 +12308,7 @@ implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 2634.
+## Ends in an error in state: 2636.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12355,7 +12356,7 @@ Expecting one of the following:
 
 implementation: TYPE UIDENT DOT WITH
 ##
-## Ends in an error in state: 2068.
+## Ends in an error in state: 2069.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -12369,7 +12370,7 @@ implementation: TYPE UIDENT DOT WITH
 
 implementation: TYPE UIDENT WITH
 ##
-## Ends in an error in state: 2067.
+## Ends in an error in state: 2068.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident . DOT UIDENT [ DOT ]
@@ -12456,7 +12457,7 @@ implementation: UIDENT COLONEQUAL WITH
 
 implementation: UIDENT DOT LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 2161.
+## Ends in an error in state: 2162.
 ##
 ## lbl_expr -> label_longident . COLON expr [ COMMA ]
 ## lbl_expr -> label_longident . [ COMMA ]
@@ -12470,7 +12471,7 @@ implementation: UIDENT DOT LBRACE LIDENT WITH
 
 implementation: UIDENT DOT LBRACE WITH
 ##
-## Ends in an error in state: 2141.
+## Ends in an error in state: 2142.
 ##
 ## _simple_expr -> mod_longident DOT LBRACE . RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12484,7 +12485,7 @@ implementation: UIDENT DOT LBRACE WITH
 
 implementation: UIDENT DOT LBRACELESS WITH
 ##
-## Ends in an error in state: 2136.
+## Ends in an error in state: 2137.
 ##
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12497,7 +12498,7 @@ implementation: UIDENT DOT LBRACELESS WITH
 
 implementation: UIDENT DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2126.
+## Ends in an error in state: 2127.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12509,7 +12510,7 @@ implementation: UIDENT DOT LBRACKET WITH
 
 implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2120.
+## Ends in an error in state: 2121.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12531,14 +12532,14 @@ implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ## In state 918, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 882, spurious reduction of production expr -> mark_position_exp(_expr)
 ## In state 1123, spurious reduction of production expr_optional_constraint -> expr
-## In state 2119, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 2120, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LBRACKETBAR WITH
 ##
-## Ends in an error in state: 2118.
+## Ends in an error in state: 2119.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12551,7 +12552,7 @@ implementation: UIDENT DOT LBRACKETBAR WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2104.
+## Ends in an error in state: 2105.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12571,7 +12572,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2102.
+## Ends in an error in state: 2103.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12584,7 +12585,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2101.
+## Ends in an error in state: 2102.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -12624,7 +12625,7 @@ implementation: UIDENT DOT LPAREN MODULE WITH
 
 implementation: UIDENT DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2106.
+## Ends in an error in state: 2107.
 ##
 ## expr_comma_list -> expr_optional_constraint . COMMA expr_optional_constraint [ RPAREN COMMA ]
 ##
@@ -12643,7 +12644,7 @@ implementation: UIDENT DOT LPAREN UIDENT SEMI
 ## In state 883, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 918, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 882, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2115, spurious reduction of production expr_optional_constraint -> expr
+## In state 2116, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
@@ -12778,7 +12779,7 @@ Expecting an attribute id
 
 implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2444.
+## Ends in an error in state: 2445.
 ##
 ## attribute -> LBRACKETAT attr_id payload . RBRACKET [ error WITH UIDENT STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARRBRACKET BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12797,15 +12798,15 @@ implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ## In state 883, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 918, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 882, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1909, spurious reduction of production post_item_attributes ->
-## In state 1910, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1911, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1859, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1725, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1912, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1860, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1726, spurious reduction of production structure -> structure_item
-## In state 1855, spurious reduction of production payload -> structure
+## In state 1910, spurious reduction of production post_item_attributes ->
+## In state 1911, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1912, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1860, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1726, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1913, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1861, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1727, spurious reduction of production structure -> structure_item
+## In state 1856, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
@@ -12824,7 +12825,7 @@ Expecting an attributed id
 
 implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2441.
+## Ends in an error in state: 2442.
 ##
 ## item_attribute -> LBRACKETATAT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -12843,15 +12844,15 @@ implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ## In state 883, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 918, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 882, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1909, spurious reduction of production post_item_attributes ->
-## In state 1910, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1911, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1859, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1725, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1912, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1860, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1726, spurious reduction of production structure -> structure_item
-## In state 1855, spurious reduction of production payload -> structure
+## In state 1910, spurious reduction of production post_item_attributes ->
+## In state 1911, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1912, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1860, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1726, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1913, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1861, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1727, spurious reduction of production structure -> structure_item
+## In state 1856, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
@@ -12899,7 +12900,7 @@ implementation: UIDENT LPAREN WITH
 ## _simple_expr -> LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . expr error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . expr type_constraint RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
-## _simple_expr -> LPAREN . expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
+## _simple_expr -> LPAREN . expr_comma_list opt_comma RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . expr_comma_list error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . MODULE module_expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN . MODULE module_expr COLON package_type RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -13078,7 +13079,7 @@ Expecting an expression
 
 implementation: UIDENT RBRACKET
 ##
-## Ends in an error in state: 2667.
+## Ends in an error in state: 2669.
 ##
 ## implementation -> structure . EOF [ # ]
 ##
@@ -13097,21 +13098,21 @@ implementation: UIDENT RBRACKET
 ## In state 883, spurious reduction of production _expr -> less_aggressive_simple_expression
 ## In state 918, spurious reduction of production mark_position_exp(_expr) -> _expr
 ## In state 882, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1909, spurious reduction of production post_item_attributes ->
-## In state 1910, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1911, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1859, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1725, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1912, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1860, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1726, spurious reduction of production structure -> structure_item
+## In state 1910, spurious reduction of production post_item_attributes ->
+## In state 1911, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1912, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1860, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1726, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1913, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1861, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1727, spurious reduction of production structure -> structure_item
 ##
 
 Invalid token
 
 implementation: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2052.
+## Ends in an error in state: 2053.
 ##
 ## structure -> structure_item SEMI . structure [ RBRACKET RBRACE EOF ]
 ##
@@ -13147,7 +13148,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 2192.
+## Ends in an error in state: 2193.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13198,7 +13199,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 2191.
+## Ends in an error in state: 2192.
 ##
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -13210,7 +13211,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2189.
+## Ends in an error in state: 2190.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13262,7 +13263,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2188.
+## Ends in an error in state: 2189.
 ##
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW NATIVEINT MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT64 INT32 INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -13275,7 +13276,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2186.
+## Ends in an error in state: 2187.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -2873,7 +2873,7 @@ _simple_expr:
       { $2 }
   | LBRACE as_loc(semi_terminated_seq_expr) error
       { syntax_error_exp $2.loc "SyntaxError in block" }
-  | LPAREN expr_comma_list RPAREN
+  | LPAREN expr_comma_list opt_comma RPAREN
       { mkexp(Pexp_tuple(List.rev $2)) }
   | as_loc(LPAREN) expr_comma_list as_loc(error)
       { unclosed_exp (with_txt $1 "(") (with_txt $3 ")") }


### PR DESCRIPTION
Implements https://github.com/facebook/reason/issues/889

This does not print trailing commas when line breaks are needed.
I think this requires an enhancement in the EasyFormat lib.