### PR TITLE
Supporting menhir.20170418

### DIFF
--- a/reason-parser/opam
+++ b/reason-parser/opam
@@ -23,7 +23,7 @@ build-test: [
 ]
 depends: [
   "ocamlfind"               {build}
-  "menhir"                  {= "20170101"}
+  "menhir"                  {= "20170418"}
   "merlin-extend"           {>= "0.3"}
   "result"                  {=  "1.2"}
   "topkg"                   {=  "0.8.1"}

--- a/reason-parser/opam.in
+++ b/reason-parser/opam.in
@@ -22,7 +22,7 @@ build-test: [
 ]
 depends: [
   "ocamlfind"               {build}
-  "menhir"                  {= "20170101"}
+  "menhir"                  {= "20170418"}
   "merlin-extend"           {>= "0.3"}
   "result"                  {=  "1.2"}
   "topkg"                   {=  "0.8.1"}

--- a/reason-parser/src/reason_toolchain.ml
+++ b/reason-parser/src/reason_toolchain.ml
@@ -506,20 +506,16 @@ module JS_syntax = struct
        if in_error then
          begin
            match supplier.last_token with
+           | None -> assert false
            | Some triple ->
               (* We just recovered from the error state, try the original token again *)
               let checkpoint_with_previous_token = I.offer checkpoint triple in
-              let accept_new = I.loop_test
-                                 (fun _ _ -> true)
-                                 checkpoint_with_previous_token
-                                 false
-              in
-              if accept_new then
-                loop_handle_yacc supplier false checkpoint_with_previous_token
-              else
+              match I.shifts checkpoint_with_previous_token with
+              | None ->
                 (* The original token still fail to be parsed, discard *)
                 loop_handle_yacc supplier false checkpoint
-           | None -> assert false
+              | Some env ->
+                loop_handle_yacc supplier false checkpoint_with_previous_token
          end
        else
          let triple = read supplier in


### PR DESCRIPTION
There was a new release of menhir that changed the public API.  The commit that broke our builds was https://gitlab.inria.fr/fpottier/menhir/commit/9a0277612a4c025a88a32d800d30e80064d5b89d.  The new function `shifts` has a slightly different signature so it's not a drop-in replacement.