### PR TITLE
don't apply sugar to Js.t({.}) and Js.t({..})

### DIFF
--- a/formatTest/unit_tests/expected_output/object.re
+++ b/formatTest/unit_tests/expected_output/object.re
@@ -18,3 +18,7 @@ let five = 2 <..> 3;
 type closedObjSugar = {. "foo": bar, "baz": int};
 
 type openObjSugar = {.. "x": int, "y": int};
+
+type x = Js.t({.});
+
+type y = Js.t({..});

--- a/formatTest/unit_tests/input/object.re
+++ b/formatTest/unit_tests/input/object.re
@@ -24,3 +24,7 @@ let five = 2 <..> 3;
 type closedObjSugar = Js.t({. foo: bar, baz: int});
 
 type openObjSugar = Js.t({.. x: int, y: int});
+
+type x = Js.t({.});
+
+type y = Js.t({..});

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -3092,7 +3092,9 @@ class printer  ()= object(self:'self)
           SourceMap (li.loc, ensureSingleTokenSticksToLabel (self#longident_loc li))
         | Ptyp_constr (li, l) ->
             (match l with
-            | [{ptyp_desc = Ptyp_object (l, o) }] when isJsDotTLongIdent li.txt ->
+            | [{ptyp_desc = Ptyp_object (l, o) }] when isJsDotTLongIdent li.txt && List.length l > 0 ->
+                (* should have one or more rows, Js.t({..}) should print as Js.t({..})
+                 * {..} has a totally different meaning than Js.t({..}) *)
                 self#unparseObject ~withStringKeys:true l o
             | _ ->
               (* The single identifier has to be wrapped in a [ensureSingleTokenSticksToLabel] to


### PR DESCRIPTION
There's a bug in the printer which formats `Js.t({.})` to `{.}`. (Idem for `Js.t({..})`).

This PR gives the following printing.
```reason
type x = Js.t({.});
type y = Js.t({..});
type z = {. "foo": bar}; /* idem for {.. "etc": baz} */
```