### PR TITLE
Deprecating single hyphen refmt args

### DIFF
--- a/docs/highlightJs/src/languages/less.js
+++ b/docs/highlightJs/src/languages/less.js
@@ -85,7 +85,7 @@ function(hljs) {
     variants: [
       // using more strict pattern for higher relevance to increase chances of Less detection.
       // this is *the only* Less specific statement used in most of the sources, so...
-      // (we’ll still often loose to the css-parser unless there's '//' comment,
+      // (we’ll still often lose to the css-parser unless there's '//' comment,
       // simply because 1 variable just can't beat 99 properties :)
       {begin: '@' + IDENT_RE + '\\s*:', relevance: 15},
       {begin: '@' + IDENT_RE}

--- a/docs/tools.html
+++ b/docs/tools.html
@@ -65,10 +65,10 @@ when upgrading their source code to include new syntax features, and others
 will want to run it after every new line of code directly from their editor.
 
 ####Options
-You can specify which syntax to parse, and which to print via `-parse` and
-`-print` flags. For example, you can convert your `ocaml` project to `Reason`
-by processing each file with the command `refmt -parse ml -print
-re yourFile.ml`. Execute `refmt -help` for more options.
+You can specify which syntax to parse, and which to print via `--parse` and
+`--print` flags. For example, you can convert your `ocaml` project to `Reason`
+by processing each file with the command `refmt --parse ml --print
+re yourFile.ml`. Execute `refmt --help` for more options.
 
 
 
@@ -148,7 +148,7 @@ B relative/path/to/your/build/artifacts/dir/
 > - `refmt` will wrap your lines at the width you have configured in your
 > plugin settings. To change these, open the Package Settings (`Packages > Settings View > Manage Packages`)
 > and click on `nuclide`; scroll to the `Nuclide-ocaml` section add add
-> "-print-width yourWidthNumber" to "Additional flags to pass to refmt".
+> "--print-width yourWidthNumber" to "Additional flags to pass to refmt".
 
 
 <img style="width:100%; max-width:470px; max-height:440px" src="images/Autocomplete.png" />
@@ -209,7 +209,7 @@ know if `C (1, 2)` in OCaml should be translated to `C (1, 2)` or `C 1 2` in Rea
 By default, we will convert it to `C 1 2 [@implicit_arity]`, which tells the compiler
 this can be either `C 1 2` or `C (1, 2)`.
 
-To prevent `[@implicit_arity]` from being generated, one can supply `-assume-explicit-arity`
+To prevent `[@implicit_arity]` from being generated, one can supply `--assume-explicit-arity`
 to `refmt`. This forces the formatter to generate `C 1 2` instead of `C 1 2 [@implicit_arity]`.
 
 However, since `C 1 2` requires multiple arugments, it may fail the compilation if it is actually
@@ -219,7 +219,7 @@ as argument so that they will be converted correctly (e.g., `Some (1, 2)` will b
 to `Some (1, 2)` instead of `Some 1 2`, which doesn't compile).
 
 To provide your own exception list, create a line-separated file that contains all constructors (without module prefix)
-in your project that expects a single tuple as argument, and use `-heuristics-file <filename>`
+in your project that expects a single tuple as argument, and use `--heuristics-file <filename>`
 to tell `refmt` that all constructors
 listed in the file will be treated as constructor with a single tuple as argument:
 
@@ -251,9 +251,9 @@ let c = Some (1, 2)
 Then only the constructor identifiers that were listed will be assumed to accept tuples instead of multiple arguments.
 
 ```sh
-> refmt -heuristics-file \
-    ./heuristics.txt -assume-explicit-arity \
-    -parse ml -print re test.ml
+> refmt --heuristics-file \
+    ./heuristics.txt --assume-explicit-arity \
+    --parse ml --print re test.ml
 ```
 
 

--- a/editorSupport/VimReason/README.md
+++ b/editorSupport/VimReason/README.md
@@ -92,20 +92,20 @@ are actually modified (so that undo/redo take you to the position where
 formatting actually effected the file).
 
 You can set `g:vimreason_extra_args_expr_reason` to control the arguments
-passed to `refmt` (such as `-print-width`). The contents of
+passed to `refmt` (such as `--print-width`). The contents of
 `g:vimreason_extra_args_expr_reason` is a string that contains a `VimScript`
 expression. This allows you do dynamically determine the formatting arguments
 based on things like your window width.
 
 ```vim
 " Always wrap at 90 columns
-let g:vimreason_extra_args_expr_reason = '"-print-width 90"'
+let g:vimreason_extra_args_expr_reason = '"--print-width 90"'
 
 " Wrap at the window width
-let g:vimreason_extra_args_expr_reason = '"-print-width " . ' .  "winwidth('.')"
+let g:vimreason_extra_args_expr_reason = '"--print-width " . ' .  "winwidth('.')"
 
 " Wrap at the window width but not if it exceeds 120 characters.
-let g:vimreason_extra_args_expr_reason = '"-print-width " . ' .  "min([120, winwidth('.')])"
+let g:vimreason_extra_args_expr_reason = '"--print-width " . ' .  "min([120, winwidth('.')])"
 ```
 
 Key Mappings:
@@ -195,5 +195,3 @@ if executable('refmt')
   let g:syntastic_reason_checkers=['merlin']
 endif
 ```
-
-

--- a/editorSupport/VimReason/plugin/reason.vim
+++ b/editorSupport/VimReason/plugin/reason.vim
@@ -23,7 +23,7 @@ endif
 " From auto-format plugin:
 " https://github.com/Chiel92/vim-autoformat/blob/master/plugin/autoformat.vim
 let g:vimreason_reason = "refmt"
-let g:vimreason_args_expr_reason = '"-use-stdin true -print re -is-interface-pp " .  (match(expand("%"), "\\.rei$") == -1 ? "false " : "true ")  . expand("%")'
+let g:vimreason_args_expr_reason = '"--use-stdin true --print re --interface " .  (match(expand("%"), "\\.rei$") == -1 ? "false " : "true ")  . expand("%")'
 
 function! Strip(input_string)
   return substitute(a:input_string, '\s*$', '\1', '')

--- a/editorSupport/emacs/refmt.el
+++ b/editorSupport/emacs/refmt.el
@@ -175,9 +175,9 @@ function."
           (width-args
            (cond
             ((equal refmt-width-mode 'window)
-             (list "-print-width" (number-to-string (window-body-width))))
+             (list "--print-width" (number-to-string (window-body-width))))
             ((equal refmt-width-mode 'fill)
-             (list "-print-width" (number-to-string fill-column)))
+             (list "--print-width" (number-to-string fill-column)))
             (t
              '()))))
      (unwind-protect
@@ -192,7 +192,7 @@ function."
              (erase-buffer))
            (if (zerop (apply 'call-process
                              refmt-command nil (list (list :file outputfile) errorfile)
-                             nil (append width-args (list "-parse" "re" "-print" "re" bufferfile))))
+                             nil (append width-args (list "--parse" "re" "--print" "re" bufferfile))))
                (progn
                  (call-process-region (point-min) (point-max) "diff" nil patchbuf nil "-n" "-"
                                       outputfile)

--- a/editorSupport/sublime-reason/Reason.py
+++ b/editorSupport/sublime-reason/Reason.py
@@ -28,9 +28,9 @@ def reason_command_line(file_name):
 
     return [
         refmt,
-        '-use-stdin', 'true',
-        '-parse', 're',
-        '-is-interface-pp', is_interface(file_name),
+        '--use-stdin', 'true',
+        '--parse', 're',
+        '--interface', is_interface(file_name),
         file_name
     ]
 
@@ -42,8 +42,8 @@ class ReasonFormatCommand(sublime_plugin.TextCommand):
 
         try:
             proc = Popen(reason_command_line(file_name) + [
-                '-print', 're',
-                '-print-width', max_width,
+                '--print', 're',
+                '--print-width', max_width,
             ], stdin=PIPE, stdout=PIPE, stderr=PIPE)
         except FileNotFoundError:
             error = 'Can\'t find `%s` ($PATH=%s).\n\n' \
@@ -89,5 +89,4 @@ class Reason(Linter):
     line_col_base = (1, 0)
 
     def cmd(self):
-        return reason_command_line(self.view.file_name()) + ['-print', 'none']
-
+        return reason_command_line(self.view.file_name()) + ['--print', 'none']

--- a/formatTest/test.sh
+++ b/formatTest/test.sh
@@ -86,33 +86,33 @@ function stdin_test() {
     FILEEXT="${FILENAME##*.}"
 
     if [[ $FILEEXT = "re" ]]; then
-      cat $INPUT_FILE | $REFMT -is-interface-pp false -print-width 50 -parse re -print re -use-stdin true 2>&1 > $OUTPUT_FILE
+      cat $INPUT_FILE | $REFMT --interface false --print-width 50 --parse re --print re --use-stdin true 2>&1 > $OUTPUT_FILE
     elif [[ $FILEEXT = "rei" ]]; then
-      cat $INPUT_FILE | $REFMT -is-interface-pp true -print-width 50 -parse re -print re -use-stdin true 2>&1 > $OUTPUT_FILE
+      cat $INPUT_FILE | $REFMT --interface true --print-width 50 --parse re --print re --use-stdin true 2>&1 > $OUTPUT_FILE
     elif [[ $FILEEXT = "ml" ]]; then
-      cat $INPUT_FILE | $REFMT -heuristics-file $HEURISTICS_FILE -is-interface-pp false -print-width 50 -parse ml -print re -use-stdin true 2>&1 > $OUTPUT_FILE
+      cat $INPUT_FILE | $REFMT --heuristics-file $HEURISTICS_FILE --interface false --print-width 50 --parse ml --print re --use-stdin true 2>&1 > $OUTPUT_FILE
     elif [[ $FILEEXT = "mli" ]]; then
-      cat $INPUT_FILE | $REFMT -heuristics-file $HEURISTICS_FILE -is-interface-pp true -print-width 50 -parse ml -print re -use-stdin true 2>&1 > $OUTPUT_FILE
+      cat $INPUT_FILE | $REFMT --heuristics-file $HEURISTICS_FILE --interface true --print-width 50 --parse ml --print re --use-stdin true 2>&1 > $OUTPUT_FILE
     else
-      warning "  ⊘ FAILED -use-stdin \n"
+      warning "  ⊘ FAILED --use-stdin \n"
       info "  Cannot determine default implementation parser for extension ${FILEEXT}"
       return 1
     fi
 
     if ! [[ $? -eq 0 ]]; then
-        warning "  ⊘ FAILED -use-stdin \n"
-        info "  There was an error when testing -use-stdin"
+        warning "  ⊘ FAILED --use-stdin \n"
+        info "  There was an error when testing --use-stdin"
         info "  for input file $INPUT_FILE"
         info "  and output file $OUTPUT_FILE${RESET}"
         echo ""
         return 1
     fi
 
-    debug "  Comparing -use-stdin results:  diff $OUTPUT_FILE $EXPECTED_OUTPUT_FILE"
+    debug "  Comparing --use-stdin results:  diff $OUTPUT_FILE $EXPECTED_OUTPUT_FILE"
     diff --unchanged-line-format="" --new-line-format=":%dn: %L" --old-line-format=":%dn: %L" $OUTPUT_FILE $EXPECTED_OUTPUT_FILE
 
     if ! [[ $? -eq 0 ]]; then
-        warning "  ⊘ FAILED -use-stdin \n"
+        warning "  ⊘ FAILED --use-stdin \n"
         info "  ${INFO}$OUTPUT_FILE${RESET}"
         info "  doesn't match expected output"
         info "  ${INFO}$EXPECTED_OUTPUT_FILE${RESET}"
@@ -138,16 +138,16 @@ function unit_test() {
         else
           REFILE="$(basename $FILE .mli).rei"
         fi
-        debug "$REFMT -heuristics-file $INPUT/arity.txt -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE"
-        $REFMT -heuristics-file $INPUT/arity.txt -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE
+        debug "$REFMT --heuristics-file $INPUT/arity.txt --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE"
+        $REFMT --heuristics-file $INPUT/arity.txt --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE
         if ! [[ $? -eq 0 ]]; then
             warning "  ⊘ TEST FAILED CONVERTING ML TO RE\n"
             return 1
         fi
         FILE=$REFILE
     else
-      debug "  '$REFMT -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE'"
-      $REFMT -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE
+      debug "  '$REFMT --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE'"
+      $REFMT --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE
     fi
 
     debug "  Comparing results:  diff $OUTPUT/$FILE $EXPECTED_OUTPUT/$FILE"
@@ -163,7 +163,7 @@ function unit_test() {
         return 1
     fi
 
-    debug "Testing -use-stdin"
+    debug "Testing --use-stdin"
     stdin_test $INPUT/$1 $OUTPUT/$FILE $EXPECTED_OUTPUT/$FILE $INPUT/arity.txt
 
     if ! [[ $? -eq 0 ]]; then
@@ -191,21 +191,21 @@ function idempotent_test() {
         fi
         debug "  Converting $FILE to $REFILE:"
 
-        debug "  Formatting Once: $REFMT -heuristics-file $INPUT/arity.txt -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE"
-        $REFMT -heuristics-file $INPUT/arity.txt -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE
+        debug "  Formatting Once: $REFMT --heuristics-file $INPUT/arity.txt --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE"
+        $REFMT --heuristics-file $INPUT/arity.txt --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE
         if ! [[ $? -eq 0 ]]; then
             warning "⊘ FAILED\n"
             return 1
         fi
         FILE=$REFILE
-        debug "  Generating output again: $REFMT -print-width 50 -print re $OUTPUT/$FILE 2>&1 > $OUTPUT/$FILE.formatted"
-        $REFMT -print-width 50 -print re $OUTPUT/$FILE 2>&1 > $OUTPUT/$FILE.formatted
+        debug "  Generating output again: $REFMT --print-width 50 --print re $OUTPUT/$FILE 2>&1 > $OUTPUT/$FILE.formatted"
+        $REFMT --print-width 50 --print re $OUTPUT/$FILE 2>&1 > $OUTPUT/$FILE.formatted
     else
-      debug "  Formatting Once: '$REFMT -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE'"
-      $REFMT -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE
+      debug "  Formatting Once: '$REFMT --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE'"
+      $REFMT --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE
 
-      debug "  Generating output again: $REFMT -print-width 50 -print re $OUTPUT/$FILE 2>&1 > $OUTPUT/$FILE.formatted"
-      $REFMT -print-width 50 -print re $OUTPUT/$FILE 2>&1 > $OUTPUT/$FILE.formatted
+      debug "  Generating output again: $REFMT --print-width 50 --print re $OUTPUT/$FILE 2>&1 > $OUTPUT/$FILE.formatted"
+      $REFMT --print-width 50 --print re $OUTPUT/$FILE 2>&1 > $OUTPUT/$FILE.formatted
     fi
 
     diff --unchanged-line-format="" --new-line-format=":%dn: %L" --old-line-format=":%dn: %L" $OUTPUT/$FILE $OUTPUT/$FILE.formatted
@@ -217,7 +217,7 @@ function idempotent_test() {
         return 1
     fi
 
-    debug "Testing -use-stdin"
+    debug "Testing --use-stdin"
     stdin_test $INPUT/$1 $OUTPUT/$FILE $OUTPUT/$FILE $INPUT/arity.txt
 
     if ! [[ $? -eq 0 ]]; then
@@ -246,16 +246,16 @@ function typecheck_test() {
           REFILE="$(basename $FILE .mli).rei"
         fi
         debug "  Converting $FILE to $REFILE:"
-        debug "$REFMT -heuristics-file $INPUT/arity.txt -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE"
-        $REFMT -heuristics-file $INPUT/arity.txt -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE
+        debug "$REFMT --heuristics-file $INPUT/arity.txt --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE"
+        $REFMT --heuristics-file $INPUT/arity.txt --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$REFILE
         if ! [[ $? -eq 0 ]]; then
             warning "  ⊘ FAILED\n"
             return 1
         fi
         FILE=$REFILE
     else
-        debug "  Formatting: $REFMT -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE"
-        $REFMT -print-width 50 -print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE
+        debug "  Formatting: $REFMT --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE"
+        $REFMT --print-width 50 --print re $INPUT/$FILE 2>&1 > $OUTPUT/$FILE
         if ! [[ $? -eq 0 ]]; then
             warning "  ⊘ FAILED\n"
             return 1
@@ -289,10 +289,10 @@ function error_test() {
       warning "  ⊘ FAILED: .ml files should not need to be run against error tests. \n"
       return 1
     else
-      debug "  '$REFMT -print-width 50 -print re $INPUT/$FILE &> $OUTPUT/$FILE'"
+      debug "  '$REFMT --print-width 50 --print re $INPUT/$FILE &> $OUTPUT/$FILE'"
       # ensure errors are not absolute filepaths
       cd $INPUT
-      $REFMT -print-width 50 -print re $(basename $FILE) &> $OUTPUT/$FILE
+      $REFMT --print-width 50 --print re $(basename $FILE) &> $OUTPUT/$FILE
       cd - > /dev/null
     fi
 

--- a/miscTests/jsxPpxTest.sh
+++ b/miscTests/jsxPpxTest.sh
@@ -11,7 +11,7 @@ do
 
   ocamlc -dsource -ppx ./reactjs_jsx_ppx.native -pp ./refmt_impl.native -impl $test \
     2>&1 | sed '$ d' | sed '$ d' | \
-    ./refmt_impl.native -use-stdin true -parse ml -print re -is-interface-pp false \
+    ./refmt_impl.native --use-stdin true --parse ml --print re --interface false \
     > $testPath/actual${i}.re
     # remove the last two lines. It's noise about command failure and changes at
     # every run because the temporary file name in the error message changes

--- a/src/refmt_merlin_impl.sh
+++ b/src/refmt_merlin_impl.sh
@@ -20,4 +20,4 @@ then
     exit 1
 fi
 
-$REFMT $@ -recoverable true -parse re
+$REFMT $@ --recoverable true --parse re

--- a/src/reup.sh
+++ b/src/reup.sh
@@ -130,14 +130,14 @@ cp -af $DIR $BACKUP_DIR
 
 find $DIR -type f -name "*.re" | while read file; do
     set -x
-    $OPAM_BIN/refmt-$VERSION -print binary_reason $file | $OPAM_BIN/refmt -print-width $PRINTWIDTH -use-stdin true -is-interface-pp false -parse binary_reason -print re > $file.new
+    $OPAM_BIN/refmt-$VERSION --print binary_reason $file | $OPAM_BIN/refmt --print-width $PRINTWIDTH --use-stdin true --interface false --parse binary_reason --print re > $file.new
     mv -f $file.new $file
     set +x
 done
 
 set -x
 find $DIR -type f -name "*.rei" | while read file; do
-    $OPAM_BIN/refmt-$VERSION -is-interface-pp true -print binary_reason $file | $OPAM_BIN/refmt -is-interface-pp true -print-width $PRINTWIDTH -use-stdin true -parse binary_reason -print re > $file.new
+    $OPAM_BIN/refmt-$VERSION --interface true --print binary_reason $file | $OPAM_BIN/refmt --interface true --print-width $PRINTWIDTH --use-stdin true --parse binary_reason --print re > $file.new
     mv -f $file.new $file
 done
 set +x

--- a/src/rtop.sh
+++ b/src/rtop.sh
@@ -29,7 +29,7 @@ let () =
 fi
 
 if [[ $@ =~ "stdin" ]]; then
-    refmt -parse re -print ml -use-stdin true -is-interface-pp false | utop $@
+    refmt --parse re --print ml --use-stdin true --is-interface-pp false | utop $@
 else
     utop -init $DIR/rtop_init.ml $@ -I $HOME -safe-string
 fi

--- a/upgradeSyntax.sh
+++ b/upgradeSyntax.sh
@@ -14,9 +14,9 @@ die () {
 
 find . | grep "\.re$" | xargs -0 node -e "\
 process.argv[1].split('\n').filter(function(n){return n;}).forEach(function(filePath) { \
-  var binary = require('child_process').execSync('$1 ' + filePath + ' -print binary_reason');
+  var binary = require('child_process').execSync('$1 ' + filePath + ' --print binary_reason');
   var reformatted = require('child_process').execSync(
-     '$2 -use-stdin true -is-interface-pp false -parse binary_reason -print re -print-width $3 | sed -e \'s/ *\$//g\'',
+     '$2 --use-stdin true --interface false --parse binary_reason --print re --print-width $3 | sed -e \'s/ *\$//g\'',
      {input: binary}
   );
   require('fs').writeFileSync(filePath, reformatted);
@@ -25,9 +25,9 @@ process.argv[1].split('\n').filter(function(n){return n;}).forEach(function(file
 
 find . | grep "\.rei$" | xargs -0 node -e "\
 process.argv[1].split('\n').filter(function(n){return n;}).forEach(function(filePath) { \
-  var binary = require('child_process').execSync('$1 ' + filePath + ' -print binary_reason');
+  var binary = require('child_process').execSync('$1 ' + filePath + ' --print binary_reason');
   var reformatted = require('child_process').execSync(
-    '$2 -use-stdin true -is-interface-pp true -parse binary_reason -print re -print-width $3 | sed -e \'s/ *\$//g\'',
+    '$2 --use-stdin true --interface true --parse binary_reason --print re --print-width $3 | sed -e \'s/ *\$//g\'',
     {input: binary}
   );
   require('fs').writeFileSync(filePath, reformatted);


### PR DESCRIPTION
This aligns `refmt` parameters with GNU's recommendations of two hyphens (`--`) for long-form parameters.  We also additionally support two short-form parameters, `-h` and `-i` for `--help` and `--interface`.

This also defaults `--interface` to false; the biggest change here is that piping stdin from the terminal now assumes that it is not an interface unless explicitly told so.  `refmt` would fail out in this situation before this PR.

I have left support in for the old flags but now log deprecation messages to stderr.  This might cause some regressions if people are piping stdout to a file and not handling stderr.