### PR TITLE
ES6 style function

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -110,7 +110,7 @@ let add a => a [@onRet];
 
 let add a => a [@onRet];
 
-let add = (fun a => a) [@onEntireFunction];
+let add = ((a) => a) [@onEntireFunction];
 
 let res =
   if true {false} else {false [@onFalse]};
@@ -125,7 +125,7 @@ let add a b =>
 
 let add a b => a + b [@onB];
 
-let both = (fun a => a) [@onEntireFunction];
+let both = ((a) => a) [@onEntireFunction];
 
 let both a b => (a [@onA] && b) [@onEverything];
 

--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -207,7 +207,7 @@ let selfClosing3 =
     b="cause the entire thing to wrap"
   />;
 
-let a = <Foo> <Bar c=(fun a => a + 2) /> </Foo>;
+let a = <Foo> <Bar c=((a) => a + 2) /> </Foo>;
 
 let a3 = <So> <Much> <Nesting /> </Much> </So>;
 
@@ -463,7 +463,7 @@ let asd2 = video test::false 10 [@JSX] [@foo];
 
 let div ::children => 1;
 
-((fun () => div) ()) children::[] [@JSX];
+(((()) => div) ()) children::[] [@JSX];
 
 let myFun () =>
   <>

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -312,7 +312,7 @@ let incrementMyClassInstance:
   int =>
   #tupleClass int int =>
   #tupleClass int int =
-  fun i inst => {
+  (i, inst) => {
     let (x, y) = inst#pr;
     {pub pr = (x + i, y + i)}
   };

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -196,14 +196,14 @@ let printIfFirstArgGreater = true;
 
 let result =
   if printIfFirstArgGreater {
-    fun a b =>
+    (a, b) =>
       if (a > b) {
         print_string "a > b"
       } else {
         print_string "b >= a"
       }
   } else if (
-    fun a b =>
+    (a, b) =>
       if (a > b) {
         print_string "b < a"
       } else {
@@ -232,12 +232,12 @@ let myRecord = {
 };
 
 if printIfFirstArgGreater {
-  fun a b =>
+  (a, b) =>
     if (a > b) {
       print_string "a > b"
     }
 } else {
-  fun a b =>
+  (a, b) =>
     if (a > b) {
       print_string "b < a"
     }
@@ -245,30 +245,30 @@ if printIfFirstArgGreater {
 
 /* Should Be Parsed As: Cleary a type error, but at least the parsing makes that clear */
 if printIfFirstArgGreater {
-  fun a b =>
+  (a, b) =>
     if (a > b) {
       print_string "a > b"
     } else {
-      fun a b =>
+      (a, b) =>
         if (a > b) {
           print_string "b < a"
         }
     }
 };
 
-fun a b =>
+(a, b) =>
   if (a > b) {
     print_string "a > b"
   };
 
 /* What you probably wanted was: */
 if printIfFirstArgGreater {
-  fun a b =>
+  (a, b) =>
     if (a > b) {
       print_string "a > b"
     }
 } else {
-  fun a b =>
+  (a, b) =>
     if (a > b) {
       print_string "b < a"
     }
@@ -527,7 +527,7 @@ let myFunction (a: int) (b: int) :int => a + b;
 let functionReturnValueType
     (i: int, s: string)
     :(int => int) =>
-  fun x => x + 1;
+  (x) => x + 1;
 
 let curriedFormOne (i: int, s: string) =>
   s ^ string_of_int i;
@@ -555,7 +555,7 @@ let curriedFormThree
  */
 type myFuncType = (int, int) => int;
 
-let myFunc: myFuncType = fun (a, b) => a + b;
+let myFunc: myFuncType = ((a, b)) => a + b;
 
 let funcWithTypeLocallyAbstractTypes
     (type atype btype)

--- a/formatTest/unit_tests/expected_output/features403.re
+++ b/formatTest/unit_tests/expected_output/features403.re
@@ -24,7 +24,7 @@ type expr 'a =
       :expr 'a;
 
 let rec eval: type a. expr a => a =
-  fun e =>
+  (e) =>
     switch e {
     | Is0 {test} => eval test == 0
     | Val {value} => value

--- a/formatTest/unit_tests/expected_output/functionInfix.re
+++ b/formatTest/unit_tests/expected_output/functionInfix.re
@@ -21,45 +21,45 @@ fff >>= (xx yy >>= aa bb);
 
 
 /** Parse tree */
-fff >>= ((fun xx => 0) >>= (fun aa => 10));
+fff >>= (((xx) => 0) >>= ((aa) => 10));
 
 /* Minimum parenthesis */
-fff >>= ((fun xx => 0) >>= (fun aa => 10));
+fff >>= (((xx) => 0) >>= ((aa) => 10));
 
 /* Actually printed parenthesis */
-fff >>= ((fun xx => 0) >>= (fun aa => 10));
+fff >>= (((xx) => 0) >>= ((aa) => 10));
 
 
 /** Parse tree */
-fff >>= (fun xx => 0) >>= (fun aa => 10);
+fff >>= ((xx) => 0) >>= ((aa) => 10);
 
 /* Minimum parenthesis */
 /* It is very difficult to actually achieve this. */
-fff >>= (fun xx => 0) >>= (fun aa => 10);
+fff >>= ((xx) => 0) >>= ((aa) => 10);
 
 /* Actually printed. */
-fff >>= (fun xx => 0) >>= (fun aa => 10);
+fff >>= ((xx) => 0) >>= ((aa) => 10);
 
 
 /** Parse tree */
-fff >>= (fun xx => 0 >>= (fun aa cc => 10));
+fff >>= ((xx) => 0 >>= ((aa, cc) => 10));
 
 /* Minimum parens - grouping the zero */
 /* Difficult to achieve. */
-fff >>= (fun xx => 0 >>= (fun aa cc => 10));
+fff >>= ((xx) => 0 >>= ((aa, cc) => 10));
 
 /* Actually printed parenthesis. */
-fff >>= (fun xx => 0) >>= (fun aa cc => 10);
+fff >>= ((xx) => 0) >>= ((aa, cc) => 10);
 
 /* Another way you could also write it it */
-fff >>= (fun xx => 0) >>= (fun aa cc => 10);
+fff >>= ((xx) => 0) >>= ((aa, cc) => 10);
 
 
 /** Parse tree */
-fff >>= (fun xx => 0);
+fff >>= ((xx) => 0);
 
 /* Minimum parens - grouping the zero */
-fff >>= (fun xx => 0);
+fff >>= ((xx) => 0);
 
 /* Printed parens - see how more are printed than necessary. */
-fff >>= (fun xx => 0);
+fff >>= ((xx) => 0);

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -322,7 +322,7 @@ module ResultFromNonSimpleFunctorArg =
 
 /* TODO: Functor type signatures should more resemble value signatures */
 let curriedFunc: int => int => int =
-  fun a b => a + b;
+  (a, b) => a + b;
 
 module type FunctorType =
   ASig => BSig => SigResult;

--- a/formatTest/unit_tests/expected_output/polymorphism.re
+++ b/formatTest/unit_tests/expected_output/polymorphism.re
@@ -38,7 +38,7 @@ let myFunc
     (a: int => int)
     (b: int => int)
     :(myType int => myType int) =>
-  fun lst => lst;
+  (lst) => lst;
 
 let certainlyRequiresWrapping:
   option (Mod.handler p re, Mod.Types.handler) =>

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -197,7 +197,7 @@ let desiredFormattingForWrappedLambda:
    pre-   /firstarg\
    fix   /-coupled--\
     |-\ /-to-prefix--\       */
-  fun curriedArg anotherArg lastArg => {
+  (curriedArg, anotherArg, lastArg) => {
     nameBlah: 10
   };
 
@@ -214,7 +214,7 @@ let desiredFormattingForWrappedLambdaWrappedArrow:
    pre-   /firstarg\
    fix   /-coupled--\
     |-\ /-to-prefix--\       */
-  fun curriedArg anotherArg lastArg => {
+  (curriedArg, anotherArg, lastArg) => {
     nameBlah: 10
   };
 
@@ -614,7 +614,7 @@ let tupleInsideALetSequence = {
 /* We *require* that function return types be wrapped in
    parenthesis. In this example, there's no ambiguity */
 let makeIncrementer (delta: int) :(int => int) =>
-  fun a => a + delta;
+  (a) => a + delta;
 
 /* We could even force that consistency with let bindings - it's allowed
       currently but not forced.

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -260,16 +260,16 @@ let rec eval: type a. term a => a =
   fun
   | Int n => n
   /* a = int */
-  | Add => (fun x y => x + y)
+  | Add => ((x, y) => x + y)
   /* a = int => int => int */
   | App f x => (eval f) (eval x);
 
 let rec eval: type a. term a => a =
-  fun x =>
+  (x) =>
     switch x {
     | Int n => n
     /* a = int */
-    | Add => (fun x y => x + y)
+    | Add => ((x, y) => x + y)
     /* a = int => int => int */
     | App f x => (eval f) (eval x)
     };

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -263,7 +263,7 @@ let explictlyPassed =
     /* None; */
     b::?None;
 
-let complex_default ::callback=(fun k d => 4) x => 3;
+let complex_default ::callback=((k, d) => 4) x => 3;
 
 let myList = /*CommentAfterEqualBeforeList */ [
   1,
@@ -691,24 +691,26 @@ let echoTheEchoer
 
 /* Nothing annotated fun, passed to func */
 echoTheEchoer (
-  fun (
-        a,
-        b,
-        c,
-        d,
-        e,
-        f,
-        g,
-        h,
-        i,
-        j,
-        k,
-        l,
-        m,
-        n,
-        o,
-        p
-      ) => (
+  (
+    (
+      a,
+      b,
+      c,
+      d,
+      e,
+      f,
+      g,
+      h,
+      i,
+      j,
+      k,
+      l,
+      m,
+      n,
+      o,
+      p
+    )
+  ) => (
     a,
     b,
     c,
@@ -1885,9 +1887,9 @@ let (the, type_, and_, value, should, both, wrap): (
   "wrap"
 );
 
-let myPolyFunc: 'a .'a => 'a = fun o => o;
+let myPolyFunc: 'a .'a => 'a = (o) => o;
 
-let myNonPolyFunc: 'a => 'a = fun o => o;
+let myNonPolyFunc: 'a => 'a = (o) => o;
 
 let locallyAbstractFunc (type a) (input: a) => input;
 
@@ -1902,9 +1904,9 @@ let locallyAbstractFuncAnnotated: type a. a => a =
   Examples of how long versions of these should be wrapped: df stands for
   "desired formatting" when the function binding itself must wrap.
  */
-let df_myPolyFunc: 'a .'a => 'a = fun o => o;
+let df_myPolyFunc: 'a .'a => 'a = (o) => o;
 
-let df_myNonPolyFunc: 'a => 'a = fun o => o;
+let df_myNonPolyFunc: 'a => 'a = (o) => o;
 
 type nameBlahType = {nameBlah: int};
 
@@ -1940,7 +1942,7 @@ let df_locallyAbstractFuncNotSugared
  */
 let df_locallyAbstractFuncAnnotated:
   type a. a => a => inputEchoRecord a =
-  fun (input: a) (input: a) => {inputIs: input};
+  ((input: a), (input: a)) => {inputIs: input};
 
 
 /**
@@ -1989,7 +1991,7 @@ let df_locallyAbstractFuncAnnotated:
     a =>
     b =>
     (inputEchoRecord a, inputEchoRecord b) =
-  fun (input: a) (input2: b) => (
+  ((input: a), (input2: b)) => (
     {inputIs: input},
     {inputIs: input2}
   );
@@ -2003,7 +2005,7 @@ let df_locallyAbstractFuncAnnotated:
  */
 let df_locallyAbstractFuncAnnotated: 'figureMeOut =
   fun (type a b) => (
-    fun (input: a) (input2: b) => (
+    ((input: a), (input2: b)) => (
       {inputIs: input},
       {inputIs: input2}
     ):
@@ -2016,7 +2018,7 @@ let createTuple_thisFuncShouldWrapCorrectlyNow:
   'a .
   'a => 'a => 'a => ('a, 'a, 'a)
  =
-  fun someVar someVar2 someVar3 => (
+  (someVar, someVar2, someVar3) => (
     someVar,
     someVar2,
     someVar3
@@ -2473,55 +2475,55 @@ let myPolyFuncCommentBeforeColon /*beforeColon */:
   'a .
   'a => 'a
  =
-  fun o => o;
+  (o) => o;
 
 let myPolyFuncCommentAfterColon: 'a .'a => 'a =
   /*afterColon */
-  fun o => o;
+  (o) => o;
 
 let myPolyFuncCommentBeforeArrow:
   'a .
   'a /*beforeArrow */ => 'a
  =
-  fun o => o;
+  (o) => o;
 
 let myPolyFuncCommentAfterArrow:
   'a .
   'a => /*afterArrow */ 'a
  =
-  fun o => o;
+  (o) => o;
 
 let myPolyFuncCommentBeforeEqual:
   'a .
   'a => 'a /*beforeEqual */
  =
-  fun o => o;
+  (o) => o;
 
 let myPolyFuncCommentAfterEqual: 'a .'a => 'a =
-  /*afterEqual */ fun o => o;
+  /*afterEqual */ (o) => o;
 
 let myNonPolyFuncCommentBeforeColon /*BeforeColon */:
   'a => 'a =
-  fun o => o;
+  (o) => o;
 
 let myNonPolyFuncCommentAfterColon:
   /*AfterColon */ 'a => 'a =
-  fun o => o;
+  (o) => o;
 
 let myNonPolyFuncCommentBeforeArrow:
   'a /*BeforeArrow */ => 'a =
-  fun o => o;
+  (o) => o;
 
 let myNonPolyFuncCommentAfterArrow:
   'a => /*AfterArrow */ 'a =
-  fun o => o;
+  (o) => o;
 
 let myNonPolyFuncCommentBeforeEqual:
   'a => 'a /*BeforeEqual */ =
-  fun o => o;
+  (o) => o;
 
 let myNonPolyFuncCommentAfterEqual: 'a => 'a =
-  /*AfterEqual */ fun o => o;
+  /*AfterEqual */ (o) => o;
 
 let lATCurrySugarCommentBeforeType /*BeforeType */
     (type a)

--- a/reason-parser/src/reason_lexer.mll
+++ b/reason-parser/src/reason_lexer.mll
@@ -792,9 +792,9 @@ and skip_sharp_bang = parse
             lparen :: fake_triple ES6_FUN lparen :: acc
           | [] -> assert false
         in
-        lex_balanced_step closing lexbuf (rparen @ acc) tok
-      | tok ->
-        lex_balanced_step closing lexbuf (rparen @ acc) tok
+        lex_balanced_step closing lexbuf (rparen @ acc) EQUALGREATER
+      | tok' ->
+        lex_balanced_step closing lexbuf (rparen @ acc) tok'
       end
     | _ -> lex_balanced closing lexbuf acc
 

--- a/reason-parser/src/reason_lexer.mll
+++ b/reason-parser/src/reason_lexer.mll
@@ -87,6 +87,7 @@ let keyword_table =
     "false", FALSE;
     "for", FOR;
     "fun", FUN;
+    "esfun", ES6_FUN;
     "function", FUNCTION;
     "functor", FUNCTOR;
     "if", IF;

--- a/reason-parser/src/reason_parser.messages
+++ b/reason-parser/src/reason_parser.messages
@@ -60,7 +60,7 @@
 
 use_file: SHARP LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2894.
+## Ends in an error in state: 2915.
 ##
 ## _use_file -> toplevel_directive SEMI . use_file [ # ]
 ##
@@ -72,7 +72,7 @@ use_file: SHARP LIDENT SEMI WITH
 
 use_file: SHARP LIDENT TRUE WITH
 ##
-## Ends in an error in state: 2893.
+## Ends in an error in state: 2914.
 ##
 ## _use_file -> toplevel_directive . SEMI use_file [ # ]
 ## _use_file -> toplevel_directive . EOF [ # ]
@@ -85,7 +85,7 @@ use_file: SHARP LIDENT TRUE WITH
 
 use_file: UIDENT RPAREN
 ##
-## Ends in an error in state: 2896.
+## Ends in an error in state: 2917.
 ##
 ## _use_file -> structure_item . SEMI use_file [ # ]
 ## _use_file -> structure_item . EOF [ # ]
@@ -98,27 +98,27 @@ use_file: UIDENT RPAREN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 937, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2885, spurious reduction of production post_item_attributes ->
-## In state 2886, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 2887, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 2865, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 2851, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 2889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 2866, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 946, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2906, spurious reduction of production post_item_attributes ->
+## In state 2907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 2908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 2886, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 2872, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 2910, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 2887, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 use_file: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2897.
+## Ends in an error in state: 2918.
 ##
 ## _use_file -> structure_item SEMI . use_file [ # ]
 ##
@@ -130,7 +130,7 @@ use_file: UIDENT SEMI WITH
 
 use_file: WITH
 ##
-## Ends in an error in state: 2890.
+## Ends in an error in state: 2911.
 ##
 ## use_file' -> . use_file [ # ]
 ##
@@ -142,7 +142,7 @@ use_file: WITH
 
 toplevel_phrase: SHARP UIDENT EOF
 ##
-## Ends in an error in state: 2849.
+## Ends in an error in state: 2870.
 ##
 ## _toplevel_phrase -> toplevel_directive . SEMI [ # ]
 ##
@@ -153,14 +153,14 @@ toplevel_phrase: SHARP UIDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2757, spurious reduction of production toplevel_directive -> SHARP ident
+## In state 2778, spurious reduction of production toplevel_directive -> SHARP ident
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 ##
-## Ends in an error in state: 922.
+## Ends in an error in state: 931.
 ##
 ## mod_longident -> mod_longident DOT . UIDENT [ SEMI EOF DOT ]
 ## val_longident -> mod_longident DOT . val_ident [ UIDENT TRUE STRING STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE EQUALGREATER EOF COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -173,7 +173,7 @@ toplevel_phrase: SHARP UIDENT UIDENT DOT WITH
 
 toplevel_phrase: SHARP UIDENT UIDENT WITH
 ##
-## Ends in an error in state: 2763.
+## Ends in an error in state: 2784.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ SEMI EOF DOT ]
 ## toplevel_directive -> SHARP ident mod_longident . [ SEMI EOF ]
@@ -187,7 +187,7 @@ toplevel_phrase: SHARP UIDENT UIDENT WITH
 
 toplevel_phrase: SHARP UIDENT WITH
 ##
-## Ends in an error in state: 2757.
+## Ends in an error in state: 2778.
 ##
 ## toplevel_directive -> SHARP ident . [ SEMI EOF ]
 ## toplevel_directive -> SHARP ident . STRING [ SEMI EOF ]
@@ -205,7 +205,7 @@ toplevel_phrase: SHARP UIDENT WITH
 
 toplevel_phrase: SHARP WITH
 ##
-## Ends in an error in state: 2756.
+## Ends in an error in state: 2777.
 ##
 ## toplevel_directive -> SHARP . ident [ SEMI EOF ]
 ## toplevel_directive -> SHARP . ident STRING [ SEMI EOF ]
@@ -223,7 +223,7 @@ toplevel_phrase: SHARP WITH
 
 toplevel_phrase: UIDENT RPAREN
 ##
-## Ends in an error in state: 2852.
+## Ends in an error in state: 2873.
 ##
 ## _toplevel_phrase -> structure_item . SEMI [ # ]
 ##
@@ -235,27 +235,27 @@ toplevel_phrase: UIDENT RPAREN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 937, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2885, spurious reduction of production post_item_attributes ->
-## In state 2886, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 2887, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 2865, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 2851, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 2889, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 2866, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 946, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2906, spurious reduction of production post_item_attributes ->
+## In state 2907, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 2908, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 2886, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 2872, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 2910, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 2887, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 <SYNTAX ERROR>
 
 toplevel_phrase: WITH
 ##
-## Ends in an error in state: 2714.
+## Ends in an error in state: 2735.
 ##
 ## toplevel_phrase' -> . toplevel_phrase [ # ]
 ##
@@ -602,7 +602,7 @@ parse_pattern: LBRACKETBAR WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 ##
-## Ends in an error in state: 2480.
+## Ends in an error in state: 2501.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ error RPAREN LBRACKETAT COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ error RPAREN LBRACKETAT COLONCOLON AS ]
@@ -620,7 +620,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 2479.
+## Ends in an error in state: 2500.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA . pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -633,7 +633,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE COMMA WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2478.
+## Ends in an error in state: 2499.
 ##
 ## _pattern_without_or -> pattern_without_or . AS val_ident [ LBRACKETAT COMMA COLONCOLON AS ]
 ## _pattern_without_or -> pattern_without_or . AS error [ LBRACKETAT COMMA COLONCOLON AS ]
@@ -651,7 +651,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN UNDERSCORE WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2477.
+## Ends in an error in state: 2498.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN LPAREN . pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -664,7 +664,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN LPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2476.
+## Ends in an error in state: 2497.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON RPAREN . LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -677,7 +677,7 @@ parse_pattern: LPAREN COLONCOLON RPAREN WITH
 
 parse_pattern: LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2475.
+## Ends in an error in state: 2496.
 ##
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
 ## _pattern_without_or -> LPAREN COLONCOLON . RPAREN LPAREN pattern_without_or COMMA pattern_without_or error [ WHEN SEMI RPAREN RBRACKET LBRACKETAT IN EQUALGREATER EQUAL EOF COMMA COLONCOLON COLON BAR AS ]
@@ -1038,7 +1038,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WHILE
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LBRACE DOTDOT RBRACE AND WITH
 ##
-## Ends in an error in state: 2473.
+## Ends in an error in state: 2494.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ error RPAREN ]
 ##
@@ -1050,7 +1050,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LBRACE D
 
 parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LBRACE DOTDOT RBRACE WITH
 ##
-## Ends in an error in state: 2472.
+## Ends in an error in state: 2493.
 ##
 ## package_type_cstrs -> package_type_cstr . [ error RPAREN ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ error RPAREN ]
@@ -1068,7 +1068,7 @@ parse_pattern: LPAREN MODULE UIDENT COLON UIDENT WITH TYPE LIDENT EQUAL LBRACE D
 ## In state 647, spurious reduction of production _core_type -> core_type2
 ## In state 658, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 646, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 2470, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 2491, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
@@ -1534,7 +1534,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LIDENT UNDERSCORE WHILE
 
 parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2580.
+## Ends in an error in state: 2601.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN MODULE package_type . RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1554,7 +1554,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE UIDENT COLONGREATER
 
 parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE WITH
 ##
-## Ends in an error in state: 2579.
+## Ends in an error in state: 2600.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN MODULE . package_type RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ##
@@ -1566,7 +1566,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LPAREN MODULE WITH
 
 parse_pattern: LPAREN UNDERSCORE COLON LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2582.
+## Ends in an error in state: 2603.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN core_type_comma_list . RPAREN [ error WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BARRBRACKET BAR AS AND ]
 ## core_type_comma_list -> core_type_comma_list . COMMA core_type [ RPAREN COMMA ]
@@ -1584,7 +1584,7 @@ parse_pattern: LPAREN UNDERSCORE COLON LPAREN UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 290, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 277, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1206, spurious reduction of production core_type_comma_list -> core_type
+## In state 1227, spurious reduction of production core_type_comma_list -> core_type
 ##
 
 <SYNTAX ERROR>
@@ -1893,7 +1893,7 @@ parse_pattern: UNDERSCORE BAR WITH
 
 parse_pattern: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2711.
+## Ends in an error in state: 2732.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EOF BAR ]
 ## parse_pattern -> pattern . EOF [ # ]
@@ -1912,7 +1912,7 @@ parse_pattern: UNDERSCORE WITH
 
 parse_pattern: WITH
 ##
-## Ends in an error in state: 2710.
+## Ends in an error in state: 2731.
 ##
 ## parse_pattern' -> . parse_pattern [ # ]
 ##
@@ -1924,7 +1924,7 @@ parse_pattern: WITH
 
 parse_expression: UIDENT SEMI
 ##
-## Ends in an error in state: 2708.
+## Ends in an error in state: 2729.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -1960,20 +1960,20 @@ parse_expression: UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 937, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 946, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 parse_expression: WITH
 ##
-## Ends in an error in state: 2706.
+## Ends in an error in state: 2727.
 ##
 ## parse_expression' -> . parse_expression [ # ]
 ##
@@ -2009,7 +2009,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT UNDERSCORE AMPERSAND WITH
 
 parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 ##
-## Ends in an error in state: 1229.
+## Ends in an error in state: 1250.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET tag_field . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field -> tag_field . [ BAR ]
@@ -2029,7 +2029,7 @@ parse_core_type: LBRACKET BACKQUOTE UIDENT WITH
 
 parse_core_type: LBRACKET BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 1227.
+## Ends in an error in state: 1248.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET BAR row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2042,7 +2042,7 @@ parse_core_type: LBRACKET BAR UNDERSCORE WITH
 
 parse_core_type: LBRACKET BAR WITH
 ##
-## Ends in an error in state: 1226.
+## Ends in an error in state: 1247.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET BAR . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2054,7 +2054,7 @@ parse_core_type: LBRACKET BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 1233.
+## Ends in an error in state: 1254.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2067,7 +2067,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR UNDERSCORE WITH
 
 parse_core_type: LBRACKET UNDERSCORE BAR WITH
 ##
-## Ends in an error in state: 1232.
+## Ends in an error in state: 1253.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field BAR . row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2079,7 +2079,7 @@ parse_core_type: LBRACKET UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKET UNDERSCORE WITH
 ##
-## Ends in an error in state: 1231.
+## Ends in an error in state: 1252.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKET row_field . BAR row_field_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2117,7 +2117,7 @@ parse_core_type: LBRACKETGREATER BAR ASSERT
 
 parse_core_type: LBRACKETGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 2560.
+## Ends in an error in state: 2581.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETGREATER opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## row_field_list -> row_field_list . BAR row_field [ RBRACKET BAR ]
@@ -2168,7 +2168,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE BAR WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2565.
+## Ends in an error in state: 2586.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER name_tag_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## name_tag_list -> name_tag_list . name_tag [ RBRACKET BACKQUOTE ]
@@ -2181,7 +2181,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 ##
-## Ends in an error in state: 2564.
+## Ends in an error in state: 2585.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list GREATER . name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ##
@@ -2193,7 +2193,7 @@ parse_core_type: LBRACKETLESS UNDERSCORE GREATER WITH
 
 parse_core_type: LBRACKETLESS UNDERSCORE WITH
 ##
-## Ends in an error in state: 2562.
+## Ends in an error in state: 2583.
 ##
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## _non_arrowed_simple_core_type -> LBRACKETLESS opt_bar row_field_list . GREATER name_tag_list RBRACKET [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2246,7 +2246,7 @@ parse_core_type: LBRACE LIDENT COLON LBRACE DOTDOT RBRACE COMMA WITH
 
 parse_core_type: LBRACE LIDENT COLON QUOTE UIDENT DOT WITH
 ##
-## Ends in an error in state: 1607.
+## Ends in an error in state: 1628.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ RBRACE LBRACKETAT EQUAL COMMA ]
 ##
@@ -2258,7 +2258,7 @@ parse_core_type: LBRACE LIDENT COLON QUOTE UIDENT DOT WITH
 
 parse_core_type: LBRACE LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1606.
+## Ends in an error in state: 1627.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ RBRACE LBRACKETAT EQUAL COMMA ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -2271,7 +2271,7 @@ parse_core_type: LBRACE LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH
 
 parse_core_type: LBRACE LIDENT COLON QUOTE UIDENT QUOTE WITH
 ##
-## Ends in an error in state: 1413.
+## Ends in an error in state: 1434.
 ##
 ## typevar_list -> typevar_list QUOTE . ident [ QUOTE DOT ]
 ##
@@ -2283,7 +2283,7 @@ parse_core_type: LBRACE LIDENT COLON QUOTE UIDENT QUOTE WITH
 
 parse_core_type: LBRACE LIDENT COLON QUOTE WITH
 ##
-## Ends in an error in state: 1505.
+## Ends in an error in state: 1526.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ RBRACE LBRACKETAT EQUALGREATER EQUAL COMMA COLONGREATER AS ]
 ## typevar_list -> QUOTE . ident [ QUOTE DOT ]
@@ -2296,7 +2296,7 @@ parse_core_type: LBRACE LIDENT COLON QUOTE WITH
 
 parse_core_type: LBRACE LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 2557.
+## Ends in an error in state: 2578.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## object_record_type -> LBRACE label_declarations . opt_comma RBRACE [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
@@ -2314,11 +2314,11 @@ parse_core_type: LBRACE LIDENT COLON UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 290, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 277, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1613, spurious reduction of production _poly_type -> core_type
-## In state 1614, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1612, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 2549, spurious reduction of production attributes ->
-## In state 2550, spurious reduction of production label_declaration -> mutable_flag LIDENT attributes COLON poly_type attributes
+## In state 1634, spurious reduction of production _poly_type -> core_type
+## In state 1635, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1633, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 2570, spurious reduction of production attributes ->
+## In state 2571, spurious reduction of production label_declaration -> mutable_flag LIDENT attributes COLON poly_type attributes
 ## In state 319, spurious reduction of production label_declarations -> label_declaration
 ##
 
@@ -2408,7 +2408,7 @@ parse_core_type: LPAREN MODULE UIDENT SEMI
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LBRACE DOTDOT RBRACE AND WITH
 ##
-## Ends in an error in state: 2576.
+## Ends in an error in state: 2597.
 ##
 ## package_type_cstrs -> package_type_cstr AND . package_type_cstrs [ RPAREN COLONGREATER ]
 ##
@@ -2420,7 +2420,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LBRACE DOTDOT RBRAC
 
 parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LBRACE DOTDOT RBRACE WITH
 ##
-## Ends in an error in state: 2575.
+## Ends in an error in state: 2596.
 ##
 ## package_type_cstrs -> package_type_cstr . [ RPAREN COLONGREATER ]
 ## package_type_cstrs -> package_type_cstr . AND package_type_cstrs [ RPAREN COLONGREATER ]
@@ -2438,7 +2438,7 @@ parse_core_type: LPAREN MODULE UIDENT WITH TYPE LIDENT EQUAL LBRACE DOTDOT RBRAC
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 290, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 277, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 2573, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
+## In state 2594, spurious reduction of production package_type_cstr -> TYPE label_longident EQUAL core_type
 ##
 
 <SYNTAX ERROR>
@@ -2505,7 +2505,7 @@ parse_core_type: LPAREN MODULE WITH
 
 parse_core_type: LPAREN UNDERSCORE COMMA WITH
 ##
-## Ends in an error in state: 1204.
+## Ends in an error in state: 1225.
 ##
 ## core_type_comma_list -> core_type_comma_list COMMA . core_type [ RPAREN COMMA ]
 ##
@@ -2517,7 +2517,7 @@ parse_core_type: LPAREN UNDERSCORE COMMA WITH
 
 parse_core_type: LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1202.
+## Ends in an error in state: 1223.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN core_type_comma_list . RPAREN [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLON BAR AS AND AMPERSAND ]
 ## core_type_comma_list -> core_type_comma_list . COMMA core_type [ RPAREN COMMA ]
@@ -2535,7 +2535,7 @@ parse_core_type: LPAREN UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 290, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 277, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1206, spurious reduction of production core_type_comma_list -> core_type
+## In state 1227, spurious reduction of production core_type_comma_list -> core_type
 ##
 
 Expecting one of the following:
@@ -2556,7 +2556,7 @@ parse_core_type: QUOTE WITH
 
 parse_core_type: SHARP LIDENT UNDERSCORE WHILE
 ##
-## Ends in an error in state: 2578.
+## Ends in an error in state: 2599.
 ##
 ## _non_arrowed_non_simple_core_type -> SHARP class_longident non_arrowed_simple_core_type_list . [ WITH SEMI RPAREN RBRACKET RBRACE QUESTION LBRACKETATAT LBRACKETAT GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ WITH UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER BAR AS AND AMPERSAND ]
@@ -2723,7 +2723,7 @@ parse_core_type: UNDERSCORE EQUALGREATER WITH
 
 parse_core_type: UNDERSCORE WITH
 ##
-## Ends in an error in state: 2704.
+## Ends in an error in state: 2725.
 ##
 ## parse_core_type -> core_type . EOF [ # ]
 ##
@@ -2746,7 +2746,7 @@ parse_core_type: UNDERSCORE WITH
 
 parse_core_type: WITH
 ##
-## Ends in an error in state: 2702.
+## Ends in an error in state: 2723.
 ##
 ## parse_core_type' -> . parse_core_type [ # ]
 ##
@@ -2758,7 +2758,7 @@ parse_core_type: WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 ##
-## Ends in an error in state: 2036.
+## Ends in an error in state: 2057.
 ##
 ## and_class_description -> AND . class_description_details post_item_attributes [ SEMI AND ]
 ##
@@ -2770,7 +2770,7 @@ interface: CLASS LIDENT COLON NEW LIDENT AND WITH
 
 interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ##
-## Ends in an error in state: 2035.
+## Ends in an error in state: 2056.
 ##
 ## _signature_item -> many_class_descriptions . [ SEMI ]
 ## many_class_descriptions -> many_class_descriptions . and_class_description [ SEMI AND ]
@@ -2782,22 +2782,22 @@ interface: CLASS LIDENT COLON NEW LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1697, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1701, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1695, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1699, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1710, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1708, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
-## In state 1982, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
-## In state 1983, spurious reduction of production post_item_attributes ->
-## In state 1984, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
+## In state 1718, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1722, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1716, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1720, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1731, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1729, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 2003, spurious reduction of production class_description_details -> virtual_flag LIDENT class_type_parameters COLON class_constructor_type
+## In state 2004, spurious reduction of production post_item_attributes ->
+## In state 2005, spurious reduction of production many_class_descriptions -> CLASS class_description_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 1981.
+## Ends in an error in state: 2002.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters COLON . class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -2809,7 +2809,7 @@ interface: CLASS LIDENT COLON WITH
 
 interface: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1458.
+## Ends in an error in state: 1479.
 ##
 ## type_parameter -> type_variance . type_variable [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS MINUS LPAREN LIDENTCOLONCOLON LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT FLOAT FALSE EQUAL COLONCOLONLIDENT COLON CHAR BACKQUOTE ]
 ##
@@ -2821,7 +2821,7 @@ interface: CLASS LIDENT PLUS WITH
 
 interface: CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1980.
+## Ends in an error in state: 2001.
 ##
 ## class_description_details -> virtual_flag LIDENT class_type_parameters . COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS COLON ]
@@ -2834,7 +2834,7 @@ interface: CLASS LIDENT WITH
 
 interface: CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 1978.
+## Ends in an error in state: 1999.
 ##
 ## class_description_details -> virtual_flag . LIDENT class_type_parameters COLON class_constructor_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -2846,7 +2846,7 @@ interface: CLASS VIRTUAL LET
 
 interface: CLASS WITH
 ##
-## Ends in an error in state: 1969.
+## Ends in an error in state: 1990.
 ##
 ## many_class_descriptions -> CLASS . class_description_details post_item_attributes [ SEMI AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ SEMI AND ]
@@ -2859,7 +2859,7 @@ interface: CLASS WITH
 
 interface: EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1947.
+## Ends in an error in state: 1968.
 ##
 ## extension_constructor_declaration -> UIDENT . generalized_constructor_arguments attributes [ SEMI LBRACKETATAT BAR ]
 ##
@@ -2871,7 +2871,7 @@ interface: EXCEPTION UIDENT WITH
 
 interface: EXCEPTION WITH
 ##
-## Ends in an error in state: 1946.
+## Ends in an error in state: 1967.
 ##
 ## sig_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ SEMI ]
 ##
@@ -2883,7 +2883,7 @@ interface: EXCEPTION WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1941.
+## Ends in an error in state: 1962.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -2895,7 +2895,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1940.
+## Ends in an error in state: 1961.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -2918,7 +2918,7 @@ interface: EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 interface: EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1939.
+## Ends in an error in state: 1960.
 ##
 ## _signature_item -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -2930,7 +2930,7 @@ interface: EXTERNAL LIDENT COLON WITH
 
 interface: EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 1938.
+## Ends in an error in state: 1959.
 ##
 ## _signature_item -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -2942,7 +2942,7 @@ interface: EXTERNAL LIDENT WITH
 
 interface: EXTERNAL WITH
 ##
-## Ends in an error in state: 1937.
+## Ends in an error in state: 1958.
 ##
 ## _signature_item -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ SEMI ]
 ##
@@ -2954,7 +2954,7 @@ interface: EXTERNAL WITH
 
 interface: INCLUDE LBRACE OPEN UIDENT WITH
 ##
-## Ends in an error in state: 1985.
+## Ends in an error in state: 2006.
 ##
 ## signature -> signature_item . SEMI signature [ error RBRACE ]
 ##
@@ -2965,18 +2965,18 @@ interface: INCLUDE LBRACE OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1822, spurious reduction of production post_item_attributes ->
-## In state 1823, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 2015, spurious reduction of production _signature_item -> open_statement
-## In state 2043, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 2016, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 1843, spurious reduction of production post_item_attributes ->
+## In state 1844, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 2036, spurious reduction of production _signature_item -> open_statement
+## In state 2064, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 2037, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 1986.
+## Ends in an error in state: 2007.
 ##
 ## signature -> signature_item SEMI . signature [ error RBRACE ]
 ##
@@ -2988,7 +2988,7 @@ interface: INCLUDE LBRACE TYPE LIDENT SEMI WITH
 
 interface: INCLUDE LBRACE WITH
 ##
-## Ends in an error in state: 1819.
+## Ends in an error in state: 1840.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LBRACE . signature error [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3001,7 +3001,7 @@ interface: INCLUDE LBRACE WITH
 
 interface: INCLUDE LPAREN LBRACE WITH
 ##
-## Ends in an error in state: 1175.
+## Ends in an error in state: 1196.
 ##
 ## _simple_module_type -> LBRACE . signature RBRACE [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _simple_module_type -> LBRACE . signature error [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3014,7 +3014,7 @@ interface: INCLUDE LPAREN LBRACE WITH
 
 interface: INCLUDE LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 1764.
+## Ends in an error in state: 1785.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3030,7 +3030,7 @@ interface: INCLUDE LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 ##
-## Ends in an error in state: 2095.
+## Ends in an error in state: 2116.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3046,7 +3046,7 @@ interface: INCLUDE LPAREN LPAREN LIDENT WHILE
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 2103.
+## Ends in an error in state: 2124.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3061,7 +3061,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER LID
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2102.
+## Ends in an error in state: 2123.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3073,7 +3073,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WIT
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2101.
+## Ends in an error in state: 2122.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3085,7 +3085,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2100.
+## Ends in an error in state: 2121.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3101,22 +3101,22 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 133, spurious reduction of production ident -> UIDENT
 ## In state 792, spurious reduction of production mty_longident -> ident
-## In state 1830, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1859, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1855, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1828, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1860, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1856, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1829, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1861, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1857, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1851, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1880, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1876, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1849, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1881, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1877, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1850, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1882, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1878, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 2099.
+## Ends in an error in state: 2120.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3128,7 +3128,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2098.
+## Ends in an error in state: 2119.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3140,7 +3140,7 @@ interface: INCLUDE LPAREN LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN LPAREN WITH
 ##
-## Ends in an error in state: 1173.
+## Ends in an error in state: 1194.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3206,7 +3206,7 @@ interface: INCLUDE LPAREN UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 ##
-## Ends in an error in state: 1808.
+## Ends in an error in state: 1829.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
@@ -3221,7 +3221,7 @@ interface: INCLUDE LPAREN UIDENT EQUALGREATER LIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1807.
+## Ends in an error in state: 1828.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3253,7 +3253,7 @@ interface: INCLUDE LPAREN UIDENT LPAREN UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UIDENT WHILE
 ##
-## Ends in an error in state: 1174.
+## Ends in an error in state: 1195.
 ##
 ## functor_arg_name -> UIDENT . [ COLON ]
 ## ident -> UIDENT . [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -3268,7 +3268,7 @@ interface: INCLUDE LPAREN UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 ##
-## Ends in an error in state: 1790.
+## Ends in an error in state: 1811.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3281,7 +3281,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT DOT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1787.
+## Ends in an error in state: 1808.
 ##
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ RPAREN LPAREN DOT ]
 ## mod_ext2 -> UIDENT LPAREN mod_ext_longident . RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3301,7 +3301,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN UID
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1786.
+## Ends in an error in state: 1807.
 ##
 ## mod_ext2 -> UIDENT LPAREN . mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ##
@@ -3326,7 +3326,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT LPAREN WIT
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1784.
+## Ends in an error in state: 1805.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3338,7 +3338,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 1799.
+## Ends in an error in state: 1820.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3351,7 +3351,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 ##
-## Ends in an error in state: 1785.
+## Ends in an error in state: 1806.
 ##
 ## mod_ext2 -> UIDENT . LPAREN mod_ext_longident RPAREN [ error WITH SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
 ## mod_ext_longident -> UIDENT . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF DOT AND ]
@@ -3364,7 +3364,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1800.
+## Ends in an error in state: 1821.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3376,7 +3376,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1783.
+## Ends in an error in state: 1804.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3389,7 +3389,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 1782.
+## Ends in an error in state: 1803.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3402,7 +3402,7 @@ interface: INCLUDE LPAREN UIDENT WITH MODULE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRACE AND WITH
 ##
-## Ends in an error in state: 1803.
+## Ends in an error in state: 1824.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3414,7 +3414,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRAC
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRACE EQUAL
 ##
-## Ends in an error in state: 1802.
+## Ends in an error in state: 1823.
 ##
 ## _module_type -> module_type WITH with_constraints . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ## with_constraints -> with_constraints . AND with_constraint [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3432,15 +3432,15 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRAC
 ## In state 647, spurious reduction of production _core_type -> core_type2
 ## In state 658, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 646, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1773, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1805, spurious reduction of production with_constraints -> with_constraint
+## In state 1794, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1826, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1772.
+## Ends in an error in state: 1793.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3452,7 +3452,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRI WITH
 ##
-## Ends in an error in state: 1774.
+## Ends in an error in state: 1795.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ##
@@ -3464,7 +3464,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL PRI WITH
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ##
-## Ends in an error in state: 1776.
+## Ends in an error in state: 1797.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3482,14 +3482,14 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE EQUAL
 ## In state 647, spurious reduction of production _core_type -> core_type2
 ## In state 658, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 646, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1775, spurious reduction of production constraints ->
+## In state 1796, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ##
-## Ends in an error in state: 1769.
+## Ends in an error in state: 1790.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3501,14 +3501,14 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE LIDENT UNDERSCORE AND
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1292, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 1313, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 1767.
+## Ends in an error in state: 1788.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF AND ]
@@ -3521,7 +3521,7 @@ interface: INCLUDE LPAREN UIDENT WITH TYPE WITH
 
 interface: INCLUDE LPAREN UIDENT WITH WITH
 ##
-## Ends in an error in state: 1766.
+## Ends in an error in state: 1787.
 ##
 ## _module_type -> module_type WITH . with_constraints [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF ]
 ##
@@ -3533,7 +3533,7 @@ interface: INCLUDE LPAREN UIDENT WITH WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2050.
+## Ends in an error in state: 2071.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER module_type . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3549,22 +3549,22 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER UIDENT COL
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 133, spurious reduction of production ident -> UIDENT
 ## In state 792, spurious reduction of production mty_longident -> ident
-## In state 1830, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1859, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1855, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1828, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1860, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1856, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1829, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1861, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1857, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1851, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1880, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1876, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1849, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1881, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1877, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1850, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1882, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1878, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2049.
+## Ends in an error in state: 2070.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN EQUALGREATER . module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3576,7 +3576,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN EQUALGREATER WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 2048.
+## Ends in an error in state: 2069.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON module_type RPAREN . EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3588,7 +3588,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT RPAREN WITH
 
 interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2047.
+## Ends in an error in state: 2068.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> LPAREN functor_arg_name COLON module_type . RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3604,22 +3604,22 @@ interface: INCLUDE LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 133, spurious reduction of production ident -> UIDENT
 ## In state 792, spurious reduction of production mty_longident -> ident
-## In state 1830, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1859, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1855, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1828, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1860, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1856, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1829, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1861, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1857, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1851, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1880, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1876, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1849, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1881, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1877, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1850, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1882, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1878, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1818.
+## Ends in an error in state: 1839.
 ##
 ## _module_type -> LPAREN functor_arg_name COLON . module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3631,7 +3631,7 @@ interface: INCLUDE LPAREN UNDERSCORE COLON WITH
 
 interface: INCLUDE LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1817.
+## Ends in an error in state: 1838.
 ##
 ## _module_type -> LPAREN functor_arg_name . COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3643,7 +3643,7 @@ interface: INCLUDE LPAREN UNDERSCORE WITH
 
 interface: INCLUDE LPAREN WITH
 ##
-## Ends in an error in state: 1760.
+## Ends in an error in state: 1781.
 ##
 ## _module_type -> LPAREN . functor_arg_name COLON module_type RPAREN EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _simple_module_type -> LPAREN . module_type RPAREN [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3709,7 +3709,7 @@ interface: INCLUDE UIDENT DOT WITH
 
 interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1853.
+## Ends in an error in state: 1874.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3725,22 +3725,22 @@ interface: INCLUDE UIDENT EQUALGREATER UIDENT COLONGREATER
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 133, spurious reduction of production ident -> UIDENT
 ## In state 792, spurious reduction of production mty_longident -> ident
-## In state 1830, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1859, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1855, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1828, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1860, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1856, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1829, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1861, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1857, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1851, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1880, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1876, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1849, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1881, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1877, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1850, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1882, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1878, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1852.
+## Ends in an error in state: 1873.
 ##
 ## _module_type -> module_type EQUALGREATER . module_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3800,7 +3800,7 @@ interface: INCLUDE UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1843.
+## Ends in an error in state: 1864.
 ##
 ## with_constraint -> MODULE UIDENT COLONEQUAL . mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3812,7 +3812,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT DOT UIDENT WITH
 ##
-## Ends in an error in state: 1845.
+## Ends in an error in state: 1866.
 ##
 ## mod_longident -> mod_longident . DOT UIDENT [ EQUAL DOT ]
 ## with_constraint -> MODULE mod_longident . EQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3838,7 +3838,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1846.
+## Ends in an error in state: 1867.
 ##
 ## with_constraint -> MODULE mod_longident EQUAL . mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3850,7 +3850,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1842.
+## Ends in an error in state: 1863.
 ##
 ## mod_longident -> UIDENT . [ EQUAL DOT ]
 ## with_constraint -> MODULE UIDENT . COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3863,7 +3863,7 @@ interface: INCLUDE UIDENT WITH MODULE UIDENT WITH
 
 interface: INCLUDE UIDENT WITH MODULE WITH
 ##
-## Ends in an error in state: 1841.
+## Ends in an error in state: 1862.
 ##
 ## with_constraint -> MODULE . mod_longident EQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> MODULE . UIDENT COLONEQUAL mod_ext_longident [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3876,7 +3876,7 @@ interface: INCLUDE UIDENT WITH MODULE WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRACE AND WITH
 ##
-## Ends in an error in state: 1849.
+## Ends in an error in state: 1870.
 ##
 ## with_constraints -> with_constraints AND . with_constraint [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3888,7 +3888,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRACE AND W
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRACE GREATER
 ##
-## Ends in an error in state: 1848.
+## Ends in an error in state: 1869.
 ##
 ## _module_type -> module_type WITH with_constraints . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraints -> with_constraints . AND with_constraint [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3906,15 +3906,15 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRACE GREAT
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 290, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 277, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1837, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1851, spurious reduction of production with_constraints -> with_constraint
+## In state 1858, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1872, spurious reduction of production with_constraints -> with_constraint
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1836.
+## Ends in an error in state: 1857.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL . core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3926,7 +3926,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT COLONEQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRI WITH
 ##
-## Ends in an error in state: 1838.
+## Ends in an error in state: 1859.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder . core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -3938,7 +3938,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL PRI WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ##
-## Ends in an error in state: 1840.
+## Ends in an error in state: 1861.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters with_type_binder core_type constraints . [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3956,14 +3956,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE GREATER
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 290, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 277, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1839, spurious reduction of production constraints ->
+## In state 1860, spurious reduction of production constraints ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1770.
+## Ends in an error in state: 1791.
 ##
 ## with_type_binder -> EQUAL . [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENTCOLONCOLON LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET LBRACE ]
 ## with_type_binder -> EQUAL . PRI [ UNDERSCORE UIDENT SHARP QUOTE LPAREN LIDENTCOLONCOLON LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKET LBRACE ]
@@ -3976,7 +3976,7 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT EQUAL WITH
 
 interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1835.
+## Ends in an error in state: 1856.
 ##
 ## with_constraint -> TYPE label_longident optional_type_parameters . with_type_binder core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE label_longident optional_type_parameters . COLONEQUAL core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -3988,14 +3988,14 @@ interface: INCLUDE UIDENT WITH TYPE LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1834, spurious reduction of production optional_type_parameters ->
+## In state 1855, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 interface: INCLUDE UIDENT WITH TYPE WITH
 ##
-## Ends in an error in state: 1833.
+## Ends in an error in state: 1854.
 ##
 ## with_constraint -> TYPE . label_longident optional_type_parameters with_type_binder core_type constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## with_constraint -> TYPE . label_longident optional_type_parameters COLONEQUAL core_type [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4008,7 +4008,7 @@ interface: INCLUDE UIDENT WITH TYPE WITH
 
 interface: INCLUDE UIDENT WITH WITH
 ##
-## Ends in an error in state: 1832.
+## Ends in an error in state: 1853.
 ##
 ## _module_type -> module_type WITH . with_constraints [ WITH SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ##
@@ -4020,7 +4020,7 @@ interface: INCLUDE UIDENT WITH WITH
 
 interface: INCLUDE WITH
 ##
-## Ends in an error in state: 1934.
+## Ends in an error in state: 1955.
 ##
 ## _signature_item -> INCLUDE . module_type post_item_attributes [ SEMI ]
 ##
@@ -4032,7 +4032,7 @@ interface: INCLUDE WITH
 
 interface: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 1866.
+## Ends in an error in state: 1887.
 ##
 ## _signature_item -> LET val_ident COLON . core_type post_item_attributes [ SEMI ]
 ##
@@ -4044,7 +4044,7 @@ interface: LET LIDENT COLON WITH
 
 interface: LET LIDENT WITH
 ##
-## Ends in an error in state: 1865.
+## Ends in an error in state: 1886.
 ##
 ## _signature_item -> LET val_ident . COLON core_type post_item_attributes [ SEMI ]
 ##
@@ -4068,7 +4068,7 @@ interface: LET LPAREN WITH
 
 interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
 ##
-## Ends in an error in state: 2026.
+## Ends in an error in state: 2047.
 ##
 ## and_module_rec_declaration -> AND . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4080,7 +4080,7 @@ interface: LET MODULE REC UIDENT COLON LIDENT AND WITH
 
 interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 2025.
+## Ends in an error in state: 2046.
 ##
 ## _signature_item -> many_module_rec_declarations . [ SEMI ]
 ## many_module_rec_declarations -> many_module_rec_declarations . and_module_rec_declaration [ SEMI AND ]
@@ -4092,16 +4092,16 @@ interface: LET MODULE REC UIDENT COLON LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1530, spurious reduction of production post_item_attributes ->
-## In state 1531, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2014, spurious reduction of production many_module_rec_declarations -> opt_let_module REC module_rec_declaration_details post_item_attributes
+## In state 1551, spurious reduction of production post_item_attributes ->
+## In state 1552, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2035, spurious reduction of production many_module_rec_declarations -> opt_let_module REC module_rec_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 2012.
+## Ends in an error in state: 2033.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER AND ]
@@ -4117,22 +4117,22 @@ interface: LET MODULE REC UIDENT COLON UIDENT RPAREN
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 133, spurious reduction of production ident -> UIDENT
 ## In state 792, spurious reduction of production mty_longident -> ident
-## In state 1830, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1859, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1855, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1828, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1860, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1856, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1829, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1861, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1857, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1851, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1880, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1876, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1849, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1881, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1877, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1850, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1882, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1878, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE REC UIDENT COLON WITH
 ##
-## Ends in an error in state: 2011.
+## Ends in an error in state: 2032.
 ##
 ## module_rec_declaration_details -> UIDENT COLON . module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4144,7 +4144,7 @@ interface: LET MODULE REC UIDENT COLON WITH
 
 interface: LET MODULE REC UIDENT WITH
 ##
-## Ends in an error in state: 2010.
+## Ends in an error in state: 2031.
 ##
 ## module_rec_declaration_details -> UIDENT . COLON module_type [ SEMI LBRACKETATAT AND ]
 ##
@@ -4156,7 +4156,7 @@ interface: LET MODULE REC UIDENT WITH
 
 interface: LET MODULE REC WITH
 ##
-## Ends in an error in state: 2009.
+## Ends in an error in state: 2030.
 ##
 ## many_module_rec_declarations -> opt_let_module REC . module_rec_declaration_details post_item_attributes [ SEMI AND ]
 ##
@@ -4168,7 +4168,7 @@ interface: LET MODULE REC WITH
 
 interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ##
-## Ends in an error in state: 1998.
+## Ends in an error in state: 2019.
 ##
 ## _module_declaration -> COLON module_type . [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH SEMI LBRACKETATAT LBRACKETAT EQUALGREATER ]
@@ -4184,22 +4184,22 @@ interface: LET MODULE UIDENT COLON UIDENT RPAREN
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 133, spurious reduction of production ident -> UIDENT
 ## In state 792, spurious reduction of production mty_longident -> ident
-## In state 1830, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1859, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1855, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1828, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1860, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1856, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1829, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1861, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1857, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1851, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1880, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1876, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1849, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1881, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1877, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1850, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1882, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1878, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 1997.
+## Ends in an error in state: 2018.
 ##
 ## _module_declaration -> COLON . module_type [ SEMI LBRACKETATAT ]
 ##
@@ -4211,7 +4211,7 @@ interface: LET MODULE UIDENT COLON WITH
 
 interface: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2004.
+## Ends in an error in state: 2025.
 ##
 ## _signature_item -> opt_let_module UIDENT EQUAL . mod_longident post_item_attributes [ SEMI ]
 ##
@@ -4223,7 +4223,7 @@ interface: LET MODULE UIDENT EQUAL WITH
 
 interface: LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2002.
+## Ends in an error in state: 2023.
 ##
 ## _module_declaration -> LPAREN RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4235,7 +4235,7 @@ interface: LET MODULE UIDENT LPAREN RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1996.
+## Ends in an error in state: 2017.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type RPAREN . module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4247,7 +4247,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT RPAREN WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 1995.
+## Ends in an error in state: 2016.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON module_type . RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -4263,22 +4263,22 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 133, spurious reduction of production ident -> UIDENT
 ## In state 792, spurious reduction of production mty_longident -> ident
-## In state 1830, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1859, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1855, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1828, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1860, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1856, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1829, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1861, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1857, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1851, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1880, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1876, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1849, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1881, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1877, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1850, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1882, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1878, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1994.
+## Ends in an error in state: 2015.
 ##
 ## _module_declaration -> LPAREN UIDENT COLON . module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4290,7 +4290,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT COLON WITH
 
 interface: LET MODULE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1993.
+## Ends in an error in state: 2014.
 ##
 ## _module_declaration -> LPAREN UIDENT . COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ##
@@ -4302,7 +4302,7 @@ interface: LET MODULE UIDENT LPAREN UIDENT WITH
 
 interface: LET MODULE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1992.
+## Ends in an error in state: 2013.
 ##
 ## _module_declaration -> LPAREN . UIDENT COLON module_type RPAREN module_declaration [ SEMI LBRACKETATAT ]
 ## _module_declaration -> LPAREN . RPAREN module_declaration [ SEMI LBRACKETATAT ]
@@ -4315,7 +4315,7 @@ interface: LET MODULE UIDENT LPAREN WITH
 
 interface: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1991.
+## Ends in an error in state: 2012.
 ##
 ## _signature_item -> opt_let_module UIDENT . module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> opt_let_module UIDENT . EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4328,7 +4328,7 @@ interface: LET MODULE UIDENT WITH
 
 interface: LET MODULE WITH
 ##
-## Ends in an error in state: 1990.
+## Ends in an error in state: 2011.
 ##
 ## _signature_item -> opt_let_module . UIDENT module_declaration post_item_attributes [ SEMI ]
 ## _signature_item -> opt_let_module . UIDENT EQUAL mod_longident post_item_attributes [ SEMI ]
@@ -4342,7 +4342,7 @@ interface: LET MODULE WITH
 
 interface: LET WITH
 ##
-## Ends in an error in state: 1864.
+## Ends in an error in state: 1885.
 ##
 ## _signature_item -> LET . val_ident COLON core_type post_item_attributes [ SEMI ]
 ## opt_let_module -> LET . MODULE [ UIDENT REC ]
@@ -4355,7 +4355,7 @@ interface: LET WITH
 
 interface: MODULE TYPE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1827.
+## Ends in an error in state: 1848.
 ##
 ## _signature_item -> MODULE TYPE ident EQUAL . module_type post_item_attributes [ SEMI ]
 ##
@@ -4367,7 +4367,7 @@ interface: MODULE TYPE UIDENT EQUAL WITH
 
 interface: MODULE TYPE WITH
 ##
-## Ends in an error in state: 1825.
+## Ends in an error in state: 1846.
 ##
 ## _signature_item -> MODULE TYPE . ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE TYPE . ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4380,7 +4380,7 @@ interface: MODULE TYPE WITH
 
 interface: MODULE WITH
 ##
-## Ends in an error in state: 1824.
+## Ends in an error in state: 1845.
 ##
 ## _signature_item -> MODULE . TYPE ident post_item_attributes [ SEMI ]
 ## _signature_item -> MODULE . TYPE ident EQUAL module_type post_item_attributes [ SEMI ]
@@ -4394,7 +4394,7 @@ interface: MODULE WITH
 
 interface: OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2696.
+## Ends in an error in state: 2717.
 ##
 ## signature -> signature_item . SEMI signature [ EOF ]
 ##
@@ -4405,18 +4405,18 @@ interface: OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1822, spurious reduction of production post_item_attributes ->
-## In state 1823, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
-## In state 2015, spurious reduction of production _signature_item -> open_statement
-## In state 2043, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
-## In state 2016, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
+## In state 1843, spurious reduction of production post_item_attributes ->
+## In state 1844, spurious reduction of production open_statement -> OPEN override_flag mod_longident post_item_attributes
+## In state 2036, spurious reduction of production _signature_item -> open_statement
+## In state 2064, spurious reduction of production mark_position_sig(_signature_item) -> _signature_item
+## In state 2037, spurious reduction of production signature_item -> mark_position_sig(_signature_item)
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 2083.
+## Ends in an error in state: 2104.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4428,7 +4428,7 @@ interface: TYPE LIDENT PLUSEQ BAR WITH
 
 interface: TYPE LIDENT PLUSEQ PRI BANG
 ##
-## Ends in an error in state: 2082.
+## Ends in an error in state: 2103.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4440,7 +4440,7 @@ interface: TYPE LIDENT PLUSEQ PRI BANG
 
 interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 2085.
+## Ends in an error in state: 2106.
 ##
 ## sig_extension_constructors -> sig_extension_constructors BAR . extension_constructor_declaration [ SEMI LBRACKETATAT BAR ]
 ##
@@ -4452,7 +4452,7 @@ interface: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 interface: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 2080.
+## Ends in an error in state: 2101.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4464,7 +4464,7 @@ interface: TYPE LIDENT PLUSEQ WITH
 
 interface: TYPE LIDENT RBRACKET
 ##
-## Ends in an error in state: 1296.
+## Ends in an error in state: 1317.
 ##
 ## potentially_long_ident_and_optional_type_parameters -> LIDENT optional_type_parameters . [ PLUSEQ ]
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ SEMI LBRACKETATAT EOF AND ]
@@ -4476,14 +4476,14 @@ interface: TYPE LIDENT RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1295, spurious reduction of production optional_type_parameters ->
+## In state 1316, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 interface: TYPE LIDENT SEMI WITH
 ##
-## Ends in an error in state: 2697.
+## Ends in an error in state: 2718.
 ##
 ## signature -> signature_item SEMI . signature [ EOF ]
 ##
@@ -4495,7 +4495,7 @@ interface: TYPE LIDENT SEMI WITH
 
 interface: TYPE NONREC LET
 ##
-## Ends in an error in state: 1177.
+## Ends in an error in state: 1198.
 ##
 ## many_type_declarations -> TYPE nonrec_flag . type_declaration_details post_item_attributes [ SEMI AND ]
 ## sig_type_extension -> TYPE nonrec_flag . potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
@@ -4508,7 +4508,7 @@ interface: TYPE NONREC LET
 
 interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ##
-## Ends in an error in state: 2079.
+## Ends in an error in state: 2100.
 ##
 ## sig_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters . PLUSEQ private_flag opt_bar sig_extension_constructors post_item_attributes [ SEMI ]
 ##
@@ -4519,15 +4519,15 @@ interface: TYPE UIDENT DOT LIDENT UNDERSCORE SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1292, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
-## In state 1300, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
+## In state 1313, spurious reduction of production optional_type_parameters -> optional_type_parameter_list
+## In state 1321, spurious reduction of production potentially_long_ident_and_optional_type_parameters -> type_strictly_longident optional_type_parameters
 ##
 
 <SYNTAX ERROR>
 
 interface: WITH
 ##
-## Ends in an error in state: 2695.
+## Ends in an error in state: 2716.
 ##
 ## interface' -> . interface [ # ]
 ##
@@ -4539,7 +4539,7 @@ interface: WITH
 
 implementation: CLASS LIDENT COLON LIDENTCOLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1713.
+## Ends in an error in state: 1734.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4551,7 +4551,7 @@ implementation: CLASS LIDENT COLON LIDENTCOLONCOLON UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT COLON LIDENTCOLONCOLON WITH
 ##
-## Ends in an error in state: 1702.
+## Ends in an error in state: 1723.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON . QUESTION non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _class_constructor_type -> LIDENTCOLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
@@ -4564,7 +4564,7 @@ implementation: CLASS LIDENT COLON LIDENTCOLONCOLON WITH
 
 implementation: CLASS LIDENT COLON LIDENTCOLONCOLON QUESTION UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1705.
+## Ends in an error in state: 1726.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON QUESTION non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4576,7 +4576,7 @@ implementation: CLASS LIDENT COLON LIDENTCOLONCOLON QUESTION UNDERSCORE EQUALGRE
 
 implementation: CLASS LIDENT COLON LIDENTCOLONCOLON QUESTION UNDERSCORE WITH
 ##
-## Ends in an error in state: 1704.
+## Ends in an error in state: 1725.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON QUESTION non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4589,7 +4589,7 @@ implementation: CLASS LIDENT COLON LIDENTCOLONCOLON QUESTION UNDERSCORE WITH
 
 implementation: CLASS LIDENT COLON LIDENTCOLONCOLON QUESTION WITH
 ##
-## Ends in an error in state: 1703.
+## Ends in an error in state: 1724.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON QUESTION . non_arrowed_core_type EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4601,7 +4601,7 @@ implementation: CLASS LIDENT COLON LIDENTCOLONCOLON QUESTION WITH
 
 implementation: CLASS LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1706.
+## Ends in an error in state: 1727.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -4623,7 +4623,7 @@ implementation: CLASS LIDENT COLON LIDENT WITH
 
 implementation: CLASS LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1686.
+## Ends in an error in state: 1707.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4635,7 +4635,7 @@ implementation: CLASS LIDENT COLON NEW WITH
 
 implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1707.
+## Ends in an error in state: 1728.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ SEMI RPAREN LBRACKETATAT EQUAL AND ]
 ##
@@ -4647,7 +4647,7 @@ implementation: CLASS LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: CLASS LIDENT MINUS WITH
 ##
-## Ends in an error in state: 1471.
+## Ends in an error in state: 1492.
 ##
 ## signed_constant -> MINUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS MINUS LPAREN LIDENTCOLONCOLON LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT FLOAT FALSE EQUALGREATER DOTDOT COLONCOLONLIDENT COLON CHAR BACKQUOTE ]
 ## signed_constant -> MINUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS MINUS LPAREN LIDENTCOLONCOLON LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT FLOAT FALSE EQUALGREATER DOTDOT COLONCOLONLIDENT COLON CHAR BACKQUOTE ]
@@ -4661,7 +4661,7 @@ implementation: CLASS LIDENT MINUS WITH
 
 implementation: CLASS LIDENT PLUS WITH
 ##
-## Ends in an error in state: 1470.
+## Ends in an error in state: 1491.
 ##
 ## signed_constant -> PLUS . INT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS MINUS LPAREN LIDENTCOLONCOLON LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT FLOAT FALSE EQUALGREATER DOTDOT COLONCOLONLIDENT COLON CHAR BACKQUOTE ]
 ## signed_constant -> PLUS . FLOAT [ UNDERSCORE UIDENT TRUE STRING SHARP PLUS MINUS LPAREN LIDENTCOLONCOLON LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT FLOAT FALSE EQUALGREATER DOTDOT COLONCOLONLIDENT COLON CHAR BACKQUOTE ]
@@ -4675,7 +4675,7 @@ implementation: CLASS LIDENT PLUS WITH
 
 implementation: CLASS LIDENT QUOTE WITH
 ##
-## Ends in an error in state: 1459.
+## Ends in an error in state: 1480.
 ##
 ## _type_variable -> QUOTE . ident [ UNDERSCORE UIDENT TRUE STRING SHARP QUOTE PLUS MINUS LPAREN LIDENTCOLONCOLON LIDENT LBRACKETPERCENT LBRACKETBAR LBRACKET LBRACE INT FLOAT FALSE EQUAL COLONCOLONLIDENT COLON CHAR BACKQUOTE ]
 ##
@@ -4687,7 +4687,7 @@ implementation: CLASS LIDENT QUOTE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1388.
+## Ends in an error in state: 1409.
 ##
 ## class_sig_body -> class_self_type . class_sig_fields opt_semi [ error RBRACE ]
 ##
@@ -4699,7 +4699,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 ##
-## Ends in an error in state: 1383.
+## Ends in an error in state: 1404.
 ##
 ## class_self_type -> AS core_type . SEMI [ error VAL SEMI RBRACE PUB PRI LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -4722,7 +4722,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 ##
-## Ends in an error in state: 1382.
+## Ends in an error in state: 1403.
 ##
 ## class_self_type -> AS . core_type SEMI [ error VAL SEMI RBRACE PUB PRI LBRACKETPERCENTPERCENT LBRACKETATATAT INHERIT CONSTRAINT ]
 ##
@@ -4734,7 +4734,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE AS WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1441.
+## Ends in an error in state: 1462.
 ##
 ## _class_sig_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4746,7 +4746,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE CONSTRAINT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1436.
+## Ends in an error in state: 1457.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT ]
 ## _class_sig_field -> INHERIT class_instance_type . [ error SEMI RBRACE ]
@@ -4759,16 +4759,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1434, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1440, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1432, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1455, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1461, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1453, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1428.
+## Ends in an error in state: 1449.
 ##
 ## _class_sig_field -> INHERIT . class_instance_type [ error SEMI RBRACE ]
 ## _class_sig_field -> INHERIT . class_instance_type item_attribute post_item_attributes [ error SEMI RBRACE ]
@@ -4781,7 +4781,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE INHERIT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH RBRACKET WITH
 ##
-## Ends in an error in state: 1689.
+## Ends in an error in state: 1710.
 ##
 ## _class_instance_type -> LBRACE class_sig_body . RBRACE [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE class_sig_body . error [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -4793,20 +4793,20 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE LBRACKETPERCENTPERCENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1448, spurious reduction of production post_item_attributes ->
-## In state 1449, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
-## In state 1454, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
-## In state 1447, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
-## In state 1456, spurious reduction of production class_sig_fields -> class_sig_field
-## In state 1451, spurious reduction of production opt_semi ->
-## In state 1455, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
+## In state 1469, spurious reduction of production post_item_attributes ->
+## In state 1470, spurious reduction of production _class_sig_field -> item_extension post_item_attributes
+## In state 1475, spurious reduction of production mark_position_ctf(_class_sig_field) -> _class_sig_field
+## In state 1468, spurious reduction of production class_sig_field -> mark_position_ctf(_class_sig_field)
+## In state 1477, spurious reduction of production class_sig_fields -> class_sig_field
+## In state 1472, spurious reduction of production opt_semi ->
+## In state 1476, spurious reduction of production class_sig_body -> class_self_type class_sig_fields opt_semi
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PUB LIDENT COLON WITH
 ##
-## Ends in an error in state: 1409.
+## Ends in an error in state: 1430.
 ##
 ## _class_sig_field -> PUB private_virtual_flags label COLON . poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4818,7 +4818,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PUB LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PUB LIDENT WITH
 ##
-## Ends in an error in state: 1408.
+## Ends in an error in state: 1429.
 ##
 ## _class_sig_field -> PUB private_virtual_flags label . COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4830,7 +4830,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PUB LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PRI WITH
 ##
-## Ends in an error in state: 1422.
+## Ends in an error in state: 1443.
 ##
 ## _class_sig_field -> PRI . private_virtual_flags label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4842,7 +4842,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PRI WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PRI VIRTUAL WITH
 ##
-## Ends in an error in state: 1423.
+## Ends in an error in state: 1444.
 ##
 ## _class_sig_field -> PRI private_virtual_flags . label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4854,7 +4854,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PRI VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PUB VIRTUAL WITH
 ##
-## Ends in an error in state: 1407.
+## Ends in an error in state: 1428.
 ##
 ## _class_sig_field -> PUB private_virtual_flags . label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4866,7 +4866,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PUB VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PUB WITH
 ##
-## Ends in an error in state: 1405.
+## Ends in an error in state: 1426.
 ##
 ## _class_sig_field -> PUB . private_virtual_flags label COLON poly_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -4878,7 +4878,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE PUB WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1403.
+## Ends in an error in state: 1424.
 ##
 ## value_type -> label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -4890,7 +4890,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT COLON WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1402.
+## Ends in an error in state: 1423.
 ##
 ## value_type -> label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -4902,7 +4902,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WITH
 ##
-## Ends in an error in state: 1398.
+## Ends in an error in state: 1419.
 ##
 ## value_type -> MUTABLE virtual_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -4914,7 +4914,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 ##
-## Ends in an error in state: 1397.
+## Ends in an error in state: 1418.
 ##
 ## value_type -> MUTABLE virtual_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -4926,7 +4926,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 ##
-## Ends in an error in state: 1396.
+## Ends in an error in state: 1417.
 ##
 ## value_type -> MUTABLE virtual_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -4938,7 +4938,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE VIRTUAL LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1395.
+## Ends in an error in state: 1416.
 ##
 ## value_type -> MUTABLE . virtual_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -4950,7 +4950,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL MUTABLE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1393.
+## Ends in an error in state: 1414.
 ##
 ## value_type -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -4962,7 +4962,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT COLON WI
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1392.
+## Ends in an error in state: 1413.
 ##
 ## value_type -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -4974,7 +4974,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1391.
+## Ends in an error in state: 1412.
 ##
 ## value_type -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -4986,7 +4986,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1390.
+## Ends in an error in state: 1411.
 ##
 ## value_type -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -4998,7 +4998,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL VIRTUAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 ##
-## Ends in an error in state: 1389.
+## Ends in an error in state: 1410.
 ##
 ## _class_sig_field -> VAL . value_type post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -5010,7 +5010,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE VAL WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 ##
-## Ends in an error in state: 1688.
+## Ends in an error in state: 1709.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5023,7 +5023,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LBRACE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ##
-## Ends in an error in state: 1731.
+## Ends in an error in state: 1752.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## _non_arrowed_class_constructor_type -> class_instance_type . [ EQUALGREATER ]
@@ -5035,16 +5035,16 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1697, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1701, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1695, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1718, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1722, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1716, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1698.
+## Ends in an error in state: 1719.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EQUALGREATER EQUAL EOF AND ]
@@ -5057,7 +5057,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT UNDERSCORE WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 ##
-## Ends in an error in state: 1697.
+## Ends in an error in state: 1718.
 ##
 ## _class_instance_type -> clty_longident . [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ SEMI RPAREN LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF AND ]
@@ -5070,7 +5070,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LIDENT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1725.
+## Ends in an error in state: 1746.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN class_constructor_type . RPAREN [ EQUALGREATER ]
 ##
@@ -5081,19 +5081,19 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1697, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1701, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1695, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1699, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1710, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1708, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1718, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1722, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1716, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1720, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1731, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1729, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 ##
-## Ends in an error in state: 1724.
+## Ends in an error in state: 1745.
 ##
 ## _non_arrowed_class_constructor_type -> LPAREN . class_constructor_type RPAREN [ EQUALGREATER ]
 ##
@@ -5105,7 +5105,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON LPAREN WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 ##
-## Ends in an error in state: 1693.
+## Ends in an error in state: 1714.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5119,7 +5119,7 @@ implementation: CLASS LIDENT UNDERSCORE COLON UIDENT DOT WITH
 
 implementation: CLASS LIDENT UNDERSCORE COLON UIDENT WITH
 ##
-## Ends in an error in state: 1692.
+## Ends in an error in state: 1713.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ UNDERSCORE UIDENT SHARP SEMI RPAREN QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EQUALGREATER EQUAL EOF AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -5159,9 +5159,9 @@ implementation: FOR UNDERSCORE IN UIDENT TO UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 819, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 825, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -5207,9 +5207,9 @@ implementation: FUN LIDENTCOLONCOLON UNDERSCORE EQUAL UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 819, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 825, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -5256,7 +5256,7 @@ implementation: FUN LIDENTCOLONCOLON WITH
 
 implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2118.
+## Ends in an error in state: 2139.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -5272,15 +5272,15 @@ implementation: INCLUDE FUN LPAREN UNDERSCORE COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 133, spurious reduction of production ident -> UIDENT
 ## In state 792, spurious reduction of production mty_longident -> ident
-## In state 1830, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1859, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1855, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1828, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1860, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1856, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1829, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1861, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1857, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1851, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1880, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1876, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1849, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1881, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1877, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1850, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1882, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1878, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
@@ -5324,7 +5324,7 @@ implementation: INCLUDE FUN LPAREN WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1717.
+## Ends in an error in state: 1738.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5336,16 +5336,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1542, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1548, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1540, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1563, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1569, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1561, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1716.
+## Ends in an error in state: 1737.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type EQUAL . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5357,7 +5357,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1715.
+## Ends in an error in state: 1736.
 ##
 ## _constrained_class_declaration -> COLON class_constructor_type . EQUAL class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5368,19 +5368,19 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1697, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1701, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1695, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
-## In state 1699, spurious reduction of production _class_constructor_type -> NEW class_instance_type
-## In state 1710, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
-## In state 1708, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
+## In state 1718, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1722, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1716, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1720, spurious reduction of production _class_constructor_type -> NEW class_instance_type
+## In state 1731, spurious reduction of production mark_position_cty(_class_constructor_type) -> _class_constructor_type
+## In state 1729, spurious reduction of production class_constructor_type -> mark_position_cty(_class_constructor_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 ##
-## Ends in an error in state: 1685.
+## Ends in an error in state: 1706.
 ##
 ## _constrained_class_declaration -> COLON . class_constructor_type EQUAL class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5392,7 +5392,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1901.
+## Ends in an error in state: 1922.
 ##
 ## and_class_declaration -> AND . class_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5404,7 +5404,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1900.
+## Ends in an error in state: 1921.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_class_declarations -> many_class_declarations . and_class_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5416,16 +5416,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1313, spurious reduction of production post_item_attributes ->
-## In state 1314, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1740, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
+## In state 1334, spurious reduction of production post_item_attributes ->
+## In state 1335, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1761, spurious reduction of production many_class_declarations -> CLASS class_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1684.
+## Ends in an error in state: 1705.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5437,16 +5437,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1542, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1548, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1540, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1563, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1569, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1561, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1472.
+## Ends in an error in state: 1493.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5458,7 +5458,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 1729.
+## Ends in an error in state: 1750.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5470,16 +5470,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1542, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1548, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1540, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1563, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1569, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1561, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 1728.
+## Ends in an error in state: 1749.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type EQUALGREATER . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5491,7 +5491,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LIDENT EQUALGREATER
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT RPAREN WITH
 ##
-## Ends in an error in state: 1727.
+## Ends in an error in state: 1748.
 ##
 ## class_fun_return -> COLON non_arrowed_class_constructor_type . EQUALGREATER class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5503,7 +5503,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON LPAREN NEW LIDENT R
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1723.
+## Ends in an error in state: 1744.
 ##
 ## class_fun_return -> COLON . non_arrowed_class_constructor_type EQUALGREATER class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5515,7 +5515,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPAREN
 ##
-## Ends in an error in state: 1722.
+## Ends in an error in state: 1743.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_fun_return -> EQUALGREATER class_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5527,16 +5527,16 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER LIDENT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1542, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1548, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1540, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1563, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1569, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1561, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1721.
+## Ends in an error in state: 1742.
 ##
 ## class_fun_return -> EQUALGREATER . class_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5548,7 +5548,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE EQUALGREATER WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1720.
+## Ends in an error in state: 1741.
 ##
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _class_fun_binding -> labeled_simple_pattern . class_fun_return [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5561,7 +5561,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1469.
+## Ends in an error in state: 1490.
 ##
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag LIDENT class_type_parameters . constrained_class_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5576,7 +5576,7 @@ implementation: INCLUDE LBRACE CLASS LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 ##
-## Ends in an error in state: 1896.
+## Ends in an error in state: 1917.
 ##
 ## and_class_type_declaration -> AND . class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5588,7 +5588,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT AND WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1895.
+## Ends in an error in state: 1916.
 ##
 ## _structure_item_without_item_extension_sugar -> many_class_type_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_class_type_declarations -> many_class_type_declarations . and_class_type_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5600,16 +5600,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT LBRACKETATAT AND R
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1313, spurious reduction of production post_item_attributes ->
-## In state 1314, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 1466, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
+## In state 1334, spurious reduction of production post_item_attributes ->
+## In state 1335, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 1487, spurious reduction of production many_class_type_declarations -> CLASS TYPE class_type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ##
-## Ends in an error in state: 1457.
+## Ends in an error in state: 1478.
 ##
 ## _class_instance_type -> class_instance_type . attribute [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL class_instance_type . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5621,16 +5621,16 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1434, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1440, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1432, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1455, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1461, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1453, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1379.
+## Ends in an error in state: 1400.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters EQUAL . class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5642,7 +5642,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 ##
-## Ends in an error in state: 1376.
+## Ends in an error in state: 1397.
 ##
 ## class_type_declaration_details -> virtual_flag LIDENT class_type_parameters . EQUAL class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_type_parameters -> class_type_parameters . type_parameter [ QUOTE PLUS MINUS EQUAL ]
@@ -5655,7 +5655,7 @@ implementation: INCLUDE LBRACE CLASS TYPE LIDENT WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 ##
-## Ends in an error in state: 1374.
+## Ends in an error in state: 1395.
 ##
 ## class_type_declaration_details -> virtual_flag . LIDENT class_type_parameters EQUAL class_instance_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -5667,7 +5667,7 @@ implementation: INCLUDE LBRACE CLASS TYPE VIRTUAL WITH
 
 implementation: INCLUDE LBRACE CLASS TYPE WITH
 ##
-## Ends in an error in state: 1373.
+## Ends in an error in state: 1394.
 ##
 ## many_class_type_declarations -> CLASS TYPE . class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -5679,7 +5679,7 @@ implementation: INCLUDE LBRACE CLASS TYPE WITH
 
 implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 ##
-## Ends in an error in state: 1467.
+## Ends in an error in state: 1488.
 ##
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters class_fun_binding [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## class_declaration_details -> virtual_flag . LIDENT class_type_parameters constrained_class_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -5693,7 +5693,7 @@ implementation: INCLUDE LBRACE CLASS VIRTUAL LET
 
 implementation: INCLUDE LBRACE CLASS WITH
 ##
-## Ends in an error in state: 1371.
+## Ends in an error in state: 1392.
 ##
 ## many_class_declarations -> CLASS . class_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ## many_class_type_declarations -> CLASS . TYPE class_type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -5706,7 +5706,7 @@ implementation: INCLUDE LBRACE CLASS WITH
 
 implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 ##
-## Ends in an error in state: 1339.
+## Ends in an error in state: 1360.
 ##
 ## extension_constructor_declaration -> LPAREN . RPAREN generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## extension_constructor_rebind -> LPAREN . RPAREN EQUAL constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -5719,7 +5719,7 @@ implementation: INCLUDE LBRACE EXCEPTION LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 1324.
+## Ends in an error in state: 1345.
 ##
 ## generalized_constructor_arguments -> COLON . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -5731,7 +5731,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 ##
-## Ends in an error in state: 1319.
+## Ends in an error in state: 1340.
 ##
 ## constr_longident -> LBRACKET . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -5743,7 +5743,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LBRACKET WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 1318.
+## Ends in an error in state: 1339.
 ##
 ## constr_longident -> LPAREN . RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF BAR ]
 ##
@@ -5755,7 +5755,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL LPAREN WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1317.
+## Ends in an error in state: 1338.
 ##
 ## extension_constructor_rebind -> UIDENT EQUAL . constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ##
@@ -5767,7 +5767,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT EQUAL WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1331.
+## Ends in an error in state: 1352.
 ##
 ## generalized_constructor_arguments -> constructor_arguments COLON . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT BAR AND ]
 ##
@@ -5779,7 +5779,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE COLON WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1326.
+## Ends in an error in state: 1347.
 ##
 ## constructor_arguments -> non_arrowed_simple_core_type . [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT COLON BAR AND ]
 ## constructor_arguments -> non_arrowed_simple_core_type . non_arrowed_simple_core_type_list [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF CONSTRAINT COLON BAR AND ]
@@ -5792,7 +5792,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 ##
-## Ends in an error in state: 1316.
+## Ends in an error in state: 1337.
 ##
 ## extension_constructor_declaration -> UIDENT . generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## extension_constructor_rebind -> UIDENT . EQUAL constr_longident attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -5805,7 +5805,7 @@ implementation: INCLUDE LBRACE EXCEPTION UIDENT WITH
 
 implementation: INCLUDE LBRACE EXCEPTION WITH
 ##
-## Ends in an error in state: 1315.
+## Ends in an error in state: 1336.
 ##
 ## str_exception_declaration -> EXCEPTION . extension_constructor_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## str_exception_declaration -> EXCEPTION . extension_constructor_rebind post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
@@ -5818,7 +5818,7 @@ implementation: INCLUDE LBRACE EXCEPTION WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH
 ##
-## Ends in an error in state: 1309.
+## Ends in an error in state: 1330.
 ##
 ## primitive_declaration -> STRING . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ## primitive_declaration -> STRING . primitive_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
@@ -5831,7 +5831,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WIT
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1308.
+## Ends in an error in state: 1329.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type EQUAL . primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -5843,7 +5843,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1307.
+## Ends in an error in state: 1328.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON core_type . EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -5866,7 +5866,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON UNDERSCORE WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1306.
+## Ends in an error in state: 1327.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident COLON . core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -5878,7 +5878,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT COLON WITH
 
 implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 ##
-## Ends in an error in state: 1305.
+## Ends in an error in state: 1326.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL val_ident . COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -5890,7 +5890,7 @@ implementation: INCLUDE LBRACE EXTERNAL LIDENT WITH
 
 implementation: INCLUDE LBRACE EXTERNAL WITH
 ##
-## Ends in an error in state: 1304.
+## Ends in an error in state: 1325.
 ##
 ## _structure_item_without_item_extension_sugar -> EXTERNAL . val_ident COLON core_type EQUAL primitive_declaration post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -5941,7 +5941,7 @@ A module's name needs to begin with a upper-case letter
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1154.
+## Ends in an error in state: 1175.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER module_expr . [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -5956,7 +5956,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER LPAREN RPAREN WHIL
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 1152.
+## Ends in an error in state: 1173.
 ##
 ## _module_expr -> FUN functor_args EQUALGREATER . module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -5968,7 +5968,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN EQUALGREATER WITH
 
 implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 1151.
+## Ends in an error in state: 1172.
 ##
 ## _module_expr -> FUN functor_args . EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## functor_args -> functor_args . functor_arg [ LPAREN EQUALGREATER ]
@@ -5981,7 +5981,7 @@ implementation: INCLUDE LPAREN FUN LPAREN RPAREN WITH
 
 implementation: INCLUDE LPAREN FUN WITH
 ##
-## Ends in an error in state: 1150.
+## Ends in an error in state: 1171.
 ##
 ## _module_expr -> FUN . functor_args EQUALGREATER module_expr [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -5993,7 +5993,7 @@ implementation: INCLUDE LPAREN FUN WITH
 
 implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2104.
+## Ends in an error in state: 2125.
 ##
 ## _module_type -> module_type . WITH with_constraints [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ error WITH RPAREN LBRACKETAT EQUALGREATER ]
@@ -6010,22 +6010,22 @@ implementation: INCLUDE LPAREN UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 231, spurious reduction of production ident -> UIDENT
 ## In state 477, spurious reduction of production mty_longident -> ident
-## In state 1763, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1814, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1810, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1761, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1815, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1811, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1762, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1816, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1812, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1784, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1835, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1831, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1782, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1836, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1832, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1783, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1837, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1833, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1172.
+## Ends in an error in state: 1193.
 ##
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN module_expr COLON . module_type error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6038,7 +6038,7 @@ implementation: INCLUDE LPAREN UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 2455.
+## Ends in an error in state: 2476.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -6055,19 +6055,19 @@ implementation: INCLUDE LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1752, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1756, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1753, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1153, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1758, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1757, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1773, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1777, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1774, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1174, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1779, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1778, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1166.
+## Ends in an error in state: 1187.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6087,7 +6087,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT COLON
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1165.
+## Ends in an error in state: 1186.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON package_type COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6099,7 +6099,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 2453.
+## Ends in an error in state: 2474.
 ##
 ## _module_expr -> LPAREN VAL expr COLON . error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6113,7 +6113,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 ##
-## Ends in an error in state: 1160.
+## Ends in an error in state: 1181.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER package_type . RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6133,7 +6133,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER UIDENT COLONGREATER
 
 implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 2451.
+## Ends in an error in state: 2472.
 ##
 ## _module_expr -> LPAREN VAL expr COLONGREATER . error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6146,7 +6146,7 @@ implementation: INCLUDE LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 2449.
+## Ends in an error in state: 2470.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -6188,13 +6188,13 @@ implementation: INCLUDE LPAREN VAL UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -6242,7 +6242,7 @@ implementation: INCLUDE LPAREN WITH
 
 implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ##
-## Ends in an error in state: 2109.
+## Ends in an error in state: 2130.
 ##
 ## _simple_module_expr -> LBRACE structure . RBRACE [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6254,28 +6254,28 @@ implementation: INCLUDE UIDENT LBRACE UIDENT EOF
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1926, spurious reduction of production post_item_attributes ->
-## In state 1927, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1928, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1875, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1741, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1929, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1876, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1742, spurious reduction of production structure -> structure_item
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1947, spurious reduction of production post_item_attributes ->
+## In state 1948, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1949, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1896, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1762, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1950, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1897, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1763, spurious reduction of production structure -> structure_item
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 1148.
+## Ends in an error in state: 1169.
 ##
 ## _simple_module_expr -> LBRACE . structure RBRACE [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6287,7 +6287,7 @@ implementation: INCLUDE UIDENT LBRACE WITH
 
 implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ##
-## Ends in an error in state: 1169.
+## Ends in an error in state: 1190.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -6304,19 +6304,19 @@ implementation: INCLUDE UIDENT LPAREN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1752, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1756, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1753, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1153, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1758, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1757, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1773, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1777, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1774, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1174, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1779, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1778, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 ##
-## Ends in an error in state: 1162.
+## Ends in an error in state: 1183.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL expr COLON . package_type COLONGREATER package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6329,7 +6329,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLON WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1159.
+## Ends in an error in state: 1180.
 ##
 ## _simple_module_expr -> LPAREN VAL expr COLONGREATER . package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ##
@@ -6341,7 +6341,7 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT COLONGREATER WITH
 
 implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ##
-## Ends in an error in state: 1157.
+## Ends in an error in state: 1178.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONGREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -6380,20 +6380,20 @@ implementation: INCLUDE UIDENT LPAREN VAL UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 937, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 946, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: INCLUDE UIDENT LPAREN VAL WITH
 ##
-## Ends in an error in state: 1156.
+## Ends in an error in state: 1177.
 ##
 ## _simple_module_expr -> LPAREN VAL . expr RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN VAL . expr COLON package_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6408,7 +6408,7 @@ implementation: INCLUDE UIDENT LPAREN VAL WITH
 
 implementation: INCLUDE UIDENT LPAREN WITH
 ##
-## Ends in an error in state: 1155.
+## Ends in an error in state: 1176.
 ##
 ## _module_expr -> module_expr LPAREN . module_expr error [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## _simple_module_expr -> LPAREN . module_expr COLON module_type RPAREN [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
@@ -6428,7 +6428,7 @@ implementation: INCLUDE UIDENT LPAREN WITH
 
 implementation: INCLUDE UIDENT WHILE
 ##
-## Ends in an error in state: 1752.
+## Ends in an error in state: 1773.
 ##
 ## _simple_module_expr -> mod_longident . [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF COLON AND ]
 ## mod_longident -> mod_longident . DOT UIDENT [ error WITH UIDENT SEMI RPAREN RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EQUALGREATER EOF DOT COLON AND ]
@@ -6441,7 +6441,7 @@ implementation: INCLUDE UIDENT WHILE
 
 implementation: INCLUDE WITH
 ##
-## Ends in an error in state: 1149.
+## Ends in an error in state: 1170.
 ##
 ## _structure_item_without_item_extension_sugar -> INCLUDE . module_expr post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -6453,7 +6453,7 @@ implementation: INCLUDE WITH
 
 implementation: LBRACE AS UNDERSCORE SEMI WITH
 ##
-## Ends in an error in state: 1564.
+## Ends in an error in state: 1585.
 ##
 ## class_self_pattern_and_structure -> class_self_pattern . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -6465,7 +6465,7 @@ implementation: LBRACE AS UNDERSCORE SEMI WITH
 
 implementation: LBRACE AS UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1553.
+## Ends in an error in state: 1574.
 ##
 ## _class_self_pattern -> AS pattern . SEMI [ error VAL RBRACE PUB PRI LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ## _or_pattern -> pattern . BAR pattern [ SEMI BAR ]
@@ -6484,7 +6484,7 @@ implementation: LBRACE AS UNDERSCORE WHEN
 
 implementation: LBRACE AS WITH
 ##
-## Ends in an error in state: 1552.
+## Ends in an error in state: 1573.
 ##
 ## _class_self_pattern -> AS . pattern SEMI [ error VAL RBRACE PUB PRI LBRACKETPERCENTPERCENT LBRACKETATATAT INITIALIZER INHERIT CONSTRAINT ]
 ##
@@ -6496,7 +6496,7 @@ implementation: LBRACE AS WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1443.
+## Ends in an error in state: 1464.
 ##
 ## constrain_field -> core_type EQUAL . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -6508,7 +6508,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1442.
+## Ends in an error in state: 1463.
 ##
 ## constrain_field -> core_type . EQUAL core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -6531,7 +6531,7 @@ implementation: LBRACE CONSTRAINT UNDERSCORE WITH
 
 implementation: LBRACE CONSTRAINT WITH
 ##
-## Ends in an error in state: 1639.
+## Ends in an error in state: 1660.
 ##
 ## _class_field -> CONSTRAINT . constrain_field post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -6543,7 +6543,7 @@ implementation: LBRACE CONSTRAINT WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2286.
+## Ends in an error in state: 2307.
 ##
 ## opt_comma -> COMMA . [ RBRACE ]
 ## record_expr -> DOTDOTDOT expr_optional_constraint COMMA . lbl_expr_list [ error RBRACE ]
@@ -6557,7 +6557,7 @@ implementation: LBRACE DOTDOTDOT UIDENT COMMA WITH
 
 implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ##
-## Ends in an error in state: 2285.
+## Ends in an error in state: 2306.
 ##
 ## _simple_expr -> LBRACE DOTDOTDOT expr_optional_constraint . opt_comma RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## record_expr -> DOTDOTDOT expr_optional_constraint . COMMA lbl_expr_list [ error RBRACE ]
@@ -6571,21 +6571,21 @@ implementation: LBRACE DOTDOTDOT UIDENT RBRACKET
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 937, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2131, spurious reduction of production expr_optional_constraint -> expr
+## In state 946, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2152, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE DOTDOTDOT WITH
 ##
-## Ends in an error in state: 2284.
+## Ends in an error in state: 2305.
 ##
 ## _simple_expr -> LBRACE DOTDOTDOT . expr_optional_constraint opt_comma RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## record_expr -> DOTDOTDOT . expr_optional_constraint COMMA lbl_expr_list [ error RBRACE ]
@@ -6599,7 +6599,7 @@ implementation: LBRACE DOTDOTDOT WITH
 
 implementation: LBRACE INHERIT BANG WITH
 ##
-## Ends in an error in state: 1633.
+## Ends in an error in state: 1654.
 ##
 ## _class_field -> INHERIT override_flag . class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -6611,7 +6611,7 @@ implementation: LBRACE INHERIT BANG WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1538.
+## Ends in an error in state: 1559.
 ##
 ## _class_expr -> CLASS class_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EOF COLON AS AND ]
@@ -6624,7 +6624,7 @@ implementation: LBRACE INHERIT CLASS LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT CLASS LIDENT WITH
 ##
-## Ends in an error in state: 1537.
+## Ends in an error in state: 1558.
 ##
 ## _class_expr -> CLASS class_longident . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> CLASS class_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6637,7 +6637,7 @@ implementation: LBRACE INHERIT CLASS LIDENT WITH
 
 implementation: LBRACE INHERIT CLASS WITH
 ##
-## Ends in an error in state: 1536.
+## Ends in an error in state: 1557.
 ##
 ## _class_expr -> CLASS . class_longident [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> CLASS . class_longident non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6650,7 +6650,7 @@ implementation: LBRACE INHERIT CLASS WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1545.
+## Ends in an error in state: 1566.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER class_expr . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6663,7 +6663,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER LBRACKETPERCENT AND R
 
 implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1535.
+## Ends in an error in state: 1556.
 ##
 ## _class_fun_def -> labeled_simple_pattern EQUALGREATER . class_expr [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ##
@@ -6675,7 +6675,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 1534.
+## Ends in an error in state: 1555.
 ##
 ## _class_fun_def -> labeled_simple_pattern . EQUALGREATER class_expr [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_fun_def -> labeled_simple_pattern . class_fun_def [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6688,7 +6688,7 @@ implementation: LBRACE INHERIT FUN UNDERSCORE WITH
 
 implementation: LBRACE INHERIT FUN WITH
 ##
-## Ends in an error in state: 1532.
+## Ends in an error in state: 1553.
 ##
 ## _class_expr -> FUN . class_fun_def [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ##
@@ -6700,7 +6700,7 @@ implementation: LBRACE INHERIT FUN WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 1558.
+## Ends in an error in state: 1579.
 ##
 ## _class_expr_lets_and_rest -> let_bindings SEMI . class_expr_lets_and_rest [ error RBRACE ]
 ##
@@ -6712,7 +6712,7 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR SEMI WITH
 
 implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ##
-## Ends in an error in state: 1557.
+## Ends in an error in state: 1578.
 ##
 ## _class_expr_lets_and_rest -> let_bindings . SEMI class_expr_lets_and_rest [ error RBRACE ]
 ## let_bindings -> let_bindings . and_let_binding [ SEMI AND ]
@@ -6724,22 +6724,22 @@ implementation: LBRACE INHERIT LBRACE LET CHAR EQUAL CHAR WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1527, spurious reduction of production let_binding_body -> pattern EQUAL expr
-## In state 1528, spurious reduction of production post_item_attributes ->
-## In state 1529, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
-## In state 1559, spurious reduction of production let_binding -> let_binding_impl
-## In state 1560, spurious reduction of production let_bindings -> let_binding
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1548, spurious reduction of production let_binding_body -> pattern EQUAL expr
+## In state 1549, spurious reduction of production post_item_attributes ->
+## In state 1550, spurious reduction of production let_binding_impl -> LET rec_flag let_binding_body post_item_attributes
+## In state 1580, spurious reduction of production let_binding -> let_binding_impl
+## In state 1581, spurious reduction of production let_bindings -> let_binding
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE LET WITH
 ##
-## Ends in an error in state: 1475.
+## Ends in an error in state: 1496.
 ##
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI AND ]
 ##
@@ -6751,7 +6751,7 @@ implementation: LBRACE INHERIT LBRACE LET WITH
 
 implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ##
-## Ends in an error in state: 1652.
+## Ends in an error in state: 1673.
 ##
 ## _class_expr -> class_expr . attribute [ error RBRACE LBRACKETAT ]
 ## _class_expr_lets_and_rest -> class_expr . [ error RBRACE ]
@@ -6763,16 +6763,16 @@ implementation: LBRACE INHERIT LBRACE LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1542, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1548, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1540, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1563, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1569, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1561, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 ##
-## Ends in an error in state: 1561.
+## Ends in an error in state: 1582.
 ##
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI AND ]
 ##
@@ -6791,7 +6791,7 @@ implementation: LBRACE INHERIT LBRACE PERCENT AND WHILE
 
 implementation: LBRACE INHERIT LBRACE WITH
 ##
-## Ends in an error in state: 1474.
+## Ends in an error in state: 1495.
 ##
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest RBRACE [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT FLOAT FALSE EOF COLONCOLONLIDENT COLONCOLON COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LBRACE . class_expr_lets_and_rest error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT FLOAT FALSE EOF COLONCOLONLIDENT COLONCOLON COLON CHAR BANG BACKQUOTE AS AND ]
@@ -6804,7 +6804,7 @@ implementation: LBRACE INHERIT LBRACE WITH
 
 implementation: LBRACE INHERIT LIDENT AS WITH
 ##
-## Ends in an error in state: 1635.
+## Ends in an error in state: 1656.
 ##
 ## parent_binder -> AS . LIDENT [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -6816,7 +6816,7 @@ implementation: LBRACE INHERIT LIDENT AS WITH
 
 implementation: LBRACE INHERIT LIDENT RPAREN
 ##
-## Ends in an error in state: 1634.
+## Ends in an error in state: 1655.
 ##
 ## _class_expr -> class_expr . attribute [ error SEMI RBRACE LBRACKETATAT LBRACKETAT AS ]
 ## _class_field -> INHERIT override_flag class_expr . parent_binder post_item_attributes [ error SEMI RBRACE ]
@@ -6828,16 +6828,16 @@ implementation: LBRACE INHERIT LIDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1542, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1548, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1540, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1563, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1569, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1561, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT SEMI WITH
 ##
-## Ends in an error in state: 1648.
+## Ends in an error in state: 1669.
 ##
 ## semi_terminated_class_fields -> class_field SEMI . semi_terminated_class_fields [ error RBRACE ]
 ##
@@ -6849,7 +6849,7 @@ implementation: LBRACE INHERIT LIDENT SEMI WITH
 
 implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ##
-## Ends in an error in state: 1543.
+## Ends in an error in state: 1564.
 ##
 ## _class_expr -> class_simple_expr simple_labeled_expr_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## simple_labeled_expr_list -> simple_labeled_expr_list . labeled_simple_expr [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT FLOAT FALSE EOF COLONCOLONLIDENT COLONCOLON COLON CHAR BANG BACKQUOTE AS AND ]
@@ -6862,19 +6862,19 @@ implementation: LBRACE INHERIT LIDENT UIDENT STAR
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 859, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 872, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 883, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
-## In state 886, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
+## In state 830, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 843, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 854, spurious reduction of production labeled_simple_expr -> less_aggressive_simple_expression
+## In state 857, spurious reduction of production simple_labeled_expr_list -> labeled_simple_expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LIDENT WITH
 ##
-## Ends in an error in state: 1542.
+## Ends in an error in state: 1563.
 ##
 ## _class_expr -> class_simple_expr . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
 ## _class_expr -> class_simple_expr . simple_labeled_expr_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF COLON AS AND ]
@@ -6887,7 +6887,7 @@ implementation: LBRACE INHERIT LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1679.
+## Ends in an error in state: 1700.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -6899,7 +6899,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON UNDERSCORE E
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1678.
+## Ends in an error in state: 1699.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -6912,7 +6912,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON UNDERSCORE W
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON WITH
 ##
-## Ends in an error in state: 1668.
+## Ends in an error in state: 1689.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON . QUESTION non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _class_constructor_type -> LIDENTCOLONCOLON . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
@@ -6925,7 +6925,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON QUESTION UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1671.
+## Ends in an error in state: 1692.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON QUESTION non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -6937,7 +6937,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON QUESTION UND
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON QUESTION UNDERSCORE WITH
 ##
-## Ends in an error in state: 1670.
+## Ends in an error in state: 1691.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON QUESTION non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -6950,7 +6950,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON QUESTION UND
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON QUESTION WITH
 ##
-## Ends in an error in state: 1669.
+## Ends in an error in state: 1690.
 ##
 ## _class_constructor_type -> LIDENTCOLONCOLON QUESTION . non_arrowed_core_type EQUALGREATER class_constructor_type [ error RPAREN ]
 ##
@@ -6962,7 +6962,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENTCOLONCOLON QUESTION WIT
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 ##
-## Ends in an error in state: 1672.
+## Ends in an error in state: 1693.
 ##
 ## _class_constructor_type -> non_arrowed_core_type . EQUALGREATER class_constructor_type [ error RPAREN ]
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
@@ -6984,7 +6984,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 ##
-## Ends in an error in state: 1381.
+## Ends in an error in state: 1402.
 ##
 ## _class_instance_type -> LBRACE . class_sig_body RBRACE [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_instance_type -> LBRACE . class_sig_body error [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -6997,7 +6997,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LBRACE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ##
-## Ends in an error in state: 1667.
+## Ends in an error in state: 1688.
 ##
 ## _class_constructor_type -> NEW class_instance_type . [ error RPAREN ]
 ## _class_instance_type -> class_instance_type . attribute [ error RPAREN LBRACKETAT ]
@@ -7009,16 +7009,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1434, spurious reduction of production _class_instance_type -> clty_longident
-## In state 1440, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
-## In state 1432, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
+## In state 1455, spurious reduction of production _class_instance_type -> clty_longident
+## In state 1461, spurious reduction of production mark_position_cty(_class_instance_type) -> _class_instance_type
+## In state 1453, spurious reduction of production class_instance_type -> mark_position_cty(_class_instance_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1435.
+## Ends in an error in state: 1456.
 ##
 ## _class_instance_type -> clty_longident non_arrowed_simple_core_type_list . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## non_arrowed_simple_core_type_list -> non_arrowed_simple_core_type_list . non_arrowed_simple_core_type [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EOF AND ]
@@ -7031,7 +7031,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT UNDERSCORE WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 ##
-## Ends in an error in state: 1434.
+## Ends in an error in state: 1455.
 ##
 ## _class_instance_type -> clty_longident . [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
 ## _class_instance_type -> clty_longident . non_arrowed_simple_core_type_list [ error SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EOF AND ]
@@ -7044,7 +7044,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW LIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 ##
-## Ends in an error in state: 1430.
+## Ends in an error in state: 1451.
 ##
 ## clty_longident -> mod_ext_longident DOT . LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EOF AND ]
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -7058,7 +7058,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT DOT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 ##
-## Ends in an error in state: 1429.
+## Ends in an error in state: 1450.
 ##
 ## clty_longident -> mod_ext_longident . DOT LIDENT [ error UNDERSCORE UIDENT SHARP SEMI RPAREN RBRACKET RBRACE QUOTE LPAREN LIDENT LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETATAT LBRACKETAT LBRACKET LBRACE EOF AND ]
 ## mod_ext2 -> mod_ext_longident . DOT UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
@@ -7078,7 +7078,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW UIDENT WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 ##
-## Ends in an error in state: 1666.
+## Ends in an error in state: 1687.
 ##
 ## _class_constructor_type -> NEW . class_instance_type [ error RPAREN ]
 ##
@@ -7090,7 +7090,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON NEW WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1673.
+## Ends in an error in state: 1694.
 ##
 ## _class_constructor_type -> non_arrowed_core_type EQUALGREATER . class_constructor_type [ error RPAREN ]
 ##
@@ -7102,7 +7102,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 ##
-## Ends in an error in state: 1665.
+## Ends in an error in state: 1686.
 ##
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT FLOAT FALSE EOF COLONCOLONLIDENT COLONCOLON COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN class_expr COLON . class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT FLOAT FALSE EOF COLONCOLONLIDENT COLONCOLON COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7115,7 +7115,7 @@ implementation: LBRACE INHERIT LPAREN LIDENT COLON WITH
 
 implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ##
-## Ends in an error in state: 1662.
+## Ends in an error in state: 1683.
 ##
 ## _class_expr -> class_expr . attribute [ error RPAREN LBRACKETAT COLON ]
 ## _class_simple_expr -> LPAREN class_expr . COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT FLOAT FALSE EOF COLONCOLONLIDENT COLONCOLON COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7130,16 +7130,16 @@ implementation: LBRACE INHERIT LPAREN LIDENT SEMI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1542, spurious reduction of production _class_expr -> class_simple_expr
-## In state 1548, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
-## In state 1540, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
+## In state 1563, spurious reduction of production _class_expr -> class_simple_expr
+## In state 1569, spurious reduction of production mark_position_cl(_class_expr) -> _class_expr
+## In state 1561, spurious reduction of production class_expr -> mark_position_cl(_class_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE INHERIT LPAREN WITH
 ##
-## Ends in an error in state: 1473.
+## Ends in an error in state: 1494.
 ##
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type RPAREN [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT FLOAT FALSE EOF COLONCOLONLIDENT COLONCOLON COLON CHAR BANG BACKQUOTE AS AND ]
 ## _class_simple_expr -> LPAREN . class_expr COLON class_constructor_type error [ error UIDENT TRUE STRING SEMI RPAREN RBRACKET RBRACE PREFIXOP NEW LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT FLOAT FALSE EOF COLONCOLONLIDENT COLONCOLON COLON CHAR BANG BACKQUOTE AS AND ]
@@ -7154,7 +7154,7 @@ implementation: LBRACE INHERIT LPAREN WITH
 
 implementation: LBRACE INHERIT WITH
 ##
-## Ends in an error in state: 1632.
+## Ends in an error in state: 1653.
 ##
 ## _class_field -> INHERIT . override_flag class_expr parent_binder post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7166,7 +7166,7 @@ implementation: LBRACE INHERIT WITH
 
 implementation: LBRACE INITIALIZER EQUALGREATER WITH
 ##
-## Ends in an error in state: 1629.
+## Ends in an error in state: 1650.
 ##
 ## _class_field -> INITIALIZER EQUALGREATER . expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7178,7 +7178,7 @@ implementation: LBRACE INITIALIZER EQUALGREATER WITH
 
 implementation: LBRACE INITIALIZER WITH
 ##
-## Ends in an error in state: 1628.
+## Ends in an error in state: 1649.
 ##
 ## _class_field -> INITIALIZER . EQUALGREATER expr post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7190,7 +7190,7 @@ implementation: LBRACE INITIALIZER WITH
 
 implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ##
-## Ends in an error in state: 2301.
+## Ends in an error in state: 2322.
 ##
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACE semi_terminated_seq_expr . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -7202,17 +7202,17 @@ implementation: LBRACE LET CHAR EQUAL CHAR SEMI WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2334, spurious reduction of production opt_semi -> SEMI
-## In state 2345, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
-## In state 2343, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2332, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2355, spurious reduction of production opt_semi -> SEMI
+## In state 2366, spurious reduction of production _semi_terminated_seq_expr -> let_bindings opt_semi
+## In state 2364, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2353, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
 ##
 
 Expecting "}" to finish the block
 
 implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2329.
+## Ends in an error in state: 2350.
 ##
 ## _semi_terminated_seq_expr_row -> opt_let_module UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7224,7 +7224,7 @@ implementation: LBRACE LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 
 implementation: LBRACE LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2318.
+## Ends in an error in state: 2339.
 ##
 ## _semi_terminated_seq_expr_row -> opt_let_module UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7236,7 +7236,7 @@ implementation: LBRACE LET MODULE UIDENT WITH
 
 implementation: LBRACE LET MODULE WITH
 ##
-## Ends in an error in state: 2317.
+## Ends in an error in state: 2338.
 ##
 ## _semi_terminated_seq_expr_row -> opt_let_module . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7248,7 +7248,7 @@ implementation: LBRACE LET MODULE WITH
 
 implementation: LBRACE LET OPEN BANG WITH
 ##
-## Ends in an error in state: 2312.
+## Ends in an error in state: 2333.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7260,7 +7260,7 @@ implementation: LBRACE LET OPEN BANG WITH
 
 implementation: LBRACE LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2315.
+## Ends in an error in state: 2336.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7272,7 +7272,7 @@ implementation: LBRACE LET OPEN UIDENT SEMI WITH
 
 implementation: LBRACE LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2314.
+## Ends in an error in state: 2335.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7283,14 +7283,14 @@ implementation: LBRACE LET OPEN UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2313, spurious reduction of production post_item_attributes ->
+## In state 2334, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LET OPEN WITH
 ##
-## Ends in an error in state: 2311.
+## Ends in an error in state: 2332.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ error RBRACE ]
 ##
@@ -7316,7 +7316,7 @@ implementation: LBRACE LET WITH
 
 implementation: LBRACE LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2185.
+## Ends in an error in state: 2206.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7353,20 +7353,20 @@ implementation: LBRACE LIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 2184.
+## Ends in an error in state: 2205.
 ##
 ## lbl_expr -> label_longident COLON . expr [ COMMA ]
 ## non_punned_lbl_expression -> label_longident COLON . expr [ error RBRACE ]
@@ -7379,7 +7379,7 @@ implementation: LBRACE LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2174.
+## Ends in an error in state: 2195.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7415,20 +7415,20 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 ##
-## Ends in an error in state: 2173.
+## Ends in an error in state: 2194.
 ##
 ## lbl_expr -> label_longident COLON . expr [ error RBRACE COMMA ]
 ##
@@ -7440,7 +7440,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COLON WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 ##
-## Ends in an error in state: 2170.
+## Ends in an error in state: 2191.
 ##
 ## lbl_expr_list -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ## lbl_expr_list -> lbl_expr COMMA . [ error RBRACE ]
@@ -7453,7 +7453,7 @@ implementation: LBRACE LIDENT COMMA LIDENT COMMA WITH
 
 implementation: LBRACE LIDENT COMMA LIDENT WITH
 ##
-## Ends in an error in state: 2172.
+## Ends in an error in state: 2193.
 ##
 ## lbl_expr -> label_longident . COLON expr [ error RBRACE COMMA ]
 ## lbl_expr -> label_longident . [ error RBRACE COMMA ]
@@ -7466,7 +7466,7 @@ implementation: LBRACE LIDENT COMMA LIDENT WITH
 
 implementation: LBRACE LIDENT COMMA WITH
 ##
-## Ends in an error in state: 2181.
+## Ends in an error in state: 2202.
 ##
 ## lbl_expr_list_that_is_not_a_single_punned_field -> lbl_expr COMMA . lbl_expr_list [ error RBRACE ]
 ##
@@ -7478,7 +7478,7 @@ implementation: LBRACE LIDENT COMMA WITH
 
 implementation: LBRACE PUB BANG WITH
 ##
-## Ends in an error in state: 1589.
+## Ends in an error in state: 1610.
 ##
 ## method_ -> override_flag . VIRTUAL label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag . label curried_binding [ error SEMI RBRACE LBRACKETATAT ]
@@ -7494,7 +7494,7 @@ implementation: LBRACE PUB BANG WITH
 
 implementation: LBRACE PUB LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1605.
+## Ends in an error in state: 1626.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7530,20 +7530,20 @@ implementation: LBRACE PUB LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL UIDENT 
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE PUB LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1604.
+## Ends in an error in state: 1625.
 ##
 ## method_ -> override_flag label COLON TYPE lident_list DOT core_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7555,7 +7555,7 @@ implementation: LBRACE PUB LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LBRACE PUB LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1603.
+## Ends in an error in state: 1624.
 ##
 ## method_ -> override_flag label COLON TYPE lident_list DOT core_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7578,7 +7578,7 @@ implementation: LBRACE PUB LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LBRACE PUB LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1602.
+## Ends in an error in state: 1623.
 ##
 ## method_ -> override_flag label COLON TYPE lident_list DOT . core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7590,7 +7590,7 @@ implementation: LBRACE PUB LIDENT COLON TYPE LIDENT DOT WITH
 
 implementation: LBRACE PUB LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 1600.
+## Ends in an error in state: 1621.
 ##
 ## method_ -> override_flag label COLON TYPE . lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7602,7 +7602,7 @@ implementation: LBRACE PUB LIDENT COLON TYPE WITH
 
 implementation: LBRACE PUB LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1611.
+## Ends in an error in state: 1632.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7638,20 +7638,20 @@ implementation: LBRACE PUB LIDENT COLON UNDERSCORE EQUAL UIDENT RPAREN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE PUB LIDENT COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1610.
+## Ends in an error in state: 1631.
 ##
 ## method_ -> override_flag label COLON poly_type EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7663,7 +7663,7 @@ implementation: LBRACE PUB LIDENT COLON UNDERSCORE EQUAL WITH
 
 implementation: LBRACE PUB LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1609.
+## Ends in an error in state: 1630.
 ##
 ## method_ -> override_flag label COLON poly_type . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7680,16 +7680,16 @@ implementation: LBRACE PUB LIDENT COLON UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 290, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 277, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1613, spurious reduction of production _poly_type -> core_type
-## In state 1614, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1612, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 1634, spurious reduction of production _poly_type -> core_type
+## In state 1635, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1633, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE PUB LIDENT COLON WITH
 ##
-## Ends in an error in state: 1599.
+## Ends in an error in state: 1620.
 ##
 ## method_ -> override_flag label COLON . poly_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## method_ -> override_flag label COLON . TYPE lident_list DOT core_type EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -7702,7 +7702,7 @@ implementation: LBRACE PUB LIDENT COLON WITH
 
 implementation: LBRACE PUB LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1598.
+## Ends in an error in state: 1619.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7738,20 +7738,20 @@ implementation: LBRACE PUB LIDENT EQUAL UIDENT RPAREN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE PUB LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1597.
+## Ends in an error in state: 1618.
 ##
 ## method_ -> override_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7763,7 +7763,7 @@ implementation: LBRACE PUB LIDENT EQUAL WITH
 
 implementation: LBRACE PUB LIDENT EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1647.
+## Ends in an error in state: 1668.
 ##
 ## semi_terminated_class_fields -> class_field . [ error RBRACE ]
 ## semi_terminated_class_fields -> class_field . SEMI semi_terminated_class_fields [ error RBRACE ]
@@ -7776,26 +7776,26 @@ implementation: LBRACE PUB LIDENT EQUALGREATER UIDENT RPAREN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1596, spurious reduction of production curried_binding -> EQUALGREATER expr
-## In state 1622, spurious reduction of production method_ -> override_flag label curried_binding
-## In state 1623, spurious reduction of production post_item_attributes ->
-## In state 1624, spurious reduction of production _class_field -> PUB method_ post_item_attributes
-## In state 1650, spurious reduction of production mark_position_cf(_class_field) -> _class_field
-## In state 1643, spurious reduction of production class_field -> mark_position_cf(_class_field)
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1617, spurious reduction of production curried_binding -> EQUALGREATER expr
+## In state 1643, spurious reduction of production method_ -> override_flag label curried_binding
+## In state 1644, spurious reduction of production post_item_attributes ->
+## In state 1645, spurious reduction of production _class_field -> PUB method_ post_item_attributes
+## In state 1671, spurious reduction of production mark_position_cf(_class_field) -> _class_field
+## In state 1664, spurious reduction of production class_field -> mark_position_cf(_class_field)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE PRI VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1592.
+## Ends in an error in state: 1613.
 ##
 ## method_ -> override_flag VIRTUAL label COLON . poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7807,7 +7807,7 @@ implementation: LBRACE PRI VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE PRI VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1591.
+## Ends in an error in state: 1612.
 ##
 ## method_ -> override_flag VIRTUAL label . COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7819,7 +7819,7 @@ implementation: LBRACE PRI VIRTUAL LIDENT WITH
 
 implementation: LBRACE PRI VIRTUAL WITH
 ##
-## Ends in an error in state: 1590.
+## Ends in an error in state: 1611.
 ##
 ## method_ -> override_flag VIRTUAL . label COLON poly_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7831,7 +7831,7 @@ implementation: LBRACE PRI VIRTUAL WITH
 
 implementation: LBRACE PRI WITH
 ##
-## Ends in an error in state: 1625.
+## Ends in an error in state: 1646.
 ##
 ## _class_field -> PRI . method_ post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7843,7 +7843,7 @@ implementation: LBRACE PRI WITH
 
 implementation: LBRACE PUB VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 1415.
+## Ends in an error in state: 1436.
 ##
 ## _poly_type -> typevar_list DOT . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -7855,7 +7855,7 @@ implementation: LBRACE PUB VIRTUAL LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LBRACE PUB VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 1412.
+## Ends in an error in state: 1433.
 ##
 ## _poly_type -> typevar_list . DOT core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -7868,7 +7868,7 @@ implementation: LBRACE PUB VIRTUAL LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 
 implementation: LBRACE PUB VIRTUAL LIDENT COLON QUOTE WITH
 ##
-## Ends in an error in state: 1410.
+## Ends in an error in state: 1431.
 ##
 ## _non_arrowed_simple_core_type -> QUOTE . ident [ error SEMI RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER AS ]
 ## typevar_list -> QUOTE . ident [ QUOTE DOT ]
@@ -7881,7 +7881,7 @@ implementation: LBRACE PUB VIRTUAL LIDENT COLON QUOTE WITH
 
 implementation: LBRACE PUB WITH
 ##
-## Ends in an error in state: 1588.
+## Ends in an error in state: 1609.
 ##
 ## _class_field -> PUB . method_ post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -7893,7 +7893,7 @@ implementation: LBRACE PUB WITH
 
 implementation: LBRACE PERCENT WITH TYPE
 ##
-## Ends in an error in state: 2336.
+## Ends in an error in state: 2357.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ error RBRACE ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ error SEMI RBRACE AND ]
@@ -7913,7 +7913,7 @@ implementation: LBRACE PERCENT WITH TYPE
 
 implementation: LBRACE UIDENT DOT WITH
 ##
-## Ends in an error in state: 2357.
+## Ends in an error in state: 2378.
 ##
 ## _simple_expr -> mod_longident DOT . LPAREN expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL COLONCOLONLIDENT COLONCOLON CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT . LPAREN expr_comma_list RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COLONEQUAL COLONCOLONLIDENT COLONCOLON CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
@@ -7940,7 +7940,7 @@ implementation: LBRACE UIDENT DOT WITH
 
 implementation: LBRACE VAL BANG WITH
 ##
-## Ends in an error in state: 1574.
+## Ends in an error in state: 1595.
 ##
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag . MUTABLE VIRTUAL label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -7955,7 +7955,7 @@ implementation: LBRACE VAL BANG WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LBRACE DOTDOT RBRACE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1587.
+## Ends in an error in state: 1608.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -7991,20 +7991,20 @@ implementation: LBRACE VAL LIDENT COLONGREATER LBRACE DOTDOT RBRACE EQUAL UIDENT
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT COLONGREATER LBRACE DOTDOT RBRACE EQUAL WITH
 ##
-## Ends in an error in state: 1586.
+## Ends in an error in state: 1607.
 ##
 ## value -> override_flag mutable_flag label type_constraint EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8016,7 +8016,7 @@ implementation: LBRACE VAL LIDENT COLONGREATER LBRACE DOTDOT RBRACE EQUAL WITH
 
 implementation: LBRACE VAL LIDENT COLONGREATER LBRACE DOTDOT RBRACE WITH
 ##
-## Ends in an error in state: 1585.
+## Ends in an error in state: 1606.
 ##
 ## value -> override_flag mutable_flag label type_constraint . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8033,14 +8033,14 @@ implementation: LBRACE VAL LIDENT COLONGREATER LBRACE DOTDOT RBRACE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 290, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 277, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1128, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1149, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 1584.
+## Ends in an error in state: 1605.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8076,20 +8076,20 @@ implementation: LBRACE VAL LIDENT EQUAL UIDENT RPAREN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACE VAL LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1583.
+## Ends in an error in state: 1604.
 ##
 ## value -> override_flag mutable_flag label EQUAL . expr [ error SEMI RBRACE LBRACKETATAT ]
 ##
@@ -8101,7 +8101,7 @@ implementation: LBRACE VAL LIDENT EQUAL WITH
 
 implementation: LBRACE VAL LIDENT WITH
 ##
-## Ends in an error in state: 1582.
+## Ends in an error in state: 1603.
 ##
 ## value -> override_flag mutable_flag label . EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag mutable_flag label . type_constraint EQUAL expr [ error SEMI RBRACE LBRACKETATAT ]
@@ -8114,7 +8114,7 @@ implementation: LBRACE VAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1579.
+## Ends in an error in state: 1600.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8138,7 +8138,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON UNDERSCORE WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1578.
+## Ends in an error in state: 1599.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8151,7 +8151,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1577.
+## Ends in an error in state: 1598.
 ##
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8164,7 +8164,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 ##
-## Ends in an error in state: 1576.
+## Ends in an error in state: 1597.
 ##
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> override_flag MUTABLE VIRTUAL . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8177,7 +8177,7 @@ implementation: LBRACE VAL MUTABLE VIRTUAL WITH
 
 implementation: LBRACE VAL MUTABLE WITH
 ##
-## Ends in an error in state: 1575.
+## Ends in an error in state: 1596.
 ##
 ## mutable_flag -> MUTABLE . [ LIDENT ]
 ## value -> override_flag MUTABLE . VIRTUAL label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
@@ -8191,7 +8191,7 @@ implementation: LBRACE VAL MUTABLE WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1570.
+## Ends in an error in state: 1591.
 ##
 ## value -> VIRTUAL mutable_flag label COLON core_type . [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON core_type . EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8215,7 +8215,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON UNDERSCORE WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 ##
-## Ends in an error in state: 1569.
+## Ends in an error in state: 1590.
 ##
 ## value -> VIRTUAL mutable_flag label COLON . core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label COLON . core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8228,7 +8228,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT COLON WITH
 
 implementation: LBRACE VAL VIRTUAL LIDENT WITH
 ##
-## Ends in an error in state: 1568.
+## Ends in an error in state: 1589.
 ##
 ## value -> VIRTUAL mutable_flag label . COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag label . COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8241,7 +8241,7 @@ implementation: LBRACE VAL VIRTUAL LIDENT WITH
 
 implementation: LBRACE VAL VIRTUAL MUTABLE LET
 ##
-## Ends in an error in state: 1567.
+## Ends in an error in state: 1588.
 ##
 ## value -> VIRTUAL mutable_flag . label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL mutable_flag . label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8254,7 +8254,7 @@ implementation: LBRACE VAL VIRTUAL MUTABLE LET
 
 implementation: LBRACE VAL VIRTUAL WITH
 ##
-## Ends in an error in state: 1566.
+## Ends in an error in state: 1587.
 ##
 ## value -> VIRTUAL . mutable_flag label COLON core_type [ error SEMI RBRACE LBRACKETATAT ]
 ## value -> VIRTUAL . mutable_flag label COLON core_type EQUAL [ error SEMI RBRACE LBRACKETATAT ]
@@ -8267,7 +8267,7 @@ implementation: LBRACE VAL VIRTUAL WITH
 
 implementation: LBRACE VAL WITH
 ##
-## Ends in an error in state: 1565.
+## Ends in an error in state: 1586.
 ##
 ## _class_field -> VAL . value post_item_attributes [ error SEMI RBRACE ]
 ##
@@ -8279,7 +8279,7 @@ implementation: LBRACE VAL WITH
 
 implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2518.
+## Ends in an error in state: 2539.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8315,13 +8315,13 @@ implementation: LBRACELESS LIDENT COLON UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -8366,7 +8366,7 @@ implementation: LBRACELESS LIDENT WITH
 
 implementation: LBRACKET DOTDOTDOT WITH
 ##
-## Ends in an error in state: 2149.
+## Ends in an error in state: 2170.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT . expr_optional_constraint RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -8378,7 +8378,7 @@ implementation: LBRACKET DOTDOTDOT WITH
 
 implementation: LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2152.
+## Ends in an error in state: 2173.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint . opt_comma RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## expr_comma_seq_extension -> expr_optional_constraint . COMMA expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -8391,14 +8391,14 @@ implementation: LBRACKET UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 937, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2131, spurious reduction of production expr_optional_constraint -> expr
+## In state 946, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2152, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 Expecting one of the following:
@@ -8435,7 +8435,7 @@ implementation: LBRACKETATATAT UNDERSCORE
 
 implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2218.
+## Ends in an error in state: 2239.
 ##
 ## floating_attribute -> LBRACKETATATAT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -8447,22 +8447,22 @@ implementation: LBRACKETATATAT WITH UIDENT RBRACE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1926, spurious reduction of production post_item_attributes ->
-## In state 1927, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1928, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1875, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1741, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1929, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1876, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1742, spurious reduction of production structure -> structure_item
-## In state 1871, spurious reduction of production payload -> structure
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1947, spurious reduction of production post_item_attributes ->
+## In state 1948, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1949, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1896, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1762, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1950, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1897, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1763, spurious reduction of production structure -> structure_item
+## In state 1892, spurious reduction of production payload -> structure
 ##
 
 Expecting "]" to finish current floating attribute
@@ -8481,7 +8481,7 @@ implementation: LBRACKETBAR BANG WITH
 
 implementation: LBRACKETBAR MINUSDOT WITH
 ##
-## Ends in an error in state: 862.
+## Ends in an error in state: 833.
 ##
 ## _expr -> subtractive . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -8493,7 +8493,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR PLUSDOT WITH
 ##
-## Ends in an error in state: 902.
+## Ends in an error in state: 873.
 ##
 ## _expr -> additive . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -8517,7 +8517,7 @@ Expecting an expression
 
 implementation: LBRACKETBAR UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1115.
+## Ends in an error in state: 1136.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8529,7 +8529,7 @@ Expecting a type name
 
 implementation: LBRACKETBAR UIDENT COLON WITH
 ##
-## Ends in an error in state: 1112.
+## Ends in an error in state: 1133.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8541,7 +8541,7 @@ implementation: LBRACKETBAR UIDENT COLON WITH
 
 implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1110.
+## Ends in an error in state: 1131.
 ##
 ## type_constraint -> COLONGREATER . core_type [ error RPAREN COMMA BARRBRACKET ]
 ##
@@ -8553,7 +8553,7 @@ implementation: LBRACKETBAR UIDENT COLONGREATER WITH
 
 implementation: LBRACKETBAR UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2143.
+## Ends in an error in state: 2164.
 ##
 ## expr_comma_seq -> expr_comma_seq COMMA . expr_optional_constraint [ error COMMA BARRBRACKET ]
 ## opt_comma -> COMMA . [ error BARRBRACKET ]
@@ -8578,7 +8578,7 @@ implementation: LBRACKETPERCENTPERCENT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH COLON WITH
 ##
-## Ends in an error in state: 1369.
+## Ends in an error in state: 1390.
 ##
 ## payload -> COLON . core_type [ RBRACKET ]
 ##
@@ -8592,7 +8592,7 @@ implementation: LBRACKETPERCENTPERCENT WITH DOT UNDERSCORE
 ##
 ## Ends in an error in state: 74.
 ##
-## attr_id -> single_attr_id DOT . attr_id [ error WHILE UIDENT TYPE TRY TRUE SWITCH STRING RBRACKET QUESTION PREFIXOP PLUSDOT PLUS PERCENT OPEN NEW MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION COLON CLASS CHAR BANG BACKQUOTE ASSERT ]
+## attr_id -> single_attr_id DOT . attr_id [ error WHILE UIDENT TYPE TRY TRUE SWITCH STRING RBRACKET QUESTION PREFIXOP PLUSDOT PLUS PERCENT OPEN NEW MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION ES6_FUN COLON CLASS CHAR BANG BACKQUOTE ASSERT ]
 ##
 ## The known suffix of the stack is as follows:
 ## single_attr_id DOT
@@ -8602,7 +8602,7 @@ implementation: LBRACKETPERCENTPERCENT WITH DOT UNDERSCORE
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 ##
-## Ends in an error in state: 2483.
+## Ends in an error in state: 2504.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN RBRACKET BAR ]
 ## payload -> QUESTION pattern . [ RBRACKET ]
@@ -8622,7 +8622,7 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE SEMI
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2485.
+## Ends in an error in state: 2506.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -8658,20 +8658,20 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 937, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 946, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2484.
+## Ends in an error in state: 2505.
 ##
 ## payload -> QUESTION pattern WHEN . expr [ RBRACKET ]
 ##
@@ -8696,7 +8696,7 @@ implementation: LBRACKETPERCENTPERCENT WITH QUESTION WITH
 
 implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2220.
+## Ends in an error in state: 2241.
 ##
 ## item_extension -> LBRACKETPERCENTPERCENT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF ]
 ##
@@ -8708,22 +8708,22 @@ implementation: LBRACKETPERCENTPERCENT WITH UIDENT RBRACE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1926, spurious reduction of production post_item_attributes ->
-## In state 1927, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1928, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1875, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1741, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1929, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1876, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1742, spurious reduction of production structure -> structure_item
-## In state 1871, spurious reduction of production payload -> structure
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1947, spurious reduction of production post_item_attributes ->
+## In state 1948, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1949, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1896, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1762, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1950, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1897, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1763, spurious reduction of production structure -> structure_item
+## In state 1892, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
@@ -8732,8 +8732,8 @@ implementation: LBRACKETPERCENTPERCENT WITH WITH
 ##
 ## Ends in an error in state: 73.
 ##
-## attr_id -> single_attr_id . [ error WHILE UIDENT TYPE TRY TRUE SWITCH STRING RBRACKET QUESTION PREFIXOP PLUSDOT PLUS PERCENT OPEN NEW MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION COLON CLASS CHAR BANG BACKQUOTE ASSERT ]
-## attr_id -> single_attr_id . DOT attr_id [ error WHILE UIDENT TYPE TRY TRUE SWITCH STRING RBRACKET QUESTION PREFIXOP PLUSDOT PLUS PERCENT OPEN NEW MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION COLON CLASS CHAR BANG BACKQUOTE ASSERT ]
+## attr_id -> single_attr_id . [ error WHILE UIDENT TYPE TRY TRUE SWITCH STRING RBRACKET QUESTION PREFIXOP PLUSDOT PLUS PERCENT OPEN NEW MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION ES6_FUN COLON CLASS CHAR BANG BACKQUOTE ASSERT ]
+## attr_id -> single_attr_id . DOT attr_id [ error WHILE UIDENT TYPE TRY TRUE SWITCH STRING RBRACKET QUESTION PREFIXOP PLUSDOT PLUS PERCENT OPEN NEW MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION ES6_FUN COLON CLASS CHAR BANG BACKQUOTE ASSERT ]
 ##
 ## The known suffix of the stack is as follows:
 ## single_attr_id
@@ -8743,7 +8743,7 @@ implementation: LBRACKETPERCENTPERCENT WITH WITH
 
 implementation: LET CHAR EQUAL CHAR AND WITH
 ##
-## Ends in an error in state: 1906.
+## Ends in an error in state: 1927.
 ##
 ## and_let_binding -> AND . let_binding_body post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -8755,7 +8755,7 @@ implementation: LET CHAR EQUAL CHAR AND WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ##
-## Ends in an error in state: 2268.
+## Ends in an error in state: 2289.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -8791,20 +8791,20 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL UIDENT RPAREN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2272.
+## Ends in an error in state: 2293.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -8816,7 +8816,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2271.
+## Ends in an error in state: 2292.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -8839,7 +8839,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 ##
-## Ends in an error in state: 2270.
+## Ends in an error in state: 2291.
 ##
 ## let_binding_body -> val_ident COLON typevar_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -8851,7 +8851,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH
 
 implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 ##
-## Ends in an error in state: 2269.
+## Ends in an error in state: 2290.
 ##
 ## let_binding_body -> val_ident COLON typevar_list . DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## typevar_list -> typevar_list . QUOTE ident [ QUOTE DOT ]
@@ -8864,7 +8864,7 @@ implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2266.
+## Ends in an error in state: 2287.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type EQUAL . mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -8876,7 +8876,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2265.
+## Ends in an error in state: 2286.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT core_type . EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -8899,7 +8899,7 @@ implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH
 
 implementation: LET LIDENT COLON TYPE LIDENT DOT WITH
 ##
-## Ends in an error in state: 2264.
+## Ends in an error in state: 2285.
 ##
 ## let_binding_body -> val_ident COLON TYPE lident_list DOT . core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -8924,7 +8924,7 @@ implementation: LET LIDENT COLON TYPE LIDENT WITH
 
 implementation: LET LIDENT COLON TYPE WITH
 ##
-## Ends in an error in state: 2262.
+## Ends in an error in state: 2283.
 ##
 ## let_binding_body -> val_ident COLON TYPE . lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -8936,7 +8936,7 @@ implementation: LET LIDENT COLON TYPE WITH
 
 implementation: LET LIDENT COLON WITH
 ##
-## Ends in an error in state: 2261.
+## Ends in an error in state: 2282.
 ##
 ## let_binding_body -> val_ident COLON . typevar_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## let_binding_body -> val_ident COLON . TYPE lident_list DOT core_type EQUAL mark_position_exp(expr) [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -8950,7 +8950,7 @@ implementation: LET LIDENT COLON WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2275.
+## Ends in an error in state: 2296.
 ##
 ## let_binding_body -> val_ident type_constraint EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -8962,7 +8962,7 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH
 
 implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ##
-## Ends in an error in state: 2274.
+## Ends in an error in state: 2295.
 ##
 ## let_binding_body -> val_ident type_constraint . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -8979,7 +8979,7 @@ implementation: LET LIDENT COLONGREATER UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 290, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 277, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1128, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 1149, spurious reduction of production type_constraint -> COLONGREATER core_type
 ##
 
 <SYNTAX ERROR>
@@ -9033,7 +9033,7 @@ implementation: LET LIDENT LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 1619.
+## Ends in an error in state: 1640.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EOF COLONEQUAL BARBAR AND AMPERSAND AMPERAMPER ]
@@ -9069,20 +9069,20 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER UIDENT RPARE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1618.
+## Ends in an error in state: 1639.
 ##
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9094,7 +9094,7 @@ implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE EQUALGREATER WITH
 
 implementation: LET LIDENT UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1617.
+## Ends in an error in state: 1638.
 ##
 ## _non_arrowed_non_simple_core_type -> non_arrowed_core_type . attribute [ LBRACKETAT EQUALGREATER ]
 ## curried_binding_return_typed_ -> COLON non_arrowed_core_type . EQUALGREATER expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9108,7 +9108,7 @@ Expecting "=>" to start the function body
 
 implementation: LET LIDENT UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1616.
+## Ends in an error in state: 1637.
 ##
 ## curried_binding_return_typed_ -> COLON . non_arrowed_core_type EQUALGREATER expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9120,7 +9120,7 @@ implementation: LET LIDENT UNDERSCORE COLON WITH
 
 implementation: LET LIDENT UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 1595.
+## Ends in an error in state: 1616.
 ##
 ## curried_binding -> EQUALGREATER . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9179,7 +9179,7 @@ implementation: LET LIDENT UNDERSCORE LPAREN WITH
 
 implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 1615.
+## Ends in an error in state: 1636.
 ##
 ## curried_binding -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9191,7 +9191,7 @@ implementation: LET LIDENT UNDERSCORE UNDERSCORE WITH
 
 implementation: LET LIDENT UNDERSCORE WITH
 ##
-## Ends in an error in state: 2278.
+## Ends in an error in state: 2299.
 ##
 ## _curried_binding_return_typed -> labeled_simple_pattern . curried_binding_return_typed_ [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9223,7 +9223,7 @@ implementation: LET LIDENT WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 ##
-## Ends in an error in state: 1891.
+## Ends in an error in state: 1912.
 ##
 ## and_nonlocal_module_bindings -> AND . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9235,7 +9235,7 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT AND WITH
 
 implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1890.
+## Ends in an error in state: 1911.
 ##
 ## _structure_item_without_item_extension_sugar -> many_nonlocal_module_bindings . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> many_nonlocal_module_bindings . and_nonlocal_module_bindings [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -9247,16 +9247,16 @@ implementation: LET MODULE REC UIDENT EQUAL UIDENT LBRACKETATAT AND RBRACKET WIT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1313, spurious reduction of production post_item_attributes ->
-## In state 1314, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2071, spurious reduction of production many_nonlocal_module_bindings -> opt_let_module REC nonlocal_module_binding_details post_item_attributes
+## In state 1334, spurious reduction of production post_item_attributes ->
+## In state 1335, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2092, spurious reduction of production many_nonlocal_module_bindings -> opt_let_module REC nonlocal_module_binding_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE REC WITH
 ##
-## Ends in an error in state: 2069.
+## Ends in an error in state: 2090.
 ##
 ## many_nonlocal_module_bindings -> opt_let_module REC . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -9268,7 +9268,7 @@ implementation: LET MODULE REC WITH
 
 implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2053.
+## Ends in an error in state: 2074.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9282,19 +9282,19 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1752, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1756, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1753, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1153, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1758, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1757, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1773, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1777, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1774, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1174, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1779, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1778, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 2052.
+## Ends in an error in state: 2073.
 ##
 ## module_binding_body_expr -> COLON module_type EQUAL . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9306,7 +9306,7 @@ implementation: LET MODULE UIDENT COLON UIDENT EQUAL WITH
 
 implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2051.
+## Ends in an error in state: 2072.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER EQUAL ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER EQUAL ]
@@ -9322,22 +9322,22 @@ implementation: LET MODULE UIDENT COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 133, spurious reduction of production ident -> UIDENT
 ## In state 792, spurious reduction of production mty_longident -> ident
-## In state 1830, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1859, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1855, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1828, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1860, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1856, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
-## In state 1829, spurious reduction of production _module_type -> non_arrowed_module_type
-## In state 1861, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1857, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1851, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1880, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1876, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1849, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1881, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1877, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1850, spurious reduction of production _module_type -> non_arrowed_module_type
+## In state 1882, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1878, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 1759.
+## Ends in an error in state: 1780.
 ##
 ## module_binding_body_expr -> COLON . module_type EQUAL module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9349,7 +9349,7 @@ implementation: LET MODULE UIDENT COLON WITH
 
 implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 1750.
+## Ends in an error in state: 1771.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9363,19 +9363,19 @@ implementation: LET MODULE UIDENT EQUAL UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1752, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1756, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1753, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1153, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1758, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1757, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1773, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1777, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1774, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1174, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1779, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1778, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1749.
+## Ends in an error in state: 1770.
 ##
 ## module_binding_body_expr -> EQUAL . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9387,7 +9387,7 @@ implementation: LET MODULE UIDENT EQUAL WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2064.
+## Ends in an error in state: 2085.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER module_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9401,19 +9401,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER UIDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1752, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1756, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1753, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1153, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1758, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1757, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1773, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1777, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1774, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1174, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1779, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1778, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2063.
+## Ends in an error in state: 2084.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type EQUALGREATER . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9425,7 +9425,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT EQUALGREATER WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ##
-## Ends in an error in state: 2062.
+## Ends in an error in state: 2083.
 ##
 ## _module_binding_body_functor -> functor_args COLON non_arrowed_module_type . EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_type -> non_arrowed_module_type . [ WITH LBRACKETAT EQUALGREATER ]
@@ -9439,19 +9439,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT SEMI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 133, spurious reduction of production ident -> UIDENT
 ## In state 792, spurious reduction of production mty_longident -> ident
-## In state 1830, spurious reduction of production _simple_module_type -> mty_longident
-## In state 1859, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
-## In state 1855, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
-## In state 1828, spurious reduction of production _non_arrowed_module_type -> simple_module_type
-## In state 1860, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
-## In state 1856, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
+## In state 1851, spurious reduction of production _simple_module_type -> mty_longident
+## In state 1880, spurious reduction of production mark_position_mty(_simple_module_type) -> _simple_module_type
+## In state 1876, spurious reduction of production simple_module_type -> mark_position_mty(_simple_module_type)
+## In state 1849, spurious reduction of production _non_arrowed_module_type -> simple_module_type
+## In state 1881, spurious reduction of production mark_position_mty(_non_arrowed_module_type) -> _non_arrowed_module_type
+## In state 1877, spurious reduction of production non_arrowed_module_type -> mark_position_mty(_non_arrowed_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT COLONEQUAL LBRACE DOTDOT RBRACE SEMI
 ##
-## Ends in an error in state: 2065.
+## Ends in an error in state: 2086.
 ##
 ## _module_type -> module_type . WITH with_constraints [ WITH LBRACKETAT EQUALGREATER ]
 ## _module_type -> module_type . EQUALGREATER module_type [ WITH LBRACKETAT EQUALGREATER ]
@@ -9470,18 +9470,18 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON UIDENT WITH TYPE LIDENT CO
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 290, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 277, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1837, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
-## In state 1851, spurious reduction of production with_constraints -> with_constraint
-## In state 1848, spurious reduction of production _module_type -> module_type WITH with_constraints
-## In state 1861, spurious reduction of production mark_position_mty(_module_type) -> _module_type
-## In state 1857, spurious reduction of production module_type -> mark_position_mty(_module_type)
+## In state 1858, spurious reduction of production with_constraint -> TYPE label_longident optional_type_parameters COLONEQUAL core_type
+## In state 1872, spurious reduction of production with_constraints -> with_constraint
+## In state 1869, spurious reduction of production _module_type -> module_type WITH with_constraints
+## In state 1882, spurious reduction of production mark_position_mty(_module_type) -> _module_type
+## In state 1878, spurious reduction of production module_type -> mark_position_mty(_module_type)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
 ##
-## Ends in an error in state: 2061.
+## Ends in an error in state: 2082.
 ##
 ## _module_binding_body_functor -> functor_args COLON . non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9493,7 +9493,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN COLON WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ##
-## Ends in an error in state: 2060.
+## Ends in an error in state: 2081.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER module_expr . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_expr -> module_expr . simple_module_expr [ error UIDENT SEMI RBRACKET RBRACE LPAREN LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE EOF AND ]
@@ -9507,19 +9507,19 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER UIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1752, spurious reduction of production _simple_module_expr -> mod_longident
-## In state 1756, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
-## In state 1753, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
-## In state 1153, spurious reduction of production _module_expr -> simple_module_expr
-## In state 1758, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
-## In state 1757, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
+## In state 1773, spurious reduction of production _simple_module_expr -> mod_longident
+## In state 1777, spurious reduction of production mark_position_mod(_simple_module_expr) -> _simple_module_expr
+## In state 1774, spurious reduction of production simple_module_expr -> mark_position_mod(_simple_module_expr)
+## In state 1174, spurious reduction of production _module_expr -> simple_module_expr
+## In state 1779, spurious reduction of production mark_position_mod(_module_expr) -> _module_expr
+## In state 1778, spurious reduction of production module_expr -> mark_position_mod(_module_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 ##
-## Ends in an error in state: 2059.
+## Ends in an error in state: 2080.
 ##
 ## _module_binding_body_functor -> functor_args EQUALGREATER . module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9531,7 +9531,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN EQUALGREATER WITH
 
 implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 2058.
+## Ends in an error in state: 2079.
 ##
 ## _module_binding_body_functor -> functor_args . EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ## _module_binding_body_functor -> functor_args . COLON non_arrowed_module_type EQUALGREATER module_expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9545,7 +9545,7 @@ implementation: LET MODULE UIDENT LPAREN RPAREN WITH
 
 implementation: LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 1748.
+## Ends in an error in state: 1769.
 ##
 ## nonlocal_module_binding_details -> UIDENT . module_binding_body [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9557,7 +9557,7 @@ implementation: LET MODULE UIDENT WITH
 
 implementation: LET MODULE WITH
 ##
-## Ends in an error in state: 1747.
+## Ends in an error in state: 1768.
 ##
 ## _structure_item_without_item_extension_sugar -> opt_let_module . nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ## many_nonlocal_module_bindings -> opt_let_module . REC nonlocal_module_binding_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -9582,7 +9582,7 @@ implementation: LET REC ASSERT
 
 implementation: LET UIDENT UNDERSCORE WHEN
 ##
-## Ends in an error in state: 1912.
+## Ends in an error in state: 1933.
 ##
 ## _or_pattern -> pattern . BAR pattern [ EQUAL BAR ]
 ## let_binding_body -> pattern . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9604,7 +9604,7 @@ implementation: LET UIDENT UNDERSCORE WHEN
 
 implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1910.
+## Ends in an error in state: 1931.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9616,7 +9616,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 ##
-## Ends in an error in state: 1909.
+## Ends in an error in state: 1930.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON core_type . EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9639,7 +9639,7 @@ implementation: LET UNDERSCORE COLON UNDERSCORE WITH
 
 implementation: LET UNDERSCORE COLON WITH
 ##
-## Ends in an error in state: 1908.
+## Ends in an error in state: 1929.
 ##
 ## let_binding_body -> simple_pattern_not_ident COLON . core_type EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9651,7 +9651,7 @@ implementation: LET UNDERSCORE COLON WITH
 
 implementation: LET UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1913.
+## Ends in an error in state: 1934.
 ##
 ## let_binding_body -> pattern EQUAL . expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -9663,7 +9663,7 @@ implementation: LET UNDERSCORE EQUAL WITH
 
 implementation: LET UNDERSCORE WITH
 ##
-## Ends in an error in state: 1907.
+## Ends in an error in state: 1928.
 ##
 ## _simple_pattern -> simple_pattern_not_ident . [ LBRACKETAT EQUAL COLONCOLON BAR AS ]
 ## let_binding_body -> simple_pattern_not_ident . COLON core_type EQUAL expr [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -9689,7 +9689,7 @@ Incomplete let binding
 
 implementation: LPAREN ASSERT WITH
 ##
-## Ends in an error in state: 849.
+## Ends in an error in state: 807.
 ##
 ## _expr -> ASSERT . simple_expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -9713,7 +9713,7 @@ implementation: LPAREN BACKQUOTE WITH
 
 implementation: LPAREN BANG WITH
 ##
-## Ends in an error in state: 1105.
+## Ends in an error in state: 1126.
 ##
 ## _simple_expr -> BANG . simple_expr [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP RPAREN QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER FLOAT FALSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARBAR BANG BACKQUOTE AMPERSAND AMPERAMPER ]
 ## operator -> BANG . [ RPAREN ]
@@ -9758,9 +9758,9 @@ implementation: LPAREN FOR UNDERSCORE IN UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 819, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 825, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -9791,7 +9791,7 @@ implementation: LPAREN FOR WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2201.
+## Ends in an error in state: 2222.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -9826,17 +9826,17 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2200.
+## Ends in an error in state: 2221.
 ##
 ## leading_bar_match_case -> pattern_with_bar EQUALGREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -9848,7 +9848,7 @@ implementation: LPAREN FUN BAR UNDERSCORE EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2199.
+## Ends in an error in state: 2220.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -9883,17 +9883,17 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2198.
+## Ends in an error in state: 2219.
 ##
 ## leading_bar_match_case -> pattern_with_bar WHEN expr EQUALGREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -9905,7 +9905,7 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2197.
+## Ends in an error in state: 2218.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -9941,20 +9941,20 @@ implementation: LPAREN FUN BAR UNDERSCORE WHEN UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 937, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 946, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN FUN BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2196.
+## Ends in an error in state: 2217.
 ##
 ## leading_bar_match_case -> pattern_with_bar WHEN . expr EQUALGREATER expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10013,7 +10013,7 @@ implementation: LPAREN FUN LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ##
-## Ends in an error in state: 2186.
+## Ends in an error in state: 2207.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -10048,10 +10048,10 @@ implementation: LPAREN FUN UNDERSCORE EQUALGREATER STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
@@ -10117,7 +10117,7 @@ implementation: LPAREN FUN UNDERSCORE LPAREN WITH
 
 implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 ##
-## Ends in an error in state: 2191.
+## Ends in an error in state: 2212.
 ##
 ## fun_def -> labeled_simple_pattern . fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10129,7 +10129,7 @@ implementation: LPAREN FUN UNDERSCORE UNDERSCORE WITH
 
 implementation: LPAREN FUN UNDERSCORE WITH
 ##
-## Ends in an error in state: 2205.
+## Ends in an error in state: 2226.
 ##
 ## _expr -> FUN labeled_simple_pattern . fun_def [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10188,9 +10188,9 @@ implementation: LPAREN IF UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 819, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 825, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -10256,7 +10256,7 @@ implementation: LPAREN LBRACELESS WITH
 
 implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ##
-## Ends in an error in state: 2150.
+## Ends in an error in state: 2171.
 ##
 ## expr_comma_seq_extension -> DOTDOTDOT expr_optional_constraint . RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10268,21 +10268,21 @@ implementation: LPAREN LBRACKET DOTDOTDOT UIDENT COMMA
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 937, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2131, spurious reduction of production expr_optional_constraint -> expr
+## In state 946, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2152, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LBRACKET UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2153.
+## Ends in an error in state: 2174.
 ##
 ## expr_comma_seq_extension -> expr_optional_constraint COMMA . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## opt_comma -> COMMA . [ RBRACKET ]
@@ -10295,7 +10295,7 @@ implementation: LPAREN LBRACKET UIDENT COMMA WITH
 
 implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2416.
+## Ends in an error in state: 2437.
 ##
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10309,15 +10309,15 @@ implementation: LPAREN LBRACKETBAR UIDENT RPAREN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1109, spurious reduction of production expr_optional_constraint -> expr
-## In state 2141, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1130, spurious reduction of production expr_optional_constraint -> expr
+## In state 2162, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
@@ -10350,7 +10350,7 @@ implementation: LPAREN LBRACKETPERCENT UNDERSCORE
 
 implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2486.
+## Ends in an error in state: 2507.
 ##
 ## extension -> LBRACKETPERCENT attr_id payload . RBRACKET [ error WITH UNDERSCORE UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUOTE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETGREATER LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EQUALGREATER EQUAL EOF ELSE DOT CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10362,29 +10362,29 @@ implementation: LPAREN LBRACKETPERCENT WITH UIDENT RBRACE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1926, spurious reduction of production post_item_attributes ->
-## In state 1927, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1928, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1875, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1741, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1929, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1876, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1742, spurious reduction of production structure -> structure_item
-## In state 1871, spurious reduction of production payload -> structure
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1947, spurious reduction of production post_item_attributes ->
+## In state 1948, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1949, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1896, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1762, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1950, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1897, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1763, spurious reduction of production structure -> structure_item
+## In state 1892, spurious reduction of production payload -> structure
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 888.
+## Ends in an error in state: 859.
 ##
 ## _expr -> label EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10396,7 +10396,7 @@ implementation: LPAREN LIDENT EQUAL WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ##
-## Ends in an error in state: 2507.
+## Ends in an error in state: 2528.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr . RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10432,20 +10432,20 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 937, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 946, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 2506.
+## Ends in an error in state: 2527.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr COMMA . expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10457,7 +10457,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT COMMA WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2505.
+## Ends in an error in state: 2526.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN expr . COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COMMA COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -10493,20 +10493,20 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 937, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 946, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 ##
-## Ends in an error in state: 2504.
+## Ends in an error in state: 2525.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN LPAREN . expr COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10518,7 +10518,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN LPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 ##
-## Ends in an error in state: 2503.
+## Ends in an error in state: 2524.
 ##
 ## _expr -> LPAREN COLONCOLON RPAREN . LPAREN expr COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10530,7 +10530,7 @@ implementation: LPAREN LPAREN COLONCOLON RPAREN WITH
 
 implementation: LPAREN LPAREN COLONCOLON WITH
 ##
-## Ends in an error in state: 2502.
+## Ends in an error in state: 2523.
 ##
 ## _expr -> LPAREN COLONCOLON . RPAREN LPAREN expr COMMA expr RPAREN [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -10542,7 +10542,7 @@ implementation: LPAREN LPAREN COLONCOLON WITH
 
 implementation: LPAREN LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2496.
+## Ends in an error in state: 2517.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT RPAREN LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -10584,7 +10584,7 @@ Expecting a module expression
 
 implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ##
-## Ends in an error in state: 2509.
+## Ends in an error in state: 2530.
 ##
 ## _simple_expr -> LPAREN expr_comma_list . opt_comma RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN expr_comma_list . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10597,12 +10597,12 @@ implementation: LPAREN LPAREN UIDENT COMMA CHAR BARRBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1109, spurious reduction of production expr_optional_constraint -> expr
-## In state 1108, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1130, spurious reduction of production expr_optional_constraint -> expr
+## In state 1129, spurious reduction of production expr_comma_list -> expr_optional_constraint COMMA expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
@@ -10639,7 +10639,7 @@ implementation: LPAREN MINUS WITH
 ## Ends in an error in state: 802.
 ##
 ## operator -> MINUS . [ RPAREN ]
-## subtractive -> MINUS . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
+## subtractive -> MINUS . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT IF FUN FOR FLOAT FALSE ES6_FUN CHAR BANG BACKQUOTE ASSERT ]
 ##
 ## The known suffix of the stack is as follows:
 ## MINUS
@@ -10652,7 +10652,7 @@ implementation: LPAREN MINUSDOT WITH
 ## Ends in an error in state: 801.
 ##
 ## operator -> MINUSDOT . [ RPAREN ]
-## subtractive -> MINUSDOT . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
+## subtractive -> MINUSDOT . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT IF FUN FOR FLOAT FALSE ES6_FUN CHAR BANG BACKQUOTE ASSERT ]
 ##
 ## The known suffix of the stack is as follows:
 ## MINUSDOT
@@ -10662,7 +10662,7 @@ implementation: LPAREN MINUSDOT WITH
 
 implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2500.
+## Ends in an error in state: 2521.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10682,7 +10682,7 @@ implementation: LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2498.
+## Ends in an error in state: 2519.
 ##
 ## _simple_expr -> LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10735,7 +10735,7 @@ implementation: LPAREN PLUS WITH
 ##
 ## Ends in an error in state: 191.
 ##
-## additive -> PLUS . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
+## additive -> PLUS . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT IF FUN FOR FLOAT FALSE ES6_FUN CHAR BANG BACKQUOTE ASSERT ]
 ## operator -> PLUS . [ RPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -10748,7 +10748,7 @@ implementation: LPAREN PLUSDOT WITH
 ##
 ## Ends in an error in state: 190.
 ##
-## additive -> PLUSDOT . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT IF FUN FOR FLOAT FALSE CHAR BANG BACKQUOTE ASSERT ]
+## additive -> PLUSDOT . [ WHILE UIDENT TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS NEW MINUSDOT MINUS LPAREN LIDENT LESSIDENT LESSGREATER LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKET LBRACELESS LBRACE LAZY INT IF FUN FOR FLOAT FALSE ES6_FUN CHAR BANG BACKQUOTE ASSERT ]
 ## operator -> PLUSDOT . [ RPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -10784,7 +10784,7 @@ implementation: LPAREN STAR WITH
 
 implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 ##
-## Ends in an error in state: 1132.
+## Ends in an error in state: 1153.
 ##
 ## type_constraint_right_of_colon -> core_type COLONGREATER . core_type [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -10796,7 +10796,7 @@ implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH
 
 implementation: LPAREN UIDENT COLON WITH
 ##
-## Ends in an error in state: 1129.
+## Ends in an error in state: 1150.
 ##
 ## type_constraint -> COLON . type_constraint_right_of_colon [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -10808,7 +10808,7 @@ implementation: LPAREN UIDENT COLON WITH
 
 implementation: LPAREN UIDENT COLONGREATER LBRACE DOTDOT RBRACE WITH
 ##
-## Ends in an error in state: 1106.
+## Ends in an error in state: 1127.
 ##
 ## expr_comma_list -> expr_optional_constraint . COMMA expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -10825,15 +10825,15 @@ implementation: LPAREN UIDENT COLONGREATER LBRACE DOTDOT RBRACE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 290, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 277, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1128, spurious reduction of production type_constraint -> COLONGREATER core_type
-## In state 2516, spurious reduction of production expr_optional_constraint -> expr type_constraint
+## In state 1149, spurious reduction of production type_constraint -> COLONGREATER core_type
+## In state 2537, spurious reduction of production expr_optional_constraint -> expr type_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: LPAREN UIDENT COLONGREATER WITH
 ##
-## Ends in an error in state: 1127.
+## Ends in an error in state: 1148.
 ##
 ## type_constraint -> COLONGREATER . core_type [ RPAREN RBRACKET RBRACE EQUAL COMMA ]
 ##
@@ -10845,7 +10845,7 @@ implementation: LPAREN UIDENT COLONGREATER WITH
 
 implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 ##
-## Ends in an error in state: 1120.
+## Ends in an error in state: 1141.
 ##
 ## expr_comma_list -> expr_comma_list COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ## opt_comma -> COMMA . [ RPAREN ]
@@ -10858,7 +10858,7 @@ implementation: LPAREN UIDENT COMMA CHAR COMMA WITH
 
 implementation: LPAREN UIDENT COMMA WITH
 ##
-## Ends in an error in state: 1107.
+## Ends in an error in state: 1128.
 ##
 ## expr_comma_list -> expr_optional_constraint COMMA . expr_optional_constraint [ error RPAREN COMMA ]
 ##
@@ -10896,7 +10896,7 @@ implementation: PERCENT UNDERSCORE
 ##
 ## Ends in an error in state: 347.
 ##
-## item_extension_sugar -> PERCENT . attr_id [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION CLASS CHAR BANG BACKQUOTE ASSERT ]
+## item_extension_sugar -> PERCENT . attr_id [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION ES6_FUN CLASS CHAR BANG BACKQUOTE ASSERT ]
 ##
 ## The known suffix of the stack is as follows:
 ## PERCENT
@@ -10908,7 +10908,7 @@ implementation: PERCENT WITH DOT UNDERSCORE
 ##
 ## Ends in an error in state: 399.
 ##
-## attr_id -> single_attr_id DOT . attr_id [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION CLASS CHAR BANG BACKQUOTE ASSERT ]
+## attr_id -> single_attr_id DOT . attr_id [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION ES6_FUN CLASS CHAR BANG BACKQUOTE ASSERT ]
 ##
 ## The known suffix of the stack is as follows:
 ## single_attr_id DOT
@@ -10920,8 +10920,8 @@ implementation: PERCENT WITH WITH
 ##
 ## Ends in an error in state: 398.
 ##
-## attr_id -> single_attr_id . [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION CLASS CHAR BANG BACKQUOTE ASSERT ]
-## attr_id -> single_attr_id . DOT attr_id [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION CLASS CHAR BANG BACKQUOTE ASSERT ]
+## attr_id -> single_attr_id . [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION ES6_FUN CLASS CHAR BANG BACKQUOTE ASSERT ]
+## attr_id -> single_attr_id . DOT attr_id [ WHILE UIDENT TYPE TRY TRUE SWITCH STRING PREFIXOP PLUSDOT PLUS OPEN NEW MODULE MINUSDOT MINUS LPAREN LIDENT LET LESSIDENT LESSGREATER LBRACKETPERCENTPERCENT LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATATAT LBRACKET LBRACELESS LBRACE LAZY INT INCLUDE IF FUN FOR FLOAT FALSE EXTERNAL EXCEPTION ES6_FUN CLASS CHAR BANG BACKQUOTE ASSERT ]
 ##
 ## The known suffix of the stack is as follows:
 ## single_attr_id
@@ -10931,7 +10931,7 @@ implementation: PERCENT WITH WITH
 
 implementation: STRING LIDENTCOLONCOLON WITH
 ##
-## Ends in an error in state: 870.
+## Ends in an error in state: 841.
 ##
 ## label_expr -> LIDENTCOLONCOLON . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## label_expr -> LIDENTCOLONCOLON . QUESTION less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -10944,7 +10944,7 @@ implementation: STRING LIDENTCOLONCOLON WITH
 
 implementation: STRING LIDENTCOLONCOLON QUESTION WITH
 ##
-## Ends in an error in state: 871.
+## Ends in an error in state: 842.
 ##
 ## label_expr -> LIDENTCOLONCOLON QUESTION . less_aggressive_simple_expression [ error UIDENT TRUE STRING STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -10956,7 +10956,7 @@ implementation: STRING LIDENTCOLONCOLON QUESTION WITH
 
 implementation: STRING WITH
 ##
-## Ends in an error in state: 1742.
+## Ends in an error in state: 1763.
 ##
 ## structure -> structure_item . [ RBRACKET RBRACE EOF ]
 ## structure -> structure_item . error structure [ RBRACKET RBRACE EOF ]
@@ -10969,24 +10969,24 @@ implementation: STRING WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1926, spurious reduction of production post_item_attributes ->
-## In state 1927, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1928, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1875, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1741, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1929, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1876, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1947, spurious reduction of production post_item_attributes ->
+## In state 1948, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1949, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1896, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1762, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1950, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1897, spurious reduction of production structure_item -> mark_position_str(_structure_item)
 ##
 
 Incomplete statement. Did you forget a ";"?
 
 implementation: SWITCH UIDENT LBRACE BAR CHAR EQUALGREATER CHAR WITH
 ##
-## Ends in an error in state: 2543.
+## Ends in an error in state: 2564.
 ##
 ## _expr -> SWITCH simple_expr LBRACE leading_bar_match_cases_to_sequence_body . RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## leading_bar_match_cases_to_sequence_body -> leading_bar_match_cases_to_sequence_body . leading_bar_match_case_to_sequence_body [ RBRACE BAR ]
@@ -10998,27 +10998,27 @@ implementation: SWITCH UIDENT LBRACE BAR CHAR EQUALGREATER CHAR WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2400, spurious reduction of production post_item_attributes ->
-## In state 2401, spurious reduction of production opt_semi ->
-## In state 2406, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
-## In state 2404, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
-## In state 2393, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
-## In state 2378, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
-## In state 2405, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2394, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
-## In state 2409, spurious reduction of production leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER semi_terminated_seq_expr
-## In state 2413, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2421, spurious reduction of production post_item_attributes ->
+## In state 2422, spurious reduction of production opt_semi ->
+## In state 2427, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
+## In state 2425, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
+## In state 2414, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
+## In state 2399, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
+## In state 2426, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2415, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2430, spurious reduction of production leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER semi_terminated_seq_expr
+## In state 2434, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
 ##
 
 The switch expression isn't closed.
 
 implementation: SWITCH UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2542.
+## Ends in an error in state: 2563.
 ##
 ## _expr -> SWITCH simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11030,7 +11030,7 @@ implementation: SWITCH UIDENT LBRACE WITH
 
 implementation: SWITCH UIDENT WITH
 ##
-## Ends in an error in state: 2541.
+## Ends in an error in state: 2562.
 ##
 ## _expr -> SWITCH simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr . DOT label_longident [ SHARPOP SHARP LBRACE DOT ]
@@ -11050,9 +11050,9 @@ implementation: SWITCH UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 819, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 825, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
@@ -11071,7 +11071,7 @@ implementation: SWITCH WITH
 
 implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 ##
-## Ends in an error in state: 1046.
+## Ends in an error in state: 1108.
 ##
 ## _expr -> simple_expr DOT LBRACE expr RBRACE EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11083,7 +11083,7 @@ implementation: TRUE DOT LBRACE UIDENT RBRACE EQUAL WITH
 
 implementation: TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 1044.
+## Ends in an error in state: 1106.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11120,20 +11120,20 @@ implementation: TRUE DOT LBRACE UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 937, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 946, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 1043.
+## Ends in an error in state: 1105.
 ##
 ## _expr -> simple_expr DOT LBRACE . expr RBRACE EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11146,7 +11146,7 @@ implementation: TRUE DOT LBRACE WITH
 
 implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 ##
-## Ends in an error in state: 1041.
+## Ends in an error in state: 1103.
 ##
 ## _expr -> simple_expr DOT LBRACKET expr RBRACKET EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11158,7 +11158,7 @@ implementation: TRUE DOT LBRACKET UIDENT RBRACKET EQUAL WITH
 
 implementation: TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 1038.
+## Ends in an error in state: 1100.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11196,20 +11196,20 @@ implementation: TRUE DOT LBRACKET UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 1037.
+## Ends in an error in state: 1099.
 ##
 ## _expr -> simple_expr DOT LBRACKET . expr RBRACKET EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11223,7 +11223,7 @@ implementation: TRUE DOT LBRACKET WITH
 
 implementation: TRUE DOT LIDENT EQUAL WITH
 ##
-## Ends in an error in state: 1049.
+## Ends in an error in state: 1111.
 ##
 ## _expr -> simple_expr DOT label_longident EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11235,7 +11235,7 @@ implementation: TRUE DOT LIDENT EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 ##
-## Ends in an error in state: 1035.
+## Ends in an error in state: 1097.
 ##
 ## _expr -> simple_expr DOT LPAREN expr RPAREN EQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11247,7 +11247,7 @@ implementation: TRUE DOT LPAREN UIDENT RPAREN EQUAL WITH
 
 implementation: TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 1032.
+## Ends in an error in state: 1094.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11285,20 +11285,20 @@ implementation: TRUE DOT LPAREN UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRUE DOT LPAREN WITH
 ##
-## Ends in an error in state: 865.
+## Ends in an error in state: 836.
 ##
 ## _expr -> simple_expr DOT LPAREN . expr RPAREN EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LPAREN . expr RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AND AMPERSAND AMPERAMPER ]
@@ -11338,7 +11338,7 @@ implementation: TRUE DOT UIDENT WITH
 
 implementation: TRUE DOT WITH
 ##
-## Ends in an error in state: 864.
+## Ends in an error in state: 835.
 ##
 ## _expr -> simple_expr DOT . label_longident EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> simple_expr DOT . LPAREN expr RPAREN EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -11359,7 +11359,7 @@ implementation: TRUE DOT WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER CHAR BAR WITH
 ##
-## Ends in an error in state: 1086.
+## Ends in an error in state: 1076.
 ##
 ## pattern_with_bar -> BAR . pattern [ WHEN EQUALGREATER ]
 ##
@@ -11384,7 +11384,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT EQUAL UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2391.
+## Ends in an error in state: 2412.
 ##
 ## _semi_terminated_seq_expr_row -> opt_let_module UIDENT module_binding_body post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11396,7 +11396,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2388.
+## Ends in an error in state: 2409.
 ##
 ## _semi_terminated_seq_expr_row -> opt_let_module UIDENT . module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11408,7 +11408,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE UIDENT 
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 ##
-## Ends in an error in state: 2387.
+## Ends in an error in state: 2408.
 ##
 ## _semi_terminated_seq_expr_row -> opt_let_module . UIDENT module_binding_body post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11420,7 +11420,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET MODULE WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 ##
-## Ends in an error in state: 2382.
+## Ends in an error in state: 2403.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag . mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11432,7 +11432,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN BANG WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2385.
+## Ends in an error in state: 2406.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes SEMI . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11444,7 +11444,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT SE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WITH
 ##
-## Ends in an error in state: 2384.
+## Ends in an error in state: 2405.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN override_flag mod_longident post_item_attributes . SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11455,14 +11455,14 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN UIDENT WI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2383, spurious reduction of production post_item_attributes ->
+## In state 2404, spurious reduction of production post_item_attributes ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 ##
-## Ends in an error in state: 2381.
+## Ends in an error in state: 2402.
 ##
 ## _semi_terminated_seq_expr_row -> option(LET) OPEN . override_flag mod_longident post_item_attributes SEMI semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11474,7 +11474,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET OPEN WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 ##
-## Ends in an error in state: 2377.
+## Ends in an error in state: 2398.
 ##
 ## let_binding_impl -> LET . rec_flag let_binding_body post_item_attributes [ SEMI RBRACE BAR AND ]
 ## opt_let_module -> LET . MODULE [ UIDENT ]
@@ -11488,7 +11488,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER LET WITH
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 ##
-## Ends in an error in state: 2398.
+## Ends in an error in state: 2419.
 ##
 ## _semi_terminated_seq_expr -> item_extension_sugar . semi_terminated_seq_expr_row [ RBRACE BAR ]
 ## let_binding -> item_extension_sugar . let_binding_impl [ SEMI RBRACE BAR AND ]
@@ -11508,7 +11508,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER PERCENT AND TYPE
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ##
-## Ends in an error in state: 2684.
+## Ends in an error in state: 2705.
 ##
 ## _expr -> TRY simple_expr LBRACE leading_bar_match_cases_to_sequence_body . RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## leading_bar_match_cases_to_sequence_body -> leading_bar_match_cases_to_sequence_body . leading_bar_match_case_to_sequence_body [ RBRACE BAR ]
@@ -11521,23 +11521,23 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER UIDENT RPAREN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 937, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2400, spurious reduction of production post_item_attributes ->
-## In state 2401, spurious reduction of production opt_semi ->
-## In state 2406, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
-## In state 2404, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
-## In state 2393, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
-## In state 2378, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
-## In state 2405, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
-## In state 2394, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
-## In state 2409, spurious reduction of production leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER semi_terminated_seq_expr
-## In state 2413, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
+## In state 946, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2421, spurious reduction of production post_item_attributes ->
+## In state 2422, spurious reduction of production opt_semi ->
+## In state 2427, spurious reduction of production _semi_terminated_seq_expr_row -> expr post_item_attributes opt_semi
+## In state 2425, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr_row) -> _semi_terminated_seq_expr_row
+## In state 2414, spurious reduction of production semi_terminated_seq_expr_row -> mark_position_exp(_semi_terminated_seq_expr_row)
+## In state 2399, spurious reduction of production _semi_terminated_seq_expr -> semi_terminated_seq_expr_row
+## In state 2426, spurious reduction of production mark_position_exp(_semi_terminated_seq_expr) -> _semi_terminated_seq_expr
+## In state 2415, spurious reduction of production semi_terminated_seq_expr -> mark_position_exp(_semi_terminated_seq_expr)
+## In state 2430, spurious reduction of production leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER semi_terminated_seq_expr
+## In state 2434, spurious reduction of production leading_bar_match_cases_to_sequence_body -> leading_bar_match_case_to_sequence_body
 ##
 
 Expecting one of the following:
@@ -11546,7 +11546,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE EQUALGREATER WITH
 ##
-## Ends in an error in state: 2408.
+## Ends in an error in state: 2429.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11558,7 +11558,7 @@ Expecting the body of the matched pattern
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE SEMI
 ##
-## Ends in an error in state: 1087.
+## Ends in an error in state: 1077.
 ##
 ## _or_pattern -> pattern . BAR pattern [ WHEN EQUALGREATER BAR ]
 ## pattern_with_bar -> BAR pattern . [ WHEN EQUALGREATER ]
@@ -11580,7 +11580,7 @@ Expecting one of the following:
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT EQUALGREATER WITH
 ##
-## Ends in an error in state: 2376.
+## Ends in an error in state: 2397.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar WHEN expr EQUALGREATER . semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11592,7 +11592,7 @@ Expecting a sequence item
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ##
-## Ends in an error in state: 2375.
+## Ends in an error in state: 2396.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER EQUALGREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -11628,20 +11628,20 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 937, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 946, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 ##
-## Ends in an error in state: 2374.
+## Ends in an error in state: 2395.
 ##
 ## leading_bar_match_case_to_sequence_body -> pattern_with_bar WHEN . expr EQUALGREATER semi_terminated_seq_expr [ RBRACE BAR ]
 ##
@@ -11653,7 +11653,7 @@ implementation: TRY UIDENT LBRACE BAR UNDERSCORE WHEN WITH
 
 implementation: TRY UIDENT LBRACE WITH
 ##
-## Ends in an error in state: 2683.
+## Ends in an error in state: 2704.
 ##
 ## _expr -> TRY simple_expr LBRACE . leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11665,7 +11665,7 @@ implementation: TRY UIDENT LBRACE WITH
 
 implementation: LESSIDENT LIDENT EQUAL UIDENT WITH
 ##
-## Ends in an error in state: 2676.
+## Ends in an error in state: 2697.
 ##
 ## _simple_expr -> simple_expr . DOT label_longident [ SLASHGREATER SHARPOP SHARP LIDENT GREATER DOT ]
 ## _simple_expr -> simple_expr . DOT LPAREN expr RPAREN [ SLASHGREATER SHARPOP SHARP LIDENT GREATER DOT ]
@@ -11685,16 +11685,16 @@ implementation: LESSIDENT LIDENT EQUAL UIDENT WITH
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 819, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 825, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 This is a reserved keyword. Consider using a different one. For BuckleScript, add an underscore at the end (http://bloomberg.github.io/bucklescript/Manual.html#_object_label_translation_convention).
 
 implementation: TRY UIDENT UNDERSCORE
 ##
-## Ends in an error in state: 2680.
+## Ends in an error in state: 2701.
 ##
 ## _expr -> TRY simple_expr . LBRACE leading_bar_match_cases_to_sequence_body RBRACE [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> TRY simple_expr . WITH error [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -11715,16 +11715,16 @@ implementation: TRY UIDENT UNDERSCORE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 819, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 825, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
 ##
 
 <SYNTAX ERROR>
 
 implementation: TRY UIDENT WITH WITH
 ##
-## Ends in an error in state: 2681.
+## Ends in an error in state: 2702.
 ##
 ## _expr -> TRY simple_expr WITH . error [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -11749,7 +11749,7 @@ implementation: TRY WITH
 
 implementation: TYPE LIDENT AND LIDENT WITH
 ##
-## Ends in an error in state: 1884.
+## Ends in an error in state: 1905.
 ##
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -11760,14 +11760,14 @@ implementation: TYPE LIDENT AND LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1883, spurious reduction of production optional_type_parameters ->
+## In state 1904, spurious reduction of production optional_type_parameters ->
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT AND WITH
 ##
-## Ends in an error in state: 1878.
+## Ends in an error in state: 1899.
 ##
 ## and_type_declaration -> AND . type_declaration_details post_item_attributes [ error SEMI RBRACKET RBRACE EOF AND ]
 ##
@@ -11779,7 +11779,7 @@ implementation: TYPE LIDENT AND WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 1779.
+## Ends in an error in state: 1800.
 ##
 ## constrain -> core_type EQUAL . core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -11791,7 +11791,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 ##
-## Ends in an error in state: 1778.
+## Ends in an error in state: 1799.
 ##
 ## constrain -> core_type . EQUAL core_type [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -11814,7 +11814,7 @@ implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH
 
 implementation: TYPE LIDENT CONSTRAINT WITH
 ##
-## Ends in an error in state: 1777.
+## Ends in an error in state: 1798.
 ##
 ## constraints -> constraints CONSTRAINT . constrain [ error WITH SEMI RPAREN RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EOF CONSTRAINT AND ]
 ##
@@ -11826,7 +11826,7 @@ implementation: TYPE LIDENT CONSTRAINT WITH
 
 implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2630.
+## Ends in an error in state: 2651.
 ##
 ## constructor_declarations -> constructor_declarations_leading_bar . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations_leading_bar -> constructor_declarations_leading_bar . constructor_declaration_leading_bar [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
@@ -11838,17 +11838,17 @@ implementation: TYPE LIDENT EQUAL BAR UIDENT LBRACKETAT AND RBRACKET GREATER
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1322, spurious reduction of production attributes ->
-## In state 1323, spurious reduction of production attributes -> attribute attributes
-## In state 2611, spurious reduction of production constructor_declaration_leading_bar -> BAR UIDENT generalized_constructor_arguments attributes
-## In state 2635, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
+## In state 1343, spurious reduction of production attributes ->
+## In state 1344, spurious reduction of production attributes -> attribute attributes
+## In state 2632, spurious reduction of production constructor_declaration_leading_bar -> BAR UIDENT generalized_constructor_arguments attributes
+## In state 2656, spurious reduction of production constructor_declarations_leading_bar -> constructor_declaration_leading_bar
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND
 ##
-## Ends in an error in state: 1886.
+## Ends in an error in state: 1907.
 ##
 ## constraints -> constraints . CONSTRAINT constrain [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_declaration_details -> LIDENT optional_type_parameters type_kind constraints . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -11879,11 +11879,11 @@ implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON UNDERSCORE WITH
 ## In state 278, spurious reduction of production _core_type -> core_type2
 ## In state 290, spurious reduction of production mark_position_typ2(_core_type) -> _core_type
 ## In state 277, spurious reduction of production core_type -> mark_position_typ2(_core_type)
-## In state 1613, spurious reduction of production _poly_type -> core_type
-## In state 1614, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
-## In state 1612, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
-## In state 2549, spurious reduction of production attributes ->
-## In state 2550, spurious reduction of production label_declaration -> mutable_flag LIDENT attributes COLON poly_type attributes
+## In state 1634, spurious reduction of production _poly_type -> core_type
+## In state 1635, spurious reduction of production mark_position_typ(_poly_type) -> _poly_type
+## In state 1633, spurious reduction of production poly_type -> mark_position_typ(_poly_type)
+## In state 2570, spurious reduction of production attributes ->
+## In state 2571, spurious reduction of production label_declaration -> mutable_flag LIDENT attributes COLON poly_type attributes
 ## In state 319, spurious reduction of production label_declarations -> label_declaration
 ##
 
@@ -11893,7 +11893,7 @@ Expecting one of the following:
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT COLON WITH
 ##
-## Ends in an error in state: 2548.
+## Ends in an error in state: 2569.
 ##
 ## label_declaration -> mutable_flag LIDENT attributes COLON . poly_type attributes [ RBRACE COMMA ]
 ##
@@ -11905,7 +11905,7 @@ Expecting a type name describing this field
 
 implementation: TYPE LIDENT EQUAL LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 2547.
+## Ends in an error in state: 2568.
 ##
 ## label_declaration -> mutable_flag LIDENT attributes . [ RBRACE COMMA ]
 ## label_declaration -> mutable_flag LIDENT attributes . COLON poly_type attributes [ RBRACE COMMA ]
@@ -11957,7 +11957,7 @@ Expecting at least one type field definition in the form of:
 
     implementation: TYPE LIDENT EQUAL LPAREN WITH
 ##
-## Ends in an error in state: 2594.
+## Ends in an error in state: 2615.
 ##
 ## _non_arrowed_simple_core_type -> LPAREN . core_type_comma_list RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
 ## _non_arrowed_simple_core_type -> LPAREN . MODULE package_type RPAREN [ error SEMI RBRACKET RBRACE LBRACKETATAT LBRACKETAT EQUALGREATER EQUAL EOF CONSTRAINT AS AND ]
@@ -11971,7 +11971,7 @@ Expecting at least one type field definition in the form of:
 
 implementation: TYPE LIDENT EQUAL PRI WITH
 ##
-## Ends in an error in state: 2593.
+## Ends in an error in state: 2614.
 ##
 ## type_kind -> EQUAL PRI . core_type [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL PRI . constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -11998,7 +11998,7 @@ implementation: TYPE LIDENT EQUAL UIDENT WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL BAR WITH
 ##
-## Ends in an error in state: 2608.
+## Ends in an error in state: 2629.
 ##
 ## constructor_declaration_leading_bar -> BAR . UIDENT generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
 ## constructor_declaration_leading_bar -> BAR . LBRACKET RBRACKET generalized_constructor_arguments attributes [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT BAR AND ]
@@ -12015,7 +12015,7 @@ Variant constructors need to begin with an uppercase character
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LBRACE DOTDOT RBRACE AS QUOTE LIDENT LBRACKETAT AND RBRACKET SEMI
 ##
-## Ends in an error in state: 2647.
+## Ends in an error in state: 2668.
 ##
 ## label_declarations -> label_declarations . COMMA label_declaration [ RBRACE COMMA ]
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE label_declarations . opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12029,7 +12029,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LBRACE DO
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 292, spurious reduction of production attributes ->
 ## In state 293, spurious reduction of production attributes -> attribute attributes
-## In state 2550, spurious reduction of production label_declaration -> mutable_flag LIDENT attributes COLON poly_type attributes
+## In state 2571, spurious reduction of production label_declaration -> mutable_flag LIDENT attributes COLON poly_type attributes
 ## In state 319, spurious reduction of production label_declarations -> label_declaration
 ##
 
@@ -12037,7 +12037,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE LIDENT COLON LBRACE DO
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 ##
-## Ends in an error in state: 2646.
+## Ends in an error in state: 2667.
 ##
 ## type_kind -> EQUAL core_type EQUAL private_flag LBRACE . label_declarations opt_comma RBRACE [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ##
@@ -12049,7 +12049,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRI BANG
 ##
-## Ends in an error in state: 2640.
+## Ends in an error in state: 2661.
 ##
 ## private_flag -> PRI . [ LBRACE ]
 ## type_kind -> EQUAL core_type EQUAL PRI . constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12062,7 +12062,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRI BANG
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKET GREATER
 ##
-## Ends in an error in state: 2633.
+## Ends in an error in state: 2654.
 ##
 ## constructor_declarations -> constructor_declaration_no_leading_bar . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## constructor_declarations -> constructor_declaration_no_leading_bar . constructor_declarations_leading_bar [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12074,16 +12074,16 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL UIDENT LBRACKETAT AND RBRACKE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1322, spurious reduction of production attributes ->
-## In state 1323, spurious reduction of production attributes -> attribute attributes
-## In state 2589, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
+## In state 1343, spurious reduction of production attributes ->
+## In state 1344, spurious reduction of production attributes -> attribute attributes
+## In state 2610, spurious reduction of production constructor_declaration_no_leading_bar -> UIDENT generalized_constructor_arguments attributes
 ##
 
 <SYNTAX ERROR>
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 ##
-## Ends in an error in state: 2638.
+## Ends in an error in state: 2659.
 ##
 ## type_kind -> EQUAL core_type EQUAL . constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type EQUAL . PRI constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12098,7 +12098,7 @@ implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH
 
 implementation: TYPE LIDENT EQUAL UNDERSCORE WITH
 ##
-## Ends in an error in state: 2637.
+## Ends in an error in state: 2658.
 ##
 ## type_kind -> EQUAL core_type . [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
 ## type_kind -> EQUAL core_type . EQUAL constructor_declarations [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF CONSTRAINT AND ]
@@ -12145,7 +12145,7 @@ implementation: TYPE LIDENT EQUAL WITH
 
 implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ##
-## Ends in an error in state: 1877.
+## Ends in an error in state: 1898.
 ##
 ## _structure_item_without_item_extension_sugar -> many_type_declarations . [ error SEMI RBRACKET RBRACE EOF ]
 ## many_type_declarations -> many_type_declarations . and_type_declaration [ error SEMI RBRACKET RBRACE EOF AND ]
@@ -12157,9 +12157,9 @@ implementation: TYPE LIDENT LBRACKETATAT AND RBRACKET WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1313, spurious reduction of production post_item_attributes ->
-## In state 1314, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
-## In state 2657, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
+## In state 1334, spurious reduction of production post_item_attributes ->
+## In state 1335, spurious reduction of production post_item_attributes -> item_attribute post_item_attributes
+## In state 2678, spurious reduction of production many_type_declarations -> TYPE nonrec_flag type_declaration_details post_item_attributes
 ##
 
 <SYNTAX ERROR>
@@ -12216,7 +12216,7 @@ implementation: TYPE LIDENT PLUS WITH
 
 implementation: TYPE LIDENT PLUSEQ BAR WITH
 ##
-## Ends in an error in state: 2661.
+## Ends in an error in state: 2682.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag opt_bar . str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12228,7 +12228,7 @@ implementation: TYPE LIDENT PLUSEQ BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ PRI BANG
 ##
-## Ends in an error in state: 2660.
+## Ends in an error in state: 2681.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ private_flag . opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12240,7 +12240,7 @@ implementation: TYPE LIDENT PLUSEQ PRI BANG
 
 implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 ##
-## Ends in an error in state: 2663.
+## Ends in an error in state: 2684.
 ##
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_declaration [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
 ## str_extension_constructors -> str_extension_constructors BAR . extension_constructor_rebind [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF BAR ]
@@ -12253,7 +12253,7 @@ implementation: TYPE LIDENT PLUSEQ UIDENT BAR WITH
 
 implementation: TYPE LIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 2659.
+## Ends in an error in state: 2680.
 ##
 ## str_type_extension -> TYPE nonrec_flag potentially_long_ident_and_optional_type_parameters PLUSEQ . private_flag opt_bar str_extension_constructors post_item_attributes [ error SEMI RBRACKET RBRACE EOF ]
 ##
@@ -12277,7 +12277,7 @@ implementation: TYPE LIDENT QUOTE WITH
 
 implementation: TYPE LIDENT WITH
 ##
-## Ends in an error in state: 2655.
+## Ends in an error in state: 2676.
 ##
 ## potentially_long_ident_and_optional_type_parameters -> LIDENT optional_type_parameters . [ PLUSEQ ]
 ## type_declaration_details -> LIDENT optional_type_parameters . type_kind constraints [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
@@ -12289,7 +12289,7 @@ implementation: TYPE LIDENT WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 2654, spurious reduction of production optional_type_parameters ->
+## In state 2675, spurious reduction of production optional_type_parameters ->
 ##
 
 Expecting one of the following:
@@ -12301,7 +12301,7 @@ Expecting one of the following:
 
 implementation: TYPE UIDENT DOT WITH
 ##
-## Ends in an error in state: 2090.
+## Ends in an error in state: 2111.
 ##
 ## mod_ext2 -> mod_ext_longident DOT . UIDENT LPAREN mod_ext_longident RPAREN [ LPAREN DOT ]
 ## mod_ext_longident -> mod_ext_longident DOT . UIDENT [ DOT ]
@@ -12352,7 +12352,7 @@ implementation: TYPE WITH
 
 implementation: UIDENT AMPERAMPER WITH
 ##
-## Ends in an error in state: 1028.
+## Ends in an error in state: 1035.
 ##
 ## _expr -> expr AMPERAMPER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12364,7 +12364,7 @@ implementation: UIDENT AMPERAMPER WITH
 
 implementation: UIDENT AMPERSAND WITH
 ##
-## Ends in an error in state: 1026.
+## Ends in an error in state: 1033.
 ##
 ## _expr -> expr AMPERSAND . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12376,7 +12376,7 @@ implementation: UIDENT AMPERSAND WITH
 
 implementation: UIDENT BARBAR WITH
 ##
-## Ends in an error in state: 1024.
+## Ends in an error in state: 1031.
 ##
 ## _expr -> expr BARBAR . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12388,7 +12388,7 @@ implementation: UIDENT BARBAR WITH
 
 implementation: UIDENT COLONEQUAL WITH
 ##
-## Ends in an error in state: 1030.
+## Ends in an error in state: 1037.
 ##
 ## _expr -> expr COLONEQUAL . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12400,7 +12400,7 @@ implementation: UIDENT COLONEQUAL WITH
 
 implementation: UIDENT DOT LBRACE LIDENT WITH
 ##
-## Ends in an error in state: 2183.
+## Ends in an error in state: 2204.
 ##
 ## lbl_expr -> label_longident . COLON expr [ COMMA ]
 ## lbl_expr -> label_longident . [ COMMA ]
@@ -12414,7 +12414,7 @@ implementation: UIDENT DOT LBRACE LIDENT WITH
 
 implementation: UIDENT DOT LBRACE WITH
 ##
-## Ends in an error in state: 2163.
+## Ends in an error in state: 2184.
 ##
 ## _simple_expr -> mod_longident DOT LBRACE . RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACE . record_expr RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12428,7 +12428,7 @@ implementation: UIDENT DOT LBRACE WITH
 
 implementation: UIDENT DOT LBRACELESS WITH
 ##
-## Ends in an error in state: 2158.
+## Ends in an error in state: 2179.
 ##
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma GREATERRBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACELESS . field_expr_list opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12441,7 +12441,7 @@ implementation: UIDENT DOT LBRACELESS WITH
 
 implementation: UIDENT DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2148.
+## Ends in an error in state: 2169.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKET . expr_comma_seq_extension [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12453,7 +12453,7 @@ implementation: UIDENT DOT LBRACKET WITH
 
 implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ##
-## Ends in an error in state: 2142.
+## Ends in an error in state: 2163.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR expr_comma_seq . opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12467,22 +12467,22 @@ implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1109, spurious reduction of production expr_optional_constraint -> expr
-## In state 2141, spurious reduction of production expr_comma_seq -> expr_optional_constraint
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1130, spurious reduction of production expr_optional_constraint -> expr
+## In state 2162, spurious reduction of production expr_comma_seq -> expr_optional_constraint
 ##
 
 <SYNTAX ERROR>
 
 implementation: UIDENT DOT LBRACKETBAR WITH
 ##
-## Ends in an error in state: 2140.
+## Ends in an error in state: 2161.
 ##
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma BARRBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LBRACKETBAR . expr_comma_seq opt_comma error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12495,7 +12495,7 @@ implementation: UIDENT DOT LBRACKETBAR WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 ##
-## Ends in an error in state: 2126.
+## Ends in an error in state: 2147.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON package_type . RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12515,7 +12515,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT COLONGREATER
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 ##
-## Ends in an error in state: 2124.
+## Ends in an error in state: 2145.
 ##
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . package_type RPAREN [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> mod_longident DOT LPAREN MODULE module_expr COLON . error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -12528,7 +12528,7 @@ implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH
 
 implementation: UIDENT DOT LPAREN MODULE UIDENT WITH
 ##
-## Ends in an error in state: 2123.
+## Ends in an error in state: 2144.
 ##
 ## _module_expr -> module_expr . simple_module_expr [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
 ## _module_expr -> module_expr . LPAREN module_expr error [ UIDENT LPAREN LBRACKETPERCENT LBRACKETAT LBRACE COLON ]
@@ -12568,7 +12568,7 @@ implementation: UIDENT DOT LPAREN MODULE WITH
 
 implementation: UIDENT DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2128.
+## Ends in an error in state: 2149.
 ##
 ## expr_comma_list -> expr_optional_constraint . COMMA expr_optional_constraint [ RPAREN COMMA ]
 ##
@@ -12580,14 +12580,14 @@ implementation: UIDENT DOT LPAREN UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 2137, spurious reduction of production expr_optional_constraint -> expr
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 2158, spurious reduction of production expr_optional_constraint -> expr
 ##
 
 <SYNTAX ERROR>
@@ -12637,7 +12637,7 @@ implementation: UIDENT DOT WITH
 
 implementation: UIDENT GREATER WITH
 ##
-## Ends in an error in state: 1020.
+## Ends in an error in state: 1027.
 ##
 ## _expr -> expr GREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## _expr -> expr GREATER . GREATER expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -12650,7 +12650,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP0 WITH
 ##
-## Ends in an error in state: 1018.
+## Ends in an error in state: 1025.
 ##
 ## _expr -> expr INFIXOP0 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12662,7 +12662,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP1 WITH
 ##
-## Ends in an error in state: 1014.
+## Ends in an error in state: 1021.
 ##
 ## _expr -> expr INFIXOP1 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12674,7 +12674,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP2 WITH
 ##
-## Ends in an error in state: 1012.
+## Ends in an error in state: 1019.
 ##
 ## _expr -> expr INFIXOP2 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12686,7 +12686,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP3 WITH
 ##
-## Ends in an error in state: 998.
+## Ends in an error in state: 1005.
 ##
 ## _expr -> expr INFIXOP3 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12698,7 +12698,7 @@ Expecting an expression
 
 implementation: UIDENT INFIXOP4 WITH
 ##
-## Ends in an error in state: 892.
+## Ends in an error in state: 863.
 ##
 ## _expr -> expr INFIXOP4 . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12722,7 +12722,7 @@ Expecting an attribute id
 
 implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2464.
+## Ends in an error in state: 2485.
 ##
 ## attribute -> LBRACKETAT attr_id payload . RBRACKET [ error WITH UIDENT STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LPAREN LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETATAT LBRACKETAT LBRACE INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EQUALGREATER EQUAL EOF CONSTRAINT COMMA COLONGREATER COLONEQUAL COLONCOLON COLON BARRBRACKET BARBAR BAR AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -12734,22 +12734,22 @@ implementation: UIDENT LBRACKETAT WITH UIDENT RBRACE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1926, spurious reduction of production post_item_attributes ->
-## In state 1927, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1928, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1875, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1741, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1929, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1876, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1742, spurious reduction of production structure -> structure_item
-## In state 1871, spurious reduction of production payload -> structure
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1947, spurious reduction of production post_item_attributes ->
+## In state 1948, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1949, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1896, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1762, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1950, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1897, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1763, spurious reduction of production structure -> structure_item
+## In state 1892, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
@@ -12768,7 +12768,7 @@ Expecting an attributed id
 
 implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ##
-## Ends in an error in state: 2461.
+## Ends in an error in state: 2482.
 ##
 ## item_attribute -> LBRACKETATAT attr_id payload . RBRACKET [ error SEMI RBRACKET RBRACE LBRACKETATAT EOF AND ]
 ##
@@ -12780,29 +12780,29 @@ implementation: UIDENT LBRACKETATAT WITH UIDENT RBRACE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1926, spurious reduction of production post_item_attributes ->
-## In state 1927, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1928, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1875, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1741, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1929, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1876, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1742, spurious reduction of production structure -> structure_item
-## In state 1871, spurious reduction of production payload -> structure
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1947, spurious reduction of production post_item_attributes ->
+## In state 1948, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1949, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1896, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1762, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1950, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1897, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1763, spurious reduction of production structure -> structure_item
+## In state 1892, spurious reduction of production payload -> structure
 ##
 
 Expecting "]"
 
 implementation: UIDENT LESS WITH
 ##
-## Ends in an error in state: 1016.
+## Ends in an error in state: 1023.
 ##
 ## _expr -> expr LESS . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12814,7 +12814,7 @@ Expecting an expression
 
 implementation: UIDENT LESSDOTDOTGREATER WITH
 ##
-## Ends in an error in state: 1010.
+## Ends in an error in state: 1017.
 ##
 ## _expr -> expr LESSDOTDOTGREATER . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12863,7 +12863,7 @@ Expecting one of the following:
 
 implementation: UIDENT MINUS WITH
 ##
-## Ends in an error in state: 1008.
+## Ends in an error in state: 1015.
 ##
 ## _expr -> expr MINUS . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12875,7 +12875,7 @@ Expecting an expression
 
 implementation: UIDENT MINUSDOT WITH
 ##
-## Ends in an error in state: 1006.
+## Ends in an error in state: 1013.
 ##
 ## _expr -> expr MINUSDOT . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12887,7 +12887,7 @@ Expecting an expression
 
 implementation: UIDENT OR WITH
 ##
-## Ends in an error in state: 1004.
+## Ends in an error in state: 1011.
 ##
 ## _expr -> expr OR . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12899,7 +12899,7 @@ Expecting an expression
 
 implementation: UIDENT PERCENT WITH
 ##
-## Ends in an error in state: 996.
+## Ends in an error in state: 1003.
 ##
 ## _expr -> expr PERCENT . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12911,7 +12911,7 @@ Expecting an expression
 
 implementation: UIDENT PLUS WITH
 ##
-## Ends in an error in state: 1002.
+## Ends in an error in state: 1009.
 ##
 ## _expr -> expr PLUS . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12923,7 +12923,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSDOT WITH
 ##
-## Ends in an error in state: 1000.
+## Ends in an error in state: 1007.
 ##
 ## _expr -> expr PLUSDOT . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12935,7 +12935,7 @@ Expecting an expression
 
 implementation: UIDENT PLUSEQ WITH
 ##
-## Ends in an error in state: 994.
+## Ends in an error in state: 1001.
 ##
 ## _expr -> expr PLUSEQ . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12947,7 +12947,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT COLON WITH
 ##
-## Ends in an error in state: 992.
+## Ends in an error in state: 1092.
 ##
 ## _expr -> expr QUESTION expr COLON . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -12959,7 +12959,7 @@ Expecting an expression
 
 implementation: UIDENT QUESTION UIDENT SEMI
 ##
-## Ends in an error in state: 991.
+## Ends in an error in state: 1091.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL COLON BARBAR AMPERSAND AMPERAMPER ]
@@ -12995,13 +12995,13 @@ implementation: UIDENT QUESTION UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 937, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 946, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13010,7 +13010,7 @@ Expecting one of the following:
 
 implementation: UIDENT QUESTION WITH
 ##
-## Ends in an error in state: 907.
+## Ends in an error in state: 878.
 ##
 ## _expr -> expr QUESTION . expr COLON expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13022,7 +13022,7 @@ Expecting an expression
 
 implementation: UIDENT RBRACKET
 ##
-## Ends in an error in state: 2692.
+## Ends in an error in state: 2713.
 ##
 ## implementation -> structure . EOF [ # ]
 ##
@@ -13034,28 +13034,28 @@ implementation: UIDENT RBRACKET
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
-## In state 1926, spurious reduction of production post_item_attributes ->
-## In state 1927, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
-## In state 1928, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
-## In state 1875, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
-## In state 1741, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
-## In state 1929, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
-## In state 1876, spurious reduction of production structure_item -> mark_position_str(_structure_item)
-## In state 1742, spurious reduction of production structure -> structure_item
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 1947, spurious reduction of production post_item_attributes ->
+## In state 1948, spurious reduction of production _structure_item_without_item_extension_sugar -> expr post_item_attributes
+## In state 1949, spurious reduction of production mark_position_str(_structure_item_without_item_extension_sugar) -> _structure_item_without_item_extension_sugar
+## In state 1896, spurious reduction of production structure_item_without_item_extension_sugar -> mark_position_str(_structure_item_without_item_extension_sugar)
+## In state 1762, spurious reduction of production _structure_item -> structure_item_without_item_extension_sugar
+## In state 1950, spurious reduction of production mark_position_str(_structure_item) -> _structure_item
+## In state 1897, spurious reduction of production structure_item -> mark_position_str(_structure_item)
+## In state 1763, spurious reduction of production structure -> structure_item
 ##
 
 Invalid token
 
 implementation: UIDENT SEMI WITH
 ##
-## Ends in an error in state: 2074.
+## Ends in an error in state: 2095.
 ##
 ## structure -> structure_item SEMI . structure [ RBRACKET RBRACE EOF ]
 ##
@@ -13079,7 +13079,7 @@ Expecting an identifier
 
 implementation: UIDENT STAR WITH
 ##
-## Ends in an error in state: 890.
+## Ends in an error in state: 861.
 ##
 ## _expr -> expr STAR . expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETATAT LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ##
@@ -13091,7 +13091,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ##
-## Ends in an error in state: 2214.
+## Ends in an error in state: 2235.
 ##
 ## _expr -> expr . INFIXOP0 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ STAR SLASHGREATER RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13127,13 +13127,13 @@ implementation: UIDENT TRUE DOT LBRACE UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 716, spurious reduction of production constr_longident -> mod_longident
-## In state 937, spurious reduction of production _simple_expr -> constr_longident
-## In state 821, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 846, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 911, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 946, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 910, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 946, spurious reduction of production _simple_expr -> constr_longident
+## In state 827, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 817, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 910, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 920, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 955, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 919, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13142,7 +13142,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACE WITH
 ##
-## Ends in an error in state: 2213.
+## Ends in an error in state: 2234.
 ##
 ## _simple_expr -> simple_expr DOT LBRACE . expr RBRACE [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ##
@@ -13154,7 +13154,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ##
-## Ends in an error in state: 2211.
+## Ends in an error in state: 2232.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RBRACKET QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13191,13 +13191,13 @@ implementation: UIDENT TRUE DOT LBRACKET UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:
@@ -13206,7 +13206,7 @@ Expecting one of the following:
 
 implementation: UIDENT TRUE DOT LBRACKET WITH
 ##
-## Ends in an error in state: 2210.
+## Ends in an error in state: 2231.
 ##
 ## _simple_expr -> simple_expr DOT LBRACKET . expr RBRACKET [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
 ## _simple_expr -> simple_expr DOT LBRACKET . expr error [ error UIDENT TRUE STRING STAR SLASHGREATER SHARPOP SHARP SEMI RPAREN RBRACKET RBRACE QUESTION PREFIXOP PLUSEQ PLUSDOT PLUS PERCENT OR NEW MINUSDOT MINUS LPAREN LIDENTCOLONCOLON LIDENT LESSIDENT LESSGREATER LESSDOTDOTGREATER LESS LBRACKETPERCENT LBRACKETLESS LBRACKETBAR LBRACKETATAT LBRACKETAT LBRACKET LBRACELESS LBRACE INT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER FLOAT FALSE EOF ELSE DOT COMMA COLONGREATER COLONEQUAL COLONCOLONLIDENT COLONCOLON COLON CHAR BARRBRACKET BARBAR BAR BANG BACKQUOTE AS AND AMPERSAND AMPERAMPER ]
@@ -13219,7 +13219,7 @@ Expecting an expression
 
 implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ##
-## Ends in an error in state: 2208.
+## Ends in an error in state: 2229.
 ##
 ## _expr -> expr . INFIXOP0 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
 ## _expr -> expr . INFIXOP1 expr [ error STAR SLASHGREATER RPAREN QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATER COLONEQUAL BARBAR AMPERSAND AMPERAMPER ]
@@ -13256,13 +13256,13 @@ implementation: UIDENT TRUE DOT LPAREN UIDENT SEMI
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 762, spurious reduction of production constr_longident -> mod_longident
-## In state 895, spurious reduction of production _simple_expr -> constr_longident
-## In state 861, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
-## In state 851, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
-## In state 863, spurious reduction of production less_aggressive_simple_expression -> simple_expr
-## In state 869, spurious reduction of production _expr -> less_aggressive_simple_expression
-## In state 904, spurious reduction of production mark_position_exp(_expr) -> _expr
-## In state 868, spurious reduction of production expr -> mark_position_exp(_expr)
+## In state 866, spurious reduction of production _simple_expr -> constr_longident
+## In state 832, spurious reduction of production mark_position_exp(_simple_expr) -> _simple_expr
+## In state 809, spurious reduction of production simple_expr -> mark_position_exp(_simple_expr)
+## In state 834, spurious reduction of production less_aggressive_simple_expression -> simple_expr
+## In state 840, spurious reduction of production _expr -> less_aggressive_simple_expression
+## In state 875, spurious reduction of production mark_position_exp(_expr) -> _expr
+## In state 839, spurious reduction of production expr -> mark_position_exp(_expr)
 ##
 
 Expecting one of the following:

--- a/reason-parser/src/reason_parser.mly
+++ b/reason-parser/src/reason_parser.mly
@@ -360,6 +360,9 @@ let mkpat_cons consloc args loc =
 let ghpat_cons consloc args loc =
   mkpat ~ghost:true ~loc (Ppat_construct(mkloc (Lident "::") loc, Some args))
 
+let mkpat_constructor_unit consloc loc =
+  mkpat ~loc (Ppat_construct(mkloc (Lident "()") consloc, None))
+
 let simple_pattern_list_to_tuple ?(loc=dummy_loc ()) lst =
   match lst with
     | [] -> assert false
@@ -882,7 +885,7 @@ let only_labels l =
 %token <string * char option> FLOAT
 %token <string> COLONCOLONLIDENT
 %token FOR
-%token FUN
+%token FUN ES6_FUN
 %token FUNCTION
 %token FUNCTOR
 %token GREATER
@@ -2738,6 +2741,17 @@ _expr:
       let (l,o,p) = $2 in
       mkexp (Pexp_fun(l, o, p, $3))
     }
+  | ES6_FUN _l = LPAREN _r = RPAREN EQUALGREATER body = expr {
+    let loc = mklocation $startpos(_l) $endpos(_r) in
+    mkexp (Pexp_fun (Nolabel, None, mkpat_constructor_unit loc loc, body))
+  }
+  | ES6_FUN LPAREN pats = pattern_optional_constraints RPAREN
+            EQUALGREATER body = expr {
+      List.fold_left (fun body pat ->
+        mkexp ~loc:(mklocation pat.ppat_loc.loc_start $endpos)
+          (Pexp_fun (Nolabel, None, pat, body))
+      ) body pats
+    }
   | FUN LPAREN TYPE lident_list RPAREN fun_def
       { pexp_newtypes $4 $6 }
   /* List style rules like this often need a special precendence
@@ -3747,6 +3761,12 @@ _pattern_optional_constraint:
     }
 ;
 
+pattern_optional_constraints:
+    pattern_optional_constraints COMMA pattern_optional_constraint
+    { $3::$1 }
+  | pattern_optional_constraint
+    { [$1] }
+;
 
 pattern_comma_list:
     pattern                                     { [$1] }

--- a/reason-parser/src/reason_toolchain.ml
+++ b/reason-parser/src/reason_toolchain.ml
@@ -171,14 +171,12 @@ module type Toolchain_spec = sig
   val safeguard_parsing: Lexing.lexbuf ->
     (unit -> ('a * Reason_pprint_ast.commentWithCategory)) -> ('a * Reason_pprint_ast.commentWithCategory)
 
-  module rec Lexer_impl: sig
-    val init: unit -> unit
-    val token: Lexing.lexbuf -> Parser_impl.token
-    val comments: unit -> (String.t * Location.t) list
-  end
+  type token
 
-  and Parser_impl: sig
-    type token
+  module Lexer_impl: sig
+    val init: unit -> unit
+    val token: Lexing.lexbuf -> token
+    val comments: unit -> (String.t * Location.t) list
   end
 
   val core_type: Lexing.lexbuf -> Parsetree.core_type
@@ -325,8 +323,10 @@ end
 
 module OCaml_syntax = struct
   open Migrate_parsetree
+
   module Lexer_impl = Lexer
-  module Parser_impl = Parser
+  module OCaml_parser = Parser
+  type token = OCaml_parser.token
 
   (* OCaml parser parses into compiler-libs version of Ast.
      Parsetrees are converted to Reason version on the fly. *)
@@ -357,7 +357,7 @@ module OCaml_syntax = struct
   let rec skip_phrase lexbuf =
     try
       match Lexer_impl.token lexbuf with
-        Parser_impl.SEMISEMI | Parser_impl.EOF -> ()
+        OCaml_parser.SEMISEMI | OCaml_parser.EOF -> ()
       | _ -> skip_phrase lexbuf
     with
       | Lexer_impl.Error (Lexer_impl.Unterminated_comment _, _)
@@ -367,8 +367,8 @@ module OCaml_syntax = struct
           skip_phrase lexbuf
 
   let maybe_skip_phrase lexbuf =
-    if Parsing.is_current_lookahead Parser_impl.SEMISEMI
-    || Parsing.is_current_lookahead Parser_impl.EOF
+    if Parsing.is_current_lookahead OCaml_parser.SEMISEMI
+    || Parsing.is_current_lookahead OCaml_parser.EOF
     then ()
     else skip_phrase lexbuf
 
@@ -402,7 +402,7 @@ end
 module JS_syntax = struct
   module I = Reason_parser.MenhirInterpreter
   module Lexer_impl = Reason_lexer
-  module Parser_impl = Reason_parser
+  type token = Reason_parser.token
 
   let initial_checkpoint constructor lexbuf =
     (constructor lexbuf.lex_curr_p)
@@ -413,10 +413,10 @@ module JS_syntax = struct
      and end positions. Warning: before the first call to the lexer has taken
      place, a None value is stored here. *)
 
-      mutable last_token: (Reason_parser.token * Lexing.position * Lexing.position) option;
+      mutable last_token: (token * Lexing.position * Lexing.position) option;
 
       (* A supplier function that returns one token at a time*)
-      get_token: unit -> (Reason_parser.token * Lexing.position * Lexing.position)
+      get_token: unit -> (token * Lexing.position * Lexing.position)
     }
 
   (* [lexbuf_to_supplier] returns a supplier to be feed into Menhir's incremental API.
@@ -499,75 +499,85 @@ module JS_syntax = struct
      expression.
   *)
 
+  let rec normalize_checkpoint = function
+    | I.Shifting _ | I.AboutToReduce _ as checkpoint ->
+      normalize_checkpoint (I.resume checkpoint)
+    | checkpoint -> checkpoint
+
   let rec loop_handle_yacc supplier in_error checkpoint =
 
     match checkpoint with
+    | I.InputNeeded _ when in_error ->
+      begin match supplier.last_token with
+        | None -> assert false
+        | Some triple ->
+          (* We just recovered from the error state, try the original token again *)
+          let checkpoint_with_previous_token = I.offer checkpoint triple in
+          match I.shifts checkpoint_with_previous_token with
+          | None ->
+            (* The original token still fail to be parsed, discard *)
+            loop_handle_yacc supplier false checkpoint
+          | Some env ->
+            loop_handle_yacc supplier false checkpoint_with_previous_token
+      end
+
     | I.InputNeeded _ ->
-       if in_error then
-         begin
-           match supplier.last_token with
-           | None -> assert false
-           | Some triple ->
-              (* We just recovered from the error state, try the original token again *)
-              let checkpoint_with_previous_token = I.offer checkpoint triple in
-              match I.shifts checkpoint_with_previous_token with
-              | None ->
-                (* The original token still fail to be parsed, discard *)
-                loop_handle_yacc supplier false checkpoint
-              | Some env ->
-                loop_handle_yacc supplier false checkpoint_with_previous_token
-         end
-       else
-         let triple = read supplier in
-         let checkpoint = I.offer checkpoint triple in
-         loop_handle_yacc supplier false checkpoint
-    | I.Shifting _
-      | I.AboutToReduce _ ->
-       let checkpoint = I.resume checkpoint in
-       loop_handle_yacc supplier in_error checkpoint
+      let checkpoint =
+        match read supplier with
+        | (Reason_parser.ES6_FUN, _, _) as triple ->
+          let checkpoint =
+            match normalize_checkpoint (I.offer checkpoint triple) with
+            | I.HandlingError _ -> checkpoint
+            | checkpoint -> checkpoint
+          in
+          let triple = read supplier in
+          I.offer checkpoint triple
+        | triple -> I.offer checkpoint triple
+      in
+      loop_handle_yacc supplier false checkpoint
+
+    | I.HandlingError env when !Reason_config.recoverable ->
+      let loc = last_token_loc supplier in
+      begin match Syntax_util.findMenhirErrorMessage loc with
+        | Syntax_util.MenhirMessagesError err -> ()
+        | Syntax_util.NoMenhirMessagesError ->
+          let state = state checkpoint in
+          let msg =
+            try Reason_parser_message.message state
+            with Not_found -> "<SYNTAX ERROR>\n"
+          in
+          Syntax_util.add_error_message Syntax_util.{loc = loc; msg = msg};
+      end;
+      let checkpoint = I.resume checkpoint in
+      (* Enter error recovery state *)
+      loop_handle_yacc supplier true checkpoint
+
     | I.HandlingError env ->
-       if !Reason_config.recoverable then
-         (
-         let loc = last_token_loc supplier in
-         (match Syntax_util.findMenhirErrorMessage loc with
-         | Syntax_util.MenhirMessagesError err -> ()
-         | Syntax_util.NoMenhirMessagesError -> (
-           let state = state checkpoint in
-           let msg = try
-             Reason_parser_message.message state
-           with
-             | Not_found -> "<SYNTAX ERROR>\n"
-           in
-           Syntax_util.add_error_message Syntax_util.{loc = loc; msg = msg};
-         ));
-         let checkpoint = I.resume checkpoint in
-         (* Enter error recovery state *)
-         loop_handle_yacc supplier true checkpoint)
-       else
-         (* If not in a recoverable state, fail early by raising a
-          * customized Error object
-          *)
-         let loc = last_token_loc supplier in
-         let state = state checkpoint in
-         (* Check the error database to see what's the error message
-          * associated with the current parser state
-          *)
-         let msg =
-           try
-             Reason_parser_message.message state
-           with
-             | Not_found -> "<UNKNOWN SYNTAX ERROR>"
-         in
-         let msg_with_state = Printf.sprintf "%d: %s" state msg in
-         raise (Syntax_util.Error (loc, (Syntax_util.Syntax_error msg_with_state)))
+      (* If not in a recoverable state, fail early by raising a
+       * customized Error object
+       *)
+      let loc = last_token_loc supplier in
+      let state = state checkpoint in
+      (* Check the error database to see what's the error message
+       * associated with the current parser state
+       *)
+      let msg =
+        try Reason_parser_message.message state
+        with Not_found -> "<UNKNOWN SYNTAX ERROR>"
+      in
+      let msg_with_state = Printf.sprintf "%d: %s" state msg in
+      raise (Syntax_util.Error (loc, (Syntax_util.Syntax_error msg_with_state)))
+
     | I.Rejected ->
-       begin
-         let loc = last_token_loc supplier in
-         raise Syntaxerr.(Error(Syntaxerr.Other loc))
-       end
+      let loc = last_token_loc supplier in
+      raise Syntaxerr.(Error(Syntaxerr.Other loc))
+
     | I.Accepted v ->
        (* The parser has succeeded and produced a semantic value. *)
        v
+
+    | I.Shifting _ | I.AboutToReduce _ ->
+      loop_handle_yacc supplier in_error (I.resume checkpoint)
 
   let implementation lexbuf =
     let cp = initial_checkpoint Reason_parser.Incremental.implementation lexbuf in
@@ -593,7 +603,7 @@ module JS_syntax = struct
   let rec skip_phrase lexbuf =
     try
       match Lexer_impl.token lexbuf with
-        Parser_impl.SEMI | Parser_impl.EOF -> ()
+        Reason_parser.SEMI | Reason_parser.EOF -> ()
       | _ -> skip_phrase lexbuf
     with
       | Lexer_impl.Error (Lexer_impl.Unterminated_comment _, _)
@@ -602,8 +612,8 @@ module JS_syntax = struct
       | Lexer_impl.Error (Lexer_impl.Illegal_character _, _) -> skip_phrase lexbuf
 
   let maybe_skip_phrase lexbuf =
-    if Parsing.is_current_lookahead Parser_impl.SEMI
-    || Parsing.is_current_lookahead Parser_impl.EOF
+    if Parsing.is_current_lookahead Reason_parser.SEMI
+    || Parsing.is_current_lookahead Reason_parser.EOF
     then ()
     else skip_phrase lexbuf
 


### PR DESCRIPTION
This patch adds a new syntactic sugar for functions:
`(a) => ...` is `fun a => ...`
`(a,b) => ...` is `fun a b => ...`
`() => ...` is `fun () => ...`

The updated testsuite shows how that looks like.
I will add a few improvements to the printer, for instance `(a : int, b : int) => a + b` is printed as `((a : int), (b : int)) => a + b`.