### PR TITLE
Remove --output flag

### DIFF
--- a/src/refmt_args.ml
+++ b/src/refmt_args.ml
@@ -52,11 +52,6 @@ let heuristics_file =
   in
   Arg.(value & opt (some file) None & info ["h"; "heuristics-file"] ~doc)
 
-let output =
-  let docv = "FILENAME" in
-  let doc = "target file for output; default [stdout]" in
-  Arg.(value & opt (some string) None & info ["o"; "output"] ~docv ~doc)
-
 let in_place =
   let doc = "reformat a file in-place" in
   Arg.(value & flag & info ["in-place"] ~doc)

--- a/src/refmt_impl.ml
+++ b/src/refmt_impl.ml
@@ -28,7 +28,6 @@ let refmt
     print
     print_width
     h_file
-    output_file
     in_place
     input_file
     is_interface_pp
@@ -67,17 +66,11 @@ let refmt
     | true -> true
     | false -> (Filename.check_suffix input_file ".rei" || Filename.check_suffix input_file ".mli")
   in
-  let writing_to_file = match output_file with
-    | Some _ -> true
-    | None -> false
-  in
   let output_file =
-    match in_place, use_stdin, writing_to_file with
-    | (true, true, _) -> raise (Invalid_config "Cannot write in place to stdin.")
-    | (true, _, true) -> raise (Invalid_config "Cannot specify --output and --in-place.")
-    | (true, _, _) -> Some input_file
-    (* Writing to a file vs stdout handled by Printer_maker below. *)
-    | (false, _, _) -> output_file
+    match in_place, use_stdin with
+    | (true, true) -> raise (Invalid_config "Cannot write in place to stdin.")
+    | (true,    _) -> Some input_file
+    | (false,   _) -> None
   in
   let (module Printer : Printer_maker.PRINTER) =
     if interface then (module Reason_interface_printer.Reason_interface_printer)
@@ -127,7 +120,6 @@ let refmt_t =
                     $ print
                     $ print_width
                     $ heuristics_file
-                    $ output
                     $ in_place
                     $ input
                     $ is_interface_pp


### PR DESCRIPTION
Following my discussion with @nojb on https://github.com/dbuenzli/cmdliner/pull/17 and some thought, I think that introducing `--output` was a bad idea:

1. Shell redirection exists for a reason. It is trivial to write: `refmt --parse ml --print re file.ml > file.re`.
2. I introduced `--in-place` because writing to the file that we read from is a special case, and requires some shell shenanigans to work (see https://github.com/facebook/reason/issues/886). But at the same time introduced `--output`, which is wholly unnecessary and also brings with it some annoying command-line logic (mutual exclusion of `--output`, `--in-place`, etc).

I have removed `--output` in this PR ~that (at the moment) builds upon https://github.com/facebook/reason/pull/995~.

/cc @chenglou @yunxing 