### PR TITLE
Remove extra parens printed in `type a = Foo((unit => unit))`

### DIFF
--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -585,6 +585,20 @@ let funcWithTypeLocallyAbstractTypes =
     ) =>
   c(a, b);
 
+/* Checks that function types aren't unnecessary wrapped */
+type a = unit => unit;
+
+type b =
+  | Foo(unit => unit)
+  | Bar(unit => unit, unit => unit, (a, b) => c)
+  | Baz(unit => unit, unit => unit, (a, b) => c);
+
+type c =
+  | Foo((a, b) => unit)
+  | Bar((a, b) => unit);
+
+type d = [> | `Foo(unit => unit)];
+
 /**
  * Records:
  *=============================================================================

--- a/formatTest/unit_tests/input/basicStructures.re
+++ b/formatTest/unit_tests/input/basicStructures.re
@@ -476,6 +476,20 @@ let myFunc: myFuncType = fun (a,b) => a + b;
 
 let funcWithTypeLocallyAbstractTypes (type atype, type btype, a, b, c: (atype, btype) => unit) = c(a,b);
 
+/* Checks that function types aren't unnecessary wrapped */
+type a = ((unit => unit));
+
+type b =
+  | Foo((unit => unit))
+  | Bar((unit => unit), (unit => unit), ((a, b) => c))
+  | Baz(unit => unit, unit => unit, (a, b) => c);
+
+type c =
+  | Foo((a, b) => unit)
+  | Bar(((a, b) => unit));
+
+type d = [> | `Foo((unit => unit))];
+
 
 /**
  * Records:

--- a/src/README.md
+++ b/src/README.md
@@ -84,6 +84,7 @@ Random Stack Overflow answer: https://stackoverflow.com/questions/9897358/ocaml-
 - [Special case printing of foo(bar)##value](https://github.com/facebook/reason/pull/1481)
 - [Use ~ for named args](https://github.com/facebook/reason/pull/1483/)
 - [Bring back parentheses-less `switch foo`](https://github.com/facebook/reason/pull/1476)
+- [Remove extra parens printed in `type a = Foo((unit => unit))`](https://github.com/facebook/reason/pull/1491)
 
 ### Debugging Grammar Conflicts
 

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2790,7 +2790,7 @@ class printer  ()= object(self:'self)
       let lst = if print_bar then [atom "|"; sourceMappedName] else [sourceMappedName] in
       makeList ~postSpace:true lst in
     let ampersand_helper i arg =
-      let ct = self#non_arrowed_non_simple_core_type arg in
+      let ct = self#core_type arg in
       let ct = match arg.ptyp_desc with
         | Ptyp_tuple _ -> ct
         | _ -> makeTup [ct]
@@ -2804,7 +2804,7 @@ class printer  ()= object(self:'self)
       | Pcstr_record r -> [self#record_declaration r]
       | Pcstr_tuple [] -> []
       | Pcstr_tuple l when polymorphic -> List.mapi ampersand_helper l
-      | Pcstr_tuple l -> [makeTup (List.map self#non_arrowed_non_simple_core_type l)]
+      | Pcstr_tuple l -> [makeTup (List.map self#core_type l)]
     in
     let gadtRes = match pcd_res with
       | None -> None


### PR DESCRIPTION
Fixes #1490 

Summoning @let-def and @IwanKaramazow to review this. I have no idea what I'm doing. Heck, what's the difference between `non_arrowed_non_simple_core_type` and `core_type`?.

This seems to pass the tests though...