### PR TITLE
[JSX] Add support for reason-react jsx for spread API

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "OCaml",
+            "type": "ocamldebug",
+            "request": "launch",
+            "program": "${workspaceRoot}/main.d.byte",
+            "stopOnEntry": false,
+            "preLaunchTask": "build" // Build before launch
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.1.0",
+	"command": "make",
+	"showOutput": "always",
+	"tasks": [{
+		"taskName": "clean"
+	}, {
+		"taskName": "build",
+		"problemMatcher": "$ocamlc"
+	}]
+}

--- a/miscTests/jsxPpxTest.sh
+++ b/miscTests/jsxPpxTest.sh
@@ -1,15 +1,19 @@
+#set -x
 echo "Testing reactjs @JSX ppx..."
 
 testPath="miscTests/reactjs_jsx_ppx_tests"
 
+ppx[1]="./reactjs_jsx_ppx.native"
+ppx[2]="./reasonreact_jsx_ppx.native"
+
 # used to have more than one tests. Keep the loop for now
-for i in 1
+for i in {1..2}
 do
-  test="$testPath/test$i.re"
+  test="$testPath/test.re"
 
   expected=`cat $testPath/expected$i.re`
 
-  ocamlc -dsource -ppx ./reactjs_jsx_ppx.native -pp "./refmt_impl.native --print binary" -impl $test \
+  ocamlc -dsource -ppx ${ppx[$i]} -pp "./refmt_impl.native --print binary" -impl $test \
     2>&1 | sed '$ d' | sed '$ d' | \
     ./refmt_impl.native --parse ml --print re --interface false \
     > $testPath/actual${i}.re
@@ -19,9 +23,9 @@ do
   actual=`cat $testPath/actual$i.re`
 
   if [[ "$expected" = "$actual" ]]; then
-    echo "OK"
+    echo "OK$i"
   else
-    echo "Wrong"
+    echo "Wrong$1"
     # show the error
     diff -u $testPath/expected$i.re $testPath/actual$i.re
     exit 1

--- a/miscTests/reactjs_jsx_ppx_tests/expected1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected1.re
@@ -31,3 +31,7 @@ Foo.createElement
   comp::(Bar.createElement bar::1 children::[] ())
   children::[ReactDOMRe.createElement "li" [||], Bar.createElement bar::2 children::[] ()]
   ();
+
+Foo.createElement key::"someKey" className::"hello" children::[] ();
+
+Foo.createElement key::"someKey" ref::(some ref) className::"hello" children::[] ();

--- a/miscTests/reactjs_jsx_ppx_tests/expected2.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected2.re
@@ -1,0 +1,41 @@
+ReactDOMRe.createElement "div" [||];
+
+ReactDOMRe.createElement "div" props::(ReactDOMRe.props className::"hello" ()) [||];
+
+ReactDOMRe.createElement "div" props::(ReactDOMRe.props className::"hello" width::"10" ()) [||];
+
+ReactDOMRe.createElement
+  "div"
+  props::(ReactDOMRe.props className::"hello" width::"10" ())
+  [|ReactDOMRe.createElement "li" [||], ReasonReact.element (Foo.make [||])|];
+
+ReactDOMRe.createElement
+  "div"
+  props::(
+    ReactDOMRe.props className::"hello" comp::(ReasonReact.element (Foo.make bar::1 [||])) ()
+  )
+  [|ReactDOMRe.createElement "li" [||], ReasonReact.element (Foo.make bar::2 [||])|];
+
+ReasonReact.element (Foo.make [||]);
+
+ReasonReact.element (Foo.make className::"hello" [||]);
+
+ReasonReact.element (Foo.make className::"hello" width::"10" [||]);
+
+ReasonReact.element (
+  Foo.make
+    className::"hello"
+    width::"10"
+    [|ReactDOMRe.createElement "li" [||], ReasonReact.element (Bar.make [||])|]
+);
+
+ReasonReact.element (
+  Foo.make
+    className::"hello"
+    comp::<Bar bar=1 />
+    [|ReactDOMRe.createElement "li" [||], ReasonReact.element (Bar.make bar::2 [||])|]
+);
+
+ReasonReact.element key::"someKey" (Foo.make className::"hello" [||]);
+
+ReasonReact.element key::"someKey" ref::(some ref) (Foo.make className::"hello" [||]);

--- a/miscTests/reactjs_jsx_ppx_tests/test.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test.re
@@ -20,3 +20,9 @@
 <Foo className="hello" width="10"> <li /> <Bar /> </Foo>;
 
 <Foo className="hello" comp=(<Bar bar=1 />)> <li /> <Bar bar=2 /> </Foo>;
+
+/* ============== */
+
+<Foo key="someKey" className="hello" />;
+
+<Foo key="someKey" ref=(some ref) className="hello" />;

--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -43,6 +43,7 @@ let () =
     Pkg.bin ~auto:false "_reasonbuild/_build/myocamlbuild" ~dst:"rebuild";
     Pkg.bin "src/reason_format_type" ~dst:"refmttype";
     Pkg.bin "src/reactjs_jsx_ppx" ~dst:"reactjs_jsx_ppx";
+    Pkg.bin "src/reasonreact_jsx_ppx" ~dst:"reasonreact_jsx_ppx";
     Pkg.bin "src/ppx_react" ~dst:"ppx_react";
 
     (* VimReason *)

--- a/src/reasonreact_jsx_ppx.ml
+++ b/src/reasonreact_jsx_ppx.ml
@@ -1,0 +1,167 @@
+(* transform `div props1::a props2::b children::[foo, bar] () [@JSX]` into
+  `ReactDOMRe.createElement "div" props::[%bs.obj {props1: 1, props2: b}] [|foo, bar|]`.
+  Don't transform the upper-cased case: `Foo.createElement foo::bar children::[] () [@JSX]`.
+*)
+
+(* Why do we need a transform, instead of just using the original format?
+Because that one currently doesn't work well for the existing React.js *)
+open Migrate_parsetree
+open Ast_404
+
+open Ast_helper
+open Ast_mapper
+open Asttypes
+open Parsetree
+open Longident
+
+let rec listToArray' lst accum =
+  (* not in the sense of converting a list to an array; convert the AST
+    reprensentation of a list to the AST reprensentation of an array *)
+  match lst with
+  | {pexp_desc = Pexp_construct ({txt = Lident "[]"}, None)} -> accum
+  | {
+      pexp_desc = Pexp_construct (
+        {txt = Lident "::"},
+        Some {pexp_desc = Pexp_tuple (v::acc::[])}
+      )
+  } -> listToArray' acc (v::accum)
+  | _ -> raise (
+    Invalid_argument "JSX: the `children` prop must be a literal list (of react elements)."
+  )
+
+let listToArray lst = listToArray' lst [] |> List.rev
+
+let extractChildrenForDOMElements ?(removeLastPositionUnit=false) ~loc propsAndChildren =
+  let rec allButLast_ lst acc = match lst with
+    | [] -> []
+    | (Nolabel, {pexp_desc = Pexp_construct ({txt = Lident "()"}, None)})::[] -> acc
+    | (Nolabel, _)::rest -> raise (Invalid_argument "JSX: found non-labelled argument before the last position")
+    | arg::rest -> allButLast_ rest (arg::acc)
+  in
+  let allButLast lst = allButLast_ lst [] |> List.rev in
+  match (List.partition (fun (label, expr) -> label = Labelled "children") propsAndChildren) with
+  | ((label, childrenExpr)::[], props) ->
+    (childrenExpr, if removeLastPositionUnit then allButLast props else props)
+  | ([], props) ->
+    (* no children provided? Place a placeholder list (don't forgot we're talking about DOM element conversion here only) *)
+    (Exp.construct ~loc {loc; txt = Lident "[]"} None, if removeLastPositionUnit then allButLast props else props)
+  | (moreThanOneChild, props) -> raise (Invalid_argument "JSX: somehow there's more than one `children` label")
+
+(* TODO: some line number might still be wrong *)
+let jsxMapper = Reason_toolchain.To_current.copy_mapper {
+  default_mapper with
+  expr = (fun mapper expression -> match expression with
+    (* spotted a function application! Does it have the @JSX attribute? *)
+    | {
+        pexp_desc = Pexp_apply ({pexp_desc = createElementWrap}, propsAndChildren);
+        pexp_attributes
+      } when Syntax_util.attribute_exists "JSX" pexp_attributes ->
+        (match createElementWrap with
+        | Pexp_ident caller ->
+          (match caller with
+
+          | {txt = Lident "createElement"} ->
+            raise (Invalid_argument "JSX: `createElement` should be preceeded by a module name.")
+
+          (* Foo.createElement key::k ref::r prop1::foo prop2:bar children::[bla] ()
+             --->
+             ReasonReact.element key::k ref::r (Foo.make prop1::foo prop2::bar [|bla|])  *)
+          | {loc; txt = Ldot (Lident moduleIdentifier, "createElement")} ->
+            let (children, argsWithLabels) =
+              extractChildrenForDOMElements ~loc ~removeLastPositionUnit:true propsAndChildren in
+            let argIsKeyRef = function
+              | (Labelled ("key" | "ref") , _) -> true
+              | _ -> false in
+            let (argsKeyRef, argsForMake) = List.partition argIsKeyRef argsWithLabels in
+
+            let childrenExpr =
+              Exp.array (
+                listToArray children |> List.map (fun a -> mapper.expr mapper a)
+              ) in
+            let args = argsForMake @ [ (Nolabel, childrenExpr) ] in
+            let wrapWithReasonReactElement e = (* ReasonReact.element ::key ::ref (...) *)
+              Exp.apply
+                ~loc
+                (Exp.ident ~loc {loc; txt = Ldot (Lident "ReasonReact", "element")})
+                (argsKeyRef @ [(Nolabel, e)]) in
+            Exp.apply
+              ~loc
+              (* throw away the [@JSX] attribute and keep the others, if any *)
+              ~attrs:(pexp_attributes |> List.filter (fun (attribute, _) -> attribute.txt <> "JSX"))
+              (* Foo.make *)
+              (Exp.ident ~loc {loc; txt = Ldot (Lident moduleIdentifier, "make")})
+              args
+            |> wrapWithReasonReactElement
+
+          (* div prop1::foo prop2:bar children::[bla] ()
+             ----->
+             ReactDOMRe.createElement props::(ReactDOMRe.props props1::foo props2::bar ()) [|bla|] *)
+          | {loc; txt = Lident lowercaseIdentifier} ->
+            let (children, propsWithLabelsPlusUnitAtEnd (* labelled args and () at the end *)) =
+              extractChildrenForDOMElements ~loc propsAndChildren
+            in
+            let componentNameExpr =
+              Exp.constant ~loc (Pconst_string (lowercaseIdentifier, None))
+            in
+            let childrenExpr =
+              Exp.array (
+                listToArray children |> List.map (fun a -> mapper.expr mapper a)
+              )
+            in
+            let args = match propsWithLabelsPlusUnitAtEnd with
+            | [theUnitArgumentAtEnd] ->
+              [
+                (* "div" *)
+                (Nolabel, componentNameExpr);
+                (* [|moreCreateElementCallsHere|] *)
+                (Nolabel, childrenExpr)
+              ]
+            | nonEmptyProps ->
+              let propsCall =
+                Exp.apply
+                  ~loc
+                  (Exp.ident ~loc {loc; txt = Ldot (Lident "ReactDOMRe", "props")})
+                  (nonEmptyProps |> List.map (fun (label, expression) -> (label, mapper.expr mapper expression)))
+              in
+              [
+                (* "div" *)
+                (Nolabel, componentNameExpr);
+                (* ReactDOMRe.props className:blabla foo::bar () *)
+                (Labelled "props", propsCall);
+                (* [|moreCreateElementCallsHere|] *)
+                (Nolabel, childrenExpr)
+              ]
+            in
+            Exp.apply
+              ~loc
+              (* throw away the [@JSX] attribute and keep the others, if any *)
+              ~attrs:(pexp_attributes |> List.filter (fun (attribute, _) -> attribute.txt <> "JSX"))
+              (* ReactDOMRe.createDOMElement *)
+              (Exp.ident ~loc {loc; txt = Ldot (Lident "ReactDOMRe", "createElement")})
+              args
+
+          | {txt = Ldot (_, anythingNotCreateElement)} ->
+            raise (
+              Invalid_argument
+                ("JSX: the JSX attribute should be attached to a `YourModuleName.createElement` call. We saw `"
+                  ^ anythingNotCreateElement
+                  ^ "` instead"
+                )
+            )
+
+          | {txt = Lapply _} ->
+            (* don't think there's ever a case where this is reached *)
+            raise (
+              Invalid_argument "JSX: encountered a weird case while processing the code. Please report this!"
+            )
+          )
+        | anythingElseThanIdent ->
+          raise (
+            Invalid_argument "JSX: `createElement` should be preceeded by a simple, direct module name."
+          )
+        )
+    (* Delegate to the default mapper, a deep identity traversal *)
+    | x -> default_mapper.expr mapper x)
+}
+
+let () = Compiler_libs.Ast_mapper.register "JSX" (fun _argv -> jsxMapper)


### PR DESCRIPTION
The jsx for the existing API is `src/reactjs_jsx_ppx.ml`.
The new jsx is `src/reasonreact_jsx_ppx.ml`.
Currently both forms of jsx are built, and there are separate tests.