### PR TITLE
Add support for punning of an explicitly passed optional

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -606,3 +606,7 @@ let w =
       paddingBottom: 10
     }
   />;
+
+let foo = None;
+
+let g = <Two ?foo />;

--- a/formatTest/typeCheckedTests/input/jsx.re
+++ b/formatTest/typeCheckedTests/input/jsx.re
@@ -406,3 +406,8 @@ let w =
             paddingBottom: 10
           }
   />;
+
+
+let foo = None;
+
+let g = <Two ?foo />;

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -141,3 +141,6 @@ let icon =
 
 /* punning for explicitly passed optional */
 <Foo ?bar />;
+
+/* don't pun explicitly passed optional with module identifier */
+<Foo bar=?Baz.bar />;

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -135,3 +135,9 @@ let icon =
   )
   key=node##legacy_attachment_id
 />;
+
+/* punning */
+<Foo bar />;
+
+/* punning for explicitly passed optional */
+<Foo ?bar />;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -102,3 +102,6 @@ let icon = <Icon
 
 /* punning for explicitly passed optional */
 <Foo bar=?bar />;
+
+/* don't pun explicitly passed optional with module identifier */
+<Foo bar=?Baz.bar />;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -96,3 +96,9 @@ let icon = <Icon
        )
   key=node##legacy_attachment_id
 />;
+
+/* punning */
+<Foo bar />;
+
+/* punning for explicitly passed optional */
+<Foo bar=?bar />;

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -2429,6 +2429,11 @@ jsx_arguments:
     { (* a=?b *)
       [(Optional $1, $4)] @ $5
     }
+  | QUESTION LIDENT jsx_arguments
+    { (* <Foo ?bar /> punning with explicitly passed optional *)
+      let loc_lident = mklocation $startpos($2) $endpos($2) in
+      [(Optional $2, mkexp (Pexp_ident {txt = Lident $2; loc = loc_lident}) ~loc:loc_lident)] @ $3
+    }
   | LIDENT EQUAL simple_expr jsx_arguments
     { (* a=b *)
       [(Labelled $1, $3)] @ $4


### PR DESCRIPTION
https://github.com/facebook/reason/issues/1392

Puns `<Foo bar=?bar />` into `<Foo ?bar />`.