### PR TITLE
Fix printing of attributes in interface files

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.rei
+++ b/formatTest/typeCheckedTests/expected_output/attributes.rei
@@ -1,7 +1,38 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 let test: int;
+
+
 /**
  * Attributes with doc/text attributes should be stripped. They're left over from a
  * conversion from ML likely.
  * ----------------------
  */
+
+/**
+ * #990: don't strip attributes in interface files
+ */
+let x: int [@@bs.val];
+
+type t 'a;
+
+type reactClass;
+
+type reactElement;
+
+external createClassInternalHack :
+  t 'classSpec => reactClass =
+  "createClass" [@@bs.val] [@@bs.module "React"];
+
+external map : ('a => 'b) [@bs] => array 'b =
+  "" [@@bs.send.pipe : array 'a];
+
+external createClassInternalHack :
+  t 'classSpec => reactClass =
+  "createClass" [@@bs.val] [@@bs.module "react"];
+
+external createCompositeElementInternalHack :
+  reactClass =>
+  t {.. reasonProps : 'props} =>
+  array reactElement =>
+  reactElement =
+  "createElement" [@@bs.val] [@@bs.module "react"] [@@bs.splice];

--- a/formatTest/typeCheckedTests/input/attributes.rei
+++ b/formatTest/typeCheckedTests/input/attributes.rei
@@ -11,3 +11,25 @@ let test : int;
 
 [@@@ocaml.doc "Floating doc text should be removed"];
 
+
+/**
+ * #990: don't strip attributes in interface files
+ */
+let x: int [@@bs.val];
+
+type t 'a;
+
+type reactClass;
+
+type reactElement;
+
+external createClassInternalHack : t 'classSpec => reactClass = "createClass" [@@bs.val] [@@bs.module "React"];
+
+external map : ('a => 'b) [@bs] => array 'b = "" [@@bs.send.pipe : array 'a];
+
+external createClassInternalHack : t 'classSpec => reactClass =
+  "createClass" [@@bs.val] [@@bs.module "react"];
+
+external createCompositeElementInternalHack :
+  reactClass => t {.. reasonProps : 'props} => array reactElement => reactElement =
+  "createElement" [@@bs.val] [@@bs.module "react"] [@@bs.splice];

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -5485,14 +5485,8 @@ class printer  ()= object(self:'self)
       )
 
   method value_description x =
-    if x.pval_prim<>[] then
-      makeList ~postSpace:true [
-        self#core_type x.pval_type;
-        atom "=";
-        makeSpacedBreakableInlineList (List.map self#constant_string x.pval_prim)
-      ]
-    else
-      self#core_type x.pval_type;
+    let vd = self#core_type x.pval_type in
+    self#attach_std_item_attrs x.pval_attributes vd
 
   method signature_item x :layoutNode =
     let item: layoutNode =
@@ -5500,11 +5494,13 @@ class printer  ()= object(self:'self)
         | Psig_type l ->
             self#type_def_list l
         | Psig_value vd ->
-            let intro = if vd.pval_prim = [] then atom "let" else atom "external" in
-            (formatTypeConstraint
-               (label ~space:true intro (wrapLayoutWithLoc (Some (vd.pval_name.loc)) (protectIdentifier vd.pval_name.txt)))
-               (self#value_description vd)
-            )
+            if vd.pval_prim <> [] then
+              self#primitive_declaration vd
+            else
+              let intro = atom "let" in
+              (formatTypeConstraint
+                 (label ~space:true intro (wrapLayoutWithLoc (Some (vd.pval_name.loc)) (protectIdentifier vd.pval_name.txt)))
+                 (self#value_description vd))
 
         | Psig_typext te ->
             self#type_extension te


### PR DESCRIPTION
https://github.com/facebook/reason/issues/990

Printing of attributes in interface files was non-existent.
This pr implements the printing of those attributes.

Example:
```ocaml
let x: int [@@bs.val];

type t 'a;

type reactClass;

type reactElement;

external createClassInternalHack :
  t 'classSpec => reactClass =
  "createClass" [@@bs.val] [@@bs.module "React"];

external map : ('a => 'b) [@bs] => array 'b =
  "" [@@bs.send.pipe : array 'a];

external createClassInternalHack :
  t 'classSpec => reactClass =
  "createClass" [@@bs.val] [@@bs.module "react"];

external createCompositeElementInternalHack :
  reactClass =>
  t {.. reasonProps : 'props} =>
  array reactElement =>
  reactElement =
  "createElement" [@@bs.val] [@@bs.module "react"] [@@bs.splice];
```