### PR TITLE
make jsx indentation smoother

### DIFF
--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -12,3 +12,49 @@ let x =
     }
     onKey=(updater handleInput)
   />;
+
+let y =
+  <Routes
+    path=(Routes.stateToPath state)
+    isHistorical=true
+    onHashChange=(
+      fun _oldPath _oldUrl newUrl =>
+        updater
+          (
+            fun latestComponentBag _ => {
+              let currentActualPath =
+                Routes.hashOfUri newUrl;
+              let pathFromState =
+                Routes.stateToPath
+                  latestComponentBag.state;
+              currentActualPath == pathFromState ?
+                None :
+                dispatchEventless
+                  (
+                    State.UriNavigated currentActualPath
+                  )
+                  latestComponentBag
+                  ()
+            }
+          )
+          ()
+    )
+  />;
+
+let z =
+  <div
+    style=(
+      ReactDOMRe.Style.make
+        ::width
+        ::height
+        ::color
+        ::backgroundColor
+        ::margin
+        ::padding
+        ::border
+        ::borderColor
+        ::someOtherAttribute
+        ()
+    )
+    key=(string_of_int 1)
+  />;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -12,3 +12,42 @@ let x =
             }
     onKey=(updater handleInput)
   />;
+
+let y =
+  <Routes
+    path=(Routes.stateToPath state)
+    isHistorical=true
+    onHashChange=(
+                   fun _oldPath _oldUrl newUrl =>
+                     updater
+                       (
+                         fun latestComponentBag _ => {
+                           let currentActualPath = Routes.hashOfUri newUrl;
+                           let pathFromState = Routes.stateToPath latestComponentBag.state;
+                           currentActualPath == pathFromState ?
+                             None :
+                             dispatchEventless
+                               (State.UriNavigated currentActualPath) latestComponentBag ()
+                         }
+                       )
+                       ()
+                 )
+  />;
+
+let z =
+  <div
+    style=(
+            ReactDOMRe.Style.make
+              ::width
+              ::height
+              ::color
+              ::backgroundColor
+              ::margin
+              ::padding
+              ::border
+              ::borderColor
+              ::someOtherAttribute
+              ()
+          )
+    key=(string_of_int 1)
+  />;

--- a/reason-parser/src/reason_pprint_ast.ml
+++ b/reason-parser/src/reason_pprint_ast.ml
@@ -3688,10 +3688,10 @@ class printer  ()= object(self:'self)
            match expression.pexp_desc with
            | Pexp_ident (ident) when (not (isLongIdentWithDot ident.txt)
                                         && (Longident.last ident.txt) = lbl) -> atom lbl
-           | Pexp_record (l, eo) ->
-              label (makeList [atom lbl; atom "="]) (self#unparseRecord l eo)
-           | Pexp_extension e ->
-              label (makeList [atom lbl; atom "="]) (self#extension e)
+           | Pexp_record _
+           | Pexp_extension _
+           | Pexp_fun _
+           | Pexp_apply _ -> label (makeList [atom lbl; atom "="]) (self#simplifyUnparseExpr expression)
            | _ -> makeList ([atom lbl; atom "="; self#simplifyUnparseExpr expression])
          in
          processArguments tail (nextAttr :: processedAttrs) children


### PR DESCRIPTION
I just couldn't live with the weird indentation anymore.
PR places closing paren add the right indentation.
Fixes: https://github.com/facebook/reason/issues/1194 (Pexp_apply) &  additional `Pexp_fun`.
