### PR TITLE
ensure valid parsing of constraint expressions after printing

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -70,3 +70,10 @@ let expectedPrecendence =
 module X: {let x: (:x: unit=?, unit) => unit;} = {
   let x (:x=(), ()) = ();
 };
+
+let display
+    (
+      :message=("hello": string),
+      :person: string="Reason",
+      time: float
+    ) = 1;

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -50,3 +50,5 @@ let expectedPrecendence = 1 \+ 1 \=== 1 \+ 1 && 1 \+ 1 \!== 1 \+ 1;
 module X: {let x: (:x: unit=?, unit) => unit;} = {
   let x(:x=(),()) = ();
 };
+
+let display (:message=("hello": string), :person: string="Reason", time: float) = 1;


### PR DESCRIPTION
https://github.com/facebook/reason/issues/1457

Idempotent printing of:
```reason
let display (:message=("hello": string), :person: string="Reason", time: float) = 1;
```