### PR TITLE
Add check to confirm release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,10 @@ endif
 
 .PHONY: pre_release
 
-release: pre_release
+release_check:
+	./release-check.sh
+
+release: release_check pre_release
 	git add package.json package.ml opam
 	git commit -m "Version $(version)"
 	git tag -a $(version) -m "Version $(version)."

--- a/release-check.sh
+++ b/release-check.sh
@@ -1,12 +1,22 @@
 #!/usr/bin/env bash
 
-RANDSTR=`head -c2 </dev/urandom|xxd -p -u`
+die () { echo "${1}"; exit 1; }
+
+# Check that the current HEAD is on origin/master.
+HEAD=`git rev-parse --verify HEAD`
+MASTERURL="https://api.github.com/repos/facebook/reason/git/refs/heads/master"
+HEADMSG="Current HEAD is not on upstream master. This is a requirement before releasing.
+If you are sure it is, try switching branches to master and pulling changes."
+echo "Checking HEAD against upstream master..."
+curl --silent $MASTERURL | grep "sha" | grep $HEAD || die "$HEADMSG"
+
+# Confirm that the user actually means to release.
+RANDSTR=`head -c2 </dev/urandom | xxd -plain -u` # -u is uppercase
 echo "Do you want to release? This *WILL* publish to GitHub AND npm!!!"
 read -p "If so, please type '${RANDSTR}' (no quotes): " inp
 if [ "$inp" = "$RANDSTR" ]; then
     echo "Preparing to release..."
     exit 0
 else
-    echo "Not releasing."
-    exit 1
+    die "Not releasing."
 fi

--- a/release-check.sh
+++ b/release-check.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+RANDSTR=`head -c2 </dev/urandom|xxd -p -u`
+read -p "Do you want to release? If so, please type '${RANDSTR}' (no quotes): " inp
+if [ "$inp" = "$RANDSTR" ]; then
+    echo "Preparing to release..."
+    exit 0
+else
+    echo "Not releasing."
+    exit 1
+fi

--- a/release-check.sh
+++ b/release-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RANDSTR=`head -c2 </dev/urandom|xxd -p -u`
 echo "Do you want to release? This *WILL* publish to GitHub AND npm!!!"

--- a/release-check.sh
+++ b/release-check.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 RANDSTR=`head -c2 </dev/urandom|xxd -p -u`
-read -p "Do you want to release? If so, please type '${RANDSTR}' (no quotes): " inp
+echo "Do you want to release? This *WILL* publish to GitHub AND npm!!!"
+read -p "If so, please type '${RANDSTR}' (no quotes): " inp
 if [ "$inp" = "$RANDSTR" ]; then
     echo "Preparing to release..."
     exit 0


### PR DESCRIPTION
Following a number of accidental releases that I have seen and executed in my short stay as an intern on the Reason team, I would like to propose a pre-release check mechanism. Idea: you are much less likely to publish to npm accidentally if you are required to type a pseudo-random string to confirm.