### PR TITLE
Fix printing of private extensible variants

### DIFF
--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -490,9 +490,11 @@ let listPatternMayEvenIncludeAliases x =>
 type attr = ..;
 
 /* `of` is optional */
-type attr += Str string;
+type attr +=
+  | Str string;
 
-type attr += Point int int;
+type attr +=
+  | Point int int;
 
 type attr +=
   | Float float
@@ -510,11 +512,14 @@ module Graph = {
   type node = ..;
 };
 
-type Graph.node += Str = Graph.Str;
+type Graph.node +=
+  | Str = Graph.Str;
 
 type water = ..;
 
-type water += pri Ocean;
+type water +=
+  pri
+  | Ocean;
 
 type water +=
   pri
@@ -523,7 +528,9 @@ type water +=
   | TapWater
   | TableWater;
 
-type Graph.node += pri Node = Expr.Node;
+type Graph.node +=
+  pri
+  | Node = Expr.Node;
 
 type Graph.node +=
   pri

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -490,11 +490,9 @@ let listPatternMayEvenIncludeAliases x =>
 type attr = ..;
 
 /* `of` is optional */
-type attr +=
-  | Str string;
+type attr += Str string;
 
-type attr +=
-  | Point int int;
+type attr += Point int int;
 
 type attr +=
   | Float float
@@ -512,5 +510,22 @@ module Graph = {
   type node = ..;
 };
 
+type Graph.node += Str = Graph.Str;
+
+type water = ..;
+
+type water += pri Ocean;
+
+type water +=
+  pri
+  | MineralWater
+  | SpringWater
+  | TapWater
+  | TableWater;
+
+type Graph.node += pri Node = Expr.Node;
+
 type Graph.node +=
-  | Str = Graph.Str;
+  pri
+  | Node = Expr.Node
+  | Atom = Expr.Atom;

--- a/formatTest/unit_tests/input/variants.re
+++ b/formatTest/unit_tests/input/variants.re
@@ -368,3 +368,13 @@ module Graph = {
 
 type Graph.node +=
   | Str = Graph.Str;
+
+type water = ..;
+
+type water += pri Ocean;
+
+type water += pri MineralWater | SpringWater | TapWater | TableWater;
+
+type Graph.node += pri Node = Expr.Node;
+
+type Graph.node += pri | Node = Expr.Node | Atom = Expr.Atom;

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2456,13 +2456,10 @@ class printer  ()= object(self:'self)
     let privatize scope lst = match scope with
       | Public -> lst
       | Private -> privateAtom::lst in
-    let ctrsLength = List.length te.ptyext_constructors in
-    let omitBar = ctrsLength == 1 in
     let equalInitiatedSegments =
-      let segments = List.map (self#type_extension_binding_segments ~omitBar) te.ptyext_constructors in
+      let segments = List.map self#type_extension_binding_segments te.ptyext_constructors in
       let privatized_segments = privatize te.ptyext_private segments in
-      let break = if ctrsLength > 1 then Always_rec else IfNeed in
-      [makeList ~break ~postSpace:true ~inline:(true, true) privatized_segments] in
+      [makeList ~break:Always_rec ~postSpace:true ~inline:(true, true) privatized_segments] in
     let formattedTypeParams = List.map self#type_param te.ptyext_params in
     let binding = makeList ~postSpace:true (prepend::name::[]) in
     let labelWithParams = match formattedTypeParams with
@@ -2477,7 +2474,7 @@ class printer  ()= object(self:'self)
     in
     SourceMap (te.ptyext_path.loc, everything)
 
-  method type_extension_binding_segments ~omitBar {pext_kind; pext_loc; pext_attributes; pext_name} =
+  method type_extension_binding_segments {pext_kind; pext_loc; pext_attributes; pext_name} =
     let normalize lst = match lst with
         | [] -> raise (NotPossible "should not be called")
         | [hd] -> hd
@@ -2485,15 +2482,11 @@ class printer  ()= object(self:'self)
       in
       let add_bar name args =
         let lbl = label ~space:true name args in
-        if omitBar == true
-          then lbl
-          else makeList ~postSpace:true [atom "|"; lbl]
+        makeList ~postSpace:true [atom "|"; lbl]
       in
     let sourceMappedName = SourceMap (pext_name.loc, atom pext_name.txt) in
     let nameOf = makeList ~postSpace:true [sourceMappedName] in
-    let barName = if (omitBar == true)
-      then sourceMappedName
-      else makeList ~postSpace:true [atom "|"; sourceMappedName] in
+    let barName = makeList ~postSpace:true [atom "|"; sourceMappedName] in
     let resolved = match pext_kind with
       | Pext_decl (ctor_args, gadt) ->
         let formattedArgs = match ctor_args with

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2452,9 +2452,17 @@ class printer  ()= object(self:'self)
     (SourceMap (ptype_loc, everything))
 
   method formatOneTypeExt prepend name assignToken te =
+    let privateAtom = (atom "pri") in
+    let privatize scope lst = match scope with
+      | Public -> lst
+      | Private -> privateAtom::lst in
+    let ctrsLength = List.length te.ptyext_constructors in
+    let omitBar = ctrsLength == 1 in
     let equalInitiatedSegments =
-      let segments = List.map self#type_extension_binding_segments te.ptyext_constructors in
-      [makeList ~break:Always_rec ~postSpace:true ~inline:(true, true) segments] in
+      let segments = List.map (self#type_extension_binding_segments ~omitBar) te.ptyext_constructors in
+      let privatized_segments = privatize te.ptyext_private segments in
+      let break = if ctrsLength > 1 then Always_rec else IfNeed in
+      [makeList ~break ~postSpace:true ~inline:(true, true) privatized_segments] in
     let formattedTypeParams = List.map self#type_param te.ptyext_params in
     let binding = makeList ~postSpace:true (prepend::name::[]) in
     let labelWithParams = match formattedTypeParams with
@@ -2469,7 +2477,7 @@ class printer  ()= object(self:'self)
     in
     SourceMap (te.ptyext_path.loc, everything)
 
-  method type_extension_binding_segments {pext_kind; pext_loc; pext_attributes; pext_name} =
+  method type_extension_binding_segments ~omitBar {pext_kind; pext_loc; pext_attributes; pext_name} =
     let normalize lst = match lst with
         | [] -> raise (NotPossible "should not be called")
         | [hd] -> hd
@@ -2477,11 +2485,15 @@ class printer  ()= object(self:'self)
       in
       let add_bar name args =
         let lbl = label ~space:true name args in
-        makeList ~postSpace:true [atom "|"; lbl]
+        if omitBar == true
+          then lbl
+          else makeList ~postSpace:true [atom "|"; lbl]
       in
     let sourceMappedName = SourceMap (pext_name.loc, atom pext_name.txt) in
     let nameOf = makeList ~postSpace:true [sourceMappedName] in
-    let barName = makeList ~postSpace:true [atom "|"; sourceMappedName] in
+    let barName = if (omitBar == true)
+      then sourceMappedName
+      else makeList ~postSpace:true [atom "|"; sourceMappedName] in
     let resolved = match pext_kind with
       | Pext_decl (ctor_args, gadt) ->
         let formattedArgs = match ctor_args with


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/1101

Update: due to consistency with normal variants, all constructors will always break recursively, regardless of the amount of constructors & line length.
(https://github.com/facebook/reason/issues/1106)

Example:
```reason
type water = ..;

type water +=
  pri
  | Ocean;

type water +=
  pri
  | MineralWater
  | SpringWater
  | TapWater
  | TableWater;
```
