### PR TITLE
Format class type instance attributes

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -288,6 +288,11 @@ class type _y = {
   pub height: int [@@bs.set]
 };
 
+class type _z = {
+  pub height: int
+}
+[@@bs];
+
 module NestedModule = {
   [@@@floatingNestedStructureItem hello];
 };

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -218,6 +218,8 @@ and anotherClassType = {
 
 class type _y = { pub height : int [@@bs.set] };
 
+class type _z = { pub height : int }[@@bs];
+
 module NestedModule = {
   [@@@floatingNestedStructureItem hello];
 };

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -5136,7 +5136,8 @@ class printer  ()= object(self:'self)
       in
       let includingEqual = makeList ~postSpace:true [upToName; atom "="] in
       let itm = label ~space:true includingEqual (self#class_instance_type x.pci_expr) in
-      self#attach_std_item_attrs pci_attributes itm
+      let itmWithAttrs = self#attach_std_item_attrs x.pci_expr.pcty_attributes itm in
+      self#attach_std_item_attrs pci_attributes itmWithAttrs
     in
     match l with
     | [] -> failwith "Should not call class_type_declaration with no classes"


### PR DESCRIPTION
This is an attempt to fix #710 while maintaining an acceptable pretty print format.
Here's what this PR achieves, given: `class type_z = { pub height: int } [@@bs];`, it formats it to
```
class type _z = {
  pub height: int
}
[@@bs];
```

This is similar to how a virtual class is formatted [here](https://github.com/facebook/reason/blob/master/formatTest/typeCheckedTests/expected_output/oo.re#L34-L55).

