### PR TITLE
Minor example fix

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -262,7 +262,7 @@ Labeled function arguments can be made optional during declaration. You can then
 
 ```reason
 /* radius can be omitted */
-let drawCircle ::color ::radius=? () => {
+let drawCircle ::color radius::r=? () => {
   setColor color;
   switch r {
   | None => startAt 1 1;

--- a/docs/index.html
+++ b/docs/index.html
@@ -262,9 +262,9 @@ Labeled function arguments can be made optional during declaration. You can then
 
 ```reason
 /* radius can be omitted */
-let drawCircle ::color radius::r=? () => {
+let drawCircle ::color ::radius=? () => {
   setColor color;
-  switch r {
+  switch radius {
   | None => startAt 1 1;
   | Some r_ => startAt r_ r_;
   }


### PR DESCRIPTION
Parameter label for radius was missing in the drawCircle example