### PR TITLE
Enable --add-printers in reasonbuild

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,4 +1,4 @@
-PKG utop merlin_extend compiler-libs ocamlbuild easy-format MenhirLib cmdliner
+PKG utop merlin_extend compiler-libs easy-format MenhirLib cmdliner ocamlbuild
 B _build/src
 B _build
 # ^ for package.ml -- avoids errors in Merlin

--- a/.merlin
+++ b/.merlin
@@ -1,4 +1,4 @@
-PKG utop merlin_extend compiler-libs easy-format MenhirLib cmdliner
+PKG utop merlin_extend compiler-libs ocamlbuild easy-format MenhirLib cmdliner
 B _build/src
 B _build
 # ^ for package.ml -- avoids errors in Merlin

--- a/src/reasonbuild.ml
+++ b/src/reasonbuild.ml
@@ -5,7 +5,6 @@ let ext_obj = !Options.ext_obj;;
 let x_o = "%"-.-ext_obj;;
 
 let refmt = "refmt --print binary"
-let refmt_printers = refmt ^ " --add-printers"
 let add_printers_tag = "reason_add_printers"
 
 let ocamldep_command' tags =
@@ -29,7 +28,7 @@ let impl_intf ~impl ?(intf_suffix=false) arg =
 
 let choose_refmt tags =
   if Tags.mem add_printers_tag tags
-  then refmt_printers
+  then refmt ^ " --add-printers"
   else refmt
 
 let compile_c ~impl ~native tags arg out =

--- a/src/reasonbuild.ml
+++ b/src/reasonbuild.ml
@@ -4,7 +4,7 @@ open Ocamlbuild_plugin
 let ext_obj = !Options.ext_obj;;
 let x_o = "%"-.-ext_obj;;
 
-let refmt = "refmt --print binary"
+let refmt = "refmt --print binary --add-printers"
 
 let ocamldep_command' tags =
   let tags' = tags++"ocaml"++"ocamldep" in

--- a/src/reasonbuild.ml
+++ b/src/reasonbuild.ml
@@ -5,7 +5,7 @@ let ext_obj = !Options.ext_obj;;
 let x_o = "%"-.-ext_obj;;
 
 let refmt = "refmt --print binary"
-let add_printers_tag = "reason_add_printers"
+let add_printers_tag = "reason.add_printers"
 
 let ocamldep_command' tags =
   let tags' = tags++"ocaml"++"ocamldep" in

--- a/src/reasonbuild.ml
+++ b/src/reasonbuild.ml
@@ -4,9 +4,7 @@ open Ocamlbuild_plugin
 let ext_obj = !Options.ext_obj;;
 let x_o = "%"-.-ext_obj;;
 
-let should_add_printers =
-  if Sys.getenv "REFMT_ADD_PRINTERS" = "true" then " --add-printers" else ""
-let refmt = "refmt --print binary" ^ should_add_printers
+let refmt = "refmt --print binary --add-printers"
 
 let ocamldep_command' tags =
   let tags' = tags++"ocaml"++"ocamldep" in

--- a/src/reasonbuild.ml
+++ b/src/reasonbuild.ml
@@ -4,7 +4,8 @@ open Ocamlbuild_plugin
 let ext_obj = !Options.ext_obj;;
 let x_o = "%"-.-ext_obj;;
 
-let refmt = "refmt --print binary --add-printers"
+let should_add_printers = Sys.getenv("REASON_ADD_PRINTERS") = "true"
+let refmt = "refmt --print binary" ^ (if should_add_printers then " --add-printers" else "")
 
 let ocamldep_command' tags =
   let tags' = tags++"ocaml"++"ocamldep" in

--- a/src/reasonbuild.ml
+++ b/src/reasonbuild.ml
@@ -4,7 +4,9 @@ open Ocamlbuild_plugin
 let ext_obj = !Options.ext_obj;;
 let x_o = "%"-.-ext_obj;;
 
-let refmt = "refmt --print binary --add-printers"
+let should_add_printers =
+  if Sys.getenv "REFMT_ADD_PRINTERS" = "true" then " --add-printers" else ""
+let refmt = "refmt --print binary" ^ should_add_printers
 
 let ocamldep_command' tags =
   let tags' = tags++"ocaml"++"ocamldep" in

--- a/src/reasonbuild.ml
+++ b/src/reasonbuild.ml
@@ -27,13 +27,18 @@ let impl_intf ~impl ?(intf_suffix=false) arg =
   [ A (if impl then "-impl" else "-intf");
     P arg ]
 
+let choose_refmt tags =
+  if Tags.mem add_printers_tag tags
+  then refmt_printers
+  else refmt
+
 let compile_c ~impl ~native tags arg out =
   let tags =
     tags ++
     "ocaml" ++
     (if native then "native" else "byte") ++
     "compile" in
-  let refmt = if (Tags.mem add_printers_tag tags) then refmt_printers else refmt in
+  let refmt = choose_refmt tags in
   let specs =
     [ if native then !Options.ocamlopt else !Options.ocamlc;
       A "-c";
@@ -45,17 +50,20 @@ let compile_c ~impl ~native tags arg out =
     @ impl_intf ~impl ~intf_suffix:true arg in
   Cmd (S specs)
 
+let union_tags re cm tag =
+  Tags.union (tags_of_pathname re) (tags_of_pathname cm)++"implem"+++tag
+
 let byte_compile_re_implem ?tag re cmo env build =
   let re = env re and cmo = env cmo in
   Ocaml_compiler.prepare_compile build re;
-  compile_c ~impl:true ~native:false (Tags.union (tags_of_pathname re) (tags_of_pathname cmo)++"implem"+++tag) re cmo
+  compile_c ~impl:true ~native:false (union_tags re cmo tag) re cmo
 
 let native_compile_re_implem ?tag ?(cmx_ext="cmx") re env build =
   let re = env re in
   let cmi = Pathname.update_extensions "cmi" re in
   let cmx = Pathname.update_extensions cmx_ext re in
   Ocaml_compiler.prepare_link cmx cmi [cmx_ext; "cmi"] build;
-  compile_c ~impl:true ~native:true (Tags.union (tags_of_pathname re) (tags_of_pathname cmx)++"implem"+++tag) re cmx
+  compile_c ~impl:true ~native:true (union_tags re cmx tag) re cmx
 
 let compile_ocaml_interf rei cmi env build =
   let rei = env rei and cmi = env cmi in
@@ -73,7 +81,7 @@ let ocamldep_command ~impl arg out env _build =
     | last :: rev_prefix -> [Sh "|"; P "tee"] @ List.rev_append rev_prefix [Sh ">"; last] in
   let arg = env arg in
   let tags = tags_of_pathname arg in
-  let refmt = if (Tags.mem add_printers_tag tags) then refmt_printers else refmt in
+  let refmt = choose_refmt tags in
   let specs =
     [ ocamldep_command' tags;
       A "-pp"; P refmt ]


### PR DESCRIPTION
This will create printers for user-defined types by default.