### PR TITLE
Make deref be a prefix operator

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/arityConversion.re.4.02.3
+++ b/formatTest/typeCheckedTests/expected_output/arityConversion.re.4.02.3
@@ -28,6 +28,12 @@ Test.Or((1, 2));
 
 Some(1);
 
+Test.And((1, 2));
+
+Test.Or((1, 2));
+
+Some(1);
+
 module M = {
   type t =
     | TupleConstructorInModule((int, int));
@@ -42,6 +48,16 @@ type t2 =
 
 type t3 =
   | TupleConstructor3((int, int));
+
+M.TupleConstructorInModule((1, 2));
+
+M.TupleConstructor2((1, 2));
+
+TupleConstructor2((1, 2));
+
+M.TupleConstructor3((1, 2));
+
+TupleConstructor3((1, 2));
 
 M.TupleConstructorInModule((1, 2));
 

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -168,11 +168,12 @@ let bothTrue (x, y) = {contents: x && y};
 
 let something =
   [@onEverythingToRightOfEquals]
-  (bothTrue(true, true))^;
+  ^(bothTrue(true, true));
 
 let something =
-  ([@onlyOnArgumentToBang] bothTrue(true, true))
-    ^;
+  ^(
+    [@onlyOnArgumentToBang] bothTrue(true, true)
+  );
 
 let res =
   [@appliesToEntireFunctionApplication]

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -112,8 +112,8 @@ let x = [@onEverything] (- add(thisVal,thisVal));
 
 
 let bothTrue(x,y) = {contents: x && y};
-let something = [@onEverythingToRightOfEquals](bothTrue(true,true)^);
-let something = ([@onlyOnArgumentToBang]bothTrue(true,true))^;
+let something = [@onEverythingToRightOfEquals](^bothTrue(true,true));
+let something = ^([@onlyOnArgumentToBang]bothTrue(true,true));
 
 let res = [@appliesToEntireFunctionApplication] add(2,4);
  [@appliesToEntireFunctionApplication]add(2,4);

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -33,15 +33,15 @@ for (i in
   }
 };
 
-let x = foo^ ^.bar^;
+let x = ^(^foo).bar;
 
-let x = foo.bar^;
+let x = ^foo.bar;
 
-let x = foo#bar^;
+let x = ^foo#bar;
 
-let x = foo^.bar^;
+let x = ^(^foo).bar;
 
-let x = (foo^)#bar^;
+let x = ^(^foo)#bar;
 
 /* Prefix operators:
  * ! followed by zero or more appropriate_operator_suffix_chars (see the
@@ -107,17 +107,17 @@ let x = ! (! foo.bar);
 let x = ! (! foo#bar);
 
 /* Test precedence on access sugar */
-let x = arr^[0];
+let x = (^arr)[0];
 
-let x = arr^[0];
+let x = (^arr)[0];
 
-let x = str^.[0];
+let x = (^str).[0];
 
-let x = str^.[0];
+let x = (^str).[0];
 
-let x = arr^[0] = 1;
+let x = (^arr)[0] = 1;
 
-let x = arr^[0] = 1;
+let x = (^arr)[0] = 1;
 
 /* Comments */
 /*Below is an empty comment*/

--- a/formatTest/unit_tests/input/basicStructures.re
+++ b/formatTest/unit_tests/input/basicStructures.re
@@ -25,15 +25,15 @@ for (i in 0 to endOfRangeMustBeSimple(expr,soWrap)) {
   };
 };
 
-let x = (foo^)^.bar^;
+let x = ^(^foo).bar;
 
-let x = foo.bar^;
+let x = ^foo.bar;
 
-let x = foo#bar^;
+let x = ^foo#bar;
 
-let x = foo^.bar^;
+let x = ^(^foo).bar;
 
-let x = (foo^)#bar^;
+let x = ^(^foo)#bar;
 
 /* Prefix operators:
  * ! followed by zero or more appropriate_operator_suffix_chars (see the
@@ -96,17 +96,17 @@ let x = !(!foo.bar);
 let x = !(!foo#bar);
 
 /* Test precedence on access sugar */
-let x = arr^[0];
+let x = (^arr)[0];
 
-let x = Array.get(arr^,0);
+let x = Array.get(^arr,0);
 
-let x = str^.[0];
+let x = (^str).[0];
 
-let x = String.get(str^,0);
+let x = String.get(^str,0);
 
-let x = Array.set(arr^,0,1);
+let x = Array.set(^arr,0,1);
 
-let x = arr^[0] = 1;
+let x = (^arr)[0] = 1;
 
 /* Comments */
 /*Below is an empty comment*/

--- a/src/reason_lexer.mll
+++ b/src/reason_lexer.mll
@@ -582,8 +582,7 @@ rule token = parse
             { INFIXOP1(lexeme_operator lexbuf) }
   | '\\'? '^' ('\\' '.')? operator_chars*
             { match lexeme_without_comment lexbuf with
-              | "^." -> set_lexeme_length lexbuf 1; POSTFIXOP("^")
-              | "^" -> POSTFIXOP("^")
+              | "^" -> PREFIXOP("^")
               | op -> INFIXOP1(unescape_operator op) }
   | '\\'? ['+' '-'] operator_chars*
             { INFIXOP2(lexeme_operator lexbuf) }

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -613,7 +613,7 @@ let getPrintableUnaryIdent s =
    characters. *)
 let printedStringAndFixity  = function
   | s when List.mem s special_infix_strings -> Infix s
-  | "^" -> UnaryPostfix "^"
+  | "^" -> AlmostSimplePrefix "^"
   | s when List.mem s.[0] infix_symbols -> Infix s
   (* Correctness under assumption that unary operators are stored in AST with
      leading "~" *)
@@ -635,7 +635,7 @@ let printedStringAndFixity  = function
 
 (* Also, this doesn't account for != and !== being infixop!!! *)
 let isSimplePrefixToken s = match printedStringAndFixity s with
-  | AlmostSimplePrefix _ | UnaryPostfix "^" -> true
+  | AlmostSimplePrefix _ -> true
   | _ -> false
 
 
@@ -3385,7 +3385,7 @@ class printer  ()= object(self:'self)
         let forceSpace = match leftExpr.pexp_desc with
           | Pexp_apply (ee, lsls) ->
             (match printedStringAndFixityExpr ee with
-             | UnaryPostfix "^" | AlmostSimplePrefix _ -> true
+             | AlmostSimplePrefix _ -> true
              | _ -> false)
           | _ -> false
         in
@@ -5174,15 +5174,7 @@ class printer  ()= object(self:'self)
         | Pexp_field (e, li) ->
           Some (label (makeList [self#simple_enough_to_be_lhs_dot_send e; atom "."]) (self#longident_loc li))
         | Pexp_send (e, s) ->
-          let needparens = match e.pexp_desc with
-            | Pexp_apply (ee, _) ->
-              (match printedStringAndFixityExpr ee with
-               | UnaryPostfix "^" -> true
-               | _ -> false)
-            | _ -> false
-          in
           let lhs = self#simple_enough_to_be_lhs_dot_send e in
-          let lhs = if needparens then makeList ~wrap:("(",")") [lhs] else lhs in
           Some (label (makeList [lhs; atom "#";]) (atom s))
         | Pexp_extension e -> Some (self#extension e)
         | _ -> None


### PR DESCRIPTION
I can see some logic in having it be postfix -- for example
```
foo^.bar^
```
feels a little better than
```
^(^foo).bar
```

(this is on top of https://github.com/facebook/reason/pull/1462)
fixes https://github.com/facebook/reason/issues/1435