### PR TITLE
Move ocaml into a hard dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,14 +38,13 @@
         "@opam-alpha/ocamlfind": "*",
         "@opam-alpha/merlin-extend": "^ 0.3.0",
         "@opam-alpha/menhir": ">= 20160303.0.0",
-        "opam-installer-bin": "esy-ocaml/opam-installer-bin"
+        "opam-installer-bin": "esy-ocaml/opam-installer-bin",
+        "ocaml": "esy-ocaml/ocaml#esy"
     },
     "peerDependencies": {
-        "ocaml": "esy-ocaml/ocaml#esy",
         "@opam-alpha/utop": "*"
     },
     "devDependencies": {
-        "ocaml": "esy-ocaml/ocaml#esy",
         "@opam-alpha/utop": "*"
     },
     "scripts": {

--- a/package.json.in
+++ b/package.json.in
@@ -37,14 +37,13 @@
         "@opam-alpha/ocamlfind": "*",
         "@opam-alpha/merlin-extend": "^ 0.3.0",
         "@opam-alpha/menhir": ">= 20160303.0.0",
-        "opam-installer-bin": "esy-ocaml/opam-installer-bin"
+        "opam-installer-bin": "esy-ocaml/opam-installer-bin",
+        "ocaml": "esy-ocaml/ocaml#esy"
     },
     "peerDependencies": {
-        "ocaml": "esy-ocaml/ocaml#esy",
         "@opam-alpha/utop": "*"
     },
     "devDependencies": {
-        "ocaml": "esy-ocaml/ocaml#esy",
         "@opam-alpha/utop": "*"
     },
     "scripts": {


### PR DESCRIPTION
This makes it so that packages requiring reason doesn't need to add ocaml as their dep themselves, each time.