### PR TITLE
Change type 'integer' to 'int' in doc

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -504,7 +504,7 @@ Fortunately, the compiler forbids this.
 ```reason
 type possibleNum =
   | NotDefined
-  | Defined integer;
+  | Defined int;
 
 let myNumber = NotDefined;
 let Defined x = myNumber;   /* Type error! */


### PR DESCRIPTION
I think here 'integer' should be 'int' or is there something that I am missing?