### PR TITLE
Deprecating explicit --use-stdin

### DIFF
--- a/editorSupport/VimReason/plugin/reason.vim
+++ b/editorSupport/VimReason/plugin/reason.vim
@@ -23,7 +23,7 @@ endif
 " From auto-format plugin:
 " https://github.com/Chiel92/vim-autoformat/blob/master/plugin/autoformat.vim
 let g:vimreason_reason = "refmt"
-let g:vimreason_args_expr_reason = '"--use-stdin true --print re --interface " .  (match(expand("%"), "\\.rei$") == -1 ? "false " : "true ")  . expand("%")'
+let g:vimreason_args_expr_reason = '"--print re --interface " .  (match(expand("%"), "\\.rei$") == -1 ? "false " : "true ") . " --parse " . expand("%:e")'
 
 function! Strip(input_string)
   return substitute(a:input_string, '\s*$', '\1', '')

--- a/editorSupport/sublime-reason/Reason.py
+++ b/editorSupport/sublime-reason/Reason.py
@@ -28,7 +28,6 @@ def reason_command_line(file_name):
 
     return [
         refmt,
-        '--use-stdin', 'true',
         '--parse', 're',
         '--interface', is_interface(file_name),
         file_name

--- a/formatTest/test.sh
+++ b/formatTest/test.sh
@@ -86,13 +86,13 @@ function stdin_test() {
     FILEEXT="${FILENAME##*.}"
 
     if [[ $FILEEXT = "re" ]]; then
-      cat $INPUT_FILE | $REFMT --interface false --print-width 50 --parse re --print re --use-stdin true 2>&1 > $OUTPUT_FILE
+      cat $INPUT_FILE | $REFMT --interface false --print-width 50 --parse re --print re 2>&1 > $OUTPUT_FILE
     elif [[ $FILEEXT = "rei" ]]; then
-      cat $INPUT_FILE | $REFMT --interface true --print-width 50 --parse re --print re --use-stdin true 2>&1 > $OUTPUT_FILE
+      cat $INPUT_FILE | $REFMT --interface true --print-width 50 --parse re --print re 2>&1 > $OUTPUT_FILE
     elif [[ $FILEEXT = "ml" ]]; then
-      cat $INPUT_FILE | $REFMT --heuristics-file $HEURISTICS_FILE --interface false --print-width 50 --parse ml --print re --use-stdin true 2>&1 > $OUTPUT_FILE
+      cat $INPUT_FILE | $REFMT --heuristics-file $HEURISTICS_FILE --interface false --print-width 50 --parse ml --print re 2>&1 > $OUTPUT_FILE
     elif [[ $FILEEXT = "mli" ]]; then
-      cat $INPUT_FILE | $REFMT --heuristics-file $HEURISTICS_FILE --interface true --print-width 50 --parse ml --print re --use-stdin true 2>&1 > $OUTPUT_FILE
+      cat $INPUT_FILE | $REFMT --heuristics-file $HEURISTICS_FILE --interface true --print-width 50 --parse ml --print re 2>&1 > $OUTPUT_FILE
     else
       warning "  ⊘ FAILED --use-stdin \n"
       info "  Cannot determine default implementation parser for extension ${FILEEXT}"

--- a/miscTests/jsxPpxTest.sh
+++ b/miscTests/jsxPpxTest.sh
@@ -11,7 +11,7 @@ do
 
   ocamlc -dsource -ppx ./reactjs_jsx_ppx.native -pp ./refmt_impl.native -impl $test \
     2>&1 | sed '$ d' | sed '$ d' | \
-    ./refmt_impl.native --use-stdin true --parse ml --print re --interface false \
+    ./refmt_impl.native --parse ml --print re --interface false \
     > $testPath/actual${i}.re
     # remove the last two lines. It's noise about command failure and changes at
     # every run because the temporary file name in the error message changes

--- a/src/refmt_impl.ml
+++ b/src/refmt_impl.ml
@@ -54,7 +54,7 @@ let usage = {|Reason: Meta Language Utility
 [Usage]: refmt [options] some-file.[re|ml|rei|mli]
 
    // translate ocaml to reason on stdin
-   echo 'let _ = ()' | refmt --print re --parse ml --use-stdin true
+   echo 'let _ = ()' | refmt --print re --parse ml
 
    // print the AST of a file
    refmt --parse re --print ast some-file.re
@@ -73,7 +73,6 @@ let () =
   let filename = ref "" in
   let prnt = ref None in
   let prse = ref None in
-  let use_stdin = ref false in
   let intf = ref None in
   let recoverable = ref false in
   let assumeExplicitArity = ref false in
@@ -85,8 +84,8 @@ let () =
     "--is-interface-pp", Arg.Bool (fun x -> prerr_endline "--is-interface-pp is deprecated; use -i or --interface instead"; intf := Some x), "";
     "--interface", Arg.Bool (fun x -> intf := Some x), "<interface>, -i <interface>; parse AST as an interface (either true or false; default false)";
     "-i", Arg.Bool (fun x -> intf := Some x), "<interface>, --interface <interface>; parse AST as an interface (either true or false; default false)";
-    "-use-stdin", Arg.Bool (fun x -> prerr_endline "-use-stdin is deprecated; use --use-stdin instead"; use_stdin := x), "";
-    "--use-stdin", Arg.Bool (fun x -> use_stdin := x), "<use_stdin>; parse AST from <use_stdin> (either true or false; default false). You still must provide a file name even if using stdin for errors to be reported";
+    "-use-stdin", Arg.Bool (fun x -> prerr_endline "-use-stdin is deprecated; usage is assumed if not specifying a filename"), "";
+    "--use-stdin", Arg.Bool (fun x -> prerr_endline "--use-stdin is deprecated; usage is assumed if not specifying a filename"), "";
     "-recoverable", Arg.Bool (fun x -> prerr_endline "-recoverable is deprecated; use --recoverable instead"; recoverable := x), "";
     "--recoverable", Arg.Bool (fun x -> recoverable := x), "<recoverable>; enable or disable recoverable parser (either true or false; default false)";
     "-assume-explicit-arity", Arg.Unit (fun () -> prerr_endline "-assume-explicit-arity is deprecated; use --assume-explicit-arity instead" ; assumeExplicitArity := true), "";
@@ -107,8 +106,8 @@ let () =
   let () = Arg.parse options (fun arg -> filename := arg) usage in
   let print_help = !print_help in
   let filename = !filename in
-  let use_stdin = !use_stdin in
-  let _ =
+  let use_stdin = (filename = "") in
+  let () =
     if (filename = "" && not use_stdin) || print_help then
       let () = Arg.usage options usage in
         exit 1;

--- a/src/reup.sh
+++ b/src/reup.sh
@@ -130,14 +130,14 @@ cp -af $DIR $BACKUP_DIR
 
 find $DIR -type f -name "*.re" | while read file; do
     set -x
-    $OPAM_BIN/refmt-$VERSION --print binary_reason $file | $OPAM_BIN/refmt --print-width $PRINTWIDTH --use-stdin true --interface false --parse binary_reason --print re > $file.new
+    $OPAM_BIN/refmt-$VERSION --print binary_reason $file | $OPAM_BIN/refmt --print-width $PRINTWIDTH --interface false --parse binary_reason --print re > $file.new
     mv -f $file.new $file
     set +x
 done
 
 set -x
 find $DIR -type f -name "*.rei" | while read file; do
-    $OPAM_BIN/refmt-$VERSION --interface true --print binary_reason $file | $OPAM_BIN/refmt --interface true --print-width $PRINTWIDTH --use-stdin true --parse binary_reason --print re > $file.new
+    $OPAM_BIN/refmt-$VERSION --interface true --print binary_reason $file | $OPAM_BIN/refmt --interface true --print-width $PRINTWIDTH --parse binary_reason --print re > $file.new
     mv -f $file.new $file
 done
 set +x

--- a/src/rtop.sh
+++ b/src/rtop.sh
@@ -29,7 +29,7 @@ let () =
 fi
 
 if [[ $@ =~ "stdin" ]]; then
-    refmt --parse re --print ml --use-stdin true --is-interface-pp false | utop $@
+    refmt --parse re --print ml --interface false | utop $@
 else
     utop -init $DIR/rtop_init.ml $@ -I $HOME -safe-string
 fi

--- a/upgradeSyntax.sh
+++ b/upgradeSyntax.sh
@@ -16,7 +16,7 @@ find . | grep "\.re$" | xargs -0 node -e "\
 process.argv[1].split('\n').filter(function(n){return n;}).forEach(function(filePath) { \
   var binary = require('child_process').execSync('$1 ' + filePath + ' --print binary_reason');
   var reformatted = require('child_process').execSync(
-     '$2 --use-stdin true --interface false --parse binary_reason --print re --print-width $3 | sed -e \'s/ *\$//g\'',
+     '$2 --interface false --parse binary_reason --print re --print-width $3 | sed -e \'s/ *\$//g\'',
      {input: binary}
   );
   require('fs').writeFileSync(filePath, reformatted);
@@ -27,7 +27,7 @@ find . | grep "\.rei$" | xargs -0 node -e "\
 process.argv[1].split('\n').filter(function(n){return n;}).forEach(function(filePath) { \
   var binary = require('child_process').execSync('$1 ' + filePath + ' --print binary_reason');
   var reformatted = require('child_process').execSync(
-    '$2 --use-stdin true --interface true --parse binary_reason --print re --print-width $3 | sed -e \'s/ *\$//g\'',
+    '$2 --interface true --parse binary_reason --print re --print-width $3 | sed -e \'s/ *\$//g\'',
     {input: binary}
   );
   require('fs').writeFileSync(filePath, reformatted);


### PR DESCRIPTION
This PR makes `refmt` behave more like other command line tools like `python`, `ocaml`, and others that can both take a pipe as stdin or specify a file on the command line.

In a situation where the user specifies both `--use-stdin` and a filename, such as`echo 'let _ = ()' | refmt --print re --use-stdin thisdoesntexist.ml`, `refmt` would try to infer the source type from the filename, making the `--parse` arg optional.

This PR changes the behavior to always prefer a filename if it is present, ignoring the piped stdin if it is present.  This also means that both `--print` and `--parse` are always required when using stdin.