### PR TITLE
Fix #914.

### DIFF
--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -86,3 +86,5 @@ let d = {
     "a": fun arg1 arg2 => arg1 + arg2
   }
 };
+
+let a = {"/foo": 10};

--- a/formatTest/unit_tests/input/bucklescript.re
+++ b/formatTest/unit_tests/input/bucklescript.re
@@ -63,3 +63,5 @@ let b = {"nested": {"objs": {"are": {"nice": "<3"}}}};
 let c = {"a": a, "b": b, "func": fun a => a##c#=(func 10)};
 
 let d = {"a": a2, "b": b , "func": fun a => {"a": (fun arg1 arg2 => arg1 + arg2)}};
+
+let a = {"/foo": 10};

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -4656,13 +4656,13 @@ class printer  ()= object(self:'self)
 
   method unparseRecord ?withStringKeys:(withStringKeys=false) ?allowPunning:(allowPunning=true) l eo =
     let quote = (atom "\"") in
-    let maybeQuoteFirstElem l =
-      if withStringKeys then
-      (match l with
-      | fst::rest -> quote::fst::quote::rest
-      | _ -> l
-      )
-      else l
+    let maybeQuoteFirstElem fst rest =
+        if withStringKeys then (match fst.txt with
+          | Lident s -> quote::(atom s)::quote::rest
+          | Ldot _  | Lapply _ -> assert false
+          )
+        else
+          (self#longident_loc fst)::rest
     in
     let makeRow (li, e) appendComma shouldPun =
       let comma = atom "," in
@@ -4675,13 +4675,13 @@ class printer  ()= object(self:'self)
         match e.pexp_desc with
           (* Punning *)
           |  Pexp_ident {txt} when li.txt = txt && shouldPun && allowPunning ->
-              makeList (maybeQuoteFirstElem ((self#longident_loc li)::(if appendComma then [comma] else [])))
+              makeList (maybeQuoteFirstElem li (if appendComma then [comma] else []))
           | _ ->
              let (argsList, return) = self#curriedPatternsAndReturnVal e in (
                match (argsList, return.pexp_desc) with
                  | ([], _) ->
                    let appTerms = self#unparseExprApplicationItems e in
-                   let upToColon = makeList (maybeQuoteFirstElem [self#longident_loc li; atom ":"]) in
+                   let upToColon = makeList (maybeQuoteFirstElem li [atom ":"]) in
                    let labelExpr =
                      formatAttachmentApplication
                        applicationFinalWrapping
@@ -4692,7 +4692,7 @@ class printer  ()= object(self:'self)
                    else
                      labelExpr
                  | (firstArg::tl, _) ->
-                   let upToColon = makeList (maybeQuoteFirstElem [self#longident_loc li; atom ":"]) in
+                   let upToColon = makeList (maybeQuoteFirstElem li [atom ":"]) in
                    let returnedAppTerms = self#unparseExprApplicationItems return in
                    let labelExpr =
                        (self#wrapCurriedFunctionBinding ~attachTo:upToColon "fun" firstArg tl returnedAppTerms) in


### PR DESCRIPTION
This is a pretty simple fix.
I use the existent parameter `withStringKeys` to when to format the key
as an ident, or as a simple string.

For now we don't support `Ldot` and `Lapply` in the string keys. I'm not sure what the behavior should be in this case.

cc @chenglou 