### PR TITLE
transform ocaml pervasives interfaces to reason correctly

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/pervasive.rei
+++ b/formatTest/typeCheckedTests/expected_output/pervasive.rei
@@ -1,0 +1,5 @@
+let (==): ('a, 'a) => bool;
+
+let (!=): ('a, 'a) => bool;
+
+let (!): bool => bool;

--- a/formatTest/typeCheckedTests/input/pervasive.mli
+++ b/formatTest/typeCheckedTests/input/pervasive.mli
@@ -1,0 +1,5 @@
+val ( = ) : 'a -> 'a -> bool
+
+val ( <> ) : 'a -> 'a -> bool
+
+val not : bool -> bool

--- a/src/syntax_util.ml
+++ b/src/syntax_util.ml
@@ -192,6 +192,18 @@ let identifier_mapper f super =
     in
     super.pat mapper pat
   end;
+  signature = begin fun mapper signature -> 
+    let signature = 
+      List.map (fun signatureItem ->
+        match signatureItem with
+          | {psig_desc=Psig_value ({pval_name} as name);
+             psig_loc} ->
+              {signatureItem with psig_desc=Psig_value ({name with pval_name=({pval_name with txt=(f name.pval_name.txt)})})}
+          | _ -> signatureItem
+        ) signature
+    in
+    super.signature mapper signature
+  end;
 }
 
 (** escape_stars_slashes_mapper escapes all stars and slases in an AST *)


### PR DESCRIPTION
Currently on master:

```
$ echo "val ( = ) : 'a -> 'a -> bool" | refmt --parse=ml --print=re --interface=true
```

Actual result
```
let (=): ('a, 'a) => bool;
```

Expected result
```
let (==): 'a => 'a => bool;
```

I think there is 2 issues here :
- `(=)` should mapped to `(==)`
- ~~`'a -> 'a` should not become a tupple~~

This PR fixes only the first one. ~~The second one seems to be a regression.~~

Currently the Pervasives reason documentation page is misleading and I think this PR will fix it. E.g. https://reasonml.github.io/api/Pervasives.html#VAL(=)

And probably that one too #1427

I'm still a new to OCaml / Reason so feel free to tell me if I misunderstood something.