### PR TITLE
Record field type punning

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -341,6 +341,20 @@ let meNextYear =  {
 };
 ```
 
+When the name of a field coincides with the type of a record field in a record definition, Reason provides a handy syntactic shortcut. For example, the field name `horsePower` binds the `type horsePower` to its name.
+This is called field type punning.
+
+```reason
+type horsePower = {power: int, metric: bool};
+
+type car = {name: string, horsePower};
+
+/**
+  Equivalent to:
+  type car = {name: string, horsePower: horsePower};
+*/
+```
+
 ##### Mutable record fields.
 
 When defining the record type, you can mark some record fields as `mutable`.

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -644,6 +644,23 @@ let anotherRecord = {
   age: testRecord.age + 10
 };
 
+/* Record type punning */
+type props = {title: string};
+
+type state = unit;
+
+type component = {props};
+
+type component2 = {props, state, updater: unit};
+
+type mutableComponent = {mutable props};
+
+type mutabeleComponent2 = {
+  mutable props,
+  mutable state,
+  style: int
+};
+
 /* Requested in #566 */
 let break_after_equal =
   no_break_from_here (some_call to_here);

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -661,6 +661,12 @@ type mutabeleComponent2 = {
   style: int
 };
 
+/* Don't pun parameterized types */
+type description 'props = {
+  element: string,
+  tag: tag 'props
+};
+
 /* Requested in #566 */
 let break_after_equal =
   no_break_from_here (some_call to_here);

--- a/formatTest/unit_tests/input/basicStructures.re
+++ b/formatTest/unit_tests/input/basicStructures.re
@@ -533,5 +533,18 @@ let anotherRecord = {
   age: testRecord.age + 10
 };
 
+/* Record type punning */
+type props = {title: string};
+
+type state = unit;
+
+type component = {props};
+
+type component2 = {props, state, updater: unit,};
+
+type mutableComponent = {mutable props};
+
+type mutabeleComponent2 = {mutable props, mutable state, style: int,};
+
 /* Requested in #566 */
 let break_after_equal = no_break_from_here (some_call to_here);

--- a/formatTest/unit_tests/input/basicStructures.re
+++ b/formatTest/unit_tests/input/basicStructures.re
@@ -546,5 +546,11 @@ type mutableComponent = {mutable props};
 
 type mutabeleComponent2 = {mutable props, mutable state, style: int,};
 
+/* Don't pun parameterized types */
+type description 'props = {
+  element: string,
+  tag: tag 'props
+};
+
 /* Requested in #566 */
 let break_after_equal = no_break_from_here (some_call to_here);

--- a/src/reason_parser.messages
+++ b/src/reason_parser.messages
@@ -11965,6 +11965,7 @@ implementation: TYPE LIDENT EQUAL LBRACE LIDENT WITH
 ##
 ## Ends in an error in state: 2528.
 ##
+## label_declaration -> mutable_flag LIDENT attributes . [ RBRACE COMMA ]
 ## label_declaration -> mutable_flag LIDENT attributes . COLON poly_type attributes [ RBRACE COMMA ]
 ##
 ## The known suffix of the stack is as follows:
@@ -11984,6 +11985,7 @@ implementation: TYPE LIDENT EQUAL LBRACE MUTABLE LET
 ##
 ## Ends in an error in state: 160.
 ##
+## label_declaration -> mutable_flag . LIDENT attributes [ RBRACE COMMA ]
 ## label_declaration -> mutable_flag . LIDENT attributes COLON poly_type attributes [ RBRACE COMMA ]
 ##
 ## The known suffix of the stack is as follows:

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -233,6 +233,18 @@ let mkctf ?(loc=dummy_loc()) ?(ghost=false) d =
     let loc = set_loc_state ghost loc in
     Ctf.mk ~loc d
 
+(**
+  Make a core_type from a as_loc(LIDENT).
+  Useful for record type punning.
+  type props = {width: int, height: int};
+  type state = {nbrOfClicks: int};
+  type component = {props, state};
+*)
+let mkct lbl =
+  let lident = Lident lbl.txt in
+  let ttype = Ptyp_constr({txt = lident; loc = lbl.loc}, []) in
+  {ptyp_desc = ttype; ptyp_loc = lbl.loc; ptyp_attributes = []}
+
 let mkcf ?(loc=dummy_loc()) ?(ghost=false) d =
     let loc = set_loc_state ghost loc in
     Cf.mk ~loc d
@@ -3942,7 +3954,13 @@ label_declarations:
 ;
 
 label_declaration:
-    mutable_flag as_loc(LIDENT) attributes COLON poly_type attributes
+    mutable_flag as_loc(LIDENT) attributes
+      {
+       let loc = mklocation $symbolstartpos $endpos in
+       let ct = mkct $2 in
+       (Type.field $2 ct ~mut:$1 ~loc, $3)
+      }
+  |  mutable_flag as_loc(LIDENT) attributes COLON poly_type attributes
       {
        let loc = mklocation $symbolstartpos $endpos in
        (Type.field $2 $5 ~mut:$1 ~attrs:$6 ~loc, $3)

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2287,8 +2287,11 @@ let pun_labelled_pattern e lbl =
 let recordRowIsPunned pld =
       let name = pld.pld_name.txt in
       (match pld.pld_type with
-        | { ptyp_desc = (Ptyp_constr ({ txt; _ }, _)); _}
-            when (Longident.last txt = name) -> true
+        | { ptyp_desc = (Ptyp_constr ({ txt; _ }, args)); _}
+            when 
+            (Longident.last txt = name 
+              (* don't pun parameterized types, e.g. {tag: tag 'props} *)
+              && (List.length args) == 0) -> true
         | _ -> false)
 
 class printer  ()= object(self:'self)


### PR DESCRIPTION
PR for https://github.com/facebook/reason/issues/865

This implements field type punning for record type definition.
```rust
type props = {message: string};

type state = {degrees: float};

type component = {props, state};
```
Also did update the docs to inform future developers.