### PR TITLE
Add space between list, array, tuple and opening/closing jsx bracket

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -246,29 +246,29 @@ let spaceBefore2 = <So> <Much /> </So>;
 let siblingNotSpaced =
   <So> <Much /> <Much /> </So>;
 
-let jsxInList = [<Foo />];
+let jsxInList = [ <Foo /> ];
 
-let jsxInList2 = [<Foo />];
+let jsxInList2 = [ <Foo /> ];
 
-let jsxInListA = [<Foo />];
+let jsxInListA = [ <Foo /> ];
 
-let jsxInListB = [<Foo />];
+let jsxInListB = [ <Foo /> ];
 
-let jsxInListC = [<Foo />];
+let jsxInListC = [ <Foo /> ];
 
-let jsxInListD = [<Foo />];
+let jsxInListD = [ <Foo /> ];
 
-let jsxInList3 = [<Foo />, <Foo />, <Foo />];
+let jsxInList3 = [ <Foo />, <Foo />, <Foo /> ];
 
-let jsxInList4 = [<Foo />, <Foo />, <Foo />];
+let jsxInList4 = [ <Foo />, <Foo />, <Foo /> ];
 
-let jsxInList5 = [<Foo />, <Foo />];
+let jsxInList5 = [ <Foo />, <Foo /> ];
 
-let jsxInList6 = [<Foo />, <Foo />];
+let jsxInList6 = [ <Foo />, <Foo /> ];
 
-let jsxInList7 = [<Foo />, <Foo />];
+let jsxInList7 = [ <Foo />, <Foo /> ];
 
-let jsxInList8 = [<Foo />, <Foo />];
+let jsxInList8 = [ <Foo />, <Foo /> ];
 
 let testFunc b => b;
 
@@ -375,58 +375,62 @@ let thisIsAlsoOkay =
 
 <a /> > <b />;
 
-let listOfListOfJsx = [<> </>];
+let listOfListOfJsx = [ <> </> ];
 
-let listOfListOfJsx = [<> <Foo /> </>];
+let listOfListOfJsx = [ <> <Foo /> </> ];
 
 let listOfListOfJsx = [
   <> <Foo /> </>,
   <> <Bar /> </>
-];
+ ];
 
 let listOfListOfJsx = [
   <> <Foo /> </>,
   <> <Bar /> </>,
   ...listOfListOfJsx
-];
+ ];
 
-let sameButWithSpaces = [<> </>];
+let sameButWithSpaces = [ <> </> ];
 
-let sameButWithSpaces = [<> <Foo /> </>];
+let sameButWithSpaces = [ <> <Foo /> </> ];
 
 let sameButWithSpaces = [
   <> <Foo /> </>,
   <> <Bar /> </>
-];
+ ];
 
 let sameButWithSpaces = [
   <> <Foo /> </>,
   <> <Bar /> </>,
   ...sameButWithSpaces
-];
+ ];
 
 /*
  * Test named tag right next to an open bracket.
  */
 let listOfJsx = [];
 
-let listOfJsx = [<Foo />];
+let listOfJsx = [ <Foo /> ];
 
-let listOfJsx = [<Foo />, <Bar />];
+let listOfJsx = [ <Foo />, <Bar /> ];
 
-let listOfJsx = [<Foo />, <Bar />, ...listOfJsx];
+let listOfJsx = [
+  <Foo />,
+  <Bar />,
+  ...listOfJsx
+ ];
 
 let sameButWithSpaces = [];
 
-let sameButWithSpaces = [<Foo />];
+let sameButWithSpaces = [ <Foo /> ];
 
-let sameButWithSpaces = [<Foo />, <Bar />];
+let sameButWithSpaces = [ <Foo />, <Bar /> ];
 
 let sameButWithSpaces = [
   <Foo />,
   <Bar />,
   ...sameButWithSpaces
-];
+ ];
 
 
 /**

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -119,3 +119,9 @@ let icon =
       }
     )
   />;
+
+let x = [| <Button />, <Button /> |];
+
+let y = [ <Button />, <Button /> ];
+
+let z = ( <Button />, <Button /> );

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -98,3 +98,7 @@ let icon = <Icon
                      }
                    )
             />;
+
+let x = [| <Button />, <Button /> |];
+let y = [ <Button />, <Button /> ];
+let z = ( <Button />, <Button /> );

--- a/reason-parser/src/reason_pprint_ast.ml
+++ b/reason-parser/src/reason_pprint_ast.ml
@@ -1395,9 +1395,9 @@ let atom ?loc str =
 let easyAtom str = Easy_format.Atom(str, labelStringStyle)
 
 (** Take x,y,z and n and generate [x, y, z, ...n] *)
-let makeES6List lst last =
+let makeES6List ?(wrap=("[", "]")) lst last =
   let last_dots = makeList [atom "..."; last] in
-  makeList ~wrap:("[", "]") ~break:IfNeed ~postSpace:true ~sep:"," (lst @ [last_dots])
+  makeList ~wrap ~break:IfNeed ~postSpace:true ~sep:"," (lst @ [last_dots])
 
 let makeNonIndentedBreakingList lst =
     (* No align closing: So that semis stick to the ends of every break *)
@@ -2301,6 +2301,12 @@ let recordRowIsPunned pld =
               (* don't pun parameterized types, e.g. {tag: tag 'props} *)
               && List.length args == 0) -> true
         | _ -> false)
+
+let exprListHasJsx = function
+  | x::xs ->
+    let (_, _, _, jsxAttrs) = partitionAttributes x.pexp_attributes in
+    jsxAttrs != []
+  | [] -> false
 
 class printer  ()= object(self:'self)
   val pipe = false
@@ -4853,12 +4859,21 @@ class printer  ()= object(self:'self)
                       ~pad:(true, true)
                       actualChildren
                 else
-                  makeList ~break:IfNeed ~wrap:("[", "]") ~sep:"," ~postSpace:true (List.map self#unparseExpr xs)
+                  let hasJsx = exprListHasJsx xs in
+                  let wrap = if hasJsx then ("[ ", " ]") else ("[","]") in
+                  makeList
+                    ~break:IfNeed
+                    ~wrap
+                    ~sep:","
+                    ~postSpace:true
+                   (List.map self#unparseExpr xs)
               | `cons xs ->
                 let seq, ext = match List.rev xs with
                   | ext :: seq_rev -> (List.rev seq_rev, ext)
                   | [] -> assert false in
-                 makeES6List (List.map self#unparseExpr seq) (self#unparseExpr ext)
+                let hasJsx = exprListHasJsx xs in
+                let wrap = if hasJsx then ("[ ", " ]") else ("[","]") in
+                makeES6List ~wrap (List.map self#unparseExpr seq) (self#unparseExpr ext)
               | `simple x -> self#longident x
               | _ -> assert false
             )
@@ -4880,9 +4895,11 @@ class printer  ()= object(self:'self)
         | Pexp_tuple l ->
             (* TODO: These may be simple, non-simple, or type constrained
                non-simple expressions *)
+          let hasJsx = exprListHasJsx l in
+          let wrap = if hasJsx then ("( ", " )") else ("(",")") in
           Some (
             makeList
-              ~wrap:("(", ")")
+              ~wrap
               ~sep:","
               ~break:IfNeed
               ~postSpace:true
@@ -4909,12 +4926,14 @@ class printer  ()= object(self:'self)
             Some (ensureSingleTokenSticksToLabel (atom ("`" ^ l)))
         | Pexp_record (l, eo) -> Some (self#unparseRecord l eo)
         | Pexp_array (l) ->
+          let hasJsx = exprListHasJsx l in
+          let wrap = if hasJsx then ("[| ", " |]") else ("[|","|]") in
           Some (
             makeList
               ~break:IfNeed
               ~sep:","
               ~postSpace:true
-              ~wrap:("[|", "|]")
+              ~wrap
               (List.map self#unparseExpr l)
           )
         | Pexp_let (rf, l, e) ->


### PR DESCRIPTION
https://github.com/facebook/reason/issues/1263

Fixes printing of jsx inside a list/array/tuple.