### PR TITLE
Fix overeager JSX punning #1099

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -585,3 +585,16 @@ notReallyJSX foo::1 [] bar::2 [@JSX] [@bla];
 <Optional1 required=(Some "hi") /> [@bla];
 
 <Optional1 required=(Some "hi") /> [@bla];
+
+/* Overeager JSX punning #1099 */
+module Metal = {
+  let fiber = "fiber";
+};
+
+module OverEager = {
+  let createElement ::fiber ::children () => {
+    displayName: "test"
+  };
+};
+
+let element = <OverEager fiber=Metal.fiber />;

--- a/formatTest/typeCheckedTests/input/jsx.re
+++ b/formatTest/typeCheckedTests/input/jsx.re
@@ -370,3 +370,14 @@ span children::[] test::true foo::2 () [@bla][@JSX];
 
 Optional1.createElement children::[] required::(Some "hi") () [@JSX][@bla];
 Optional1.createElement children::[] required::(Some "hi") () [@bla][@JSX];
+
+/* Overeager JSX punning #1099 */
+module Metal = {
+  let fiber = "fiber";
+};
+
+module OverEager = {
+  let createElement ::fiber ::children () => {displayName: "test"};
+};
+
+let element = <OverEager fiber=Metal.fiber />;

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -3672,7 +3672,8 @@ class printer  ()= object(self:'self)
       | (lbl, expression) :: tail ->
          let nextAttr =
            match expression.pexp_desc with
-           | Pexp_ident (ident) when (Longident.last ident.txt) = lbl -> atom lbl
+           | Pexp_ident (ident) when ((isLongIdentWithDot ident.txt) == false 
+                                        && (Longident.last ident.txt) = lbl) -> atom lbl
            | _ -> (
              let firstChar = String.get lbl 0 in
              if firstChar == '?' then


### PR DESCRIPTION
Fix for https://github.com/facebook/reason/issues/1099

A long identifier with a dot shouldn't be punned in jsx because it changes the semantic meaning of that identifier.