### PR TITLE
special case printing of foo(bar)##value

### DIFF
--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -63,7 +63,7 @@ res#=?!!z##q;
 
 res#=?!!z##(q##a);
 
-let result = myFunction((x(y))##z, (a(b))#=c);
+let result = myFunction(x(y)##z, a(b)#=c);
 
 (! x)##y##(b##c);
 

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -414,7 +414,7 @@ let thisReturnsA = () => a;
 
 let thisReturnsAAsWell = () => a;
 
-let recordVal: int = (thisReturnsARecord()).a;
+let recordVal: int = thisReturnsARecord().a;
 
 Printf.printf(
   "\nproof that thisReturnsARecord: %n\n",

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -4948,8 +4948,12 @@ class printer  ()= object(self:'self)
         | UnaryMinusPrefix _
         | UnaryNotPrefix _
         | UnaryPostfix _
-        | Infix _
-        | Normal -> self#simplifyUnparseExpr x
+        | Infix _ -> self#simplifyUnparseExpr x
+        | Normal ->
+          if x.pexp_attributes = [] then
+            self#unparseExpr x
+          else
+            self#simplifyUnparseExpr x
     )
     | _ -> self#simplifyUnparseExpr x
 


### PR DESCRIPTION
This only fixes the printing, parsing already works (as shown by the tests). It seems simple enough to just special case this printing that I didn't look for a more involved solution.