### PR TITLE
Don't break attributes over multiple lines.

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -328,7 +328,8 @@ let myFun
    let myFun = fun ((X hello | Y hello) [@onOrPattern]) => hello;
    */
 /* Bucklescript FFI item attributes */
-external imul : int => int => int = "Math.imul" [@@bs.val];
+external imul : int => int => int =
+  "Math.imul" [@@bs.val];
 
 module Js = {
   type t 'a;
@@ -360,5 +361,24 @@ type reconciler 'props +=
          [@onThirdRow]
 [@@onVariantType];
 
+type element;
+
+type reactElement;
+
+type reactClass;
+
 /* "react-dom" shouldn't spread the attribute over multiple lines */
-external render : int => string => unit = "render" [@@bs.val] [@@bs.module "react-dom"];
+external render : reactElement => element => unit =
+  "render" [@@bs.val] [@@bs.module "react-dom"];
+
+external f : int => int = "f" [@@bs.module "f"];
+
+external createCompositeElementInternalHack :
+  reactClass =>
+  Js.t {.. reasonProps : 'props} =>
+  array reactElement =>
+  reactElement =
+  "createElement" [@@bs.val] [@@bs.module "react"] [@@bs.splice];
+
+external add_nat : int => int => int =
+  "add_nat_bytecode" "add_nat_native";

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -359,3 +359,6 @@ type reconciler 'props +=
   | Baz :(reconciler (unit [@onUnit]))
          [@onThirdRow]
 [@@onVariantType];
+
+/* "react-dom" shouldn't spread the attribute over multiple lines */
+external render : int => string => unit = "render" [@@bs.val] [@@bs.module "react-dom"];

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -280,3 +280,6 @@ type reconciler 'props +=
  | Foo int : reconciler int [@onFirstRow]
  | Bar (int [@onInt]) : reconciler unit [@onSecondRow]
  | Baz: reconciler (unit [@onUnit]) [@onThirdRow] [@@onVariantType];
+
+/* "react-dom" shouldn't spread the attribute over multiple lines */
+external render : int => string => unit = "render" [@@bs.val] [@@bs.module "react-dom"];

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -281,5 +281,20 @@ type reconciler 'props +=
  | Bar (int [@onInt]) : reconciler unit [@onSecondRow]
  | Baz: reconciler (unit [@onUnit]) [@onThirdRow] [@@onVariantType];
 
+type element;
+
+type reactElement;
+
+type reactClass;
+
 /* "react-dom" shouldn't spread the attribute over multiple lines */
-external render : int => string => unit = "render" [@@bs.val] [@@bs.module "react-dom"];
+external render : reactElement => element => unit = "render" [@@bs.val] [@@bs.module "react-dom"];
+
+external f : int => int = "f" [@@bs.module "f"];
+
+external createCompositeElementInternalHack : reactClass =>
+                                              Js.t {.. reasonProps : 'props} =>
+                                              array reactElement =>
+                                              reactElement = "createElement" [@@bs.val] [@@bs.module"react"] [@@bs.splice];
+
+external add_nat: int => int => int = "add_nat_bytecode" "add_nat_native";

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -5065,6 +5065,36 @@ class printer  ()= object(self:'self)
     | Pstr_attribute (s, _) -> (not (s.txt = "ocaml.text") && not (s.txt = "ocaml.doc"))
     | _ -> true
 
+  (*
+    external render : reactElement => element => unit =   (* frstHalf *)
+      "render" [@@bs.val] [@@bs.module "react-dom"];      (* sndHalf *)
+
+    To improve the formatting with breaking & indentation:
+      * consider the part before the '=' as a label
+      * combine that label with '=' in a list
+      * consider the part after the '=' as a list
+      * combine both parts as a label
+  *)
+  method primitive_declaration vd =
+    let attrs = List.map (fun x -> self#item_attribute x) vd.pval_attributes in
+    let lblBefore =
+      label ~space:true
+        (makeList ~postSpace:true
+          [atom "external"; protectIdentifier vd.pval_name.txt; atom ":"])
+        (self#core_type vd.pval_type)
+    in
+    let frstHalf = makeList ~postSpace:true [lblBefore; atom "="] in
+    let string_literals = makeSpacedBreakableInlineList (List.map self#constant_string vd.pval_prim) in
+    (* when there aren't any attrs, add a final semi here *)
+    let prim = if (List.length attrs) == 0
+      then appendSep false ";" string_literals
+      else string_literals
+    in
+    let sndHalf =
+      makeList ~inline:(true, true) ~postSpace:true
+        [prim; makeList ~postSpace:true attrs]
+    in
+    label ~space:true frstHalf sndHalf
 
   method class_instance_type x = match x.pcty_desc with
     | Pcty_signature cs ->
@@ -5827,15 +5857,7 @@ class printer  ()= object(self:'self)
           )
         | Pstr_class l -> self#class_declaration_list l
         | Pstr_class_type (l) -> self#class_type_declaration_list l
-        | Pstr_primitive vd ->
-            let attrs =  List.map (fun x -> self#item_attribute x) vd.pval_attributes in
-            let lst = List.append [
-              atom ("external");
-              protectIdentifier vd.pval_name.txt;
-              atom (":");
-              self#value_description vd;
-            ] attrs in
-            makeList ~postSpace:true lst
+        | Pstr_primitive vd -> self#primitive_declaration vd
         | Pstr_include incl ->
             (* Kind of a hack *)
             let moduleExpr = incl.pincl_mod in

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -4911,7 +4911,7 @@ class printer  ()= object(self:'self)
     match e with
       | PStr [] -> atom ("[" ^ ppxToken  ^ ppxId.txt  ^ "]")
       | PStr [itm] ->
-        makeList ~wrap ~break ~pad [self#structure_item itm]
+        makeList ~wrap ~pad [self#structure_item itm]
       | PStr (_::_ as items) ->
         let rows = (List.map (self#structure_item) items) in
         makeList ~wrap ~break ~pad ~postSpace ~sep rows


### PR DESCRIPTION
Improves attribute formatting:
* doesn't break attributes on multiple lines, when it isn't necessary.
* provides better identation when breaking the declaration over multiple lines

Example rehydrate, before:
```rust
external createElement : reactClass => props::Js.t {..}? => array reactElement => reactElement = "createElement" [@@bs.splice] [@@bs.val] [@@bs.module
                                                                    "react"
                                                                    ];

external createClassInternalHack : Js.t 'classSpec => reactClass = "createClass" [@@bs.val] [@@bs.module
                                                                    "react"
                                                                    ];

external createCompositeElementInternalHack : reactClass =>
                                              Js.t {.. reasonProps : 'props} =>
                                              array reactElement =>
                                              reactElement = "createElement" [@@bs.val] [@@bs.module
                                                                    "react"
                                                                    ] [@@bs.splice];
```

After:
```rust
external createElement : reactClass => props::Js.t {..}? => array reactElement => reactElement =
  "createElement" [@@bs.splice] [@@bs.val] [@@bs.module "react"];

external createClassInternalHack : Js.t 'classSpec => reactClass =
  "createClass" [@@bs.val] [@@bs.module "react"];

type reactElementthisIsasupersupersupersupserupserupserupseruplongtype;

external createCompositeElementInternalHack :
  reactClass =>
  Js.t {.. reasonProps : 'props} =>
  array reactElementthisIsasupersupersupersupserupserupserupseruplongtype =>
  reactElement =
  "createElement" [@@bs.val] [@@bs.module "react"] [@@bs.splice];

external createCompositeElementInternalHack :
  reactClass => Js.t {.. reasonProps : 'props} => array reactElement => reactElement =
  "createElement" [@@bs.val] [@@bs.module "react"] [@@bs.splice];
```
