### PR TITLE
Fix #1472

### DIFF
--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -168,7 +168,7 @@ module InliningSig: {let x: int; let y: int;} = {
   let y = 20;
 };
 
-module MyFunctor (M: HasTT) = {
+module MyFunctor = (M: HasTT) => {
   type reexportedTT = M.tt;
   /* Inline comment inside module. */
   /** Following special comment inside module. */
@@ -210,7 +210,7 @@ module BMod = {
   let b = 10;
 };
 
-module CurriedSugar (A: ASig, B: BSig) = {
+module CurriedSugar = (A: ASig, B: BSig) => {
   let result = A.a + B.b;
 };
 
@@ -230,35 +230,35 @@ module CurriedSugar (A: ASig, B: BSig) = {
    module x (A:Foo) :Bar => Baz;
 
    */
-module CurriedSugarWithReturnType
+module CurriedSugarWithReturnType =
        (A: ASig, B: BSig)
-       : SigResult = {
+       : SigResult => {
   let result = A.a + B.b;
 };
 
 /* This is parsed as being equivalent to the above example */
-module CurriedSugarWithAnnotatedReturnVal
+module CurriedSugarWithAnnotatedReturnVal =
        (A: ASig, B: BSig)
-       : SigResult = {
+       : SigResult => {
   let result = A.a + B.b;
 };
 
-module CurriedNoSugar (A: ASig, B: BSig) = {
+module CurriedNoSugar = (A: ASig, B: BSig) => {
   let result = A.a + B.b;
 };
 
 let letsTryThatSyntaxInLocalModuleBindings = () => {
-  module CurriedSugarWithReturnType
+  module CurriedSugarWithReturnType =
          (A: ASig, B: BSig)
-         : SigResult = {
+         : SigResult => {
     let result = A.a + B.b;
   };
-  module CurriedSugarWithAnnotatedReturnVal
+  module CurriedSugarWithAnnotatedReturnVal =
          (A: ASig, B: BSig)
-         : SigResult = {
+         : SigResult => {
     let result = A.a + B.b;
   };
-  module CurriedNoSugar (A: ASig, B: BSig) = {
+  module CurriedNoSugar = (A: ASig, B: BSig) => {
     let result = A.a + B.b;
   };
   /*
@@ -283,7 +283,7 @@ let letsTryThatSyntaxInLocalModuleBindings = () => {
 
 module type EmptySig = {};
 
-module MakeAModule (X: EmptySig) = {
+module MakeAModule = (X: EmptySig) => {
   let a = 10;
 };
 
@@ -344,14 +344,14 @@ module type FunctorType3 =
 /* The following: */
 module CurriedSugarWithAnnotation2:
   (ASig, BSig) => SigResult =
-  fun (A: ASig, B: BSig) => {
+  (A: ASig, B: BSig) => {
     let result = A.a + B.b;
   };
 
 /* Becomes: */
 module CurriedSugarWithAnnotation:
   (ASig, BSig) => SigResult =
-  fun (A: ASig, B: BSig) => {
+  (A: ASig, B: BSig) => {
     let result = A.a + B.b;
   };
 
@@ -359,30 +359,30 @@ module CurriedSugarWithAnnotation:
  * for now, so we settle for: */
 module CurriedSugarWithAnnotationAndReturnAnnotated:
   (ASig, BSig) => SigResult =
-  fun (A: ASig, B: BSig) => (
+  (A: ASig, B: BSig) => (
     {
       let result = A.a + B.b;
     }:
       SigResult
   );
 
-module ReturnsAFunctor
+module ReturnsAFunctor =
        (A: ASig, B: BSig)
-       : ((ASig, BSig) => SigResult) =
-  fun (A: ASig, B: BSig) => {
+       : ((ASig, BSig) => SigResult) =>
+  (A: ASig, B: BSig) => {
     let result = 10;
   };
 
-module ReturnsSigResult
+module ReturnsSigResult =
        (A: ASig, B: BSig)
-       : SigResult = {
+       : SigResult => {
   let result = 10;
 };
 
-module ReturnsAFunctor2
+module ReturnsAFunctor2 =
        (A: ASig, B: BSig)
-       : ((ASig, BSig) => SigResult) =
-  fun (A: ASig, B: BSig) => {
+       : ((ASig, BSig) => SigResult) =>
+  (A: ASig, B: BSig) => {
     let result = 10;
   };
 
@@ -432,29 +432,29 @@ module Char = {
   type t = char;
 };
 
-module List (X: Type) = {
+module List = (X: Type) => {
   type t = list(X.t);
 };
 
-module Maybe (X: Type) = {
+module Maybe = (X: Type) => {
   type t = option(X.t);
 };
 
-module Id (X: Type) = X;
+module Id = (X: Type) => X;
 
-module Compose
+module Compose =
        (
          F: (Type) => Type,
          G: (Type) => Type,
          X: Type
-       ) =
+       ) =>
   F((G(X)));
 
 let l: Compose(List)(Maybe)(Char).t = [
   Some('a')
 ];
 
-module Example2 (F: (Type) => Type, X: Type) = {
+module Example2 = (F: (Type) => Type, X: Type) => {
   /**
    * Note: This is the one remaining syntactic issue where
    * modules/functions do not have syntax unified with values.

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -2605,7 +2605,7 @@ module BMod = {
   let b = 10;
 };
 
-module CurriedSugar
+module CurriedSugar =
        /* Commenting before First curried functor arg */
        /* If these comments aren't formatted correctly
         * see how functor args' locations aren't set
@@ -2615,7 +2615,7 @@ module CurriedSugar
          A: ASig,
          /* Commenting before Second curried functor arg */
          B: BSig
-       ) = {
+       ) => {
   let result = A.a + B.b;
   /* Comment at bottom of module expression */
 };

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -6054,7 +6054,7 @@ class printer  ()= object(self:'self)
       let (argsList, return) = self#curriedFunctorPatternsAndReturnStruct x in
       (* See #19/20 in syntax.mls - cannot annotate return type at
                the moment. *)
-      self#wrapCurriedFunctionBinding "fun" ~arrow:"=>" (makeTup argsList) []
+      self#wrapCurriedFunctionBinding "fun" ~sweet:true ~arrow:"=>" (makeTup argsList) []
         ([self#moduleExpressionToFormattedApplicationItems return], None)
     | Pmod_apply _ ->
       self#moduleExpressionToFormattedApplicationItems x
@@ -6137,7 +6137,8 @@ class printer  ()= object(self:'self)
                 | Pmod_constraint (me, ct) -> ([makeTup argsList; formatJustTheTypeConstraint (self#non_arrowed_module_type ct)], me)
                 | _ -> ([makeTup argsList], return)
             ) in
-            self#wrapCurriedFunctionBinding prefixText ~arrow:"=" bindingName argsWithConstraint
+            self#wrapCurriedFunctionBinding prefixText ~arrow:"=>"
+              (makeList [bindingName; atom " ="]) argsWithConstraint
               ([self#moduleExpressionToFormattedApplicationItems actualReturn], None)
     )
 


### PR DESCRIPTION
- add supports for `(Functor_arg : Arg_type) : Functor_body_type => Functor_body` form.
- print functor bindings as `module X = (Args) => Body`

Supported functor forms:
`(A1 : T1) => Body`
`(A1 : T1) : Constraint => Body`
`() => Body`
`() : Constraint => Body`
`(A1 : T1, A2 : T2) => Body`
`(A1 : T1, ()) : Constraint => Body`
...