### PR TITLE
Correct typo on no argument.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -186,7 +186,7 @@ If you forget to wrap `double 5` in parentheses, you'd get `increment double 5`,
 
 #### No Argument
 
-A function always takes an argument; but sometimes, we'd use it for e.g. side-effects, and don't have anything to pass to it. In other languages, we'd conceptually pass "no argumetn". In Reason, every function takes an argument; here we'd conventionally pass it the value `()`, called "unit".
+A function always takes an argument; but sometimes, we'd use it for e.g. side-effects, and don't have anything to pass to it. In other languages, we'd conceptually pass "no argument". In Reason, every function takes an argument; here we'd conventionally pass it the value `()`, called "unit".
 
 ```reason
 /* receive & destructure the unit argument */


### PR DESCRIPTION
Correct a simple typo in doc where "no argument" was spelled "no argumetn".