### PR TITLE
Record punning for value & pattern for fields with module prefix

### DIFF
--- a/FUTURE.md
+++ b/FUTURE.md
@@ -15,3 +15,5 @@ TODO: re-enable rtop integration tests in makefile (./miscTests/rtopIntegrationT
 - string concat is now `++` instead of the old `^`
 - labeled argument with type now has punning!
 - Works on ocaml 4.05 and the latest topkg (#1438)
+- Record field punning for module field prefix now prints well too: `{M.x, y}` is `{M.x: x, y: y}`
+- JSX needs {} like in JS

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The doc repo lives at https://github.com/reasonml/reasonml.github.io
 
 ### Codebase
 
+**See a list of easy tasks [here](https://github.com/facebook/reason/labels/GOOD%20FIRST%20TASK)**
+
 See the [src folder](ttps://github.com/facebook/reason/tree/master/src) and the corresponding README.
 
 ```sh
@@ -80,7 +82,7 @@ env version=x.y.z make pre_release
 env version=x.y.z make release
 ```
 
-- Use [opam-publish](https://github.com/ocaml/opam-publish) to publish the latest version to opam. 
+- Use [opam-publish](https://github.com/ocaml/opam-publish) to publish the latest version to opam.
 
 ## License
 
@@ -88,8 +90,6 @@ See Reason license in [LICENSE.txt](LICENSE.txt).
 
 Works that are forked from other projects are under their original licenses.
 
-Editor plugins (which have also been forked) in the `editorSupport/` directory include their own licenses.
-
 ## Credit
 
-The general structure of `refmt` repo was copied from @whitequark's m17n project, including parts of the `README` that instruct how to use this with the OPAM toolchain.
+The general structure of `refmt` repo was copied from @whitequark's m17n project, including parts of the `README` that instruct how to use this with the OPAM toolchain. Thank you OCaml!

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -691,6 +691,11 @@ type component2 = {
   updater: unit
 };
 
+type component3 = {
+  props: M.props,
+  state
+};
+
 type mutableComponent = {mutable props};
 
 type mutabeleComponent2 = {
@@ -708,6 +713,30 @@ type description('props) = {
 /* Don't pun types from other modules */
 module Foo = {
   type bar = {foo: Baz.foo};
+};
+
+/* record value punning */
+let props = {title: "hi"};
+
+/* no punning available for a single field. Can't tell the difference with a scope + expression */
+let componentA = {props: props};
+
+/* pun for real */
+let componentB = {props, state: ()};
+
+/* pun fields with module prefix too */
+let foo = {Foo.foo: foo};
+
+let bar = {Foo.foo, bar: 1};
+
+let bar = {bar: 1, Foo.foo};
+
+let bar = {Foo.foo, Bar.bar};
+
+({M.x, y}) => 1;
+
+switch (foo) {
+| {y: 1, M.x} => 2
 };
 
 /* Requested in #566 */

--- a/formatTest/unit_tests/input/basicStructures.re
+++ b/formatTest/unit_tests/input/basicStructures.re
@@ -562,6 +562,8 @@ type component = {props};
 
 type component2 = {props, state, updater: unit,};
 
+type component3 = {props: M.props, state};
+
 type mutableComponent = {mutable props};
 
 type mutabeleComponent2 = {mutable props, mutable state, style: int,};
@@ -575,6 +577,25 @@ type description('props) = {
 /* Don't pun types from other modules */
 module Foo = {
   type bar = {foo: Baz.foo};
+};
+
+/* record value punning */
+
+let props = {title: "hi"};
+/* no punning available for a single field. Can't tell the difference with a scope + expression */
+let componentA = {props: props};
+/* pun for real */
+let componentB = {props: props, state: ()};
+/* pun fields with module prefix too */
+let foo = {Foo.foo: foo};
+let bar = {Foo.foo: foo, bar: 1};
+let bar = {bar: 1, Foo.foo: foo};
+let bar = {Foo.foo: foo, Bar.bar: bar};
+
+fun ({M.x: x, y: y}) => 1;
+
+switch (foo) {
+| {y: 1, M.x: x} => 2
 };
 
 /* Requested in #566 */

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -4962,10 +4962,10 @@ class printer  ()= object(self:'self)
         loc_end = e.pexp_loc.loc_end;
         loc_ghost = false;
       } in
-      let theRow = match e.pexp_desc with
+      let theRow = match (e.pexp_desc, shouldPun, allowPunning) with
         (* record value punning. Turns {foo: foo, bar: 1} into {foo, bar: 1} *)
         (* also turns {Foo.bar: bar, baz: 1} into {Foo.bar, baz: 1} *)
-        |  Pexp_ident {txt = ident} when Longident.last li.txt = Longident.last ident && shouldPun && allowPunning ->
+        | (Pexp_ident {txt = ident}, true, true) when Longident.last li.txt = Longident.last ident ->
           makeList (maybeQuoteFirstElem li (if appendComma then [comma] else []))
         | _ ->
           let (sweet, argsList, return) = self#curriedPatternsAndReturnVal e in

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -3290,7 +3290,9 @@ class printer  ()= object(self:'self)
           | Ppat_record (l, closed) ->
               let longident_x_pattern (li, p) =
                 match (li, p.ppat_desc) with
-                  | ({txt=Lident s}, Ppat_var {txt}) when s = txt ->
+                  | ({txt = ident}, Ppat_var {txt}) when Longident.last ident = txt ->
+                    (* record field punning when destructuring. {x: x, y: y} becomes {x, y} *)
+                    (* works with module prefix too: {MyModule.x: x, y: y} becomes {MyModule.x, y} *)
                       self#longident_loc li
                   | _ ->
                       label ~space:true (makeList [self#longident_loc li; atom ":"]) (self#pattern p)
@@ -4961,8 +4963,9 @@ class printer  ()= object(self:'self)
         loc_ghost = false;
       } in
       let theRow = match e.pexp_desc with
-        (* Punning *)
-        |  Pexp_ident {txt} when li.txt = txt && shouldPun && allowPunning ->
+        (* record value punning. Turns {foo: foo, bar: 1} into {foo, bar: 1} *)
+        (* also turns {Foo.bar: bar, baz: 1} into {Foo.bar, baz: 1} *)
+        |  Pexp_ident {txt = ident} when Longident.last li.txt = Longident.last ident && shouldPun && allowPunning ->
           makeList (maybeQuoteFirstElem li (if appendComma then [comma] else []))
         | _ ->
           let (sweet, argsList, return) = self#curriedPatternsAndReturnVal e in
@@ -4994,7 +4997,7 @@ class printer  ()= object(self:'self)
     let allRows = match eo with
       | None -> (
         match l with
-          (* No punning (or comma) for records with only a single field. *)
+          (* No punning (or comma) for records with only a single field. It's ambiguous with an expression in a scope *)
           (* See comment in parser.mly for lbl_expr_list_with_at_least_one_non_punned_field *)
           | [hd] -> [makeRow hd false false]
           | _ -> getRows l


### PR DESCRIPTION
Aka `{M.x: x, y: 1}` puns to `{M.x, y: 1}`.

Rather positive the expectation isn't that it's a shorthand for `{M.x:
M.x, y: 1}`...

Fixes #1431