### PR TITLE
Allow non-determinism in menhir interpretation loop

### DIFF
--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -2526,6 +2526,9 @@ mark_position_exp
     { $2 }
   | ES6_FUN es6_parameters EQUALGREATER expr
     { List.fold_right mkexp_fun $2 $4 }
+  | ES6_FUN es6_parameters COLON only_core_type(non_arrowed_core_type) EQUALGREATER expr
+    { List.fold_right mkexp_fun $2
+        (ghexp_constraint (mklocation $startpos($4) $endpos) $6 (Some $4, None)) }
   /* List style rules like this often need a special precendence
      such as below_BAR in order to let the entire list "build up"
    */


### PR DESCRIPTION
This should fix https://github.com/facebook/reason/issues/1402 and also enables the `(args) : result_type => result` syntax.

# Why

```
expr ::=
| (expr, ...) // tuple former
| (pattern, ...) => expr // lambda function
```

Lambda function syntax is inherently ambiguous: the parser needs to look after the closing parenthesis to know whether an expression or a pattern should be parsed after the opening parenthesis.

This is beyond what LR parsers can handle, it is in the realm of [GLR parsers](https://en.wikipedia.org/wiki/GLR_parser).
That's not a good thing, but it is in a scope that is limited enough that it should be possible to handle it correctly. Furthermore, either we accept this GLR subset or we give up on ES6-like function syntax.

The current implementation solves the problem at lexing level: it looks for the token after the closing parenthesis, if it is a `=>` then it injects a special token (`ES6_FUN`) before the opening parenthesis.
This way the grammar is LR and Menhir is happy.

However, as discovered by @IwanKaramazow, finding a `=>` is not enough to decide between expressions and patterns. In `when` clauses, we have an expression preceding a `=>`: `when bla => bli` is parsed as `when (fun  bla => bli)`.

Worse, if we add `(args): type => expr` syntax then looking immediately after the closing parenthesis is not enough for deciding: we now have to parse arbitrarily many tokens of a type to look for the `=>`.

# How

The proposed interpreter loop forks the parser. If the lexer determined that an `ES6_FUN` should be injected, the parser will try both cases: with and without the `ES6_FUN` token.
That is it will try to parse the following tokens simultaneously as an expression and as a pattern. Hopefully, one branch will die quickly.

## Performance concerns

This patch can have an impact on performance, although it should be limited: since we are naively forking, an exponential worst case is possible. However the grammar doesn't make it easy to nest forking points, so the actual amount of parallelism is expected to be small (but maybe not bounded).

This is something to keep in mind in future extensions of the grammar!