### PR TITLE
Fix item attributes

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -417,3 +417,6 @@ external readFileSync2 :
   [@bs.string] =>
   string =
   "" [@@bs.module "fs"];
+
+/* Ensure that attributes on extensions are printed */
+[@@@test [%%extension] [@@attr]];

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -201,7 +201,7 @@ type gadtType 'x =
 
 [@@@floatingTopLevelStructureItem hello];
 
-print_string "hello";
+print_string "hello" [@@itemAttributeOnEval];
 
 let firstBinding = "first"
 and secondBinding = "second";

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -319,3 +319,7 @@ external readFileSync2 :
   ([ `utf8 [@bs.as "ascii"] | `my_name [@bs.as "ascii"] ] [@bs.string]) =>
   string = ""
   [@@bs.module "fs"];
+
+/* Ensure that attributes on extensions are printed */
+[@@@test
+  [%%extension] [@@attr]; ];

--- a/reason-parser/src/reason_pprint_ast.ml
+++ b/reason-parser/src/reason_pprint_ast.ml
@@ -5899,7 +5899,8 @@ class printer  ()= object(self:'self)
   method structure_item term =
     let item = (
       match term.pstr_desc with
-        | Pstr_eval (e, _attrs) -> self#unparseExpr e
+        | Pstr_eval (e, attrs) ->
+            self#attach_std_item_attrs attrs (self#unparseExpr e)
         | Pstr_type (_, []) -> assert false
         | Pstr_type (rf, l)  -> (self#type_def_list (rf, l))
         | Pstr_value (rf, l) -> (self#bindings (rf, l))
@@ -5953,7 +5954,7 @@ class printer  ()= object(self:'self)
         | Pstr_extension (e, a) ->
           (* Notice how extensions have attributes - but not every structure
              item does. *)
-          self#item_extension e
+          self#attach_std_item_attrs a (self#item_extension e)
     ) in
     SourceMap(term.pstr_loc, item)
 


### PR DESCRIPTION
Item attributes on `Pstr_eval` or `Pstr_extension` were dropped during printing.

This PR fixes the problem and the test.