### PR TITLE
Fix arityConversion tests

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/arityConversion.re
+++ b/formatTest/typeCheckedTests/expected_output/arityConversion.re
@@ -16,6 +16,12 @@ module Test = {
     | Or((int, int));
 };
 
+let _ = Test.And((1, 2));
+
+let _ = Test.Or((1, 2));
+
+let _ = Some(1);
+
 Test.And((1, 2));
 
 Test.Or((1, 2));
@@ -37,12 +43,22 @@ type t2 =
 type t3 =
   | TupleConstructor3((int, int));
 
+let _ = M.TupleConstructorInModule((1, 2));
+
+let _ = M.TupleConstructor2((1, 2));
+
+let _ = TupleConstructor2((1, 2));
+
+let _ = M.TupleConstructor3((1, 2));
+
+let _ = TupleConstructor3((1, 2));
+
 M.TupleConstructorInModule((1, 2));
 
 M.TupleConstructor2((1, 2));
 
 TupleConstructor2((1, 2));
 
-M.TupleConstructor3(1, 2);
+M.TupleConstructor3((1, 2));
 
 TupleConstructor3((1, 2));

--- a/formatTest/typeCheckedTests/input/arityConversion.ml
+++ b/formatTest/typeCheckedTests/input/arityConversion.ml
@@ -11,7 +11,11 @@ end;;
 
 let _ = Test.And (1, 2)
 let _ = Test.Or (1, 2)
-let _ = Some 1
+let _ = Some 1;;
+
+Test.And (1, 2);;
+Test.Or (1, 2);;
+Some 1;;
 
 module M = struct
   type t = TupleConstructorInModule of (int * int)
@@ -28,4 +32,12 @@ let _ = M.TupleConstructor2 (1,2)
 let _ = TupleConstructor2 (1,2)
 
 let _ = M.TupleConstructor3 (1,2)
-let _ = TupleConstructor3 (1,2)
+let _ = TupleConstructor3 (1,2);;
+
+M.TupleConstructorInModule (1,2);;
+
+M.TupleConstructor2 (1,2);;
+TupleConstructor2 (1,2);;
+
+M.TupleConstructor3 (1,2);;
+TupleConstructor3 (1,2);;


### PR DESCRIPTION
Post syntax change, apparently `let _ = foo` doesn't format to `foo` anymore, just `let _ = foo`. `foo` still idempotently formats to `foo`. This is probably intended? cc @let-def. I've added the extra test cases.