### PR TITLE
Support "**"

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -57,6 +57,8 @@ let reasonDoubleBarNestedAnyPatterns =
 
 let (\+) = (+);
 
+let a = 2.0 *\* 4.0;
+
 let (\===) = (===);
 
 let expectedPrecendence =

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -39,6 +39,8 @@ let reasonDoubleBarNestedAnyPatterns = fun
 
 let (\+) = (+);
 
+let a = 2.0 ** 4.0;
+
 let (\===) = (===);
 
 let expectedPrecendence = 1 + 1 \=== 1 + 1 && 1 + 1 \!== 1 + 1;

--- a/src/reason_lexer.mll
+++ b/src/reason_lexer.mll
@@ -553,7 +553,9 @@ rule token = parse
    * rule beginning with *, picking it up instead of the special double ** rule
    * below.
    *)
-  | "\\"? "*\\*" appropriate_operator_suffix_chars *
+  | "\\"? "**" appropriate_operator_suffix_chars *
+            { INFIXOP4(Lexing.lexeme lexbuf)}
+  | "\\"? "*\*" appropriate_operator_suffix_chars *
             { INFIXOP4(Lexing.lexeme lexbuf)}
   | '%'     { PERCENT }
   | "\\"? ['*'] appropriate_operator_suffix_chars *


### PR DESCRIPTION
In addition to "\*/\*", this diff adds a "sugar" to support "**".

Unfortunately it will still get printed to "\*/\*", but once we get https://github.com/facebook/reason/pull/909 right,
it will be printed to "**" automatically.