### PR TITLE
reason-parser: ppx_tools_versioned should at least be beta

### DIFF
--- a/reason-parser/opam
+++ b/reason-parser/opam
@@ -28,7 +28,7 @@ depends: [
   "result"                  {=  "1.2"}
   "topkg"                   {=  "0.8.1"}
   "ocaml-migrate-parsetree"
-  "ppx_tools_versioned"     {= "5.0alpha"}
+  "ppx_tools_versioned"     {>= "5.0beta"}
 ]
 depopts: [
 ]


### PR DESCRIPTION
The alpha has incorrect dependency specifications that can cause build failures.