### PR TITLE
Small fix for comments and refmt shortcut.

### DIFF
--- a/editorSupport/sublime-reason/Default.sublime-keymap
+++ b/editorSupport/sublime-reason/Default.sublime-keymap
@@ -2,7 +2,7 @@
   { "keys": ["'"], "command": "insert_snippet", "args": {"contents": "'"}, "context":
     [{ "key": "selector", "operator": "equal", "operand": "source.reason" }]
   },
-  { "keys": ["super+shift+m"], "command": "reason_format", "context":
+  { "keys": ["super+shift+c"], "command": "reason_format", "context":
     [{ "key": "selector", "operator": "equal", "operand": "source.reason" }]
   }
 ]

--- a/editorSupport/sublime-reason/Reason.sublime-command
+++ b/editorSupport/sublime-reason/Reason.sublime-command
@@ -1,0 +1,4 @@
+[{
+  "caption": "Reason: Format file",
+  "command": "reason_format"
+}]

--- a/editorSupport/sublime-reason/ReasonComment.JSON-tmPreferences
+++ b/editorSupport/sublime-reason/ReasonComment.JSON-tmPreferences
@@ -1,8 +1,7 @@
 { "name": "Reason Comments",
   "scope": "source.reason",
   "settings": {
-    "shellVariables": [{"name": "TM_COMMENT_START", "value": "// "},
-                       {"name": "TM_COMMENT_START_2", "value": "/*"},
+    "shellVariables": [{"name": "TM_COMMENT_START_2", "value": "/*"},
                        {"name": "TM_COMMENT_END_2", "value": "*/"},
                        {"name": "TM_COMMENT_DISABLE_INDENT", "value": "no"}
                         ]

--- a/editorSupport/sublime-reason/ReasonComment.tmPreferences
+++ b/editorSupport/sublime-reason/ReasonComment.tmPreferences
@@ -12,12 +12,6 @@
 		<array>
 			<dict>
 				<key>name</key>
-				<string>TM_COMMENT_START</string>
-				<key>value</key>
-				<string>// </string>
-			</dict>
-			<dict>
-				<key>name</key>
 				<string>TM_COMMENT_START_2</string>
 				<key>value</key>
 				<string>/*</string>


### PR DESCRIPTION
This is a step towards better Sublime support!

Ideally we'd dig into the project's node_modules to find `refmt` after trying to see if there's a global one.