### PR TITLE
Implement #1443, #1444 & #1446

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -441,7 +441,7 @@ external foo : bool => bool =
 [@bs.module "fs"]
 external readFileSync :
   (
-    :name string,
+    :name: string,
     [@bs.string]
     [ | `utf8 [@bs.as "ascii"] | `my_name]
   ) =>
@@ -451,7 +451,7 @@ external readFileSync :
 [@bs.module "fs"]
 external readFileSync2 :
   (
-    :name string,
+    :name: string,
     [@bs.string]
     [
       [@bs.as "ascii"] | `utf8

--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -67,6 +67,6 @@ let expectedPrecendence =
 let expectedPrecendence =
   1 \+ 1 \=== 1 \+ 1 && 1 \+ 1 !== 1 \+ 1;
 
-module X: {let x: (:x unit?, unit) => unit;} = {
+module X: {let x: (:x: unit=?, unit) => unit;} = {
   let x (:x=(), ()) = ();
 };

--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -89,7 +89,7 @@ module Namespace = {
     let createElement
         (
           :intended=?,
-          :anotherOptional x=100,
+          :anotherOptional as x=100,
           :children,
           ()
         ) = {
@@ -437,8 +437,8 @@ let asd2 =
   [@foo]
   [@JSX]
   One.createElementobvioustypo(
-    :test false,
-    :children ["a", "b"],
+    :test=false,
+    :children=["a", "b"],
     ()
   );
 
@@ -450,11 +450,11 @@ let asd =
 /* "video" call doesn't end with a list, so the expression isn't converted to JSX */
 let video (:test: bool, children) = children;
 
-let asd2 = [@foo] [@JSX] video(:test false, 10);
+let asd2 = [@foo] [@JSX] video(:test=false, 10);
 
 let div (:children) = 1;
 
-[@JSX] ((() => div)())(:children []);
+[@JSX] ((() => div)())(:children=[]);
 
 let myFun () =
   <>
@@ -546,15 +546,15 @@ fakeRender(defaultArg);
 
 ([@bla]
  [@JSX]
- NotReallyJSX.createElement([], :foo 1, :bar 2));
+ NotReallyJSX.createElement([], :foo=1, :bar=2));
 
 ([@bla]
  [@JSX]
- NotReallyJSX.createElement(:foo 1, [], :bar 2));
+ NotReallyJSX.createElement(:foo=1, [], :bar=2));
 
-([@bla] [@JSX] notReallyJSX([], :foo 1));
+([@bla] [@JSX] notReallyJSX([], :foo=1));
 
-([@bla] [@JSX] notReallyJSX(:foo 1, [], :bar 2));
+([@bla] [@JSX] notReallyJSX(:foo=1, [], :bar=2));
 
 /* children can be at any position */
 <span test=true foo=2 />;

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -331,7 +331,7 @@ external foo : (bool) => bool = "";
 /* Attributes on an entire polymorphic variant leaf */
 [@bs.module "fs"]
 external readFileSync : (
-  :name string,
+  :name: string,
   [@bs.string] [
     | `utf8
     [@bs.as "ascii"] | `my_name
@@ -340,7 +340,7 @@ external readFileSync : (
 
 [@bs.module "fs"]
 external readFileSync2 : (
-  :name string,
+  :name: string,
   [@bs.string] [
     [@bs.as "ascii"] | `utf8
     [@bs.as "ascii"] | `my_name

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -47,6 +47,6 @@ let expectedPrecendence = 1 + 1 \=== 1 + 1 && 1 + 1 \!== 1 + 1;
 
 let expectedPrecendence = 1 \+ 1 \=== 1 \+ 1 && 1 \+ 1 \!== 1 \+ 1;
 
-module X: {let x: (:x unit?, unit) => unit;} = {
+module X: {let x: (:x: unit=?, unit) => unit;} = {
   let x(:x=(),()) = ();
 };

--- a/formatTest/typeCheckedTests/input/jsx.re
+++ b/formatTest/typeCheckedTests/input/jsx.re
@@ -30,37 +30,37 @@ module Sibling = {
 };
 
 module Test = {
-    let createElement(yo::yo=?,::children,()) {displayName: "test"};
+    let createElement(:yo=?,:children,()) {displayName: "test"};
 };
 
 module So = {
-    let createElement(::children,()) {displayName: "test"};
+    let createElement(:children,()) {displayName: "test"};
 };
 
 module Foo2 = {
-    let createElement(::children,()) {displayName: "test"};
+    let createElement(:children,()) {displayName: "test"};
 };
 
 module Text = {
-    let createElement(::children,()) {displayName: "test"};
+    let createElement(:children,()) {displayName: "test"};
 };
 
 module Exp = {
-    let createElement(::children,()) {displayName: "test"};
+    let createElement(:children,()) {displayName: "test"};
 };
 
 module Pun = {
-    let createElement(intended::intended=?,::children,()) {displayName: "test"};
+    let createElement(:intended=?,:children,()) {displayName: "test"};
 };
 
 module Namespace = {
     module Foo = {
-        let createElement(intended::intended=?,anotherOptional::x=100,::children,()) {displayName: "test"};
+        let createElement(:intended=?,:anotherOptional as x=100,:children,()) {displayName: "test"};
     };
 };
 
 module Optional1 = {
-    let createElement(::required,::children,()) {
+    let createElement(:required,:children,()) {
         switch (required) {
             | Some(a) => {displayName: a}
             | None => {displayName: "nope"}
@@ -69,7 +69,7 @@ module Optional1 = {
 };
 
 module Optional2 = {
-    let createElement(::optional=?,::children,()) {
+    let createElement(:optional=?,:children,()) {
         switch (optional) {
             | Some(a) => {displayName: a}
             | None => {displayName: "nope"}
@@ -78,7 +78,7 @@ module Optional2 = {
 };
 
 module DefaultArg = {
-    let createElement(::default=Some("foo"),::children,()) {
+    let createElement(:default=Some("foo"),:children,()) {
          switch (default) {
             | Some(a) => {displayName: a}
             | None => {displayName: "nope"}
@@ -88,30 +88,30 @@ module DefaultArg = {
 
 
 module LotsOfArguments = {
-    let createElement(argument1::argument1=?,argument2::argument2=?,argument3::argument3=?,argument4::argument4=?,argument5::argument5=?,argument6::argument6=?,::children,()) {displayName: "test"};
+    let createElement(:argument1=?,:argument2=?,:argument3=?,:argument4=?,:argument5=?,:argument6=?,:children,()) {displayName: "test"};
 };
 
-let div(argument1::argument1=?,::children,()) {
+let div(:argument1=?,:children,()) {
     displayName: "test"
 };
 
 module List1 = {
-    let createElement(::children,()) {displayName: "test"};
+    let createElement(:children,()) {displayName: "test"};
 };
 
 module List2 = {
-    let createElement(::children,()) {displayName: "test"};
+    let createElement(:children,()) {displayName: "test"};
 };
 
 module List3 = {
-    let createElement(::children,()) {displayName: "test"};
+    let createElement(:children,()) {displayName: "test"};
 };
 
 module NotReallyJSX = {
-    let createElement(::foo,::bar,children) {displayName: "test"};
+    let createElement(:foo,:bar,children) {displayName: "test"};
 };
 
-let notReallyJSX(::foo,::bar,children) {
+let notReallyJSX(:foo,:bar,children) {
     displayName: "test"
 };
 
@@ -184,7 +184,7 @@ let a = <Foo a=a>5</Foo>;
 let a = <Foo a=b>5</Foo>;
 let a = <Foo a=b b=d>5</Foo>;
 let a = <Foo a>0.55</Foo>;
-let a = [@JSX] Foo.createElement(children::[],());
+let a = [@JSX] Foo.createElement(:children=[],());
 let ident = <Foo>{a}</Foo>;
 let fragment1 = <> <Foo /> <Foo /> </>;
 let fragment2 = <> <Foo /> <Foo /> </>;
@@ -209,8 +209,8 @@ let listOfItems3 = <List3>fragment11 fragment11</List3>;
  * Several sequential simple jsx expressions must be separated with a space.
  */
 let thisIsRight(a,b) = ();
-let tagOne = fun(::children,()) => ();
-let tagTwo = fun(::children,()) => ();
+let tagOne = fun(:children,()) => ();
+let tagTwo = fun(:children,()) => ();
 /* thisIsWrong <tagOne /><tagTwo />; */
 thisIsRight(<tagOne />,<tagTwo />);
 
@@ -218,8 +218,8 @@ thisIsRight(<tagOne />,<tagTwo />);
 thisIsRight(<tagOne> </tagOne>, <tagTwo> </tagTwo>);
 
 
-let a = fun(::children,()) => ();
-let b = fun(::children,()) => ();
+let a = fun(:children,()) => ();
+let b = fun(:children,()) => ();
 
 let thisIsOkay =
   <List1>
@@ -273,18 +273,18 @@ let sameButWithSpaces = [<Foo />, <Bar />, ...sameButWithSpaces];
 type thisType = [`Foo  | `Bar];
 type t('a) = [< thisType ] as 'a;
 
-let asd = [@JSX] [@foo] One.createElement(test::true,foo::2,children::["a", "b"],());
-let asd2 = [@JSX] [@foo] One.createElementobvioustypo(test::false,children::["a", "b"],());
+let asd = [@JSX] [@foo] One.createElement(:test=true, :foo=2, :children=["a", "b"],());
+let asd2 = [@JSX] [@foo] One.createElementobvioustypo(:test=false, :children=["a", "b"],());
 
-let span(test::(test : bool),foo::(foo : int),::children,()) = 1;
-let asd = [@JSX] [@foo] span(test::true,foo::2,children::["a", "b"],());
+let span(:test : bool,:foo : int,:children,()) = 1;
+let asd = [@JSX] [@foo] span(:test=true, :foo=2, :children=["a", "b"],());
 /* "video" call doesn't end with a list, so the expression isn't converted to JSX */
-let video(test::(test : bool),children) = children;
-let asd2 = [@JSX] [@foo] video(test::false,10);
+let video(:test:  bool,children) = children;
+let asd2 = [@JSX] [@foo] video(:test=false,10);
 
 
-let div(::children) = 1;
-([@JSX] (((fun () => div) ())(children::[])));
+let div(:children) = 1;
+([@JSX] (((fun () => div) ())(:children=[])));
 
 let myFun () {
   <>
@@ -354,22 +354,22 @@ fakeRender(defaultArg);
 let defaultArg = <DefaultArg default=zzz />;
 fakeRender(defaultArg);
 
-([@JSX][@bla] NotReallyJSX.createElement([],foo::1,bar::2));
-([@bla][@JSX] NotReallyJSX.createElement(foo::1,[],bar::2));
-([@JSX][@bla] notReallyJSX([],foo::1));
-([@bla][@JSX] notReallyJSX(foo::1,[],bar::2));
+([@JSX][@bla] NotReallyJSX.createElement([],:foo=1,:bar=2));
+([@bla][@JSX] NotReallyJSX.createElement(:foo=1,[],:bar=2));
+([@JSX][@bla] notReallyJSX([],:foo=1));
+([@bla][@JSX] notReallyJSX(:foo=1,[],:bar=2));
 
 /* children can be at any position */
-([@JSX] span(children::[],test::true,foo::2,()));
+([@JSX] span(:children=[],:test=true,:foo=2,()));
 
-([@JSX] Optional1.createElement(children::[],required::Some("hi"),()));
+([@JSX] Optional1.createElement(:children=[],:required=Some("hi"),()));
 
 /* preserve some other attributes too! */
-([@JSX][@bla] span(children::[],test::true,foo::2,()));
-([@bla][@JSX] span(children::[],test::true,foo::2,()));
+([@JSX][@bla] span(:children=[],:test=true,:foo=2,()));
+([@bla][@JSX] span(:children=[],:test=true,:foo=2,()));
 
-([@JSX][@bla] Optional1.createElement(children::[],required::Some("hi"),()));
-([@bla][@JSX] Optional1.createElement(children::[],required::Some("hi"),()));
+([@JSX][@bla] Optional1.createElement(:children=[],:required=Some("hi"),()));
+([@bla][@JSX] Optional1.createElement(:children=[],:required=Some("hi"),()));
 
 /* Overeager JSX punning #1099 */
 module Metal = {
@@ -377,7 +377,7 @@ module Metal = {
 };
 
 module OverEager = {
-  let createElement(::fiber,::children,()) {displayName: "test"};
+  let createElement(:fiber,:children,()) {displayName: "test"};
 };
 
 let element = <OverEager fiber=Metal.fiber />;
@@ -392,7 +392,7 @@ type style = {
 };
 
 module Window = {
-  let createElement(::style,::children,()) {displayName: "window"};
+  let createElement(:style,:children,()) {displayName: "window"};
 };
 
 let w =

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -284,10 +284,10 @@ let (++) = (++);
 
 let (++): int = int = (++);
 
-(++)(:label 20, :label2 30) + 40;
+(++)(:label=20, :label2=30) + 40;
 
 /* Should be parsed as: */
-(++)(:label 20, :label2 30) + 40;
+(++)(:label=20, :label2=30) + 40;
 
 /* Great idea! */
 let (==) (a, b) = a < 0;
@@ -950,27 +950,27 @@ let code =
          Requires.(
            create
            |> import_type(
-                :local "Set",
-                :source "Set"
+                :local="Set",
+                :source="Set"
               )
            |> import_type(
-                :local "Map",
-                :source "Map"
+                :local="Map",
+                :source="Map"
               )
            |> import_type(
-                :local "Immutable",
-                :source "immutable"
+                :local="Immutable",
+                :source="immutable"
               )
            |> require(
-                :local "invariant",
-                :source "invariant"
+                :local="invariant",
+                :source="invariant"
               )
            |> require(
-                :local "Image",
-                :source "Image.react"
+                :local="Image",
+                :source="Image.react"
               )
            |> side_effect(
-                :source "monkey_patches"
+                :source="monkey_patches"
               )
            |> render_lines
          )

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -844,10 +844,10 @@ let explictlyPassedAnnotated: int =
 /*U: Explicitly passing optional with identifier expression */
 let a = None;
 
-let explictlyPassed = myOptional(:a=?, :b=?None);
+let explictlyPassed = myOptional(:a?, :b=?None);
 
 let explictlyPassedAnnotated: int =
-  myOptional(:a=?, :b=?None);
+  myOptional(:a?, :b=?None);
 
 let nestedLet = {
   let _ = 1;

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -759,9 +759,9 @@ let named (:a, :b) = a + b;
 type named = (:a int, :b int) => int;
 
 /*B*/
-let namedAlias (:a aa, :b bb) = aa + bb;
+let namedAlias (:a as aa, :b as bb) = aa + bb;
 
-let namedAlias (:a aa, :b bb) = aa + bb;
+let namedAlias (:a as aa, :b as bb) = aa + bb;
 
 type namedAlias = (:a int, :b int) => int;
 
@@ -769,7 +769,8 @@ type namedAlias = (:a int, :b int) => int;
 let namedAnnot (:a: int, :b: int) = 20;
 
 /*D*/
-let namedAliasAnnot (:a aa: int, :b bb: int) = 20;
+let namedAliasAnnot
+    (:a as aa: int, :b as bb: int) = 20;
 
 /*E*/
 let myOptional (:a=?, :b=?, ()) = 10;
@@ -777,14 +778,14 @@ let myOptional (:a=?, :b=?, ()) = 10;
 type named = (:a int?, :b int?, unit) => int;
 
 /*F*/
-let optionalAlias (:a aa=?, :b bb=?, ()) = 10;
+let optionalAlias (:a as aa=?, :b as bb=?, ()) = 10;
 
 /*G*/
 let optionalAnnot (:a: int=?, :b: int=?, ()) = 10;
 
 /*H*/
 let optionalAliasAnnot
-    (:a aa: int=?, :b bb: int=?, ()) = 10;
+    (:a as aa: int=?, :b as bb: int=?, ()) = 10;
 
 /*I: */
 let defOptional (:a=10, :b=10, ()) = 10;
@@ -792,14 +793,15 @@ let defOptional (:a=10, :b=10, ()) = 10;
 type named = (:a int?, :b int?, unit) => int;
 
 /*J*/
-let defOptionalAlias (:a aa=10, :b bb=10, ()) = 10;
+let defOptionalAlias
+    (:a as aa=10, :b as bb=10, ()) = 10;
 
 /*K*/
 let defOptionalAnnot (:a: int=10, :b: int=10, ()) = 10;
 
 /*L*/
 let defOptionalAliasAnnot
-    (:a aa: int=10, :b bb: int=10, ()) = 10;
+    (:a as aa: int=10, :b as bb: int=10, ()) = 10;
 
 /*M: Invoking them - Punned */
 let resNotAnnotated = named(:a, :b);
@@ -824,19 +826,19 @@ let resAnnotated: ty = named(:a, b);
 
 /*S: Explicitly passed optionals are a nice way to say "use the default value"*/
 let explictlyPassed =
-  myOptional(:a? None, :b? None);
+  myOptional(:a=?None, :b=?None);
 
 /*T: Annotating the return value of the entire function call */
 let explictlyPassedAnnotated: int =
-  myOptional(:a? None, :b? None);
+  myOptional(:a=?None, :b=?None);
 
 /*U: Explicitly passing optional with identifier expression */
 let a = None;
 
-let explictlyPassed = myOptional(:a?, :b? None);
+let explictlyPassed = myOptional(:a=?, :b=?None);
 
 let explictlyPassedAnnotated: int =
-  myOptional(:a?, :b? None);
+  myOptional(:a=?, :b=?None);
 
 let nestedLet = {
   let _ = 1;
@@ -888,8 +890,8 @@ let f
 
 let x =
   callSomeFunction(
-    :withArg 10,
-    :andOtherArg wrappedArg
+    :withArg=10,
+    :andOtherArg=wrappedArg
   );
 
 let res = {
@@ -942,7 +944,7 @@ let newRecord = {
   ...(
     youCanEvenCallMethodsHereAndAnnotate(
       them,
-      :named 10
+      :named=10
     ): someRec
   ),
   blah: 0,
@@ -961,7 +963,7 @@ let something: blah = typeAnnotation(thing);
 
 let newRecord = {
   ...(
-    heresAFunctionWithNamedArgs(:argOne i): annotatedResult
+    heresAFunctionWithNamedArgs(:argOne=i): annotatedResult
   ),
   soAsToInstill: 0,
   developmentHabbits: 1
@@ -1019,7 +1021,8 @@ let match = "match";
 
 let method = "method";
 
-let foo (x, :x bar, :z, :foo bar, :foo z) =
+let foo
+    (x, :x as bar, :z, :foo as bar, :foo as z) =
   bar + 2;
 
 let zzz = myFunc(1, 2, [||]);

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -57,59 +57,68 @@ type myRecordType = {
 };
 
 type firstNamedArgShouldBeGroupedInParens =
-  (:first int => int, :second int) => int;
+  (:first: int => int, :second: int) => int;
 
 type allParensCanBeRemoved =
-  (:first int, :second int, :third int) => int;
+  (:first: int, :second: int, :third: int) => int;
 
 type firstTwoShouldBeGroupedAndFirstThree =
-  (:first (int => int) => int) => int;
+  (:first: (int => int) => int) => int;
 
 /* Same thing now, but with type constructors instead of int */
 type firstNamedArgShouldBeGroupedInParens =
   (
-    :first list(int) => list(int),
-    :second list(int)
+    :first: list(int) => list(int),
+    :second: list(int)
   ) =>
   list(int);
 
 type allParensCanBeRemoved =
   (
-    :first list(int),
-    :second list(int),
-    :third list(int)
+    :first: list(int),
+    :second: list(int),
+    :third: list(int)
   ) =>
   list(int);
 
 type firstTwoShouldBeGroupedAndFirstThree =
   (
-    :first (list(int) => list(int)) => list(int)
+    :first: (list(int) => list(int)) => list(int)
   ) =>
   list(int);
 
 type firstNamedArgShouldBeGroupedInParens =
-  (:first int => int?, :second list(int)?) => int;
+  (:first: int => int=?, :second: list(int)=?) =>
+  int;
 
 /* The arrow necessitates parens around the next two args. The ? isn't what
  * makes the parens necessary. */
 type firstNamedArgShouldBeGroupedInParensAndSecondNamedArg =
-  (:first int => int?, :second int => int?) =>
+  (
+    :first: int => int=?,
+    :second: int => int=?
+  ) =>
   int;
 
 type allParensCanBeRemoved =
-  (:first int?, :second int?, :third int?) => int;
+  (
+    :first: int=?,
+    :second: int=?,
+    :third: int=?
+  ) =>
+  int;
 
 type firstTwoShouldBeGroupedAndFirstThree =
-  (:first (int => int) => int) => int;
+  (:first: (int => int) => int) => int;
 
 type noParens =
-  (:one int, int, int, :two int) => int;
+  (:one: int, int, int, :two: int) => int;
 
 type noParensNeeded =
-  (:one int, int, int, :two int) => int;
+  (:one: int, int, int, :two: int) => int;
 
 type firstNamedArgNeedsParens =
-  (:one (int, int) => int, :two int) => int;
+  (:one: (int, int) => int, :two: int) => int;
 
 /* Now, let's try type aliasing */
 /* Unless wrapped in parens, types between arrows may not be aliased, may not
@@ -756,14 +765,14 @@ let b = 20;
 /*A*/
 let named (:a, :b) = a + b;
 
-type named = (:a int, :b int) => int;
+type named = (:a: int, :b: int) => int;
 
 /*B*/
 let namedAlias (:a as aa, :b as bb) = aa + bb;
 
 let namedAlias (:a as aa, :b as bb) = aa + bb;
 
-type namedAlias = (:a int, :b int) => int;
+type namedAlias = (:a: int, :b: int) => int;
 
 /*C*/
 let namedAnnot (:a: int, :b: int) = 20;
@@ -775,7 +784,7 @@ let namedAliasAnnot
 /*E*/
 let myOptional (:a=?, :b=?, ()) = 10;
 
-type named = (:a int?, :b int?, unit) => int;
+type named = (:a: int=?, :b: int=?, unit) => int;
 
 /*F*/
 let optionalAlias (:a as aa=?, :b as bb=?, ()) = 10;
@@ -790,7 +799,7 @@ let optionalAliasAnnot
 /*I: */
 let defOptional (:a=10, :b=10, ()) = 10;
 
-type named = (:a int?, :b int?, unit) => int;
+type named = (:a: int=?, :b: int=?, unit) => int;
 
 /*J*/
 let defOptionalAlias
@@ -865,23 +874,26 @@ let nestedLet = {
  */
 type typeWithNestedNamedArgs =
   (
-    :outerOne (:innerOne int, :innerTwo int) =>
-              int,
-    :outerTwo int
+    :outerOne: (:innerOne: int, :innerTwo: int) =>
+               int,
+    :outerTwo: int
   ) =>
   int;
 
 type typeWithNestedOptionalNamedArgs =
   (
-    :outerOne (:innerOne int, :innerTwo int) =>
-              int
-                ?,
-    :outerTwo int?
+    :outerOne: (:innerOne: int, :innerTwo: int) =>
+               int
+                 =?,
+    :outerTwo: int=?
   ) =>
   int;
 
 type typeWithNestedOptionalNamedArgs =
-  (:outerOne list(string)?, :outerTwo int?) =>
+  (
+    :outerOne: list(string)=?,
+    :outerTwo: int=?
+  ) =>
   int;
 
 let f

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -303,7 +303,7 @@ let explictlyPassed =
   optional
     /* a::? */
     (
-      :a=?,
+      :a?,
       /* b::? */
       /* None; */
       :b=?None

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -118,9 +118,9 @@ let named
 let namedAlias
     /* a::aa */
     (
-      :a aa,
+      :a as aa,
       /* b::bb */
-      :b bb
+      :b as bb
     ) =
   /* aa + bb */
   aa + bb;
@@ -140,9 +140,9 @@ let namedAnnot
 let namedAliasAnnot
     /* a::(aa: option int) */
     (
-      :a aa: option(int),
+      :a as aa: option(int),
       /* b::(bb: option int) */
-      :b bb: option(int)
+      :b as bb: option(int)
     ) =
   /* 20 */
   20;
@@ -164,9 +164,9 @@ let optional
 let optionalAlias
     /* a::aa */
     (
-      :a aa=?,
+      :a as aa=?,
       /* ?b:bb */
-      :b bb=?,
+      :b as bb=?,
       /* () */
       ()
     ) =
@@ -190,9 +190,9 @@ let optionalAnnot
 let optionalAliasAnnot
     /* a::(aa: option int)=? */
     (
-      :a aa: option(int)=?,
+      :a as aa: option(int)=?,
       /* b::(bb: option int)=? */
-      :b bb: option(int)=?,
+      :b as bb: option(int)=?,
       /* () = */
       ()
     ) =
@@ -216,9 +216,9 @@ let defOptional
 let defOptionalAlias
     /* a::aa=10 */
     (
-      :a aa=10,
+      :a as aa=10,
       /* b::bb=10 */
-      :b bb=10,
+      :b as bb=10,
       /* () = */
       ()
     ) =
@@ -242,9 +242,9 @@ let defOptionalAnnot
 let defOptionalAliasAnnot
     /* a::(aa:int)=10 */
     (
-      :a aa: int=10,
+      :a as aa: int=10,
       /* b::(bb:int)=10 */
-      :b bb: int=10,
+      :b as bb: int=10,
       /* () = */
       ()
     ) =
@@ -290,10 +290,10 @@ let explictlyPassed =
     /* a::? */
     /* None */
     (
-      :a? None,
+      :a=?None,
       /* b::? */
       /* None; */
-      :b? None
+      :b=?None
     );
 
 let a = None;
@@ -303,10 +303,10 @@ let explictlyPassed =
   optional
     /* a::? */
     (
-      :a?,
+      :a=?,
       /* b::? */
       /* None; */
-      :b? None
+      :b=?None
     );
 
 let complex_default (:callback=(k, d) => 4, x) = 3;

--- a/formatTest/unit_tests/expected_output/wrappingTest.rei
+++ b/formatTest/unit_tests/expected_output/wrappingTest.rei
@@ -1,34 +1,36 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
-let named: (:a int, :b int) => int;
+let named: (:a: int, :b: int) => int;
 
-let namedAlias: (:a int, :b int) => int;
+let namedAlias: (:a: int, :b: int) => int;
 
 let namedAnnot:
-  (:a option(int), :b option(int)) => int;
+  (:a: option(int), :b: option(int)) => int;
 
 let namedAliasAnnot:
-  (:a option(int), :b option(int)) => int;
+  (:a: option(int), :b: option(int)) => int;
 
-let optional: (:a 'a?, :b 'b?, unit) => int;
+let optional: (:a: 'a=?, :b: 'b=?, unit) => int;
 
-let optionalAlias: (:a 'a?, :b 'b?, unit) => int;
+let optionalAlias:
+  (:a: 'a=?, :b: 'b=?, unit) => int;
 
 let optionalAnnot:
-  (:a int?, :b int?, unit) => int;
+  (:a: int=?, :b: int=?, unit) => int;
 
 let optionalAliasAnnot:
-  (:a int?, :b int?, unit) => int;
+  (:a: int=?, :b: int=?, unit) => int;
 
-let defOptional: (:a int?, :b int?, unit) => int;
+let defOptional:
+  (:a: int=?, :b: int=?, unit) => int;
 
 let defOptionalAlias:
-  (:a int?, :b int?, unit) => int;
+  (:a: int=?, :b: int=?, unit) => int;
 
 let defOptionalAnnot:
-  (:a int?, :b int?, unit) => int;
+  (:a: int=?, :b: int=?, unit) => int;
 
 let defOptionalAliasAnnot:
-  (:a int?, :b int?, unit) => int;
+  (:a: int=?, :b: int=?, unit) => int;
 
 let fun_option_int:
   (option(int), option(int)) => int;

--- a/formatTest/unit_tests/input/infix.re
+++ b/formatTest/unit_tests/input/infix.re
@@ -179,13 +179,13 @@ let res = first |> second;
 let res = (|>)(first);
 
 /* Custom infix with labeled args */
-let (|>)(:first first, :second second) = first + second;
+let (|>)(:first as first, :second as second) = first + second;
 
 /* Should NOT reformat named args to actually be placed infix */
-let res = (|>)(:first first, :second second);
+let res = (|>)(:first=first, :second=second);
 
 /* Curried shouldn't place infix */
-let res = (|>)(:first first);
+let res = (|>)(:first=first);
 
 /* Custom infix accepting *three* without labeled args */
 let (|>)(firsfirst,second,third) = first + second + third;
@@ -203,16 +203,16 @@ let res = (|>)(first);
 
 /* In fact, if even just one of the arguments are named, it shouldn't
  * be formatted or parsed as infix! */
-(|>)(first,:second second);
+(|>)(first,:second=second);
 
-(|>)(:first first,second);
+(|>)(:first=first,second);
 
-(|>)(first,second,:third third);
+(|>)(first,second,:third=third);
 
-(first |> second)(:third third);
+(first |> second)(:third=third);
 
 /* Infix has lower precedence than function application */
-first |> second(:third third);
+first |> second(:third=third);
 
 let leftAssocGrouping = first |> second |> third;
 
@@ -230,18 +230,18 @@ let res = blah && DataConstructor(10) && DataConstructor(10) + 10;
 /* Should be parsed as */
 let res = blah && DataConstructor(10) && DataConstructor(10) + 10;
 
-let (++)(:label label,:label2 label2) = label + label2;
+let (++)(:label as label,:label2 as label2) = label + label2;
 
-let (++)(:label label,:label2 label2) = label + label2;
+let (++)(:label as label,:label2 as label2) = label + label2;
 
 let (++) = (++);
 
 let (++): int = int = (++);
 
-(++)(:label 20, :label2 30) + 40;
+(++)(:label=20, :label2=30) + 40;
 
 /* Should be parsed as: */
-(++)(:label 20, :label2 30) + 40;
+(++)(:label=20, :label2=30) + 40;
 
 /* Great idea! */
 let (==)(a,b) = a < 0;
@@ -767,12 +767,12 @@ let code = JSCodegen.Code.(
   create
   |> lines(Requires.(
     create
-    |> import_type(:local "Set", :source "Set")
-    |> import_type(:local "Map", :source "Map")
-    |> import_type(:local "Immutable", :source "immutable")
-    |> require(:local "invariant", :source "invariant")
-    |> require(:local "Image", :source "Image.react")
-    |> side_effect(:source "monkey_patches")
+    |> import_type(:local="Set", :source="Set")
+    |> import_type(:local="Map", :source="Map")
+    |> import_type(:local="Immutable", :source="immutable")
+    |> require(:local="invariant", :source="invariant")
+    |> require(:local="Image", :source="Image.react")
+    |> side_effect(:source="monkey_patches")
     |> render_lines
   ))
   |> new_line

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -32,15 +32,15 @@ let y =
 let z =
   <div
     style=ReactDOMRe.Style.make(
-              ::width,
-              ::height,
-              ::color,
-              ::backgroundColor,
-              ::margin,
-              ::padding,
-              ::border,
-              ::borderColor,
-              ::someOtherAttribute,
+              :width,
+              :height,
+              :color,
+              :backgroundColor,
+              :margin,
+              :padding,
+              :border,
+              :borderColor,
+              :someOtherAttribute,
               ())
     key=string_of_int(1)
   />;

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -661,61 +661,61 @@ let a = 10;
 let b = 20;
 
 /*A*/
-let named                (:a a,   :b b)   = a + b;
+let named                (:a as a,   :b as b)   = a + b;
 type named =             (:a int, :b int) => int;
 /*B*/
-let namedAlias           (:a aa,  :b bb)  = aa + bb;
-let namedAlias           (:a aa,  :b bb)  = aa + bb;
+let namedAlias           (:a as aa,  :b as bb)  = aa + bb;
+let namedAlias           (:a as aa,  :b as bb)  = aa + bb;
 type namedAlias =        (:a int, :b int) => int;
 /*C*/
 let namedAnnot           (:a :int, :b :int)  = 20;
 /*D*/
-let namedAliasAnnot      (:a aa:int,:b bb:int) = 20;
+let namedAliasAnnot      (:a as aa:int,:b as bb:int) = 20;
 /*E*/
 let myOptional           (:a=?,    :b=?,      ()) = 10;
 type named =             (:a int?, :b int?, unit) => int;
 /*F*/
-let optionalAlias        (:a aa=?,  :b bb=?,  ()) = 10;
+let optionalAlias        (:a as aa=?,  :b as bb=?,  ()) = 10;
 /*G*/                       
-let optionalAnnot        (:a a:int =?, :b b:int=?, ()) = 10;
+let optionalAnnot        (:a as a:int =?, :b as b:int=?, ()) = 10;
 /*H*/                       
-let optionalAliasAnnot   (:a aa:int =?, :b bb:int=?, ()) = 10;
+let optionalAliasAnnot   (:a as aa:int =?, :b as bb:int=?, ()) = 10;
 /*I: */                     
-let defOptional          (:a a=10, :b b=10, ()) = 10;
+let defOptional          (:a as a=10, :b as b=10, ()) = 10;
 type named =             (:a int?, :b int?, unit) => int;
 /*J*/                       
-let defOptionalAlias     (:a aa=10, :b bb=10, ()) = 10;
+let defOptionalAlias     (:a as aa=10, :b as bb=10, ()) = 10;
 /*K*/                       
-let defOptionalAnnot     (:a a:int=10, :b b:int=10, ()) = 10;
+let defOptionalAnnot     (:a as a:int=10, :b as b:int=10, ()) = 10;
 /*L*/                       
-let defOptionalAliasAnnot(:a aa:int=10, :b bb:int=10, ()) = 10;
+let defOptionalAliasAnnot(:a as aa:int=10, :b as bb:int=10, ()) = 10;
 
 /*M: Invoking them - Punned */
-let resNotAnnotated = named(:a a,:b b);
+let resNotAnnotated = named(:a=a,:b=b);
 /*N:*/
-let resAnnotated    = (named(:a a,:b b):int);
+let resAnnotated    = (named(:a=a,:b=b):int);
 /*O: Invoking them */
-let resNotAnnotated = named(:a a,:b b);
+let resNotAnnotated = named(:a=a,:b=b);
 /*P: Invoking them */
-let resAnnotated    = (named(:a a,:b b):int);
+let resAnnotated    = (named(:a=a,:b=b):int);
 
 /*Q: Here's why "punning" doesn't work!  */
 /* Is b:: punned with a final non-named arg, or is b:: supplied b as one named arg? */
 let b = 20;
-let resAnnotated    = (named(:a a,:b b));
+let resAnnotated    = (named(:a=a,:b=b));
 
 /*R: Proof that there are no ambiguities with return values being annotated */
-let resAnnotated    = (named(:a a,b):ty);
+let resAnnotated    = (named(:a=a,b):ty);
 
 
 /*S: Explicitly passed optionals are a nice way to say "use the default value"*/
-let explictlyPassed =          myOptional(a::?None,b::?None);
+let explictlyPassed =          myOptional(:a=?None,:b=?None);
 /*T: Annotating the return value of the entire function call */
-let explictlyPassedAnnotated = (myOptional(a::?None,b::?None):int);
+let explictlyPassedAnnotated = (myOptional(:a=?None,:b=?None):int);
 /*U: Explicitly passing optional with identifier expression */
 let a = None;
-let explictlyPassed =           myOptional(a::?a,b::?None);
-let explictlyPassedAnnotated = (myOptional(a::?a,b::?None):int);
+let explictlyPassed =           myOptional(:a=?a,:b=?None);
+let explictlyPassedAnnotated = (myOptional(:a=?a,:b=?None):int);
 
 let nestedLet = {
   let _ = 1
@@ -752,8 +752,8 @@ let f(:tuple="long string to trigger line break") = ();
 
 let x =
   callSomeFunction
-   (withArg::10,
-    andOtherArg::wrappedArg);
+   (:withArg=10,
+    :andOtherArg=wrappedArg);
 
 
 let res = {
@@ -796,7 +796,7 @@ let newRecord = {
 };
 
 let newRecord = {
-  ...youCanEvenCallMethodsHereAndAnnotate(them,named::10):someRec,
+  ...youCanEvenCallMethodsHereAndAnnotate(them,:named=10):someRec,
   blah: 0,
   foo: 1
 };
@@ -814,7 +814,7 @@ let something = (thisIsANamedArg(thing):blah);
 let something = (typeAnnotation(thing): blah);
 
 let newRecord = {
-  ...(heresAFunctionWithNamedArgs(argOne::i) :annotatedResult),
+  ...(heresAFunctionWithNamedArgs(:argOne=i) :annotatedResult),
   soAsToInstill: 0,
   developmentHabbits: 1
 };
@@ -862,7 +862,7 @@ let match = "match";
 
 let method = "method";
 
-let foo(x,:x bar,:z,:foo bar,:foo z) {
+let foo(x,:x as bar,:z,:foo as bar,:foo as z) {
   bar + 2
 };
 

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -48,35 +48,35 @@ type myRecordType = {
 };
 
 type firstNamedArgShouldBeGroupedInParens =
-    (:first (int) => int, :second int) => int;
+    (:first: (int) => int, :second: int) => int;
 type allParensCanBeRemoved =
-    (:first int) => ((:second int) => ((:third int) => int));
+    (:first: int) => ((:second: int) => ((:third: int) => int));
 type firstTwoShouldBeGroupedAndFirstThree =
-    (:first ((int) => int) => int) => int;
+    (:first: ((int) => int) => int) => int;
 
 /* Same thing now, but with type constructors instead of int */
 type firstNamedArgShouldBeGroupedInParens =
-    (:first (list(int)) => list(int)) => (:second list(int)) => list(int);
+    (:first: (list(int)) => list(int)) => (:second: list(int)) => list(int);
 type allParensCanBeRemoved =
-    (:first list(int)) => (:second list(int)) => (:third list(int)) => list(int);
+    (:first: list(int)) => (:second: list(int)) => (:third: list(int)) => list(int);
 type firstTwoShouldBeGroupedAndFirstThree =
-    (:first ((list(int)) => list(int)) => list(int)) => list(int);
+    (:first: ((list(int)) => list(int)) => list(int)) => list(int);
 
 
 type firstNamedArgShouldBeGroupedInParens =
-    (:first ((int) => int)?, :second list(int)?) => int;
+    (:first: ((int) => int)=?, :second: list(int)=?) => int;
 /* The arrow necessitates parens around the next two args. The ? isn't what
  * makes the parens necessary. */
 type firstNamedArgShouldBeGroupedInParensAndSecondNamedArg =
-    (:first ((int) => int)?, :second ((int) => int)?) => int;
+    (:first: ((int) => int)=?, :second: ((int) => int)=?) => int;
 type allParensCanBeRemoved =
-    (:first int?, :second int?, :third int?) => int;
+    (:first: int=?, :second: int=?, :third: int=?) => int;
 type firstTwoShouldBeGroupedAndFirstThree =
-    (:first (((int) => int) => int)) => int;
+    (:first: (((int) => int) => int)) => int;
 
-type noParens = (:one int, int, int, :two int) => int;
-type noParensNeeded = (:one int) => ((int) => ((int) => ((:two int) => int)));
-type firstNamedArgNeedsParens = (:one (int, int) => int, :two int) => int;
+type noParens = (:one: int, int, int, :two: int) => int;
+type noParensNeeded = (:one: int) => ((int) => ((int) => ((:two: int) => int)));
+type firstNamedArgNeedsParens = (:one: (int, int) => int, :two: int) => int;
 
 /* Now, let's try type aliasing */
 /* Unless wrapped in parens, types between arrows may not be aliased, may not
@@ -662,18 +662,18 @@ let b = 20;
 
 /*A*/
 let named                (:a as a,   :b as b)   = a + b;
-type named =             (:a int, :b int) => int;
+type named =             (:a: int, :b: int) => int;
 /*B*/
 let namedAlias           (:a as aa,  :b as bb)  = aa + bb;
 let namedAlias           (:a as aa,  :b as bb)  = aa + bb;
-type namedAlias =        (:a int, :b int) => int;
+type namedAlias =        (:a: int, :b: int) => int;
 /*C*/
 let namedAnnot           (:a :int, :b :int)  = 20;
 /*D*/
 let namedAliasAnnot      (:a as aa:int,:b as bb:int) = 20;
 /*E*/
 let myOptional           (:a=?,    :b=?,      ()) = 10;
-type named =             (:a int?, :b int?, unit) => int;
+type named =             (:a: int=?, :b: int=?, unit) => int;
 /*F*/
 let optionalAlias        (:a as aa=?,  :b as bb=?,  ()) = 10;
 /*G*/                       
@@ -682,7 +682,7 @@ let optionalAnnot        (:a as a:int =?, :b as b:int=?, ()) = 10;
 let optionalAliasAnnot   (:a as aa:int =?, :b as bb:int=?, ()) = 10;
 /*I: */                     
 let defOptional          (:a as a=10, :b as b=10, ()) = 10;
-type named =             (:a int?, :b int?, unit) => int;
+type named =             (:a: int=?, :b: int=?, unit) => int;
 /*J*/                       
 let defOptionalAlias     (:a as aa=10, :b as bb=10, ()) = 10;
 /*K*/                       
@@ -740,13 +740,13 @@ let nestedLet = {
  */
 
 type typeWithNestedNamedArgs =
-    (:outerOne (:innerOne int, :innerTwo int) => int, :outerTwo int) => int;
+    (:outerOne: (:innerOne: int, :innerTwo: int) => int, :outerTwo: int) => int;
 
 type typeWithNestedOptionalNamedArgs =
-    (:outerOne (:innerOne int, :innerTwo int) => int?, :outerTwo int?) => int;
+    (:outerOne: (:innerOne: int, :innerTwo: int) => int=?, :outerTwo: int=?) => int;
 
 type typeWithNestedOptionalNamedArgs =
-    (:outerOne list(string)?, :outerTwo int?) => int;
+    (:outerOne: list(string)=?, :outerTwo: int=?) => int;
 
 let f(:tuple="long string to trigger line break") = ();
 

--- a/formatTest/unit_tests/input/wrappingTest.re
+++ b/formatTest/unit_tests/input/wrappingTest.re
@@ -93,45 +93,45 @@ let b = 20;
 /*A*/
 let named
     /* a::a */
-   (:a a,
+   (:a as a,
     /* b::b */
-    :b b) =
+    :b as b) =
   /* a + b */
   a + b;
 
 /*B*/
 let namedAlias
     /* a::aa */
-   (:a aa,
+   (:a as aa,
     /* b::bb */
-    :b bb) =
+    :b as bb) =
   /* aa + bb */
   aa + bb;
 
 /*C*/
 let namedAnnot
     /* :a a: option(int) */
-   (:a a: option(int),
+   (:a as a: option(int),
     /* :b b: option(int) */
-    :b b: option(int)) =
+    :b as b: option(int)) =
   /* 20 */
   20;
 
 /*D*/
 let namedAliasAnnot
     /* a::(aa: option int) */
-   (:a aa: option(int),
+   (:a as aa: option(int),
     /* b::(bb: option int) */
-    :b bb: option(int)) =
+    :b as bb: option(int)) =
   /* 20 */
   20;
 
 /*E*/
 let optional
     /* a::a=? */
-   (:a a=?,
+   (:a as a=?,
     /* b::b=? */
-    :b b=?,
+    :b as b=?,
     /* () */
     ()) =
   /* 10 */
@@ -140,9 +140,9 @@ let optional
 /*F*/
 let optionalAlias
     /* a::aa */
-   (:a aa=?,
+   (:a as aa=?,
     /* ?b:bb */
-    :b bb=?,
+    :b as bb=?,
     /* () */
     ()) =
   /* 10 */
@@ -151,9 +151,9 @@ let optionalAlias
 /*G*/
 let optionalAnnot
     /* a::(a: option int)=? */
-   (a::(a: option(int))=?,
+   (:a: option(int)=?,
     /* ?b:(b: option int) */
-    b::(b: option(int))=?,
+    :b: option(int)=?,
     /* () */
     ()) =
   /* 10 */
@@ -162,9 +162,9 @@ let optionalAnnot
 /*H*/
 let optionalAliasAnnot
     /* a::(aa: option int)=? */
-   (a::(aa: option(int))=?,
+   (:a as aa: option(int)=?,
     /* b::(bb: option int)=? */
-    b::(bb: option(int))=?,
+    :b as bb: option(int)=?,
     /* () = */
     ()) =
   /* 10 */
@@ -172,9 +172,9 @@ let optionalAliasAnnot
 /*I: This one is really annoying? Where's the visual label?*/
 let defOptional
     /* a::a=10 */
-   (a::a=10,
+   (:a as a=10,
     /* b::b=10 */
-    b::b=10,
+    :b as b=10,
     /* () = */
     ()) =
   /* 10 */
@@ -183,9 +183,9 @@ let defOptional
 /*J*/
 let defOptionalAlias
     /* a::aa=10 */
-   (a::aa=10,
+   (:a as aa=10,
     /* b::bb=10 */
-    b::bb=10,
+    :b as bb=10,
     /* () = */
     ()) =
   /* 10; */
@@ -194,9 +194,9 @@ let defOptionalAlias
 /*K*/
 let defOptionalAnnot
     /* a::(a:int)=10 */
-   (a::(a:int)=10,
+   (:a :int=10,
     /* b::(b:int)=10 */
-    b::(b:int)=10,
+    :b :int=10,
     /* () = */
     ()) =
   /* 10; */
@@ -205,9 +205,9 @@ let defOptionalAnnot
 /*L*/
 let defOptionalAliasAnnot
     /* a::(aa:int)=10 */
-   (a::(aa:int)=10,
+   (:a as aa :int=10,
     /* b::(bb:int)=10 */
-    b::(bb:int)=10,
+    :b as bb :int=10,
     /* () = */
     ()) =
   /* 10; */
@@ -216,39 +216,39 @@ let defOptionalAliasAnnot
 /* Invoking them */
 named(
   /* a::a */
-  a::a,
+  :a=a,
   /* b::b; */
-  b::b
+  :b=b
 );
 
 named(
   /* a::a */
-  a::a,
+  :a=a,
   /* b::b; */
-  b::b
+  :b=b
 );
 
 optional(
   /* a::a */
-  a::a,
+  :a=a,
   /* b::b; */
-  b::b
+  :b=b
 );
 optional(
   /* a::a */
-  a::a,
+  :a=a,
   /* b::b; */
-  b::b
+  :b=b
 );
 let explictlyPassed =
   /* optional */
   optional(
     /* a::? */
-    a::?
+    :a=?
       /* None */
       None,
     /* b::? */
-    b::?
+    :b=?
       /* None; */
       None
 );
@@ -258,14 +258,14 @@ let explictlyPassed =
   /* optional */
   optional(
     /* a::? */
-    a::?a,
+    :a=?a,
     /* b::? */
-    b::?
+    :b=?
       /* None; */
       None);
 
 
-let complex_default(:callback callback=(fun(k,d) => 4),x) = 3;
+let complex_default(:callback as callback=(fun(k,d) => 4),x) = 3;
 
 
 let myList = /*CommentAfterEqualBeforeList */[1, 2, 3];
@@ -1289,9 +1289,9 @@ let df_myNonPolyFunc: ('a) => 'a = fun(o) => o;
 type nameBlahType = {nameBlah: int};
 
 let myFunc =
-  fun(firstArg::firstArg,
-      another::another,
-      fl::fl) => {
+  fun(:firstArg as firstArg,
+      :another as another,
+      :fl as fl) => {
     nameBlah: 10
   };
 

--- a/formatTest/unit_tests/input/wrappingTest.rei
+++ b/formatTest/unit_tests/input/wrappingTest.rei
@@ -1,28 +1,28 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
-let named : (:a int, :b int) => int;
+let named : (:a: int, :b: int) => int;
 
-let namedAlias : (:a int, :b int) => int;
+let namedAlias : (:a: int, :b: int) => int;
 
-let namedAnnot : (:a option(int), :b option(int)) => int;
+let namedAnnot : (:a: option(int), :b: option(int)) => int;
 
-let namedAliasAnnot : (:a option(int), :b option(int)) => int;
+let namedAliasAnnot : (:a: option(int), :b: option(int)) => int;
 
-let optional : (:a 'a?, :b 'b?, unit) => int;
+let optional : (:a: 'a=?, :b: 'b=?, unit) => int;
 
-let optionalAlias : (:a 'a?, :b 'b?, unit) => int;
+let optionalAlias : (:a: 'a=?, :b: 'b=?, unit) => int;
 
-let optionalAnnot : (:a int?, :b int?, unit) => int;
+let optionalAnnot : (:a: int=?, :b: int=?, unit) => int;
 
-let optionalAliasAnnot : (:a int?, :b int?, unit) => int;
+let optionalAliasAnnot : (:a: int=?, :b: int=?, unit) => int;
 
-let defOptional : (:a int?, :b int?, unit) => int;
+let defOptional : (:a: int=?, :b: int=?, unit) => int;
 
-let defOptionalAlias : (:a int?, :b int?, unit) => int;
+let defOptionalAlias : (:a: int=?, :b: int=?, unit) => int;
 
-let defOptionalAnnot : (:a int?, :b int?, unit) => int;
+let defOptionalAnnot : (:a: int=?, :b: int=?, unit) => int;
 
-let defOptionalAliasAnnot : (:a int?, :b int?, unit) => int;
+let defOptionalAliasAnnot : (:a: int=?, :b: int=?, unit) => int;
 
 let fun_option_int : (option(int), option(int)) => int;
 

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v2_1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v2_1.re
@@ -27,17 +27,17 @@ let divRef = ReactDOMRe.createElement("div", [||]);
 
 ReactDOMRe.createElement("div", [||]);
 
-ReactDOMRe.createElement("div", :props ReactDOMRe.props(:className "hello", ()), [||]);
+ReactDOMRe.createElement("div", :props=ReactDOMRe.props(:className="hello", ()), [||]);
 
 ReactDOMRe.createElement(
   "div",
-  :props ReactDOMRe.props(:className "hello", :width "10", ()),
+  :props=ReactDOMRe.props(:className="hello", :width="10", ()),
   [||]
 );
 
 ReactDOMRe.createElement(
   "div",
-  :props ReactDOMRe.props(:className "hello", :width "10", ()),
+  :props=ReactDOMRe.props(:className="hello", :width="10", ()),
   [|
     ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
     ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
@@ -46,20 +46,20 @@ ReactDOMRe.createElement(
 
 ReactDOMRe.createElement(
   "div",
-  :props
-    ReactDOMRe.props(:className "hello", :comp ReasonReact.element(Foo.make(:bar 1, [||])), ()),
-  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(:bar 2, [||]))|]
+  :props=
+    ReactDOMRe.props(:className="hello", :comp=ReasonReact.element(Foo.make(:bar=1, [||])), ()),
+  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(:bar=2, [||]))|]
 );
 
 ReactDOMRe.createElement(
   "div",
-  :props
+  :props=
     ReactDOMRe.props(
-      :className "hello",
-      :compCallback () => ReasonReact.element(Foo.make(:bar 1, [||])),
+      :className="hello",
+      :compCallback=() => ReasonReact.element(Foo.make(:bar=1, [||])),
       ()
     ),
-  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(:bar 2, [||])))()|]
+  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(:bar=2, [||])))()|]
 );
 
 "=== Custom component ===";
@@ -76,27 +76,27 @@ ReasonReact.element(
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", [||]));
+ReasonReact.element(Foo.make(:className="hello", [||]));
 
-ReasonReact.element(Foo.make(:className "hello", [|ReactDOMRe.createElement("div", [||])|]));
+ReasonReact.element(Foo.make(:className="hello", [|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make(:className="hello", [|ReasonReact.element(Bar.make([||]))|]));
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
+    :className="hello",
     [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|]
   )
 );
 
-ReasonReact.element(Foo.make(:className "hello", [|divRef, divRef|]));
+ReasonReact.element(Foo.make(:className="hello", [|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", :width "10", [||]));
+ReasonReact.element(Foo.make(:className="hello", :width="10", [||]));
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
-    :width "10",
+    :className="hello",
+    :width="10",
     [|
       ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
       ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
@@ -106,22 +106,22 @@ ReasonReact.element(
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
-    :comp ReasonReact.element(Bar.make(:bar 1, [||])),
-    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(:bar 2, [||]))|]
+    :className="hello",
+    :comp=ReasonReact.element(Bar.make(:bar=1, [||])),
+    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(:bar=2, [||]))|]
   )
 );
 
 ReasonReact.element(
   Foo.make(
-    :comp ReasonReact.element(Bar.make([|divRef, divRef|])),
+    :comp=ReasonReact.element(Bar.make([|divRef, divRef|])),
     [|ReactDOMRe.createElement("li", [||])|]
   )
 );
 
 ReasonReact.element(
   Foo.make(
-    :comp ReasonReact.element(Bar.make([|ReactDOMRe.createElement("div", [||])|])),
+    :comp=ReasonReact.element(Bar.make([|ReactDOMRe.createElement("div", [||])|])),
     [|ReactDOMRe.createElement("li", [||])|]
   )
 );
@@ -144,33 +144,33 @@ ReasonReact.element(Foo.make([|divRef|]));
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|() => 1|]));
+ReasonReact.element(Foo.make(:className="hello", [|() => 1|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|(1, 2)|]));
+ReasonReact.element(Foo.make(:className="hello", [|(1, 2)|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|[|1, 2|]|]));
+ReasonReact.element(Foo.make(:className="hello", [|[|1, 2|]|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|divRef|]));
+ReasonReact.element(Foo.make(:className="hello", [|divRef|]));
 
 ReasonReact.element(
   Foo.make(
-    :comp ReasonReact.element(Bar.make([|divRef|])),
+    :comp=ReasonReact.element(Bar.make([|divRef|])),
     [|ReactDOMRe.createElement("li", [||])|]
   )
 );
 
 "=== With ref/key ===";
 
-ReasonReact.element(:key "someKey", Foo.make(:className "hello", [||]));
+ReasonReact.element(:key="someKey", Foo.make(:className="hello", [||]));
 
-ReasonReact.element(:key Some("someKey"), :ref Some(ref), Foo.make(:className "hello", [||]));
+ReasonReact.element(:key=Some("someKey"), :ref=Some(ref), Foo.make(:className="hello", [||]));
 
-ReasonReact.element(:key? Some("someKey"), :ref? Some(ref), Foo.make(:className "hello", [||]));
+ReasonReact.element(:key=?Some("someKey"), :ref=?Some(ref), Foo.make(:className="hello", [||]));
 
 ReasonReact.element(
-  :key "someKey",
-  :ref Some(ref),
-  Foo.Bar.make(:className "hello", [|ReasonReact.element(Bar.make([||]))|])
+  :key="someKey",
+  :ref=Some(ref),
+  Foo.Bar.make(:className="hello", [|ReasonReact.element(Bar.make([||]))|])
 );
 
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v2_2.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v2_2.re
@@ -29,17 +29,17 @@ let divRef = ReactDOMRe.createElement("div", [||]);
 
 ReactDOMRe.createElement("div", [||]);
 
-ReactDOMRe.createElement("div", :props ReactDOMRe.props(:className "hello", ()), [||]);
+ReactDOMRe.createElement("div", :props=ReactDOMRe.props(:className="hello", ()), [||]);
 
 ReactDOMRe.createElement(
   "div",
-  :props ReactDOMRe.props(:className "hello", :width "10", ()),
+  :props=ReactDOMRe.props(:className="hello", :width="10", ()),
   [||]
 );
 
 ReactDOMRe.createElement(
   "div",
-  :props ReactDOMRe.props(:className "hello", :width "10", ()),
+  :props=ReactDOMRe.props(:className="hello", :width="10", ()),
   [|
     ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
     ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
@@ -48,20 +48,20 @@ ReactDOMRe.createElement(
 
 ReactDOMRe.createElement(
   "div",
-  :props
-    ReactDOMRe.props(:className "hello", :comp ReasonReact.element(Foo.make(:bar 1, [||])), ()),
-  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(:bar 2, [||]))|]
+  :props=
+    ReactDOMRe.props(:className="hello", :comp=ReasonReact.element(Foo.make(:bar=1, [||])), ()),
+  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(:bar=2, [||]))|]
 );
 
 ReactDOMRe.createElement(
   "div",
-  :props
+  :props=
     ReactDOMRe.props(
-      :className "hello",
-      :compCallback () => ReasonReact.element(Foo.make(:bar 1, [||])),
+      :className="hello",
+      :compCallback=() => ReasonReact.element(Foo.make(:bar=1, [||])),
       ()
     ),
-  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(:bar 2, [||])))()|]
+  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(:bar=2, [||])))()|]
 );
 
 "=== Custom component ===";
@@ -78,27 +78,27 @@ ReasonReact.element(
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", [||]));
+ReasonReact.element(Foo.make(:className="hello", [||]));
 
-ReasonReact.element(Foo.make(:className "hello", [|ReactDOMRe.createElement("div", [||])|]));
+ReasonReact.element(Foo.make(:className="hello", [|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make(:className="hello", [|ReasonReact.element(Bar.make([||]))|]));
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
+    :className="hello",
     [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|]
   )
 );
 
-ReasonReact.element(Foo.make(:className "hello", [|divRef, divRef|]));
+ReasonReact.element(Foo.make(:className="hello", [|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", :width "10", [||]));
+ReasonReact.element(Foo.make(:className="hello", :width="10", [||]));
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
-    :width "10",
+    :className="hello",
+    :width="10",
     [|
       ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
       ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
@@ -108,22 +108,22 @@ ReasonReact.element(
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
-    :comp ReasonReact.element(Bar.make(:bar 1, [||])),
-    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(:bar 2, [||]))|]
+    :className="hello",
+    :comp=ReasonReact.element(Bar.make(:bar=1, [||])),
+    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(:bar=2, [||]))|]
   )
 );
 
 ReasonReact.element(
   Foo.make(
-    :comp ReasonReact.element(Bar.make([|divRef, divRef|])),
+    :comp=ReasonReact.element(Bar.make([|divRef, divRef|])),
     [|ReactDOMRe.createElement("li", [||])|]
   )
 );
 
 ReasonReact.element(
   Foo.make(
-    :comp ReasonReact.element(Bar.make([|ReactDOMRe.createElement("div", [||])|])),
+    :comp=ReasonReact.element(Bar.make([|ReactDOMRe.createElement("div", [||])|])),
     [|ReactDOMRe.createElement("li", [||])|]
   )
 );
@@ -146,33 +146,33 @@ ReasonReact.element(Foo.make([|divRef|]));
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|() => 1|]));
+ReasonReact.element(Foo.make(:className="hello", [|() => 1|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|(1, 2)|]));
+ReasonReact.element(Foo.make(:className="hello", [|(1, 2)|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|[|1, 2|]|]));
+ReasonReact.element(Foo.make(:className="hello", [|[|1, 2|]|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|divRef|]));
+ReasonReact.element(Foo.make(:className="hello", [|divRef|]));
 
 ReasonReact.element(
   Foo.make(
-    :comp ReasonReact.element(Bar.make([|divRef|])),
+    :comp=ReasonReact.element(Bar.make([|divRef|])),
     [|ReactDOMRe.createElement("li", [||])|]
   )
 );
 
 "=== With ref/key ===";
 
-ReasonReact.element(:key "someKey", Foo.make(:className "hello", [||]));
+ReasonReact.element(:key="someKey", Foo.make(:className="hello", [||]));
 
-ReasonReact.element(:key Some("someKey"), :ref Some(ref), Foo.make(:className "hello", [||]));
+ReasonReact.element(:key=Some("someKey"), :ref=Some(ref), Foo.make(:className="hello", [||]));
 
-ReasonReact.element(:key? Some("someKey"), :ref? Some(ref), Foo.make(:className "hello", [||]));
+ReasonReact.element(:key=?Some("someKey"), :ref=?Some(ref), Foo.make(:className="hello", [||]));
 
 ReasonReact.element(
-  :key "someKey",
-  :ref Some(ref),
-  Foo.Bar.make(:className "hello", [|ReasonReact.element(Bar.make([||]))|])
+  :key="someKey",
+  :ref=Some(ref),
+  Foo.Bar.make(:className="hello", [|ReasonReact.element(Bar.make([||]))|])
 );
 
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v2_3.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v2_3.re
@@ -29,17 +29,17 @@ let divRef = ReactDOMRe.createElement("div", [||]);
 
 ReactDOMRe.createElement("div", [||]);
 
-ReactDOMRe.createElement("div", :props ReactDOMRe.props(:className "hello", ()), [||]);
+ReactDOMRe.createElement("div", :props=ReactDOMRe.props(:className="hello", ()), [||]);
 
 ReactDOMRe.createElement(
   "div",
-  :props ReactDOMRe.props(:className "hello", :width "10", ()),
+  :props=ReactDOMRe.props(:className="hello", :width="10", ()),
   [||]
 );
 
 ReactDOMRe.createElement(
   "div",
-  :props ReactDOMRe.props(:className "hello", :width "10", ()),
+  :props=ReactDOMRe.props(:className="hello", :width="10", ()),
   [|
     ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
     ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
@@ -48,20 +48,20 @@ ReactDOMRe.createElement(
 
 ReactDOMRe.createElement(
   "div",
-  :props
-    ReactDOMRe.props(:className "hello", :comp ReasonReact.element(Foo.make(:bar 1, [||])), ()),
-  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(:bar 2, [||]))|]
+  :props=
+    ReactDOMRe.props(:className="hello", :comp=ReasonReact.element(Foo.make(:bar=1, [||])), ()),
+  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(:bar=2, [||]))|]
 );
 
 ReactDOMRe.createElement(
   "div",
-  :props
+  :props=
     ReactDOMRe.props(
-      :className "hello",
-      :compCallback () => ReasonReact.element(Foo.make(:bar 1, [||])),
+      :className="hello",
+      :compCallback=() => ReasonReact.element(Foo.make(:bar=1, [||])),
       ()
     ),
-  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(:bar 2, [||])))()|]
+  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(:bar=2, [||])))()|]
 );
 
 "=== Custom component ===";
@@ -78,27 +78,27 @@ ReasonReact.element(
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", [||]));
+ReasonReact.element(Foo.make(:className="hello", [||]));
 
-ReasonReact.element(Foo.make(:className "hello", [|ReactDOMRe.createElement("div", [||])|]));
+ReasonReact.element(Foo.make(:className="hello", [|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make(:className="hello", [|ReasonReact.element(Bar.make([||]))|]));
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
+    :className="hello",
     [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|]
   )
 );
 
-ReasonReact.element(Foo.make(:className "hello", [|divRef, divRef|]));
+ReasonReact.element(Foo.make(:className="hello", [|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", :width "10", [||]));
+ReasonReact.element(Foo.make(:className="hello", :width="10", [||]));
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
-    :width "10",
+    :className="hello",
+    :width="10",
     [|
       ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
       ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
@@ -108,22 +108,22 @@ ReasonReact.element(
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
-    :comp ReasonReact.element(Bar.make(:bar 1, [||])),
-    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(:bar 2, [||]))|]
+    :className="hello",
+    :comp=ReasonReact.element(Bar.make(:bar=1, [||])),
+    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(:bar=2, [||]))|]
   )
 );
 
 ReasonReact.element(
   Foo.make(
-    :comp ReasonReact.element(Bar.make([|divRef, divRef|])),
+    :comp=ReasonReact.element(Bar.make([|divRef, divRef|])),
     [|ReactDOMRe.createElement("li", [||])|]
   )
 );
 
 ReasonReact.element(
   Foo.make(
-    :comp ReasonReact.element(Bar.make([|ReactDOMRe.createElement("div", [||])|])),
+    :comp=ReasonReact.element(Bar.make([|ReactDOMRe.createElement("div", [||])|])),
     [|ReactDOMRe.createElement("li", [||])|]
   )
 );
@@ -146,30 +146,30 @@ ReasonReact.element(Foo.make(divRef));
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", () => 1));
+ReasonReact.element(Foo.make(:className="hello", () => 1));
 
-ReasonReact.element(Foo.make(:className "hello", (1, 2)));
+ReasonReact.element(Foo.make(:className="hello", (1, 2)));
 
-ReasonReact.element(Foo.make(:className "hello", [|1, 2|]));
+ReasonReact.element(Foo.make(:className="hello", [|1, 2|]));
 
-ReasonReact.element(Foo.make(:className "hello", divRef));
+ReasonReact.element(Foo.make(:className="hello", divRef));
 
 ReasonReact.element(
-  Foo.make(:comp ReasonReact.element(Bar.make(divRef)), [|ReactDOMRe.createElement("li", [||])|])
+  Foo.make(:comp=ReasonReact.element(Bar.make(divRef)), [|ReactDOMRe.createElement("li", [||])|])
 );
 
 "=== With ref/key ===";
 
-ReasonReact.element(:key "someKey", Foo.make(:className "hello", [||]));
+ReasonReact.element(:key="someKey", Foo.make(:className="hello", [||]));
 
-ReasonReact.element(:key Some("someKey"), :ref Some(ref), Foo.make(:className "hello", [||]));
+ReasonReact.element(:key=Some("someKey"), :ref=Some(ref), Foo.make(:className="hello", [||]));
 
-ReasonReact.element(:key? Some("someKey"), :ref? Some(ref), Foo.make(:className "hello", [||]));
+ReasonReact.element(:key=?Some("someKey"), :ref=?Some(ref), Foo.make(:className="hello", [||]));
 
 ReasonReact.element(
-  :key "someKey",
-  :ref Some(ref),
-  Foo.Bar.make(:className "hello", [|ReasonReact.element(Bar.make([||]))|])
+  :key="someKey",
+  :ref=Some(ref),
+  Foo.Bar.make(:className="hello", [|ReasonReact.element(Bar.make([||]))|])
 );
 
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v3_1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v3_1.re
@@ -27,17 +27,17 @@ let divRef = ReactDOMRe.createElement("div", [||]);
 
 ReactDOMRe.createElement("div", [||]);
 
-ReactDOMRe.createElement("div", :props ReactDOMRe.props(:className "hello", ()), [||]);
+ReactDOMRe.createElement("div", :props=ReactDOMRe.props(:className="hello", ()), [||]);
 
 ReactDOMRe.createElement(
   "div",
-  :props ReactDOMRe.props(:className "hello", :width "10", ()),
+  :props=ReactDOMRe.props(:className="hello", :width="10", ()),
   [||]
 );
 
 ReactDOMRe.createElement(
   "div",
-  :props ReactDOMRe.props(:className "hello", :width "10", ()),
+  :props=ReactDOMRe.props(:className="hello", :width="10", ()),
   [|
     ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
     ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
@@ -46,20 +46,20 @@ ReactDOMRe.createElement(
 
 ReactDOMRe.createElement(
   "div",
-  :props
-    ReactDOMRe.props(:className "hello", :comp ReasonReact.element(Foo.make(:bar 1, [||])), ()),
-  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(:bar 2, [||]))|]
+  :props=
+    ReactDOMRe.props(:className="hello", :comp=ReasonReact.element(Foo.make(:bar=1, [||])), ()),
+  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(:bar=2, [||]))|]
 );
 
 ReactDOMRe.createElement(
   "div",
-  :props
+  :props=
     ReactDOMRe.props(
-      :className "hello",
-      :compCallback () => ReasonReact.element(Foo.make(:bar 1, [||])),
+      :className="hello",
+      :compCallback=() => ReasonReact.element(Foo.make(:bar=1, [||])),
       ()
     ),
-  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(:bar 2, [||])))()|]
+  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(:bar=2, [||])))()|]
 );
 
 "=== Custom component ===";
@@ -76,27 +76,27 @@ ReasonReact.element(
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", [||]));
+ReasonReact.element(Foo.make(:className="hello", [||]));
 
-ReasonReact.element(Foo.make(:className "hello", [|ReactDOMRe.createElement("div", [||])|]));
+ReasonReact.element(Foo.make(:className="hello", [|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make(:className="hello", [|ReasonReact.element(Bar.make([||]))|]));
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
+    :className="hello",
     [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|]
   )
 );
 
-ReasonReact.element(Foo.make(:className "hello", [|divRef, divRef|]));
+ReasonReact.element(Foo.make(:className="hello", [|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", :width "10", [||]));
+ReasonReact.element(Foo.make(:className="hello", :width="10", [||]));
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
-    :width "10",
+    :className="hello",
+    :width="10",
     [|
       ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
       ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
@@ -106,22 +106,22 @@ ReasonReact.element(
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
-    :comp ReasonReact.element(Bar.make(:bar 1, [||])),
-    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(:bar 2, [||]))|]
+    :className="hello",
+    :comp=ReasonReact.element(Bar.make(:bar=1, [||])),
+    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(:bar=2, [||]))|]
   )
 );
 
 ReasonReact.element(
   Foo.make(
-    :comp ReasonReact.element(Bar.make([|divRef, divRef|])),
+    :comp=ReasonReact.element(Bar.make([|divRef, divRef|])),
     [|ReactDOMRe.createElement("li", [||])|]
   )
 );
 
 ReasonReact.element(
   Foo.make(
-    :comp ReasonReact.element(Bar.make([|ReactDOMRe.createElement("div", [||])|])),
+    :comp=ReasonReact.element(Bar.make([|ReactDOMRe.createElement("div", [||])|])),
     [|ReactDOMRe.createElement("li", [||])|]
   )
 );
@@ -144,30 +144,30 @@ ReasonReact.element(Foo.make(divRef));
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", () => 1));
+ReasonReact.element(Foo.make(:className="hello", () => 1));
 
-ReasonReact.element(Foo.make(:className "hello", (1, 2)));
+ReasonReact.element(Foo.make(:className="hello", (1, 2)));
 
-ReasonReact.element(Foo.make(:className "hello", [|1, 2|]));
+ReasonReact.element(Foo.make(:className="hello", [|1, 2|]));
 
-ReasonReact.element(Foo.make(:className "hello", divRef));
+ReasonReact.element(Foo.make(:className="hello", divRef));
 
 ReasonReact.element(
-  Foo.make(:comp ReasonReact.element(Bar.make(divRef)), [|ReactDOMRe.createElement("li", [||])|])
+  Foo.make(:comp=ReasonReact.element(Bar.make(divRef)), [|ReactDOMRe.createElement("li", [||])|])
 );
 
 "=== With ref/key ===";
 
-ReasonReact.element(:key "someKey", Foo.make(:className "hello", [||]));
+ReasonReact.element(:key="someKey", Foo.make(:className="hello", [||]));
 
-ReasonReact.element(:key Some("someKey"), :ref Some(ref), Foo.make(:className "hello", [||]));
+ReasonReact.element(:key=Some("someKey"), :ref=Some(ref), Foo.make(:className="hello", [||]));
 
-ReasonReact.element(:key? Some("someKey"), :ref? Some(ref), Foo.make(:className "hello", [||]));
+ReasonReact.element(:key=?Some("someKey"), :ref=?Some(ref), Foo.make(:className="hello", [||]));
 
 ReasonReact.element(
-  :key "someKey",
-  :ref Some(ref),
-  Foo.Bar.make(:className "hello", [|ReasonReact.element(Bar.make([||]))|])
+  :key="someKey",
+  :ref=Some(ref),
+  Foo.Bar.make(:className="hello", [|ReasonReact.element(Bar.make([||]))|])
 );
 
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v3_2.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v3_2.re
@@ -29,17 +29,17 @@ let divRef = ReactDOMRe.createElement("div", [||]);
 
 ReactDOMRe.createElement("div", [||]);
 
-ReactDOMRe.createElement("div", :props ReactDOMRe.props(:className "hello", ()), [||]);
+ReactDOMRe.createElement("div", :props=ReactDOMRe.props(:className="hello", ()), [||]);
 
 ReactDOMRe.createElement(
   "div",
-  :props ReactDOMRe.props(:className "hello", :width "10", ()),
+  :props=ReactDOMRe.props(:className="hello", :width="10", ()),
   [||]
 );
 
 ReactDOMRe.createElement(
   "div",
-  :props ReactDOMRe.props(:className "hello", :width "10", ()),
+  :props=ReactDOMRe.props(:className="hello", :width="10", ()),
   [|
     ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
     ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
@@ -48,20 +48,20 @@ ReactDOMRe.createElement(
 
 ReactDOMRe.createElement(
   "div",
-  :props
-    ReactDOMRe.props(:className "hello", :comp ReasonReact.element(Foo.make(:bar 1, [||])), ()),
-  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(:bar 2, [||]))|]
+  :props=
+    ReactDOMRe.props(:className="hello", :comp=ReasonReact.element(Foo.make(:bar=1, [||])), ()),
+  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(:bar=2, [||]))|]
 );
 
 ReactDOMRe.createElement(
   "div",
-  :props
+  :props=
     ReactDOMRe.props(
-      :className "hello",
-      :compCallback () => ReasonReact.element(Foo.make(:bar 1, [||])),
+      :className="hello",
+      :compCallback=() => ReasonReact.element(Foo.make(:bar=1, [||])),
       ()
     ),
-  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(:bar 2, [||])))()|]
+  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(:bar=2, [||])))()|]
 );
 
 "=== Custom component ===";
@@ -78,27 +78,27 @@ ReasonReact.element(
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", [||]));
+ReasonReact.element(Foo.make(:className="hello", [||]));
 
-ReasonReact.element(Foo.make(:className "hello", [|ReactDOMRe.createElement("div", [||])|]));
+ReasonReact.element(Foo.make(:className="hello", [|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make(:className="hello", [|ReasonReact.element(Bar.make([||]))|]));
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
+    :className="hello",
     [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|]
   )
 );
 
-ReasonReact.element(Foo.make(:className "hello", [|divRef, divRef|]));
+ReasonReact.element(Foo.make(:className="hello", [|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", :width "10", [||]));
+ReasonReact.element(Foo.make(:className="hello", :width="10", [||]));
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
-    :width "10",
+    :className="hello",
+    :width="10",
     [|
       ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
       ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
@@ -108,22 +108,22 @@ ReasonReact.element(
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
-    :comp ReasonReact.element(Bar.make(:bar 1, [||])),
-    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(:bar 2, [||]))|]
+    :className="hello",
+    :comp=ReasonReact.element(Bar.make(:bar=1, [||])),
+    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(:bar=2, [||]))|]
   )
 );
 
 ReasonReact.element(
   Foo.make(
-    :comp ReasonReact.element(Bar.make([|divRef, divRef|])),
+    :comp=ReasonReact.element(Bar.make([|divRef, divRef|])),
     [|ReactDOMRe.createElement("li", [||])|]
   )
 );
 
 ReasonReact.element(
   Foo.make(
-    :comp ReasonReact.element(Bar.make([|ReactDOMRe.createElement("div", [||])|])),
+    :comp=ReasonReact.element(Bar.make([|ReactDOMRe.createElement("div", [||])|])),
     [|ReactDOMRe.createElement("li", [||])|]
   )
 );
@@ -146,33 +146,33 @@ ReasonReact.element(Foo.make([|divRef|]));
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|() => 1|]));
+ReasonReact.element(Foo.make(:className="hello", [|() => 1|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|(1, 2)|]));
+ReasonReact.element(Foo.make(:className="hello", [|(1, 2)|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|[|1, 2|]|]));
+ReasonReact.element(Foo.make(:className="hello", [|[|1, 2|]|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|divRef|]));
+ReasonReact.element(Foo.make(:className="hello", [|divRef|]));
 
 ReasonReact.element(
   Foo.make(
-    :comp ReasonReact.element(Bar.make([|divRef|])),
+    :comp=ReasonReact.element(Bar.make([|divRef|])),
     [|ReactDOMRe.createElement("li", [||])|]
   )
 );
 
 "=== With ref/key ===";
 
-ReasonReact.element(:key "someKey", Foo.make(:className "hello", [||]));
+ReasonReact.element(:key="someKey", Foo.make(:className="hello", [||]));
 
-ReasonReact.element(:key Some("someKey"), :ref Some(ref), Foo.make(:className "hello", [||]));
+ReasonReact.element(:key=Some("someKey"), :ref=Some(ref), Foo.make(:className="hello", [||]));
 
-ReasonReact.element(:key? Some("someKey"), :ref? Some(ref), Foo.make(:className "hello", [||]));
+ReasonReact.element(:key=?Some("someKey"), :ref=?Some(ref), Foo.make(:className="hello", [||]));
 
 ReasonReact.element(
-  :key "someKey",
-  :ref Some(ref),
-  Foo.Bar.make(:className "hello", [|ReasonReact.element(Bar.make([||]))|])
+  :key="someKey",
+  :ref=Some(ref),
+  Foo.Bar.make(:className="hello", [|ReasonReact.element(Bar.make([||]))|])
 );
 
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v3_3.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v3_3.re
@@ -29,17 +29,17 @@ let divRef = ReactDOMRe.createElement("div", [||]);
 
 ReactDOMRe.createElement("div", [||]);
 
-ReactDOMRe.createElement("div", :props ReactDOMRe.props(:className "hello", ()), [||]);
+ReactDOMRe.createElement("div", :props=ReactDOMRe.props(:className="hello", ()), [||]);
 
 ReactDOMRe.createElement(
   "div",
-  :props ReactDOMRe.props(:className "hello", :width "10", ()),
+  :props=ReactDOMRe.props(:className="hello", :width="10", ()),
   [||]
 );
 
 ReactDOMRe.createElement(
   "div",
-  :props ReactDOMRe.props(:className "hello", :width "10", ()),
+  :props=ReactDOMRe.props(:className="hello", :width="10", ()),
   [|
     ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
     ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
@@ -48,20 +48,20 @@ ReactDOMRe.createElement(
 
 ReactDOMRe.createElement(
   "div",
-  :props
-    ReactDOMRe.props(:className "hello", :comp ReasonReact.element(Foo.make(:bar 1, [||])), ()),
-  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(:bar 2, [||]))|]
+  :props=
+    ReactDOMRe.props(:className="hello", :comp=ReasonReact.element(Foo.make(:bar=1, [||])), ()),
+  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(:bar=2, [||]))|]
 );
 
 ReactDOMRe.createElement(
   "div",
-  :props
+  :props=
     ReactDOMRe.props(
-      :className "hello",
-      :compCallback () => ReasonReact.element(Foo.make(:bar 1, [||])),
+      :className="hello",
+      :compCallback=() => ReasonReact.element(Foo.make(:bar=1, [||])),
       ()
     ),
-  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(:bar 2, [||])))()|]
+  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(:bar=2, [||])))()|]
 );
 
 "=== Custom component ===";
@@ -78,27 +78,27 @@ ReasonReact.element(
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", [||]));
+ReasonReact.element(Foo.make(:className="hello", [||]));
 
-ReasonReact.element(Foo.make(:className "hello", [|ReactDOMRe.createElement("div", [||])|]));
+ReasonReact.element(Foo.make(:className="hello", [|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make(:className "hello", [|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make(:className="hello", [|ReasonReact.element(Bar.make([||]))|]));
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
+    :className="hello",
     [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|]
   )
 );
 
-ReasonReact.element(Foo.make(:className "hello", [|divRef, divRef|]));
+ReasonReact.element(Foo.make(:className="hello", [|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", :width "10", [||]));
+ReasonReact.element(Foo.make(:className="hello", :width="10", [||]));
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
-    :width "10",
+    :className="hello",
+    :width="10",
     [|
       ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
       ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
@@ -108,22 +108,22 @@ ReasonReact.element(
 
 ReasonReact.element(
   Foo.make(
-    :className "hello",
-    :comp ReasonReact.element(Bar.make(:bar 1, [||])),
-    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(:bar 2, [||]))|]
+    :className="hello",
+    :comp=ReasonReact.element(Bar.make(:bar=1, [||])),
+    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(:bar=2, [||]))|]
   )
 );
 
 ReasonReact.element(
   Foo.make(
-    :comp ReasonReact.element(Bar.make([|divRef, divRef|])),
+    :comp=ReasonReact.element(Bar.make([|divRef, divRef|])),
     [|ReactDOMRe.createElement("li", [||])|]
   )
 );
 
 ReasonReact.element(
   Foo.make(
-    :comp ReasonReact.element(Bar.make([|ReactDOMRe.createElement("div", [||])|])),
+    :comp=ReasonReact.element(Bar.make([|ReactDOMRe.createElement("div", [||])|])),
     [|ReactDOMRe.createElement("li", [||])|]
   )
 );
@@ -146,30 +146,30 @@ ReasonReact.element(Foo.make(divRef));
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(:className "hello", () => 1));
+ReasonReact.element(Foo.make(:className="hello", () => 1));
 
-ReasonReact.element(Foo.make(:className "hello", (1, 2)));
+ReasonReact.element(Foo.make(:className="hello", (1, 2)));
 
-ReasonReact.element(Foo.make(:className "hello", [|1, 2|]));
+ReasonReact.element(Foo.make(:className="hello", [|1, 2|]));
 
-ReasonReact.element(Foo.make(:className "hello", divRef));
+ReasonReact.element(Foo.make(:className="hello", divRef));
 
 ReasonReact.element(
-  Foo.make(:comp ReasonReact.element(Bar.make(divRef)), [|ReactDOMRe.createElement("li", [||])|])
+  Foo.make(:comp=ReasonReact.element(Bar.make(divRef)), [|ReactDOMRe.createElement("li", [||])|])
 );
 
 "=== With ref/key ===";
 
-ReasonReact.element(:key "someKey", Foo.make(:className "hello", [||]));
+ReasonReact.element(:key="someKey", Foo.make(:className="hello", [||]));
 
-ReasonReact.element(:key Some("someKey"), :ref Some(ref), Foo.make(:className "hello", [||]));
+ReasonReact.element(:key=Some("someKey"), :ref=Some(ref), Foo.make(:className="hello", [||]));
 
-ReasonReact.element(:key? Some("someKey"), :ref? Some(ref), Foo.make(:className "hello", [||]));
+ReasonReact.element(:key=?Some("someKey"), :ref=?Some(ref), Foo.make(:className="hello", [||]));
 
 ReasonReact.element(
-  :key "someKey",
-  :ref Some(ref),
-  Foo.Bar.make(:className "hello", [|ReasonReact.element(Bar.make([||]))|])
+  :key="someKey",
+  :ref=Some(ref),
+  Foo.Bar.make(:className="hello", [|ReasonReact.element(Bar.make([||]))|])
 );
 
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/test1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test1.re
@@ -113,4 +113,4 @@ let divRef = <div />;
   Foo.createElement. Future-proof it in the ppx by transforming both to the
   correct ReasonReact-specific call */
 
-([@JSX] Foo.make(:children [], ()));
+([@JSX] Foo.make(:children=[], ()));

--- a/miscTests/reactjs_jsx_ppx_tests/test2.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test2.re
@@ -113,4 +113,4 @@ let divRef = <div />;
   Foo.createElement. Future-proof it in the ppx by transforming both to the
   correct ReasonReact-specific call */
 
-([@JSX] Foo.make(:children [], ()));
+([@JSX] Foo.make(:children=[], ()));

--- a/miscTests/reactjs_jsx_ppx_tests/test3.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test3.re
@@ -113,4 +113,4 @@ let divRef = <div />;
   Foo.createElement. Future-proof it in the ppx by transforming both to the
   correct ReasonReact-specific call */
 
-([@JSX] Foo.make(:children [], ()));
+([@JSX] Foo.make(:children=[], ()));

--- a/src/reason_parser.messages
+++ b/src/reason_parser.messages
@@ -1,6 +1,6 @@
 implementation: PLUSDOT UIDENT ELSE
 ##
-## Ends in an error in state: 1211.
+## Ends in an error in state: 1212.
 ##
 ## expr -> simple_expr_call . [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF DOCSTRING COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## expr -> simple_expr_call . DOT label_longident EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF DOCSTRING COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -25,8 +25,8 @@ implementation: PLUSDOT UIDENT ELSE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1213, spurious reduction of production constr_longident -> mod_longident
-## In state 1351, spurious reduction of production simple_expr_call -> constr_longident
+## In state 1214, spurious reduction of production constr_longident -> mod_longident
+## In state 1352, spurious reduction of production simple_expr_call -> constr_longident
 ##
 
 When applying a function, don't forget to wrap the arguments in parens.

--- a/src/reason_parser.messages
+++ b/src/reason_parser.messages
@@ -1,6 +1,6 @@
 implementation: PLUSDOT UIDENT ELSE
 ##
-## Ends in an error in state: 1209.
+## Ends in an error in state: 1211.
 ##
 ## expr -> simple_expr_call . [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF DOCSTRING COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## expr -> simple_expr_call . DOT label_longident EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF DOCSTRING COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -25,8 +25,8 @@ implementation: PLUSDOT UIDENT ELSE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1211, spurious reduction of production constr_longident -> mod_longident
-## In state 1349, spurious reduction of production simple_expr_call -> constr_longident
+## In state 1213, spurious reduction of production constr_longident -> mod_longident
+## In state 1351, spurious reduction of production simple_expr_call -> constr_longident
 ##
 
 When applying a function, don't forget to wrap the arguments in parens.

--- a/src/reason_parser.messages
+++ b/src/reason_parser.messages
@@ -1,6 +1,6 @@
 implementation: PLUSDOT UIDENT ELSE
 ##
-## Ends in an error in state: 1119.
+## Ends in an error in state: 1209.
 ##
 ## expr -> simple_expr_call . [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF DOCSTRING COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
 ## expr -> simple_expr_call . DOT label_longident EQUAL expr [ error STAR SLASHGREATER SEMI RPAREN RBRACKET RBRACE QUESTION PLUSEQ PLUSDOT PLUS PERCENT OR MINUSDOT MINUS LESSDOTDOTGREATER LESS LBRACKETAT INFIXOP4 INFIXOP3 INFIXOP2 INFIXOP1 INFIXOP0 GREATERRBRACE GREATER EOF DOCSTRING COMMA COLONGREATER COLONEQUAL COLON BARRBRACKET BARBAR BAR AND AMPERSAND AMPERAMPER ]
@@ -25,8 +25,8 @@ implementation: PLUSDOT UIDENT ELSE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1121, spurious reduction of production constr_longident -> mod_longident
-## In state 1277, spurious reduction of production simple_expr_call -> constr_longident
+## In state 1211, spurious reduction of production constr_longident -> mod_longident
+## In state 1349, spurious reduction of production simple_expr_call -> constr_longident
 ##
 
 When applying a function, don't forget to wrap the arguments in parens.

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -2354,7 +2354,7 @@ let explicitlyPassedAnnotated = (myOptional a::?a b::?None :int);
 */
 
 labeled_pattern_constraint:
-  | pattern_optional_constraint { fun _punned -> $1 }
+  | AS pattern_optional_constraint { fun _punned -> $2 }
   | preceded(COLON, only_core_type(core_type))?
     { fun punned ->
       let pat = mkpat (Ppat_var punned) ~loc:punned.loc in
@@ -2368,7 +2368,7 @@ labeled_pattern_constraint:
 
 labeled_pattern:
 as_loc
-  ( COLON as_loc(LIDENT) labeled_pattern_constraint
+   ( COLON as_loc(LIDENT) labeled_pattern_constraint
     { Term (Labelled $2.txt, None, $3 $2) }
   | COLON as_loc(LIDENT) labeled_pattern_constraint EQUAL expr
     { Term (Optional $2.txt, Some $5, $3 $2) }
@@ -2378,30 +2378,6 @@ as_loc
     { Term (Nolabel, None, $1) }
   | TYPE LIDENT
     { Type $2 }
-
-    /* <REMOVE ME> */
-  | COLONCOLONLIDENT
-    { let loc = mklocation $startpos($1) $endpos($1) in
-      Term (Labelled $1, None, mkpat(Ppat_var (mkloc $1 loc)) ~loc)
-    }
-  | COLONCOLONLIDENT EQUAL QUESTION
-    { let loc = mklocation $symbolstartpos $endpos in
-      Term (Optional $1, None, mkpat(Ppat_var (mkloc $1 loc)) ~loc)
-    }
-  | COLONCOLONLIDENT EQUAL simple_expr
-    { let loc = mklocation $symbolstartpos $endpos in
-      Term (Optional $1, Some $3, mkpat(Ppat_var (mkloc $1 loc)) ~loc)
-    }
-   /* Case A, B, C, D */
-  | LIDENTCOLONCOLON pattern_optional_constraint
-    { Term (Labelled $1, None, $2) }
-   /* Case E, F, G, H */
-  | LIDENTCOLONCOLON pattern_optional_constraint EQUAL QUESTION
-    { Term (Optional $1, None, $2) }
-   /* Case I, J, K, L */
-  | LIDENTCOLONCOLON pattern_optional_constraint EQUAL simple_expr
-    { Term (Optional $1, Some $4, $2) }
-    /* </REMOVE ME> */
   ) { $1 }
 ;
 
@@ -2884,27 +2860,12 @@ labeled_expr_constraint:
 
 labeled_expr:
   | expr_optional_constraint { (Nolabel, $1) }
-  | COLON as_loc(val_longident) optional labeled_expr_constraint
-    { ($3 (String.concat "" (Longident.flatten $2.txt)), $4 $2) }
-
-    /* <REMOVE ME> */
-  | COLONCOLONLIDENT
-    { let loc = mklocation $symbolstartpos $endpos in
-      (Labelled $1, mkexp (Pexp_ident(mkloc (Lident $1) loc)) ~loc)
-    }
-  | LIDENTCOLONCOLON expr_optional_constraint
-    { (Labelled $1, $2) }
-  /* Expliclitly provided default optional:
-   * let res = someFunc optionalArg:?None;
-   */
-  | COLONCOLON QUESTION val_longident
-    { let loc = mklocation $symbolstartpos $endpos in
-      (Optional (String.concat "" (Longident.flatten $3)),
-       mkexp (Pexp_ident(mkloc $3 loc)) ~loc)
-    }
-  | LIDENTCOLONCOLON QUESTION expr_optional_constraint
-    { (Optional $1, $3) }
-    /* </REMOVE ME> */
+  | COLON as_loc(val_longident)
+    { 
+      let exp = mkexp (Pexp_ident $2) ~loc:$2.loc in
+      (Labelled (String.concat "" (Longident.flatten $2.txt)), exp) }
+  | COLON as_loc(val_longident) EQUAL optional labeled_expr_constraint
+    { ($4 (String.concat "" (Longident.flatten $2.txt)), $5 $2) }
 ;
 
 %inline and_let_binding:

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -2861,11 +2861,19 @@ labeled_expr_constraint:
 labeled_expr:
   | expr_optional_constraint { (Nolabel, $1) }
   | COLON as_loc(val_longident)
-  { (* add(:a, :b)  -> parses :a & :b *)
+    { (* add(:a, :b)  -> parses :a & :b *)
       let exp = mkexp (Pexp_ident $2) ~loc:$2.loc in
-      (Labelled (String.concat "" (Longident.flatten $2.txt)), exp) }
+      (Labelled (String.concat "" (Longident.flatten $2.txt)), exp)
+    }
+  | COLON as_loc(val_longident) QUESTION
+    { (* foo(:a?)  -> parses :a? *)
+      let exp = mkexp (Pexp_ident $2) ~loc:$2.loc in
+      (Optional (String.concat "" (Longident.flatten $2.txt)), exp)
+    }
   | COLON as_loc(val_longident) EQUAL optional labeled_expr_constraint
-    { ($4 (String.concat "" (Longident.flatten $2.txt)), $5 $2) }
+    { (* foo(:bar=?Some(1)) or add(:x=1, :y=2) -> parses :bar=?Some(1) & :x=1 & :y=1 *)
+      ($4 (String.concat "" (Longident.flatten $2.txt)), $5 $2)
+    }
 ;
 
 %inline and_let_binding:

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -2861,7 +2861,7 @@ labeled_expr_constraint:
 labeled_expr:
   | expr_optional_constraint { (Nolabel, $1) }
   | COLON as_loc(val_longident)
-    { 
+  { (* add(:a, :b)  -> parses :a & :b *)
       let exp = mkexp (Pexp_ident $2) ~loc:$2.loc in
       (Labelled (String.concat "" (Longident.flatten $2.txt)), exp) }
   | COLON as_loc(val_longident) EQUAL optional labeled_expr_constraint
@@ -3759,8 +3759,10 @@ unattributed_core_type:
 arrow_type_parameter:
   | only_core_type(core_type)
     { (Nolabel, $1) }
-  | COLON LIDENT only_core_type(core_type) optional
-    { ($4 $2, $3) }
+  | COLON LIDENT COLON only_core_type(core_type)
+    { ( Labelled $2, $4) }
+  | COLON LIDENT COLON only_core_type(core_type) EQUAL optional
+    {($6 $2, $4) }
 ;
 
 arrow_type_parameters:

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -6322,7 +6322,7 @@ class printer  ()= object(self:'self)
       | Labelled lbl when is_punned_labelled_expression e lbl ->
         label (atom ":") term
       | Optional lbl when is_punned_labelled_expression e lbl ->
-        label (atom ":") (label term (atom "=?"))
+        label (atom ":") (label term (atom "?"))
       | Labelled lbl ->
         label (atom (":" ^ lbl ^ "=")) term
       | Optional lbl ->

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2579,9 +2579,9 @@ class printer  ()= object(self:'self)
     match lbl with
     | Nolabel -> typ
     | Labelled lbl ->
-      makeList ~sep:" " [atom (":" ^ lbl); typ]
+      makeList ~sep:" " [atom (":" ^ lbl ^ ":"); typ]
     | Optional lbl ->
-      makeList ~sep:" " [atom (":" ^ lbl); label typ (atom "?")]
+      makeList ~sep:" " [atom (":" ^ lbl ^ ":"); label typ (atom "=?")]
 
   method type_param (ct, a) =
     makeList [atom (type_variance a); self#core_type ct]

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -3320,7 +3320,8 @@ class printer  ()= object(self:'self)
       | Labelled lbl | Optional lbl when is_punned_labelled_pattern pat lbl ->
         label (atom ":") term
       | Labelled lbl | Optional lbl ->
-        label (atom (":" ^ lbl)) ~space:true term
+          let lblLayout= makeList ~sep:" " ~break:Never [atom (":" ^ lbl); atom "as"] in
+          label lblLayout ~space:true term
     in
     match opt, lbl with
     | None, Optional _ -> makeList [param; atom "=?"]
@@ -6321,11 +6322,11 @@ class printer  ()= object(self:'self)
       | Labelled lbl when is_punned_labelled_expression e lbl ->
         label (atom ":") term
       | Optional lbl when is_punned_labelled_expression e lbl ->
-        label (atom ":") (label term (atom "?"))
+        label (atom ":") (label term (atom "=?"))
       | Labelled lbl ->
-        label (atom (":" ^ lbl)) ~space:true term
+        label (atom (":" ^ lbl ^ "=")) term
       | Optional lbl ->
-        label (atom (":" ^ lbl ^ "?")) ~space:true term
+        label (atom (":" ^ lbl ^ "=?")) term
     in
     SourceMap (e.pexp_loc, param)
 


### PR DESCRIPTION
Implements https://github.com/facebook/reason/issues/1443, Implements https://github.com/facebook/reason/issues/1444 & https://github.com/facebook/reason/issues/1446

```reason
/* 1443 */
let add = (:first as x, :second as y) => x + y;

/* 1444*/
type foo = (:first: int=?, :second: int=?) => int;
type foo = (:first: int, :second: int) => int;

/* 1446 */
let five = add(:x=3, :y=2);
let five = add(:x=3: int, :y=2: int);
let foo = bar(:x=?Some(1));
let foo = bar(:x=?Some(1): option(int))
let explictlyPassed = myOptional(:a?, :b=?None);
```