### PR TITLE
Give a nicer error when using a wrong module name

### DIFF
--- a/src/reason_parser.messages
+++ b/src/reason_parser.messages
@@ -5996,7 +5996,7 @@ implementation: INCLUDE LBRACE MODULE WITH
 ## MODULE
 ##
 
-<SYNTAX ERROR>
+A module's name needs to begin with a upper-case letter
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 ##


### PR DESCRIPTION
`module foo = {`

will now give the error: 

`A module's name needs to begin with a upper-case letter`