### PR TITLE
[Docs] Fix semicolon typo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -419,8 +419,8 @@ Constructors can carry extra data in a space-separated list.
 ```reason
 type account =
 | None
-| Instagram string;
-| Facebook string int
+| Instagram string
+| Facebook string int;
 ```
 
 Here, `Instagram` carries a `string` and `Facebook` carries a `string` and an `int`. Usage:


### PR DESCRIPTION
While reading the docs, i've seen this typo relative to constructor arguments