### PR TITLE
Don't lock topkg into minor version

### DIFF
--- a/opam.in
+++ b/opam.in
@@ -25,7 +25,7 @@ depends: [
   "utop"                    {>= "1.17"}
   "merlin-extend"           {>= "0.3"}
   "result"                  {=  "1.2"}
-  "topkg"                   {=  "0.8.1"}
+  "topkg"                   {>=  "0.8.1" & < "0.9"}
   "ocaml-migrate-parsetree"
   "reason-parser"           {= "@version@"}
 ]


### PR DESCRIPTION
Following comment by @avsm in https://github.com/ocaml/opam-repository/pull/8822