### PR TITLE
Make --print default to Reason

### DIFF
--- a/formatTest/test.sh
+++ b/formatTest/test.sh
@@ -268,7 +268,7 @@ function typecheck_test() {
     fi
 
     debug "  Compiling: ocamlc -c -pp $REFMT $COMPILE_FLAGS $OUTPUT/$FILE"
-    ocamlc -c -pp $REFMT $COMPILE_FLAGS "$OUTPUT/$FILE"
+    ocamlc -c -pp "$REFMT --print binary" $COMPILE_FLAGS "$OUTPUT/$FILE"
     if ! [[ $? -eq 0 ]]; then
         warning "  ⊘ FAILED\n"
         return 1

--- a/miscTests/jsxPpxTest.sh
+++ b/miscTests/jsxPpxTest.sh
@@ -9,7 +9,7 @@ do
 
   expected=`cat $testPath/expected$i.re`
 
-  ocamlc -dsource -ppx ./reactjs_jsx_ppx.native -pp ./refmt_impl.native -impl $test \
+  ocamlc -dsource -ppx ./reactjs_jsx_ppx.native -pp "./refmt_impl.native --print binary" -impl $test \
     2>&1 | sed '$ d' | sed '$ d' | \
     ./refmt_impl.native --parse ml --print re --interface false \
     > $testPath/actual${i}.re

--- a/src/printer_maker.ml
+++ b/src/printer_maker.ml
@@ -1,4 +1,4 @@
-type parse_itype = [ `ML | `Reason | `Binary | `BinaryReason]
+type parse_itype = [ `ML | `Reason | `Binary | `BinaryReason | `Auto ]
 type print_itype = [ `ML | `Reason | `Binary | `BinaryReason | `AST | `None ]
 
 exception Invalid_config of string
@@ -7,12 +7,12 @@ module type PRINTER =
     sig
         type t
 
-        val parse : parse_itype option ->
+        val parse : parse_itype ->
                     bool ->
                     string ->
                     ((t * Reason_pprint_ast.commentWithCategory) * bool)
 
-        val makePrinter : print_itype option ->
+        val makePrinter : print_itype ->
                           string ->
                           bool ->
                           out_channel ->

--- a/src/reason_interface_printer.ml
+++ b/src/reason_interface_printer.ml
@@ -16,14 +16,14 @@ module Reason_interface_printer : Printer_maker.PRINTER =
         let parse filetype use_stdin filename =
             let ((ast, comments), parsedAsML, parsedAsInterface) =
             (match filetype with
-            | None -> defaultInterfaceParserFor use_stdin filename
-            | Some `BinaryReason -> Printer_maker.reasonBinaryParser use_stdin filename
-            | Some `Binary -> Printer_maker.ocamlBinaryParser use_stdin filename true
-            | Some `ML ->
+            | `Auto -> defaultInterfaceParserFor use_stdin filename
+            | `BinaryReason -> Printer_maker.reasonBinaryParser use_stdin filename
+            | `Binary -> Printer_maker.ocamlBinaryParser use_stdin filename true
+            | `ML ->
                     let lexbuf = Reason_toolchain.setup_lexbuf use_stdin filename in
                     let intf = Reason_toolchain.ML.canonical_interface_with_comments in
                     ((intf lexbuf), true, true)
-            | Some `Reason ->
+            | `Reason ->
                     let lexbuf = Reason_toolchain.setup_lexbuf use_stdin filename in
                     let intf = Reason_toolchain.JS.canonical_interface_with_comments in
                     ((intf lexbuf), false, true))
@@ -34,7 +34,7 @@ module Reason_interface_printer : Printer_maker.PRINTER =
 
         let makePrinter printtype filename parsedAsML output_chan output_formatter =
             match printtype with
-                    | Some `BinaryReason -> fun (ast, comments) -> (
+                    | `BinaryReason -> fun (ast, comments) -> (
                       (* Our special format for interchange between reason should keep the
                        * comments separate.  This is not compatible for input into the
                        * ocaml compiler - only for input into another version of Reason. We
@@ -45,18 +45,17 @@ module Reason_interface_printer : Printer_maker.PRINTER =
                         Config.ast_intf_magic_number, filename, ast, comments, parsedAsML, true
                       );
                     )
-                    | Some `Binary
-                    | None -> fun (ast, comments) -> (
+                    | `Binary -> fun (ast, comments) -> (
                       output_string output_chan Config.ast_intf_magic_number;
                       output_value  output_chan filename;
                       output_value  output_chan ast
                     )
-                    | Some `AST -> fun (ast, comments) -> (
+                    | `AST -> fun (ast, comments) -> (
                       Printast.interface output_formatter ast
                     )
                     (* If you don't wrap the function in parens, it's a totally different
                      * meaning #thanksOCaml *)
-                    | Some `None -> (fun (ast, comments) -> ())
-                    | Some `ML -> Reason_toolchain.ML.print_canonical_interface_with_comments output_formatter
-                    | Some `Reason -> Reason_toolchain.JS.print_canonical_interface_with_comments output_formatter
+                    | `None -> (fun (ast, comments) -> ())
+                    | `ML -> Reason_toolchain.ML.print_canonical_interface_with_comments output_formatter
+                    | `Reason -> Reason_toolchain.JS.print_canonical_interface_with_comments output_formatter
     end;;

--- a/src/reasonbuild.ml
+++ b/src/reasonbuild.ml
@@ -4,7 +4,7 @@ open Ocamlbuild_plugin
 let ext_obj = !Options.ext_obj;;
 let x_o = "%"-.-ext_obj;;
 
-let refmt = "refmt"
+let refmt = "refmt --print binary"
 
 let ocamldep_command' tags =
   let tags' = tags++"ocaml"++"ocamldep" in

--- a/src/refmt_args.ml
+++ b/src/refmt_args.ml
@@ -17,8 +17,8 @@ let explicit_arity =
 
 let parse_ast =
   let docv = "FORM" in
-  let doc = "print AST in FORM, which is one of: (ml | re | \
-             binary (default - for compiler input) | \
+  let doc = "parse AST in FORM, which is one of: (ml | re | \
+             binary (for compiler input) | \
              binary_reason (for interchange between Reason versions))"
   in
   let opts = Arg.enum ["ml", `ML; "re", `Reason;
@@ -28,8 +28,8 @@ let parse_ast =
 
 let print =
   let docv = "FORM" in
-  let doc = "print AST in FORM, which is one of: (ml | re | \
-             binary (default - for compiler input) | \
+  let doc = "print AST in FORM, which is one of: (ml | re (default) | \
+             binary (for compiler input) | \
              binary_reason (for interchange between Reason versions) | \
              ast (print human readable AST directly) | none)"
   in
@@ -37,7 +37,7 @@ let print =
                        "binary_reason", `BinaryReason; "ast", `AST;
                        "none", `None]
   in
-  Arg.(value & opt (some opts) None & info ["p"; "print"] ~docv ~doc)
+  Arg.(value & opt (some opts) (Some `Reason) & info ["p"; "print"] ~docv ~doc)
 
 let print_width =
   let docv = "COLS" in

--- a/src/refmt_args.ml
+++ b/src/refmt_args.ml
@@ -22,9 +22,9 @@ let parse_ast =
              binary_reason (for interchange between Reason versions))"
   in
   let opts = Arg.enum ["ml", `ML; "re", `Reason;
-                       "binary_reason", `BinaryReason]
+                       "binary_reason", `BinaryReason; "auto", `Auto]
   in
-  Arg.(value & opt (some opts) None & info ["parse"] ~docv ~doc)
+  Arg.(value & opt opts `Reason & info ["parse"] ~docv ~doc)
 
 let print =
   let docv = "FORM" in
@@ -37,7 +37,7 @@ let print =
                        "binary_reason", `BinaryReason; "ast", `AST;
                        "none", `None]
   in
-  Arg.(value & opt (some opts) (Some `Reason) & info ["p"; "print"] ~docv ~doc)
+  Arg.(value & opt opts `Reason & info ["p"; "print"] ~docv ~doc)
 
 let print_width =
   let docv = "COLS" in

--- a/src/refmt_args.ml
+++ b/src/refmt_args.ml
@@ -24,7 +24,7 @@ let parse_ast =
   let opts = Arg.enum ["ml", `ML; "re", `Reason;
                        "binary_reason", `BinaryReason; "auto", `Auto]
   in
-  Arg.(value & opt opts `Reason & info ["parse"] ~docv ~doc)
+  Arg.(value & opt (some opts) None & info ["parse"] ~docv ~doc)
 
 let print =
   let docv = "FORM" in

--- a/src/refmt_impl.ml
+++ b/src/refmt_impl.ml
@@ -44,6 +44,11 @@ let refmt
     | Some name -> (false, name)
     | None -> (true, "")
   in
+  let parse_ast = match parse_ast, use_stdin with
+    | (Some x, _) -> x
+    | (None, false) -> `Auto
+    | (None, true) -> `Reason (* default *)
+  in
   Reason_config.configure ~r:is_recoverable;
   Location.input_name := input_file;
   let constructorLists = match h_file with

--- a/src/refmt_impl.ml
+++ b/src/refmt_impl.ml
@@ -44,19 +44,6 @@ let refmt
     | Some name -> (false, name)
     | None -> (true, "")
   in
-  let () =
-    let has_print = match print with
-      | Some _ -> true
-      | None -> false
-    in
-    let has_parse = match parse_ast with
-      | Some _ -> true
-      | None -> false
-    in
-    if input_file = "" && not (has_parse && has_print) then
-      raise (Invalid_config "Need an input file, parse mode, and print \
-                             mode. Modes can be auto-detected based on filename.")
-  in
   Reason_config.configure ~r:is_recoverable;
   Location.input_name := input_file;
   let constructorLists = match h_file with


### PR DESCRIPTION
Per @chenglou's request, `refmt` should default to printing Reason code, not binary. This is a saner default for people trying out the `refmt`.

/cc @yunxing 