### PR TITLE
Remove predef option in AST

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -66,3 +66,7 @@ let expectedPrecendence =
 
 let expectedPrecendence =
   1 \+ 1 \=== 1 \+ 1 && 1 \+ 1 !== 1 \+ 1;
+
+module X: {let x: x::unit? => unit => unit;} = {
+  let x ::x=() () => ();
+};

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -46,3 +46,7 @@ let (\===) = (===);
 let expectedPrecendence = 1 + 1 \=== 1 + 1 && 1 + 1 \!== 1 + 1;
 
 let expectedPrecendence = 1 \+ 1 \=== 1 \+ 1 && 1 \+ 1 \!== 1 \+ 1;
+
+module X: {let x: x::unit? => unit => unit;} = {
+  let x ::x=() () => ();
+};

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -250,10 +250,6 @@ let mkcf ?(loc=dummy_loc()) ?(ghost=false) d =
     let loc = set_loc_state ghost loc in
     Cf.mk ~loc d
 
-let mkoption d =
-  let loc = {d.ptyp_loc with loc_ghost = true} in
-  Typ.mk ~loc (Ptyp_constr(mkloc (Ldot (Lident "*predef*", "option")) loc,[d]))
-
 let simple_ghost_text_attr ?(loc=dummy_loc ()) txt =
   let loc = set_loc_state true loc in
   [({txt; loc}, PStr [])]
@@ -2297,7 +2293,7 @@ _class_constructor_type:
       {
         let core_type_loc = mklocation $startpos($3) $endpos($3) in
         let ct = only_core_type $3 core_type_loc in
-        mkcty(Pcty_arrow(Optional $1, mkoption ct, $5))
+        mkcty(Pcty_arrow(Optional $1, ct, $5))
        }
   | LIDENTCOLONCOLON non_arrowed_core_type EQUALGREATER class_constructor_type
       {
@@ -4264,7 +4260,7 @@ _core_type2:
   | LIDENTCOLONCOLON non_arrowed_core_type QUESTION EQUALGREATER core_type2
       {
       match $2, $5 with
-      | Core_type ct, Core_type ct2 -> Core_type (mktyp(Ptyp_arrow(Optional $1 , mkoption ct, ct2)))
+      | Core_type ct, Core_type ct2 -> Core_type (mktyp(Ptyp_arrow(Optional $1, ct, ct2)))
       | _ -> syntax_error()
       }
   | LIDENTCOLONCOLON non_arrowed_core_type EQUALGREATER core_type2

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2388,9 +2388,6 @@ class printer  ()= object(self:'self)
     | Nolabel ->  self#non_arrowed_non_simple_core_type c (* otherwise parenthesize *)
     | Labelled s -> formatLabeledArgument (atom s) "" (self#non_arrowed_non_simple_core_type c)
     | Optional lbl ->
-      match ptyp_desc with
-        | Ptyp_constr ({txt}, l) ->
-            assert (is_predef_option txt);
             let everythingButQuestion =
               formatLabeledArgument
                 (atom lbl)
@@ -2400,10 +2397,9 @@ class printer  ()= object(self:'self)
                    ~break:IfNeed
                    ~inline:(true, true)
                    (* I don't think you'll have more than one l here. *)
-                   (List.map (self#non_arrowed_non_simple_core_type) l)
+                   [self#non_arrowed_non_simple_core_type c]
                 )
-      in makeList [everythingButQuestion; atom "?"]
-    | _ -> failwith "invalid input in print_type_with_label"
+            in makeList [everythingButQuestion; atom "?"]
 
   method type_param (ct, a) =
     makeList [atom (type_variance a); self#core_type ct]
@@ -3688,7 +3684,7 @@ class printer  ()= object(self:'self)
       | (Labelled lbl, expression) :: tail ->
          let nextAttr =
            match expression.pexp_desc with
-           | Pexp_ident (ident) when ((isLongIdentWithDot ident.txt) == false 
+           | Pexp_ident (ident) when ((isLongIdentWithDot ident.txt) == false
                                         && (Longident.last ident.txt) = lbl) -> atom lbl
            | _ -> makeList ([atom lbl; atom "="; self#simplifyUnparseExpr expression])
          in

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2388,18 +2388,18 @@ class printer  ()= object(self:'self)
     | Nolabel ->  self#non_arrowed_non_simple_core_type c (* otherwise parenthesize *)
     | Labelled s -> formatLabeledArgument (atom s) "" (self#non_arrowed_non_simple_core_type c)
     | Optional lbl ->
-            let everythingButQuestion =
-              formatLabeledArgument
-                (atom lbl)
-                ""
-                (makeList
-                   ~postSpace:true
-                   ~break:IfNeed
-                   ~inline:(true, true)
-                   (* I don't think you'll have more than one l here. *)
-                   [self#non_arrowed_non_simple_core_type c]
-                )
-            in makeList [everythingButQuestion; atom "?"]
+       let everythingButQuestion =
+         formatLabeledArgument
+           (atom lbl)
+           ""
+           (makeList
+              ~postSpace:true
+              ~break:IfNeed
+              ~inline:(true, true)
+              (* I don't think you'll have more than one l here. *)
+              [self#non_arrowed_non_simple_core_type c]
+            )
+       in makeList [everythingButQuestion; atom "?"]
 
   method type_param (ct, a) =
     makeList [atom (type_variance a); self#core_type ct]


### PR DESCRIPTION
We needed to add a type constraint "*predef*.option" in 4.02.3. Now that we have migrate-parsetree to take care of this, we don't need to manually add it anymore.