### PR TITLE
[docs] Fix old NeoBundle instruction.

### DIFF
--- a/docs/tools.html
+++ b/docs/tools.html
@@ -162,7 +162,7 @@ from wherever `refmt` / `ocamlmerlin` live on the `PATH`. Install it like you wo
 
 ```
 " If using NeoBundle(recommended)
-NeoBundle 'jordwalke/vim-reason-loader'
+NeoBundle 'reasonml/vim-reason-loader'
 ```
 
 `vim-reason-loader` loads the *real*


### PR DESCRIPTION
From `jordwalke` to `reasonml`.