### PR TITLE
Fix overeager punning in record types (#962).

### DIFF
--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -680,6 +680,11 @@ type description 'props = {
   tag: tag 'props
 };
 
+/* Don't pun types from other modules */
+module Foo = {
+  type bar = {foo: Baz.foo};
+};
+
 /* Requested in #566 */
 let break_after_equal =
   no_break_from_here (some_call to_here);

--- a/formatTest/unit_tests/input/basicStructures.re
+++ b/formatTest/unit_tests/input/basicStructures.re
@@ -564,5 +564,10 @@ type description 'props = {
   tag: tag 'props
 };
 
+/* Don't pun types from other modules */
+module Foo = {
+  type bar = {foo: Baz.foo};
+};
+
 /* Requested in #566 */
 let break_after_equal = no_break_from_here (some_call to_here);

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2265,8 +2265,10 @@ let recordRowIsPunned pld =
         | { ptyp_desc = (Ptyp_constr ({ txt; _ }, args)); _}
             when
             (Longident.last txt = name
+              (* Don't pun types from other modules, e.g. type bar = {foo: Baz.foo}; *)
+              && List.length (Longident.flatten txt) == 1
               (* don't pun parameterized types, e.g. {tag: tag 'props} *)
-              && (List.length args) == 0) -> true
+              && List.length args == 0) -> true
         | _ -> false)
 
 class printer  ()= object(self:'self)

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2259,6 +2259,10 @@ let pun_labelled_pattern e lbl =
     | { ppat_desc = (Ppat_var { txt; _ }) } when txt = lbl -> ""
     | _ -> lbl )
 
+let isLongIdentWithDot = function
+  | Ldot _ -> true
+  | _ -> false
+
 let recordRowIsPunned pld =
       let name = pld.pld_name.txt in
       (match pld.pld_type with
@@ -2266,7 +2270,7 @@ let recordRowIsPunned pld =
             when
             (Longident.last txt = name
               (* Don't pun types from other modules, e.g. type bar = {foo: Baz.foo}; *)
-              && List.length (Longident.flatten txt) == 1
+              && isLongIdentWithDot txt == false
               (* don't pun parameterized types, e.g. {tag: tag 'props} *)
               && List.length args == 0) -> true
         | _ -> false)


### PR DESCRIPTION
Fix for https://github.com/facebook/reason/issues/962
```ocaml
module Foo = {
  type bar = {foo: Baz.foo};
};
```
should not become
```ocaml
module Foo = {
  type bar = {foo};
};
```

The latter will look for a `type foo` inside `module Foo`, which isn't what we want. 
When determining if a record row should be punned,
there is now a check in place which takes types with longer identifiers - `Baz.foo` - into account.