### PR TITLE
[Docs] Minor change in installing reason-cli

### DIFF
--- a/docs/gettingStarted.html
+++ b/docs/gettingStarted.html
@@ -71,10 +71,9 @@ Our [editor integration](./tools.html#editor-integration) need a few binaries to
 
 The tooling section explains what these binaries do.
 
-They can be installed globally through:
+**Install reason-cli globally** by following the [install instructions for your platform](https://github.com/reasonml/reason-cli#1-install-reason-cli-globally)
 
 ```sh
-npm install -g git://github.com/reasonml/reason-cli.git#beta-v-1.13.5
 ## test that you have them installed correctly
 which ocamlmerlin refmt ocamlmerlin-reason
 ```


### PR DESCRIPTION
There's a new version of reason-cli (0.13.6) and platform-specific downloads. Rather than have to keep this doc up to date with versions and platforms, let's just link to those.

(I would also be happy to inline the platform-specific download URLs into this doc just to avoid sending people elsewhere, but it would create a need to update it regularly as the CLI is updated.)