### PR TITLE
Support pretty printing extensions in include statement.

### DIFF
--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -5732,7 +5732,7 @@ class printer  ()= object(self:'self)
             | ([hd], _) -> raise (NotPossible "one functor application terms")
             | (hd::tl, _) -> formatIndentedApplication hd tl
           )
-      | Pmod_extension _ -> assert false
+      | Pmod_extension (s, e) -> self#payload "%" s e
       | Pmod_unpack _
       | Pmod_ident _
       | Pmod_constraint _


### PR DESCRIPTION
This get pretty printed correct now:
```
include
  [%matchenv
    switch (GL_BACKEND) {
      | "native" => Reglnative.Opengl
      | "web" => Reglweb.Webgl
    }
    ];
```