### PR TITLE
Remove ppx_tools again

### DIFF
--- a/opam
+++ b/opam
@@ -27,7 +27,6 @@ depends: [
   "result"                  {=  "1.2"}
   "topkg"                   {>=  "0.8.1"}
   "ocaml-migrate-parsetree"
-  "ppx_tools_versioned"     {>= "5.0beta"}
 ]
 depopts: [
 ]

--- a/opam.in
+++ b/opam.in
@@ -26,7 +26,6 @@ depends: [
   "result"                  {=  "1.2"}
   "topkg"                   {>=  "0.8.1"}
   "ocaml-migrate-parsetree"
-  "ppx_tools_versioned"     {>= "5.0beta"}
 ]
 depopts: [
 ]


### PR DESCRIPTION
It was introduced by 26f12520e58461f64b92fcccb161bc64f2c877d5 to patch 1.13.7's release into 1.13.8. We don't need it in master anymore