### PR TITLE
add more spacing when printing Ptyp_package

### DIFF
--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -613,3 +613,9 @@ module type T = (t with type t = a) => a;
 module X = [%test extension];
 
 module type T = [%test extension];
+
+let foo
+    (
+      type a,
+      (module X): (module X_t with type t = a)
+    ) = X.a;

--- a/formatTest/unit_tests/input/modules.re
+++ b/formatTest/unit_tests/input/modules.re
@@ -465,3 +465,5 @@ module type T = (t with type t = a) => a;
 
 module X = [%test extension];
 module type T = [%test extension];
+
+let foo (type a, (module X): (module X_t with type t =a)) = X.a;

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -3021,7 +3021,7 @@ class printer  ()= object(self:'self)
         | Ptyp_object (l, o) -> self#unparseObject l o
         | Ptyp_package (lid, cstrs) ->
           let typeConstraint (s, ct) =
-            label
+            label ~space:true
               (makeList ~break:IfNeed ~postSpace:true [atom "type"; self#longident_loc s; atom "="])
               (self#core_type ct)
           in


### PR DESCRIPTION
Before:
```reason
let foo (type a, (module X): (module X_t with type t =a)) = X.a;
```

After:
```reason
let foo (type a, (module X): (module X_t with type t = a)) = X.a;
```