### PR TITLE
Clarify Reason npm package is lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Reason: Build Systems Rapidly [![Build Status](https://travis-ci.org/facebook/re
 
 Install Via `npm`
 ----------------
-Installing `Reason` via `npm` is the easiest way to get started. (`npm` version > 3.0 is required - [install here](https://nodejs.org/en/download/current/)).
+Installing `Reason` via `npm` is the easiest way to get started. Like so: `npm install reason`. (`npm` version > 3.0 is required - [install here](https://nodejs.org/en/download/current/)).
 
 #### Reason Project
 


### PR DESCRIPTION
In the 'Install Via `npm` block Reason is referred to in a code block. Reading on it becomes clear the Reason project refers to Reason in a code block always, having nothing to do with the names of different Reason related things such as the npm package. Which is fine, even good I'd say. But without this knowledge seeing `Reason` everywhere and no mention of the package name had me guess it to be 'Reason' which is wrong and unfortunately results in a cryptic npm error: `npm ERR! Cannot read property 'path' of null`. Additionally, since these are code blocks I and I think many others honor the capitalization in them.

We can avoid letting the user guess and avoid possibly steering them in the wrong direction (by writing `Reason` in the block) by mentioning the package name. The project does the same in other places in the README where a name for something Reason related is required; I suggest we do the same for the npm block :].

I will also see if I can help improve this experience on the npm side ^_^ .