### PR TITLE
Format `Js.t {. foo: bar}` to `{. "foo": bar}`

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -421,7 +421,7 @@ external render : (reactElement, element) => unit =
 external createCompositeElementInternalHack :
   (
     reactClass,
-    Js.t({.. reasonProps: 'props}),
+    {.. "reasonProps": 'props},
     array(reactElement)
   ) =>
   reactElement =

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -377,3 +377,13 @@ module type T = {
 };
 
 let privacy = {pri x (c) = 5 + c};
+
+module Js = {
+  type t('a);
+};
+
+/* supports trailing comma */
+type stream('a) = {
+  .
+  "observer": ('a => unit) => unit
+};

--- a/formatTest/typeCheckedTests/input/oo.re
+++ b/formatTest/typeCheckedTests/input/oo.re
@@ -324,3 +324,10 @@ module type T = {
 let privacy = {
     pri x(c) = 5 + c;
 };
+
+module Js = {
+  type t('a);
+};
+
+/* supports trailing comma */
+type stream('a) = {. "observer": ('a => unit) => unit,};

--- a/formatTest/unit_tests/expected_output/object.re
+++ b/formatTest/unit_tests/expected_output/object.re
@@ -14,3 +14,7 @@ type t = {..};
 let (<..>) (a, b) = a + b;
 
 let five = 2 <..> 3;
+
+type closedObjSugar = {. "foo": bar, "baz": int};
+
+type openObjSugar = {.. "x": int, "y": int};

--- a/formatTest/unit_tests/input/object.re
+++ b/formatTest/unit_tests/input/object.re
@@ -20,3 +20,7 @@ type t = {..};
 
 let (<..>)(a,b) = a + b;
 let five = 2 <..> 3;
+
+type closedObjSugar = Js.t({. foo: bar, baz: int});
+
+type openObjSugar = Js.t({.. x: int, y: int});

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -894,10 +894,10 @@ type core_type_object =
   | Record_type of label_declaration list
 
 (* `{. "foo": bar}` -> `Js.t {. foo: bar}` and {.. "foo": bar} -> `Js.t {.. foo: bar} *)
-let mkBsObjTypeSugar rows closedness =
-  let obj = mktyp (Ptyp_object (prepare_immutable_labels rows, closedness)) in
-  let jsDotTCtor = { txt = Longident.parse "Js.t"; loc = dummy_loc () } in
-  Core_type(mktyp(Ptyp_constr(jsDotTCtor , [obj])))
+let mkBsObjTypeSugar ~loc ~closed rows =
+  let obj = mktyp ~loc (Ptyp_object (prepare_immutable_labels rows, closed)) in
+  let jsDotTCtor = { txt = Longident.parse "Js.t"; loc } in
+  Core_type(mktyp(Ptyp_constr(jsDotTCtor, [obj])))
 
 let only_core_type t startp endp =
   match t with
@@ -3894,11 +3894,13 @@ object_record_type:
     { Record_type (only_labels $2) }
   | LBRACE DOT string_literal_lbls RBRACE
     { (* `{. "foo": bar}` -> `Js.t {. foo: bar}` *)
-      mkBsObjTypeSugar $3 Closed
+      let loc = mklocation $symbolstartpos $endpos in
+      mkBsObjTypeSugar ~loc ~closed:Closed $3
     }
   | LBRACE DOTDOT string_literal_lbls RBRACE
     { (* `{.. "foo": bar}` -> `Js.t {.. foo: bar}` *)
-      mkBsObjTypeSugar $3 Open
+      let loc = mklocation $symbolstartpos $endpos in
+      mkBsObjTypeSugar ~loc ~closed:Open $3
     }
   | LBRACE DOT loption(label_declarations) RBRACE
     { Core_type (mktyp (Ptyp_object (prepare_immutable_labels $3, Closed))) }

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -3534,7 +3534,7 @@ label_declaration:
 ;
 
 %inline string_literal_lbls:
-  separated_nonempty_list(COMMA, string_literal_lbl) { $1 };
+  lseparated_nonempty_list(COMMA, string_literal_lbl) COMMA? { $1 };
 
 string_literal_lbl:
   | STRING COLON poly_type

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -893,6 +893,12 @@ type core_type_object =
   | Core_type of core_type
   | Record_type of label_declaration list
 
+(* `{. "foo": bar}` -> `Js.t {. foo: bar}` and {.. "foo": bar} -> `Js.t {.. foo: bar} *)
+let mkBsObjTypeSugar rows closedness =
+  let obj = mktyp (Ptyp_object (prepare_immutable_labels rows, closedness)) in
+  let jsDotTCtor = { txt = Longident.parse "Js.t"; loc = dummy_loc () } in
+  Core_type(mktyp(Ptyp_constr(jsDotTCtor , [obj])))
+
 let only_core_type t startp endp =
   match t with
   | Core_type ct -> ct
@@ -3527,6 +3533,18 @@ label_declaration:
     }
 ;
 
+%inline string_literal_lbls:
+  separated_nonempty_list(COMMA, string_literal_lbl) { $1 };
+
+string_literal_lbl:
+  | STRING COLON poly_type
+    {
+      let loc = mklocation $symbolstartpos $endpos in
+      let (s, _) = $1 in
+      (Type.field (mkloc s loc) $3 ~loc, [])
+    }
+  ;
+
 /* Type Extensions */
 
 potentially_long_ident_and_optional_type_parameters:
@@ -3874,6 +3892,14 @@ object_record_type:
     { syntax_error () }
   | LBRACE label_declarations RBRACE
     { Record_type (only_labels $2) }
+  | LBRACE DOT string_literal_lbls RBRACE
+    { (* `{. "foo": bar}` -> `Js.t {. foo: bar}` *)
+      mkBsObjTypeSugar $3 Closed
+    }
+  | LBRACE DOTDOT string_literal_lbls RBRACE
+    { (* `{.. "foo": bar}` -> `Js.t {.. foo: bar}` *)
+      mkBsObjTypeSugar $3 Open
+    }
   | LBRACE DOT loption(label_declarations) RBRACE
     { Core_type (mktyp (Ptyp_object (prepare_immutable_labels $3, Closed))) }
   | LBRACE DOTDOT loption(label_declarations) RBRACE


### PR DESCRIPTION
Implements string key sugar for Bucklescript Js.t object types
https://github.com/facebook/reason/issues/1404

```
/* before */
Js.t {. foo: bar}
Js.t {.. baz: boo}

/* after */
{. "foo": bar}
{.. "baz": boo}
```
