### PR TITLE
[Printer][optinalArgs] Do not break line if label is empty

### DIFF
--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -863,6 +863,9 @@ type typeWithNestedOptionalNamedArgs =
 type typeWithNestedOptionalNamedArgs =
   outerOne::list string? => outerTwo::int? => int;
 
+let f ::tuple="long string to trigger line break" =>
+  ();
+
 let x =
   callSomeFunction
     withArg::10 andOtherArg::wrappedArg;

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -760,6 +760,8 @@ type typeWithNestedOptionalNamedArgs =
 type typeWithNestedOptionalNamedArgs =
     outerOne::(list string)? => outerTwo::int? => int;
 
+let f ::tuple="long string to trigger line break" => ();
+
 let x =
   callSomeFunction
     withArg::10


### PR DESCRIPTION
#1198 

This patch adds a special logic to not break a line between "::" and the
argument name if the syntactic sugar to omit the label is applied.