### PR TITLE
JSX: Foo.createElement ::bar [] to Foo.createElement ::bar children::[] ()

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -555,16 +555,33 @@ let defaultArg = <DefaultArg default=zzz />;
 fakeRender defaultArg;
 
 NotReallyJSX.createElement
-  [] foo::1 bar::2 [@JSX];
+[]
+foo::1
+bar::2
+[@JSX]
+[@bla];
 
 NotReallyJSX.createElement
-  foo::1 [] bar::2 [@JSX];
+foo::1
+[]
+bar::2
+[@JSX]
+[@bla];
 
-notReallyJSX [] foo::1 [@JSX];
+notReallyJSX [] foo::1 [@JSX] [@bla];
 
-notReallyJSX foo::1 [] bar::2 [@JSX];
+notReallyJSX foo::1 [] bar::2 [@JSX] [@bla];
 
 /* children can be at any position */
 <span test=true foo=2 />;
 
 <Optional1 required=(Some "hi") />;
+
+/* preserve some other attributes too! */
+<span test=true foo=2 /> [@bla];
+
+<span test=true foo=2 /> [@bla];
+
+<Optional1 required=(Some "hi") /> [@bla];
+
+<Optional1 required=(Some "hi") /> [@bla];

--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -563,3 +563,8 @@ NotReallyJSX.createElement
 notReallyJSX [] foo::1 [@JSX];
 
 notReallyJSX foo::1 [] bar::2 [@JSX];
+
+/* children can be at any position */
+<span test=true foo=2 />;
+
+<Optional1 required=(Some "hi") />;

--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -1,40 +1,47 @@
 type component = {displayName: string};
 
 module Bar = {
-  let createElement ::c=? children => {
+  let createElement ::c=? ::children () => {
     displayName: "test"
   };
 };
 
 module Nesting = {
-  let createElement children => {
+  let createElement ::children () => {
     displayName: "test"
   };
 };
 
 module Much = {
-  let createElement children => {
+  let createElement ::children () => {
     displayName: "test"
   };
 };
 
 module Foo = {
-  let createElement ::a=? ::b=? children => {
+  let createElement ::a=? ::b=? ::children () => {
     displayName: "test"
   };
 };
 
 module One = {
-  let createElement ::test=? ::foo=? children => {
+  let createElement
+      ::test=?
+      ::foo=?
+      ::children
+      () => {
     displayName: "test"
   };
-  let createElementobvioustypo ::test children => {
+  let createElementobvioustypo
+      ::test
+      ::children
+      () => {
     displayName: "test"
   };
 };
 
 module Two = {
-  let createElement ::foo=? children => {
+  let createElement ::foo=? ::children () => {
     displayName: "test"
   };
 };
@@ -42,43 +49,44 @@ module Two = {
 module Sibling = {
   let createElement
       ::foo=?
-      (children: list component) => {
+      children::(children: list component)
+      () => {
     displayName: "test"
   };
 };
 
 module Test = {
-  let createElement ::yo=? children => {
+  let createElement ::yo=? ::children () => {
     displayName: "test"
   };
 };
 
 module So = {
-  let createElement children => {
+  let createElement ::children () => {
     displayName: "test"
   };
 };
 
 module Foo2 = {
-  let createElement children => {
+  let createElement ::children () => {
     displayName: "test"
   };
 };
 
 module Text = {
-  let createElement children => {
+  let createElement ::children () => {
     displayName: "test"
   };
 };
 
 module Exp = {
-  let createElement children => {
+  let createElement ::children () => {
     displayName: "test"
   };
 };
 
 module Pun = {
-  let createElement ::intended=? children => {
+  let createElement ::intended=? ::children () => {
     displayName: "test"
   };
 };
@@ -88,14 +96,15 @@ module Namespace = {
     let createElement
         ::intended=?
         anotherOptional::x=100
-        children => {
+        ::children
+        () => {
       displayName: "test"
     };
   };
 };
 
 module Optional1 = {
-  let createElement ::required children =>
+  let createElement ::required ::children () =>
     switch required {
     | Some a => {displayName: a}
     | None => {displayName: "nope"}
@@ -103,7 +112,7 @@ module Optional1 = {
 };
 
 module Optional2 = {
-  let createElement ::optional=? children =>
+  let createElement ::optional=? ::children () =>
     switch optional {
     | Some a => {displayName: a}
     | None => {displayName: "nope"}
@@ -113,7 +122,8 @@ module Optional2 = {
 module DefaultArg = {
   let createElement
       ::default=(Some "foo")
-      children =>
+      ::children
+      () =>
     switch default {
     | Some a => {displayName: a}
     | None => {displayName: "nope"}
@@ -128,29 +138,30 @@ module LotsOfArguments = {
       ::argument4=?
       ::argument5=?
       ::argument6=?
-      children => {
+      ::children
+      () => {
     displayName: "test"
   };
 };
 
-let div ::argument1=? children => {
+let div ::argument1=? ::children () => {
   displayName: "test"
 };
 
 module List1 = {
-  let createElement children => {
+  let createElement ::children () => {
     displayName: "test"
   };
 };
 
 module List2 = {
-  let createElement children => {
+  let createElement ::children () => {
     displayName: "test"
   };
 };
 
 module List3 = {
-  let createElement children => {
+  let createElement ::children () => {
     displayName: "test"
   };
 };
@@ -167,6 +178,7 @@ let notReallyJSX ::foo ::bar children => {
 
 let fakeRender (el: component) => el.displayName;
 
+/* end of setup */
 let (/><) a b => a + b;
 
 let (><) a b => a + b;
@@ -290,7 +302,7 @@ let a = <Foo a=b b=d> 5 </Foo>;
 
 let a = <Foo a> 0.55 </Foo>;
 
-let a = Foo.createElement "" [@JSX];
+let a = <Foo />;
 
 let ident = <Foo> a </Foo>;
 
@@ -333,9 +345,9 @@ let listOfItems3 =
  */
 let thisIsRight a b => ();
 
-let tagOne children => ();
+let tagOne ::children () => ();
 
-let tagTwo children => ();
+let tagTwo ::children () => ();
 
 /* thisIsWrong <tagOne /><tagTwo />; */
 thisIsRight <tagOne /> <tagTwo />;
@@ -343,9 +355,9 @@ thisIsRight <tagOne /> <tagTwo />;
 /* thisIsWrong <tagOne> </tagOne><tagTwo> </tagTwo>; */
 thisIsRight <tagOne /> <tagTwo />;
 
-let a children => ();
+let a ::children () => ();
 
-let b children => ();
+let b ::children () => ();
 
 let thisIsOkay =
   <List1> <a /> <b /> <a /> <b /> </List1>;
@@ -430,14 +442,16 @@ let asd =
 let asd2 =
   One.createElementobvioustypo
   test::false
-  ["a", "b"]
+  children::["a", "b"]
+  ()
   [@JSX]
   [@foo];
 
 let span
     test::(test: bool)
     foo::(foo: int)
-    children => 1;
+    ::children
+    () => 1;
 
 let asd =
   <span test=true foo=2> "a" "b" </span> [@foo];
@@ -447,9 +461,9 @@ let video test::(test: bool) children => children;
 
 let asd2 = video test::false 10 [@JSX] [@foo];
 
-let div children => 1;
+let div ::children => 1;
 
-((fun () => div) ()) [] [@JSX];
+((fun () => div) ()) children::[] [@JSX];
 
 let myFun () =>
   <>

--- a/formatTest/typeCheckedTests/input/jsx.re
+++ b/formatTest/typeCheckedTests/input/jsx.re
@@ -354,12 +354,19 @@ fakeRender defaultArg;
 let defaultArg = <DefaultArg default=zzz />;
 fakeRender defaultArg;
 
-NotReallyJSX.createElement [] foo::1 bar::2 [@JSX];
-NotReallyJSX.createElement foo::1 [] bar::2 [@JSX];
-notReallyJSX [] foo::1 [@JSX];
-notReallyJSX foo::1 [] bar::2 [@JSX];
+NotReallyJSX.createElement [] foo::1 bar::2 [@JSX][@bla];
+NotReallyJSX.createElement foo::1 [] bar::2 [@bla][@JSX];
+notReallyJSX [] foo::1 [@JSX][@bla];
+notReallyJSX foo::1 [] bar::2 [@bla][@JSX];
 
 /* children can be at any position */
 span children::[] test::true foo::2 () [@JSX];
 
 Optional1.createElement children::[] required::(Some "hi") () [@JSX];
+
+/* preserve some other attributes too! */
+span children::[] test::true foo::2 () [@JSX][@bla];
+span children::[] test::true foo::2 () [@bla][@JSX];
+
+Optional1.createElement children::[] required::(Some "hi") () [@JSX][@bla];
+Optional1.createElement children::[] required::(Some "hi") () [@bla][@JSX];

--- a/formatTest/typeCheckedTests/input/jsx.re
+++ b/formatTest/typeCheckedTests/input/jsx.re
@@ -358,3 +358,8 @@ NotReallyJSX.createElement [] foo::1 bar::2 [@JSX];
 NotReallyJSX.createElement foo::1 [] bar::2 [@JSX];
 notReallyJSX [] foo::1 [@JSX];
 notReallyJSX foo::1 [] bar::2 [@JSX];
+
+/* children can be at any position */
+span children::[] test::true foo::2 () [@JSX];
+
+Optional1.createElement children::[] required::(Some "hi") () [@JSX];

--- a/formatTest/typeCheckedTests/input/jsx.re
+++ b/formatTest/typeCheckedTests/input/jsx.re
@@ -1,66 +1,66 @@
 type component = {displayName: string};
 
 module Bar = {
-  let createElement c::c=? children => {displayName: "test"};
+  let createElement c::c=? ::children () => {displayName: "test"};
 };
 
 module Nesting = {
-  let createElement children => {displayName: "test"};
+  let createElement ::children () => {displayName: "test"};
 };
 
 module Much = {
-  let createElement children => {displayName: "test"};
+  let createElement ::children () => {displayName: "test"};
 };
 
 module Foo = {
-    let createElement a::a=? b::b=? children => {displayName: "test"};
+    let createElement a::a=? b::b=? ::children () => {displayName: "test"};
 };
 
 module One = {
-    let createElement test::test=? foo::foo=? children => {displayName: "test"};
-    let createElementobvioustypo test::test children => {displayName: "test"};
+    let createElement test::test=? foo::foo=? ::children () => {displayName: "test"};
+    let createElementobvioustypo test::test ::children () => {displayName: "test"};
 };
 
 module Two = {
-    let createElement foo::foo=? children => {displayName: "test"};
+    let createElement foo::foo=? ::children () => {displayName: "test"};
 };
 
 module Sibling = {
-    let createElement foo::foo=? (children: list component) => {displayName: "test"};
+    let createElement foo::foo=? children::(children: list component) () => {displayName: "test"};
 };
 
 module Test = {
-    let createElement yo::yo=? children => {displayName: "test"};
+    let createElement yo::yo=? ::children () => {displayName: "test"};
 };
 
 module So = {
-    let createElement children => {displayName: "test"};
+    let createElement ::children () => {displayName: "test"};
 };
 
 module Foo2 = {
-    let createElement children => {displayName: "test"};
+    let createElement ::children () => {displayName: "test"};
 };
 
 module Text = {
-    let createElement children => {displayName: "test"};
+    let createElement ::children () => {displayName: "test"};
 };
 
 module Exp = {
-    let createElement children => {displayName: "test"};
+    let createElement ::children () => {displayName: "test"};
 };
 
 module Pun = {
-    let createElement intended::intended=? children => {displayName: "test"};
+    let createElement intended::intended=? ::children () => {displayName: "test"};
 };
 
 module Namespace = {
     module Foo = {
-        let createElement intended::intended=? anotherOptional::x=100 children => {displayName: "test"};
+        let createElement intended::intended=? anotherOptional::x=100 ::children () => {displayName: "test"};
     };
 };
 
 module Optional1 = {
-    let createElement ::required children => {
+    let createElement ::required ::children () => {
         switch required {
             | Some a => {displayName: a}
             | None => {displayName: "nope"}
@@ -69,7 +69,7 @@ module Optional1 = {
 };
 
 module Optional2 = {
-    let createElement ::optional=? children => {
+    let createElement ::optional=? ::children () => {
         switch optional {
             | Some a => {displayName: a}
             | None => {displayName: "nope"}
@@ -78,7 +78,7 @@ module Optional2 = {
 };
 
 module DefaultArg = {
-    let createElement ::default=(Some "foo") children => {
+    let createElement ::default=(Some "foo") ::children () => {
          switch default {
             | Some a => {displayName: a}
             | None => {displayName: "nope"}
@@ -88,23 +88,23 @@ module DefaultArg = {
 
 
 module LotsOfArguments = {
-    let createElement argument1::argument1=? argument2::argument2=? argument3::argument3=? argument4::argument4=? argument5::argument5=? argument6::argument6=? children => {displayName: "test"};
+    let createElement argument1::argument1=? argument2::argument2=? argument3::argument3=? argument4::argument4=? argument5::argument5=? argument6::argument6=? ::children () => {displayName: "test"};
 };
 
-let div argument1::argument1=? children => {
+let div argument1::argument1=? ::children () => {
     displayName: "test"
 };
 
 module List1 = {
-    let createElement children => {displayName: "test"};
+    let createElement ::children () => {displayName: "test"};
 };
 
 module List2 = {
-    let createElement children => {displayName: "test"};
+    let createElement ::children () => {displayName: "test"};
 };
 
 module List3 = {
-    let createElement children => {displayName: "test"};
+    let createElement ::children () => {displayName: "test"};
 };
 
 module NotReallyJSX = {
@@ -118,6 +118,8 @@ let notReallyJSX ::foo ::bar children => {
 let fakeRender (el:component) => {
     el.displayName
 };
+
+/* end of setup */
 
 let (/><) a b => a + b;
 let (><) a b => a + b;
@@ -182,7 +184,7 @@ let a = <Foo a=a>5</Foo>;
 let a = <Foo a=b>5</Foo>;
 let a = <Foo a=b b=d>5</Foo>;
 let a = <Foo a>0.55</Foo>;
-let a = Foo.createElement "" [@JSX];
+let a = Foo.createElement children::[] () [@JSX];
 let ident = <Foo>{a}</Foo>;
 let fragment1 = <> <Foo /> <Foo /> </>;
 let fragment2 = <> <Foo /> <Foo /> </>;
@@ -207,8 +209,8 @@ let listOfItems3 = <List3>fragment11 fragment11</List3>;
  * Several sequential simple jsx expressions must be separated with a space.
  */
 let thisIsRight a b => ();
-let tagOne = fun children => ();
-let tagTwo = fun children => ();
+let tagOne = fun ::children () => ();
+let tagTwo = fun ::children () => ();
 /* thisIsWrong <tagOne /><tagTwo />; */
 thisIsRight <tagOne /> <tagTwo />;
 
@@ -216,8 +218,8 @@ thisIsRight <tagOne /> <tagTwo />;
 thisIsRight <tagOne> </tagOne> <tagTwo> </tagTwo>;
 
 
-let a = fun children => ();
-let b = fun children => ();
+let a = fun ::children () => ();
+let b = fun ::children () => ();
 
 let thisIsOkay =
   <List1>
@@ -271,18 +273,18 @@ let sameButWithSpaces = [<Foo />, <Bar />, ...sameButWithSpaces];
 type thisType = [`Foo  | `Bar];
 type t 'a = [< thisType ] as 'a;
 
-let asd = (One.createElement test::true foo::2 ["a", "b"]) [@JSX] [@foo];
-let asd2 = (One.createElementobvioustypo test::false ["a", "b"]) [@JSX] [@foo];
+let asd = (One.createElement test::true foo::2 children::["a", "b"] ()) [@JSX] [@foo];
+let asd2 = (One.createElementobvioustypo test::false children::["a", "b"] ()) [@JSX] [@foo];
 
-let span test::(test : bool) foo::(foo : int) children => 1;
-let asd = span test::true foo::2 ["a", "b"] [@JSX] [@foo];
+let span test::(test : bool) foo::(foo : int) ::children () => 1;
+let asd = span test::true foo::2 children::["a", "b"] ()[@JSX] [@foo];
 /* "video" call doesn't end with a list, so the expression isn't converted to JSX */
 let video test::(test : bool) children => children;
 let asd2 = video test::false 10 [@JSX] [@foo];
 
 
-let div children => 1;
-(((fun () => div) ()) [])[@JSX];
+let div ::children => 1;
+(((fun () => div) ()) children::[])[@JSX];
 
 let myFun () => {
   <>

--- a/miscTests/jsxPpxTest.sh
+++ b/miscTests/jsxPpxTest.sh
@@ -20,8 +20,7 @@ do
   else
     echo "Wrong"
     # show the error
-    # diff -u $testPath/expected$i.txt $testPath/actual$i.txt
-    icdiff $testPath/expected$i.txt $testPath/actual$i.txt
+    diff -u $testPath/expected$i.txt $testPath/actual$i.txt
     exit 1
   fi
 done

--- a/miscTests/jsxPpxTest.sh
+++ b/miscTests/jsxPpxTest.sh
@@ -2,7 +2,7 @@ echo "Testing reactjs @JSX ppx..."
 
 testPath="miscTests/reactjs_jsx_ppx_tests"
 
-for i in 1 2 3 4 5 6
+for i in 1 2 3 4 5
 do
   test="$testPath/test$i.re"
 
@@ -20,7 +20,8 @@ do
   else
     echo "Wrong"
     # show the error
-    diff -u $testPath/expected$i.txt $testPath/actual$i.txt
+    # diff -u $testPath/expected$i.txt $testPath/actual$i.txt
+    icdiff $testPath/expected$i.txt $testPath/actual$i.txt
     exit 1
   fi
 done

--- a/miscTests/reactjs_jsx_ppx_tests/expected1.txt
+++ b/miscTests/reactjs_jsx_ppx_tests/expected1.txt
@@ -4,37 +4,32 @@ let div = { createElement = (fun ()  -> ()) }
 let _ = div.createElement ()
 module Gah = struct let createElement () = () end
 let _ = Gah.createElement ()
-let asd = ((Bar.createElement ~foo:1 ~bar:2 ["a"; "b"])[@jsxa ][@foo ])
-let asd = ((Bar.createElement ~foo:1 ~bar:2 ["a"; "b"] ())[@foo ])
-let _ = Baz.Beee.createElement ~baz:2 ["a"; "b"] ()
-let _ = Bar.createElement [foo] ()
-let _ = Bar.createElement ~foo:1 ~bar:2 [] ()
+let asd =
+  ((Bar.createElement ~foo:1 ~bar:2 ~children:["a"; "b"] ())[@jsxa ][@foo ])
+let asd = ((Bar.createElement ~foo:1 ~bar:2 ~children:["a"; "b"] ())[@foo ])
+let _ = Baz.Beee.createElement ~baz:2 ~children:["a"; "b"] ()
+let _ = Bar.createElement ()
+let _ = Bar.createElement ~foo:1 ~bar:2 ~children:[] ()
 let _ =
   Bar.createElement
-    ~foo:(Baz.createElement ~baz:(Baaz.createElement [] ()) [] ()) [] ()
-let _ = Div.createElement ~foo:1 ~bar:2 [] ()
+    ~foo:(Baz.createElement ~baz:(Baaz.createElement ~children:[] ())
+            ~children:[] ()) ~children:[] ()
+let _ =
+  ReactRe.createDOMElement "div"
+    (Js.Null.return ([%bs.obj { foo = 1; bar = 2 }])) [||]
+let _ = ReactRe.createDOMElement "div" Js.null [||]
 let _ =
   Bar.createElement
-    [Baz.Beee.createElement ~baz:2 ~kek:(Foo.createElement [] ()) ["a"; "b"]
-       ();
-    Bar.createElement [] ()] ()
+    ~children:[Baz.Beee.createElement ~baz:2
+                 ~kek:(Foo.createElement ~children:[] ())
+                 ~children:["a"; "b"] ();
+              Bar.createElement ~children:[] ()] ()
 let _ =
-  ReactRe.createDOMElement "bar"
-    (Js.Null.return
-       ([%bs.obj
-          {
-            foo = 1;
-            children =
-              (ReactRe.createDOMElement "baz"
-                 (Js.Null.return ([%bs.obj { qux = 2 }])) [||])
-          }])) [||]
+  ReactRe.createDOMElement "bar" (Js.Null.return ([%bs.obj { foo = 1 }]))
+    [|(ReactRe.createDOMElement "baz"
+         (Js.Null.return ([%bs.obj { qux = 2 }])) [||])|]
 let _ =
   ReactRe.createCompositeElement bar_
-    (Js.Null.return
-       ([%bs.obj
-          {
-            foo = 1;
-            children =
-              (ReactRe.createCompositeElement baz_
-                 (Js.Null.return ([%bs.obj { qux = 2 }])) [||])
-          }])) [||]
+    (Js.Null.return ([%bs.obj { foo = 1 }]))
+    [|(ReactRe.createCompositeElement baz_
+         (Js.Null.return ([%bs.obj { qux = 2 }])) [||])|]

--- a/miscTests/reactjs_jsx_ppx_tests/expected3.txt
+++ b/miscTests/reactjs_jsx_ppx_tests/expected3.txt
@@ -1,1 +1,3 @@
-let _ = Foo.createElement () ()
+Invalid_argument("JSX: the JSX attribute should be attached to a `YourModuleName.createElement` call. We saw `createElementLol` instead")
+File "miscTests/reactjs_jsx_ppx_tests/test3.re", line 1:
+Error: Error while running external preprocessor

--- a/miscTests/reactjs_jsx_ppx_tests/expected4.txt
+++ b/miscTests/reactjs_jsx_ppx_tests/expected4.txt
@@ -1,3 +1,3 @@
-Invalid_argument("JSX: the JSX attribute should be attached to a `YourModuleName.createElement` call. We saw `createElementLol` instead")
+Invalid_argument("JSX: `createElement` should be preceeded by a simple, direct module name.")
 File "miscTests/reactjs_jsx_ppx_tests/test4.re", line 1:
 Error: Error while running external preprocessor

--- a/miscTests/reactjs_jsx_ppx_tests/expected6.txt
+++ b/miscTests/reactjs_jsx_ppx_tests/expected6.txt
@@ -1,3 +1,0 @@
-Invalid_argument("JSX: `createElement` should be preceeded by a simple, direct module name.")
-File "miscTests/reactjs_jsx_ppx_tests/test6.re", line 1:
-Error: Error while running external preprocessor

--- a/miscTests/reactjs_jsx_ppx_tests/test1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test1.re
@@ -12,34 +12,37 @@ module Gah = {
 Gah.createElement ();
 
 /* don't transform */
-let asd = Bar.createElement foo::1 bar::2 ["a", "b"] [@jsxa] [@foo];
+let asd = Bar.createElement foo::1 bar::2 children::["a", "b"] () [@jsxa] [@foo];
 
 /* transform, keep [@foo] */
-let asd = Bar.createElement foo::1 bar::2 ["a", "b"] [@JSX] [@foo];
+let asd = Bar.createElement foo::1 bar::2 children::["a", "b"] () [@JSX] [@foo];
 
 /* nested modules */
-Baz.Beee.createElement baz::2 ["a", "b"] [@JSX];
+Baz.Beee.createElement baz::2 children::["a", "b"] () [@JSX];
 
 /* no prop */
-Bar.createElement [foo] [@JSX];
+Bar.createElement () [@JSX];
 
 /* empty children */
-Bar.createElement foo::1 bar::2 [] [@JSX];
+Bar.createElement foo::1 bar::2 children::[] () [@JSX];
 
 /* createElement nested in props */
-Bar.createElement foo::(Baz.createElement baz::(Baaz.createElement [] [@JSX]) [] [@JSX]) [] [@JSX];
+Bar.createElement foo::(Baz.createElement baz::(Baaz.createElement children::[] () [@JSX]) children::[] () [@JSX]) children::[] () [@JSX];
 
 /* dom elements */
-Div.createElement foo::1 bar::2 [] [@JSX];
+div foo::1 bar::2 children::[] () [@JSX];
+
+div () [@JSX];
 
 /* createElement nested in children */
 Bar.createElement
-[
-  Baz.Beee.createElement baz::2
-    kek::(Foo.createElement [] [@JSX]) ["a", "b"] [@JSX],
-  Bar.createElement [] [@JSX]
-]
-[@JSX];
+  children::[
+    Baz.Beee.createElement baz::2
+      kek::(Foo.createElement children::[] () [@JSX]) children::["a", "b"] () [@JSX],
+    Bar.createElement children::[] () [@JSX]
+  ]
+  ()
+  [@JSX];
 
-(bar foo::1 children::((baz qux::2 [])[@JSX]) [])[@JSX ];
-(bar_ foo::1 children::((baz_ qux::2 [])[@JSX]) [])[@JSX ];
+(bar foo::1 children::[(baz qux::2 children::[] ())[@JSX]] ())[@JSX ];
+(bar_ foo::1 children::[(baz_ qux::2 children::[] ())[@JSX]] ())[@JSX ];

--- a/miscTests/reactjs_jsx_ppx_tests/test3.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test3.re
@@ -1,3 +1,3 @@
 /* hello comments */
 
-       (Foo.createElement ())[@JSX]
+       (Foo.createElementLol ())[@JSX]

--- a/miscTests/reactjs_jsx_ppx_tests/test4.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test4.re
@@ -1,3 +1,4 @@
 /* hello comments */
 
-       (Foo.createElementLol ())[@JSX]
+        let div children => 1;
+        (((fun () => div) ()) [])[@JSX];

--- a/miscTests/reactjs_jsx_ppx_tests/test5.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test5.re
@@ -1,4 +1,4 @@
 /* hello comments */
 
         let div children => 1;
-        (((fun () => div) ()) [])[@JSX];
+        (((fun () => div)) [])[@JSX];

--- a/miscTests/reactjs_jsx_ppx_tests/test6.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test6.re
@@ -1,4 +1,0 @@
-/* hello comments */
-
-        let div children => 1;
-        (((fun () => div)) [])[@JSX];

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -346,6 +346,9 @@ let mkuplus name arg =
 let mkexp_cons consloc args loc =
   mkexp ~loc (Pexp_construct(mkloc (Lident "::") consloc, Some args))
 
+let mkexp_constructor_unit consloc loc =
+  mkexp ~loc (Pexp_construct(mkloc (Lident "()") consloc, None))
+
 let ghexp_cons consloc args loc =
   mkexp ~ghost:true ~loc (Pexp_construct(mkloc (Lident "::") loc, Some args))
 
@@ -798,7 +801,7 @@ let jsx_component module_name attrs children loc =
   let ident = mkloc lident loc in
   let body = mkexp(Pexp_apply(mkexp(Pexp_ident ident) ~loc, attrs @ children)) ~loc in
   let attribute = ({txt = "JSX"; loc = loc}, PStr []) in
-  { body with pexp_attributes = [attribute] @ body.pexp_attributes }
+  { body with pexp_attributes = attribute :: body.pexp_attributes }
 
 let ensureTagsAreEqual startTag endTag loc =
   if startTag <> endTag then
@@ -2648,7 +2651,10 @@ jsx:
   | jsx_start_tag_and_args SLASHGREATER {
     let (component, _) = $1 in
     let loc = mklocation $symbolstartpos $endpos in
-    component [("", mktailexp_extension loc [] None)] loc
+    component [
+      ("children", mktailexp_extension loc [] None);
+      ("", mkexp_constructor_unit loc loc)
+    ] loc
   }
   | jsx_start_tag_and_args GREATER simple_expr_list LESSSLASHIDENTGREATER {
     let (component, start) = $1 in
@@ -2657,7 +2663,10 @@ jsx:
     let endName = Longident.parse $4 in
     let _ = ensureTagsAreEqual start endName loc in
     let siblings = if List.length $3 > 0 then $3 else [] in
-    component [("", mktailexp_extension loc siblings None)] loc
+    component [
+      ("children", mktailexp_extension loc siblings None);
+      ("", mkexp_constructor_unit loc loc)
+    ] loc
   }
 ;
 
@@ -2670,7 +2679,10 @@ jsx_without_leading_less:
   | jsx_start_tag_and_args_without_leading_less SLASHGREATER {
     let (component, _) = $1 in
     let loc = mklocation $symbolstartpos $endpos in
-    component [("", mktailexp_extension loc [] None)] loc
+    component [
+      ("children", mktailexp_extension loc [] None);
+      ("", mkexp_constructor_unit loc loc)
+    ] loc
   }
   | jsx_start_tag_and_args_without_leading_less GREATER simple_expr_list LESSSLASHIDENTGREATER {
     let (component, start) = $1 in
@@ -2679,7 +2691,10 @@ jsx_without_leading_less:
     let endName = Longident.parse $4 in
     let _ = ensureTagsAreEqual start endName loc in
     let siblings = if List.length $3 > 0 then $3 else [] in
-    component [("", mktailexp_extension loc siblings None)] loc
+    component [
+      ("children", mktailexp_extension loc siblings None);
+      ("", mkexp_constructor_unit loc loc)
+    ] loc
   }
 ;
 

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -857,17 +857,18 @@ let default = new Pprintast.printer ()
 type funcReturnStyle =
   | ReturnValOnSameLine
 
-let rec detectJSXComponent e attributes l =
-  match (e, attributes) with
+let rec detectJSXComponent e attributes l = None
+  (* match (e, attributes) with
     | (Pexp_ident loc, ({txt = "JSX"; _}, PStr []) :: tail) ->
       let rec checkChildren arguments =
         match arguments with
-        | ("", {pexp_desc = Pexp_construct ({txt = Lident "::"}, _)}) :: []
-        | ("", {pexp_desc = Pexp_construct ({txt = Lident "[]"}, _)}) :: [] ->
-          true
-        | ("", _) :: [] -> false
-        | (label, _) :: tail -> checkChildren tail
         | [] -> false
+        | ("", _) :: rest -> false
+        | ("children", {pexp_desc = Pexp_construct ({txt = Lident "::"}, _)}) :: rest
+        | ("children", {pexp_desc = Pexp_construct ({txt = Lident "[]"}, _)}) :: rest ->
+          (* true *)
+          false
+        | (label, _) :: tail -> checkChildren tail
       in
       let moduleNameList = List.rev (List.tl (List.rev (Longident.flatten loc.txt))) in
       if List.length moduleNameList > 0 then
@@ -880,7 +881,7 @@ let rec detectJSXComponent e attributes l =
       else
         None
     | (Pexp_ident loc,  hd :: tail) -> detectJSXComponent e tail l
-    | _ -> None
+    | _ -> None *)
 
 let detectTernary l = match l with
   | [{
@@ -3069,25 +3070,24 @@ class printer  ()= object(self:'self)
          the tag, then it would be consistent with array spread:
          [...list] evaluates to the thing as list.
       *)
-      let rec isLabeledArgsAndFinalList arguments =
-        match arguments with
-        | ("", {pexp_desc = Pexp_construct ({txt = Lident "::"}, _)}) :: []
-        | ("", {pexp_desc = Pexp_construct ({txt = Lident "[]"}, _)}) :: [] -> true
-        (* Any other kind of non-named argument besides the above disqualifies *)
-        | ("", _) :: _ -> false
-        | (lbl, _)::tail -> isLabeledArgsAndFinalList tail
-        | [] -> false
+      let hasLabelledChildrenListLiteral = List.exists (function
+        | ("children", {pexp_desc = Pexp_construct ({txt = Lident "::" | Lident "[]"}, _)}) -> true
+        | _ -> false
+      ) l in
+      let rec hasSingleNonLabelledUnitAndIsAtTheEnd l = match l with
+      | [] -> false
+      | ("", {pexp_desc = Pexp_construct ({txt = Lident "()"}, _)}) :: [] -> true
+      | ("", _) :: rest -> false
+      | _ :: rest -> hasSingleNonLabelledUnitAndIsAtTheEnd rest
       in
-      let moduleNameList = List.rev (List.tl (List.rev (Longident.flatten loc.txt))) in
-      if List.length moduleNameList > 0 then
-        if Longident.last loc.txt = "createElement" && isLabeledArgsAndFinalList l then
-          Some (self#formatJSXComponent (String.concat "." moduleNameList) l)
-        else
-          None
-      else if isLabeledArgsAndFinalList l then
-        Some (self#formatJSXComponent (Longident.last loc.txt) l)
-      else
-        None
+      if hasLabelledChildrenListLiteral && hasSingleNonLabelledUnitAndIsAtTheEnd l then
+        let moduleNameList = List.rev (List.tl (List.rev (Longident.flatten loc.txt))) in
+        if List.length moduleNameList > 0 then
+          if Longident.last loc.txt = "createElement" then
+            Some (self#formatJSXComponent (String.concat "." moduleNameList) l)
+          else None
+        else Some (self#formatJSXComponent (Longident.last loc.txt) l)
+      else None
     )
     | (Pexp_apply (eFun, ls), [], []) -> (
       match (printedStringAndFixityExpr eFun, ls) with
@@ -3578,10 +3578,12 @@ class printer  ()= object(self:'self)
   method formatJSXComponent componentName args =
     let rec processArguments arguments processedAttrs children =
       match arguments with
-      | ("", {pexp_desc = Pexp_construct (_, None)}) :: tail ->
+      | ("children", {pexp_desc = Pexp_construct (_, None)}) :: tail ->
         processArguments tail processedAttrs None
-      | ("", {pexp_desc = Pexp_construct ({txt = Lident"::"}, Some {pexp_desc = Pexp_tuple(components)} )}) :: tail ->
+      | ("children", {pexp_desc = Pexp_construct ({txt = Lident"::"}, Some {pexp_desc = Pexp_tuple(components)} )}) :: tail ->
         processArguments tail processedAttrs (self#formatChildren components [])
+      | [] -> (processedAttrs, children)
+      | ("", expression) :: [] -> (processedAttrs, children)
       | (lbl, expression) :: tail ->
          let nextAttr =
            match expression.pexp_desc with
@@ -3596,7 +3598,6 @@ class printer  ()= object(self:'self)
                 )
          in
          processArguments tail (nextAttr :: processedAttrs) children
-      | [] -> (processedAttrs, children)
     in
     let (reversedAttributes, children) = processArguments args [] None in
     match children with


### PR DESCRIPTION
This changes the JSX to desugar to children being just another labeled argument (motivation hidden for now =P). Since we can't use it to finish applying a function, we add a unit at the end.

This is #917 but at the syntax level. We don't really need to have it at the ppx level.