### PR TITLE
[docs] remove `:` in website tab

### DIFF
--- a/docs/tools.html
+++ b/docs/tools.html
@@ -330,7 +330,7 @@ need the `-intf/-impl/-intf-suffix` flags:
 <**/*.{re,.rei}>: package(reason), syntax(utf8)
 ```
 
-Credit:
+Credit
 -------
 The general structure of `refmt` repo was copied from @whitequark's m17n
 project, including parts of the `README` that instruct how to use this with the


### PR DESCRIPTION
better with out it
<img width="759" alt="screen shot 2017-01-13 at 3 51 54 pm" src="https://cloud.githubusercontent.com/assets/915849/21949556/3e37933c-d9a8-11e6-8faf-7eb87cd3f59e.png">
