### PR TITLE
Fix printing of module type (precedence of Pmty_with inside Pmty_functor)

### DIFF
--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -604,3 +604,7 @@ module type T = t with type t = a => a;
 module type T = t with type t = a => a;
 
 module type T = (t with type t = a) => a;
+
+module X = [%test extension];
+
+module type T = [%test extension];

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -598,3 +598,9 @@ module type SigWithModuleTypeOf = {
   include module type of String;
   include module type of Array;
 };
+
+module type T = t with type t = a => a;
+
+module type T = t with type t = a => a;
+
+module type T = (t with type t = a) => a;

--- a/formatTest/unit_tests/input/modules.re
+++ b/formatTest/unit_tests/input/modules.re
@@ -459,3 +459,6 @@ module type SigWithModuleTypeOf = {
   include module type of Array;
 };
 
+module type T = t with type t = a => a;
+module type T = t with type t = (a => a);
+module type T = (t with type t = a) => a;

--- a/formatTest/unit_tests/input/modules.re
+++ b/formatTest/unit_tests/input/modules.re
@@ -462,3 +462,6 @@ module type SigWithModuleTypeOf = {
 module type T = t with type t = a => a;
 module type T = t with type t = (a => a);
 module type T = (t with type t = a) => a;
+
+module X = [%test extension];
+module type T = [%test extension];

--- a/reason-parser/src/reason_pprint_ast.ml
+++ b/reason-parser/src/reason_pprint_ast.ml
@@ -5676,8 +5676,7 @@ class printer  ()= object(self:'self)
             ~postSpace:true
             ~sep:";"
             (List.map self#signature_item (List.filter self#shouldDisplaySigItem s))
-      (* Not sure what this is about. *)
-      | Pmty_extension _ -> assert false
+      | Pmty_extension (s, e) -> self#payload "%" s e
       | _ -> makeList ~break:IfNeed ~wrap:("(", ")") [self#module_type x]
 
   method module_type x =

--- a/reason-parser/src/reason_pprint_ast.ml
+++ b/reason-parser/src/reason_pprint_ast.ml
@@ -5686,7 +5686,7 @@ class printer  ()= object(self:'self)
       | Pmty_functor (_, None, mt2) -> (atom "()")::(functorTypeArgs mt2)
       | Pmty_functor (s, Some mt1, mt2) ->
           if s.txt = "_" then
-            (self#module_type mt1)::(functorTypeArgs mt2)
+            (self#non_arrowed_module_type mt1)::(functorTypeArgs mt2)
           else
             let cur =
               makeList ~wrap:("(",")") [


### PR DESCRIPTION
1) Fix a printing bug when mixing functor types and module type "with" operator.
Add tests for this case.
2) Add printing of module type extensions.