### PR TITLE
Use correct dependency for bytecode reason

### DIFF
--- a/pkg/META.in
+++ b/pkg/META.in
@@ -17,7 +17,7 @@ archive(byte, toploop) += "@menhirLib/menhirLib.cmo"
 archive(byte, toploop, -pkg_utop) += "reason_toploop.cmo"
 archive(byte, toploop, pkg_utop) += "reason_utop.cmo"
 
-archive(byte) = "reason.cma"
+archive(byte) = "@compiler-libs/ocamlcommon.cma @result/result.cmo easy_format.cmo ppx_deriving_show.cmo reason.cma"
 archive(native) = "reason.cmxa"
 
 package "lib" (


### PR DESCRIPTION
This ensures correct dependencies are linked for reason.cma 