### PR TITLE
Minor fixes to Makefile and release script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,8 @@ endif
 	$(SUBSTS) $(ROOT_DIR)/package.json.in; \
 	$(SUBSTS) $(ROOT_DIR)/package.ml.in; \
 	$(SUBSTS) $(ROOT_DIR)/opam.in
+	# pre_release and make tarball of subpkg
+	make -C $(ROOT_DIR)/reason-parser pre_release
 
 .PHONY: pre_release
 
@@ -79,7 +81,7 @@ release_check:
 	./scripts/release-check.sh
 
 release: release_check pre_release
-	git add package.json package.ml opam package.json.in package.ml.in opam.in
+	git add package.json package.ml opam reason-parser/package.json reason-parser/opam
 	git commit -m "Version $(version)"
 	git tag -a $(version) -m "Version $(version)."
 	# Push first the objects, then the tag.

--- a/scripts/opam-release.sh
+++ b/scripts/opam-release.sh
@@ -9,7 +9,7 @@ TOKEN="$(git config deploy.token)"
 # Make a new release on GitHub, get the ID
 
 RELEASE_ID=$(\
-curl -H 'Accept: application/vnd.github.v3+json' \
+curl --silent -H 'Accept: application/vnd.github.v3+json' \
     --user "${USERNAME}:${TOKEN}" \
     -X POST --data "{\"tag_name\": \"${version}\"}" \
     https://api.github.com/repos/facebook/reason/releases \
@@ -24,24 +24,21 @@ curl -H 'Accept: application/vnd.github.v3+json' \
 SUBPKG=reason-parser
 TARNAME="${SUBPKG}-${version}.tar.gz"
 
-# pre_release and make tarball of subpkg
-pushd "${SUBPKG}" && version="${version}" make pre_release && popd
 
 mkdir -p _build &&
-pushd _build &&
-tar -cvzf "${TARNAME}" "${SUBPKG}" &&
+tar -cvzf "_build/${TARNAME}" "${SUBPKG}" &&
 ASSET_DOWNLOAD_URL=$(\
-curl -H 'Accept: application/vnd.github.v3+json' \
+curl --silent -H 'Accept: application/vnd.github.v3+json' \
     -H 'Content-Type: application/gzip' \
     --user "${USERNAME}:${TOKEN}" \
     -X POST \
-    --data-binary "@${TARNAME}" \
+    --data-binary "@_build/${TARNAME}" \
     "https://uploads.github.com/repos/facebook/reason/releases/${RELEASE_ID}/assets?name=${TARNAME}" \
     | python -c 'import sys, json; print json.load(sys.stdin)["browser_download_url"]' \
-) && popd
+)
 
 
-
+echo
 
 echo "The build artifacts are now in _build. To continue, please cd there."
 echo


### PR DESCRIPTION
This change calls make reason-parser in reason-parser first to
generate correct package.json and opam files for reason-parser.

@tekknolagi 