### PR TITLE
Break payloads of extension nodes IfNeed

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -383,7 +383,8 @@ external createCompositeElementInternalHack :
   Js.t {.. reasonProps : 'props} =>
   array reactElement =>
   reactElement =
-  "createElement" [@@bs.val] [@@bs.module "react"] [@@bs.splice];
+  "createElement"
+  [@@bs.val] [@@bs.module "react"] [@@bs.splice];
 
 external add_nat : int => int => int =
   "add_nat_bytecode" "add_nat_native";

--- a/formatTest/typeCheckedTests/expected_output/attributes.rei
+++ b/formatTest/typeCheckedTests/expected_output/attributes.rei
@@ -35,4 +35,5 @@ external createCompositeElementInternalHack :
   t {.. reasonProps : 'props} =>
   array reactElement =>
   reactElement =
-  "createElement" [@@bs.val] [@@bs.module "react"] [@@bs.splice];
+  "createElement"
+  [@@bs.val] [@@bs.module "react"] [@@bs.splice];

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -297,6 +297,6 @@ external f : int => int = "f" [@@bs.module "f"];
 external createCompositeElementInternalHack : reactClass =>
                                               Js.t {.. reasonProps : 'props} =>
                                               array reactElement =>
-                                              reactElement = "createElement" [@@bs.val] [@@bs.module"react"] [@@bs.splice];
+                                              reactElement = "createElement" [@@bs.val] [@@bs.module "react"] [@@bs.splice];
 
 external add_nat: int => int => int = "add_nat_bytecode" "add_nat_native";

--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -88,3 +88,7 @@ let d = {
 };
 
 let a = {"/foo": 10};
+
+let isArrayPolyfill: (int => bool) [@bs] = [%bs.raw
+  "function(a) {return Object.prototype.toString.call(a) === '[object Array]'}"
+];

--- a/formatTest/unit_tests/input/bucklescript.re
+++ b/formatTest/unit_tests/input/bucklescript.re
@@ -65,3 +65,7 @@ let c = {"a": a, "b": b, "func": fun a => a##c#=(func 10)};
 let d = {"a": a2, "b": b , "func": fun a => {"a": (fun arg1 arg2 => arg1 + arg2)}};
 
 let a = {"/foo": 10};
+
+let isArrayPolyfill: (int => bool) [@bs] = [%bs.raw
+  "function(a) {return Object.prototype.toString.call(a) === '[object Array]'}"
+];

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -4919,8 +4919,7 @@ class printer  ()= object(self:'self)
     let sep = ";" in
     match e with
       | PStr [] -> atom ("[" ^ ppxToken  ^ ppxId.txt  ^ "]")
-      | PStr [itm] ->
-        makeList ~wrap ~pad [self#structure_item itm]
+      | PStr [itm] -> makeList ~break ~wrap ~pad [self#structure_item itm]
       | PStr (_::_ as items) ->
         let rows = (List.map (self#structure_item) items) in
         makeList ~wrap ~break ~pad ~postSpace ~sep rows
@@ -5098,8 +5097,8 @@ class printer  ()= object(self:'self)
       if (List.length attrs) == 0 then
         string_literals
       else
-        makeList ~inline:(true, true) ~postSpace:true
-          [string_literals; makeList ~postSpace:true attrs]
+        makeList ~inline:(true, true) ~break:IfNeed ~postSpace:true
+          [string_literals; makeList ~break:IfNeed ~postSpace:true attrs]
     in
     label ~space:true frstHalf sndHalf
 

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -5097,8 +5097,10 @@ class printer  ()= object(self:'self)
       if (List.length attrs) == 0 then
         string_literals
       else
-        makeList ~inline:(true, true) ~break:IfNeed ~postSpace:true
-          [string_literals; makeList ~break:IfNeed ~postSpace:true attrs]
+        makeSpacedBreakableInlineList [
+          string_literals;
+          makeList ~break:IfNeed ~postSpace:true attrs
+        ]
     in
     label ~space:true frstHalf sndHalf
 


### PR DESCRIPTION
https://github.com/facebook/reason/issues/997

It was just a matter of `~break:IfNeed` in the right places to get everything printed out correctly.
Had to introduce a small change on how the following is printed in the tests:
```
external createCompositeElementInternalHack :
  reactClass =>
  Js.t {.. reasonProps : 'props} =>
  array reactElement =>
  reactElement =
  "createElement"
  [@@bs.val] [@@bs.module "react"] [@@bs.splice];
```
` [@@bs.val] [@@bs.module "react"] [@@bs.splice]` now breaks on a seperate line when necessary. In reality this will appear after `"createElement"` because the tests have a pretty short print-width of `50`

Example Rehydrate:
```
let isArrayPolyfill: (Obj.t => Js.boolean) [@bs] = [%bs.raw
  "function(a) {return Object.prototype.toString.call(a) === '[object Array]'}"
];

external createClassInternalHack : Js.t 'classSpec => reactClass =
  "createClass" [@@bs.val] [@@bs.module "react"];
```