### PR TITLE
Bring outcome printer up to date w/ the new syntax, fixes #1453

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,9 @@ install:
 	./refmt_impl.native --help=groff > $(shell opam config var man)/man1/refmt.1
 
 test: build_with_outcome_test clean-tests
+	node ./formatTest/testOprint.js
 	./miscTests/rtopIntegrationTest.sh
 	./miscTests/jsxPpxTest.sh
-	# TODO(jared): enable once these are passing
-	# node ./formatTest/testOprint.js
 	cd formatTest; ./test.sh
 
 clean-tests:

--- a/formatTest/oprintTests/basic.re
+++ b/formatTest/oprintTests/basic.re
@@ -101,3 +101,48 @@ module type BSig = {let b:int;};
 module CurriedSugar (A:ASig, B:BSig) {
   let result = A.a + B.b;
 };
+
+
+let addValues = fun (a:int, b:int) => {
+  a + b;
+};
+
+let myFunction = fun (a : int, b : int) : int => a + b;
+
+let functionReturnValueType (i:int, s:string): (int) => int = fun(x) => x + 1;
+
+let curriedFormOne (i:int, s:string) = s ++ string_of_int(i);
+
+let curriedFormTwo (i:int, x:int) :(int, int) = (i, x);
+/* let nonCurriedFormTwo = fun (i:int, x:int) (:(int, int)) => (i, x); */
+
+let curriedFormThree (i:int, (a:int, b:int):(int, int)) :(int, int, int) = (i, a, b);
+
+type myFuncType = (int, int) => int;
+
+let myFunc: myFuncType = fun (a,b) => a + b;
+
+let funcWithTypeLocallyAbstractTypes (type atype, type btype, a, b, c: (atype, btype) => unit) = c(a,b);
+
+type firstNamedArgShouldBeGroupedInParens =
+    (~first: (int) => int, ~second: int) => int;
+type allParensCanBeRemoved =
+    (~first: int) => ((~second: int) => ((~third: int) => int));
+type firstTwoShouldBeGroupedAndFirstThree =
+    (~first: ((int) => int) => int) => int;
+type firstNamedArgShouldBeGroupedInParensOpt =
+    (~first: ((int) => int)=?, ~second: list(int)=?) => int;
+
+type withThreeFields = {
+  name: string,
+  age: int,
+  occupation: string
+};
+
+let testRecord = {
+  name: "joe",
+  age: 20,
+  occupation: "engineer"
+};
+
+let makeRecordBase () {name: "Joe", age: 30, occupation: "Engineer"};

--- a/formatTest/oprintTests/basic.re
+++ b/formatTest/oprintTests/basic.re
@@ -1,36 +1,43 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
-let run = () => "Basic Structures";
 
-let endOfRangeMustBeSimple = (a, b) => 10;
-let theSame = (a, b, c) => 20;
+let x1 = () => 1;
+let x2 = (a) => 1;
+let x3 = (a: int, b) => 1;
+let x4 = ((a,b)) => 1;
+let x5 = fun (a,b): int => 1;
+let x6 = (~x, ~y) => 1;
+let x7 = (~x: int, ~y: string) => 1;
+let x8 = (~x=5, ~y=?, ~z: option(string)=?, ()) => 1;
 
-type zed = {bar: ref(int)};
-let foo = ref(ref({bar: ref(10)}));
+type a = int;
+type b = float;
+type c = string;
+type t1 = (a) => b;
+type t2 = (a, b) => c;
+type t3 = ((a, b)) => c;
+type t4 = (~x: int, ~y: string) => c;
+type t5 = (~x: a=?) => b;
+
+type t6 = int;
+type t7('a) = list('a);
+type t8('a, 'b) = (list('a), 'b);
+type t9 = t8(string, int);
+
+class type restricted_point_type = {
+  pub get_x: int;
+  pub bump: unit;
+};
+class type t10('a) = {
+  pub thing: 'a;
+};
+class type t11('a, 'b) = {
+  pub thing: ('a, list('b))
+};
 
 module MyFirstModule = {
   let x = 0;
-  let y = x + x;
-  let a = 2
-  and b = 3;
   type i = int
   and n = string;
-};
-
-module type MySecondModuleType = {
-  type someType = int;
-  let x: int;
-  let y: int;
-};
-
-module MyLocalModule = {
-  type i = int;
-  let x:i = 10;
-};
-
-module MyLocalModule2: MySecondModuleType = {
-  type someType = int;
-  let x:someType = 10;
-  let y:someType = 20;
 };
 
 module type HasTT = {
@@ -69,69 +76,22 @@ module EmbedsSubPolyModule: HasSubPolyModule = {
   };
 };
 
-
 module InliningSig: {let x: int; let y:int;} = {
-  /*
-   * Comment inside of signature.
-   */
   let x = 10;
-  /* Inline comment inside signature. */
   let y = 20;
 };
 
 module MyFunctor = fun (M: HasTT) => {
   type reexportedTT = M.tt;
-  /* Inline comment inside module. */
-  /** Following special comment inside module. */
   let someValue = 1000;
 };
 
-/* Notice how
-   - Functors no longer require parens around argument.
-   - A final semicolon is required for module structures.
-   - We should eliminate both those requirements. See action items 13-14 at the
-   bottom of this file. [Actually, forgiving the trailing SEMI might not be
-   such a great idea].
-   */
 module MyFunctorResult = MyFunctor ({type tt = string;});
-
 module type ASig = {let a:int;};
 module type BSig = {let b:int;};
-
 module CurriedSugar (A:ASig, B:BSig) {
   let result = A.a + B.b;
 };
-
-
-let addValues = fun (a:int, b:int) => {
-  a + b;
-};
-
-let myFunction = fun (a : int, b : int) : int => a + b;
-
-let functionReturnValueType (i:int, s:string): (int) => int = fun(x) => x + 1;
-
-let curriedFormOne (i:int, s:string) = s ++ string_of_int(i);
-
-let curriedFormTwo (i:int, x:int) :(int, int) = (i, x);
-/* let nonCurriedFormTwo = fun (i:int, x:int) (:(int, int)) => (i, x); */
-
-let curriedFormThree (i:int, (a:int, b:int):(int, int)) :(int, int, int) = (i, a, b);
-
-type myFuncType = (int, int) => int;
-
-let myFunc: myFuncType = fun (a,b) => a + b;
-
-let funcWithTypeLocallyAbstractTypes (type atype, type btype, a, b, c: (atype, btype) => unit) = c(a,b);
-
-type firstNamedArgShouldBeGroupedInParens =
-    (~first: (int) => int, ~second: int) => int;
-type allParensCanBeRemoved =
-    (~first: int) => ((~second: int) => ((~third: int) => int));
-type firstTwoShouldBeGroupedAndFirstThree =
-    (~first: ((int) => int) => int) => int;
-type firstNamedArgShouldBeGroupedInParensOpt =
-    (~first: ((int) => int)=?, ~second: list(int)=?) => int;
 
 type withThreeFields = {
   name: string,
@@ -146,3 +106,28 @@ let testRecord = {
 };
 
 let makeRecordBase () {name: "Joe", age: 30, occupation: "Engineer"};
+
+
+type t =
+  | A
+  | B(int)
+  | C(int, int)
+  | D((int, int));
+
+
+class aClass(x) {
+  /* one value parameter x */
+  pub a1 = 0;
+  pub a2() = 0;
+  pub a3(x,y) = x + y;
+  pub a4(x,y) {
+    let result = x + y;
+    print_endline(" x + y = " ++ string_of_int(x) ++ " + " ++ string_of_int(y) ++ " = " ++ string_of_int(result));
+    result
+  };
+};
+
+
+
+
+

--- a/formatTest/oprintTests/basic.re
+++ b/formatTest/oprintTests/basic.re
@@ -95,14 +95,8 @@ module MyFunctor = fun (M: HasTT) => {
    */
 module MyFunctorResult = MyFunctor ({type tt = string;});
 
-module LookNoParensNeeded = MyFunctor {type tt = string;};
-
-module type SigResult = {let result:int;};
-
 module type ASig = {let a:int;};
 module type BSig = {let b:int;};
-module AMod = {let a = 10;};
-module BMod = {let b = 10;};
 
 module CurriedSugar (A:ASig, B:BSig) {
   let result = A.a + B.b;

--- a/formatTest/oprintTests/basic.re
+++ b/formatTest/oprintTests/basic.re
@@ -6,3 +6,104 @@ let theSame = (a, b, c) => 20;
 
 type zed = {bar: ref(int)};
 let foo = ref(ref({bar: ref(10)}));
+
+module MyFirstModule = {
+  let x = 0;
+  let y = x + x;
+  let a = 2
+  and b = 3;
+  type i = int
+  and n = string;
+};
+
+module type MySecondModuleType = {
+  type someType = int;
+  let x: int;
+  let y: int;
+};
+
+module MyLocalModule = {
+  type i = int;
+  let x:i = 10;
+};
+
+module MyLocalModule2: MySecondModuleType = {
+  type someType = int;
+  let x:someType = 10;
+  let y:someType = 20;
+};
+
+module type HasTT = {
+  type tt;
+};
+
+module SubModule: HasTT = {
+  type tt = int;
+};
+
+module type HasEmbeddedHasTT = {
+  module SubModuleThatHasTT = SubModule;
+};
+
+module type HasPolyType = {type t('a);};
+module type HasDoublePoly = {type m('b, 'c);};
+
+module type HasDestructivelySubstitutedPolyType =
+  HasPolyType with type t('a) := list('a);
+
+module type HasDestructivelySubstitutedSubPolyModule = {
+  /* Cannot perform destructive substitution on submodules! */
+  /* module X: HasPolyType with type t := list (int, int); */
+  module X: HasDestructivelySubstitutedPolyType;
+};
+
+module type HasSubPolyModule = {
+  /* Cannot perform destructive substitution on submodules! */
+  /* module X: HasPolyType with type t := list (int, int); */
+  module X: HasPolyType;
+};
+
+module EmbedsSubPolyModule: HasSubPolyModule = {
+  module X = {
+    type t('a) = list('a);
+  };
+};
+
+
+module InliningSig: {let x: int; let y:int;} = {
+  /*
+   * Comment inside of signature.
+   */
+  let x = 10;
+  /* Inline comment inside signature. */
+  let y = 20;
+};
+
+module MyFunctor = fun (M: HasTT) => {
+  type reexportedTT = M.tt;
+  /* Inline comment inside module. */
+  /** Following special comment inside module. */
+  let someValue = 1000;
+};
+
+/* Notice how
+   - Functors no longer require parens around argument.
+   - A final semicolon is required for module structures.
+   - We should eliminate both those requirements. See action items 13-14 at the
+   bottom of this file. [Actually, forgiving the trailing SEMI might not be
+   such a great idea].
+   */
+module MyFunctorResult = MyFunctor ({type tt = string;});
+
+module LookNoParensNeeded = MyFunctor {type tt = string;};
+
+module type SigResult = {let result:int;};
+
+module type ASig = {let a:int;};
+module type BSig = {let b:int;};
+module AMod = {let a = 10;};
+module BMod = {let b = 10;};
+
+module CurriedSugar (A:ASig, B:BSig) {
+  let result = A.a + B.b;
+};

--- a/formatTest/testOprint.js
+++ b/formatTest/testOprint.js
@@ -58,6 +58,7 @@ const main = async () => {
 
     const {result, error} = await outcomePrint(full)
 
+    console.log(result)
     if (error) {
       return `Printing failure ${name}:\n\n${error}`
     }

--- a/formatTest/testOprint.js
+++ b/formatTest/testOprint.js
@@ -58,7 +58,6 @@ const main = async () => {
 
     const {result, error} = await outcomePrint(full)
 
-    console.log(result)
     if (error) {
       return `Printing failure ${name}:\n\n${error}`
     }

--- a/formatTest/testOprint.js
+++ b/formatTest/testOprint.js
@@ -1,3 +1,4 @@
+/* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
 const {exec, spawn} = require('child_process')
 const {promisify} = require('util')

--- a/miscTests/rtopIntegrationTest.sh
+++ b/miscTests/rtopIntegrationTest.sh
@@ -16,7 +16,7 @@ export TERM=
 # Given the above, we're gonna test that utop integration works by piping code
 # into it and asserting the existence of some output.
 echo "Testing rtop..."
-echo "let f(a) = a;" \
+echo "let f(a) => a;" \
 | utop-full -init src/rtop_init.ml -I $HOME \
 | grep "let f : 'a => 'a = <fun>" > /dev/null
 if [ $? -ne 0 ]; then
@@ -24,7 +24,7 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-echo "let f(a) = 1 + \"hi\";" \
+echo "let f(a) => 1 + \"hi\";" \
 | utop-full -init src/rtop_init.ml -I $HOME \
 | grep "Error: This expression has type" > /dev/null
 if [ $? -ne 0 ]; then

--- a/src/reason_oprint.ml
+++ b/src/reason_oprint.ml
@@ -493,7 +493,7 @@ and print_typargs ppf =
       pp_print_space ppf ();
       pp_print_string ppf "(";
       pp_open_box ppf 1;
-      print_typlist print_out_wrap_type "" ppf tyl;
+      print_typlist print_out_wrap_type ", " ppf tyl;
       pp_close_box ppf ();
       pp_print_string ppf ")"
 
@@ -510,8 +510,8 @@ let print_out_class_params ppf =
   function
     [] -> ()
   | tyl ->
-      fprintf ppf "@[<1>%a@]@ "
-        (print_list type_parameter (fun ppf -> fprintf ppf " "))
+      fprintf ppf "(@[<1>%a@])@ "
+        (print_list type_parameter (fun ppf -> fprintf ppf ",@ "))
         tyl
 
 let rec print_out_class_type ppf =
@@ -525,7 +525,7 @@ let rec print_out_class_type ppf =
       in
       fprintf ppf "@[%a%a@]" print_ident id pr_tyl tyl
   | Octy_arrow (lab, ty, cty) ->
-      fprintf ppf "@[%s%a =>@ %a@]" (if lab <> "" then lab ^ ":" else "")
+      fprintf ppf "@[%s(%a) =>@ %a@]" (if lab <> "" then lab ^ ":" else "")
         print_out_type_2 ty print_out_class_type cty
   | Octy_signature (self_ty, csil) ->
       let pr_param ppf =
@@ -746,16 +746,16 @@ and print_out_constr ppf (name, tyl,ret_type_opt) =
       | [] ->
           pp_print_string ppf name
       | _ ->
-          fprintf ppf "@[<2>%s %a@]" name
-            (print_typlist print_simple_out_type "") tyl
+          fprintf ppf "@[<2>%s(%a)@]" name
+            (print_typlist print_simple_out_type ",") tyl
       end
   | Some ret_type ->
       begin match tyl with
       | [] ->
           fprintf ppf "@[<2>%s:@ %a@]" name print_simple_out_type ret_type
       | _ ->
-          fprintf ppf "@[<2>%s %a :%a@]" name
-            (print_typlist print_simple_out_type "") tyl
+          fprintf ppf "@[<2>%s(%a) :%a@]" name
+            (print_typlist print_simple_out_type ",") tyl
             print_simple_out_type ret_type
       end
 

--- a/src/reason_oprint.ml
+++ b/src/reason_oprint.ml
@@ -210,7 +210,7 @@ let print_out_value ppf tree =
       [] -> ()
     | (name, tree) :: fields ->
         if not first then fprintf ppf ",@ ";
-        fprintf ppf "@[<1>%a@ :@ %a@]" print_ident name (cautious (print_tree_1 false))
+        fprintf ppf "@[<1>%a@:@ %a@]" print_ident name (cautious (print_tree_1 false))
           tree;
         print_fields false ppf fields
   and print_tree_list print_item sep ppf tree_list =
@@ -528,11 +528,11 @@ and print_out_class_sig_item ppf =
       fprintf ppf "@[<2>as %a =@ %a@]" print_out_type ty1
         print_out_type ty2
   | Ocsg_method (name, priv, virt, ty) ->
-      fprintf ppf "@[<2>%s%s%s :@ %a@]"
+      fprintf ppf "@[<2>%s%s%s:@ %a@]"
         (if priv then "pri " else "pub ") (if virt then "virtual " else "")
         name print_out_type ty
   | Ocsg_value (name, mut, vr, ty) ->
-      fprintf ppf "@[<2>val %s%s%s :@ %a@]"
+      fprintf ppf "@[<2>val %s%s%s:@ %a@]"
         (if mut then "mutable " else "")
         (if vr then "virtual " else "")
         name print_out_type ty
@@ -618,7 +618,7 @@ and print_out_sig_item ppf =
   | Osig_module (name, Omty_alias id, _) ->
       fprintf ppf "@[<2>module %s =@ %a@]" name print_ident id
   | Osig_module (name, mty, rs) ->
-      fprintf ppf "@[<2>%s %s :@ %a@]"
+      fprintf ppf "@[<2>%s %s:@ %a@]"
         (match rs with Orec_not -> "module"
                     | Orec_first -> "module rec"
                     | Orec_next -> "and")
@@ -640,7 +640,7 @@ and print_out_sig_item ppf =
           fprintf ppf "@ = \"%s\"" s;
           List.iter (fun s -> fprintf ppf "@ \"%s\"" s) sl
     in
-    fprintf ppf "@[<2>%s %a :@ %a%a%a;@]" kwd value_ident oval_name
+    fprintf ppf "@[<2>%s %a:@ %a%a%a@]" kwd value_ident oval_name
         !out_type oval_type pr_prims oval_prims
         (fun ppf -> List.iter (fun a -> fprintf ppf "@ [@@@@%s]" a.oattr_name))
         oval_attributes
@@ -664,7 +664,7 @@ and print_out_sig_item ppf =
       (* fprintf ppf "@ \"%s\"" s *)
     (* ) sl *)
     (* in *)
-    (* fprintf ppf "@[<2>%s %a :@ %a%a@]" kwd value_ident oval_name *)
+    (* fprintf ppf "@[<2>%s %a:@ %a%a@]" kwd value_ident oval_name *)
         (* !out_type oval_type pr_prims oval_prims *)
 (* #end *)
 
@@ -679,11 +679,11 @@ and print_out_type_decl kwd ppf td =
   let type_defined ppf =
     match td.otype_params with
       [] -> pp_print_string ppf td.otype_name
-    | [param] -> fprintf ppf "@[%s@ %a@]" td.otype_name type_parameter param
+    | [param] -> fprintf ppf "@[%s(%a)@]" td.otype_name type_parameter param
     | _ ->
-        fprintf ppf "@[%s@ @[%a@]@]"
+        fprintf ppf "@[%s(@[%a@])@]"
           td.otype_name
-          (print_list type_parameter (fun ppf -> fprintf ppf "@ "))
+          (print_list type_parameter (fun ppf -> fprintf ppf ",@ "))
           td.otype_params
   in
   let print_manifest ppf =
@@ -720,7 +720,7 @@ and print_out_type_decl kwd ppf td =
         print_private td.otype_private
         print_out_type ty
   in
-  fprintf ppf "@[<2>@[<hv 2>%t%a@]%t;@]"
+  fprintf ppf "@[<2>@[<hv 2>%t%a@]%t@]"
     print_name_params
     print_out_tkind ty
     print_constraints
@@ -738,7 +738,7 @@ and print_out_constr ppf (name, tyl,ret_type_opt) =
   | Some ret_type ->
       begin match tyl with
       | [] ->
-          fprintf ppf "@[<2>%s :@ %a@]" name print_simple_out_type ret_type
+          fprintf ppf "@[<2>%s:@ %a@]" name print_simple_out_type ret_type
       | _ ->
           fprintf ppf "@[<2>%s %a :%a@]" name
             (print_typlist print_simple_out_type "") tyl
@@ -747,7 +747,7 @@ and print_out_constr ppf (name, tyl,ret_type_opt) =
 
 
 and print_out_label ppf (name, mut, arg) =
-  fprintf ppf "@[<2>%s%s :@ %a@]," (if mut then "mutable " else "") name
+  fprintf ppf "@[<2>%s%s:@ %a@]," (if mut then "mutable " else "") name
     print_out_type arg
 
 and print_out_extension_constructor ppf ext =
@@ -837,9 +837,9 @@ let rec print_items ppf =
   | (tree, valopt) :: items ->
       begin match valopt with
         Some v ->
-          fprintf ppf "@[<2>%a =@ %a@]" print_out_sig_item tree
+          fprintf ppf "@[<2>%a =@ %a;@]" print_out_sig_item tree
             print_out_value v
-      | None -> fprintf ppf "@[%a@]" print_out_sig_item tree
+      | None -> fprintf ppf "@[%a;@]" print_out_sig_item tree
       end;
       if items <> [] then fprintf ppf "@ %a" print_items items
 

--- a/src/reason_oprint.ml
+++ b/src/reason_oprint.ml
@@ -271,20 +271,24 @@ and print_out_type_1 ppf =
   function
     Otyp_arrow (lab, ty1, ty2) ->
       pp_open_box ppf 0;
+      pp_print_string ppf "(";
       let suffix =
         match get_label lab with
         | Nonlabeled -> ""
         | Labeled lab ->
+            pp_print_string ppf "~";
             pp_print_string ppf lab;
-            pp_print_string ppf "::";
+            pp_print_string ppf ": ";
             ""
         | Optional lab ->
+            pp_print_string ppf "~";
             pp_print_string ppf lab;
-            pp_print_string ppf "::";
-            "?"
+            pp_print_string ppf ": ";
+            "=?"
       in
       print_out_type_2 ppf ty1;
       pp_print_string ppf suffix;
+      pp_print_string ppf ")";
       pp_print_string ppf " =>";
       pp_print_space ppf ();
       print_out_type_1 ppf ty2;

--- a/src/testOprint.ml
+++ b/src/testOprint.ml
@@ -1,3 +1,4 @@
+(* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. *)
 
 module Convert = Migrate_parsetree.Convert (Migrate_parsetree.OCaml_404) (Migrate_parsetree.OCaml_current)
 module ConvertBack = Migrate_parsetree.Convert (Migrate_parsetree.OCaml_current) (Migrate_parsetree.OCaml_404)


### PR DESCRIPTION
now prints
```
let x1: (unit) => int;
let x2: ('a) => int;
let x3: (int, 'a) => int;
let x4: (('a, 'b)) => int;
let x5: ('a, 'b) => int;
let x6: (~x: 'a, ~y: 'b) => int;
let x7: (~x: int, ~y: string) => int;
let x8: (~x: int=?, ~y: 'a=?, ~z: string=?, unit) => int;
type a = int;
type b = float;
type c = string;
type t1 = (a) => b;
type t2 = (a, b) => c;
type t3 = ((a, b)) => c;
type t4 = (~x: int, ~y: string) => c;
type t5 = (~x: a=?) => b;
type t6 = int;
type t7('a) = list('a);
type t8('a, 'b) = (list('a), 'b);
type t9 = t8 (string,  int);
class type restricted_point_type = { pub bump: unit; pub get_x: int };
class type t10 ('a) = { pub thing: 'a };
class type t11 ('a, 'b) = { pub thing: ('a, list('b)) };
module MyFirstModule: { let x: int; type i = int and n = string; };
module type HasTT = { type tt; };
module SubModule: HasTT;
module type HasEmbeddedHasTT = { module SubModuleThatHasTT = SubModule; };
module type HasPolyType = { type t('a); };
module type HasDoublePoly = { type m('b, 'c); };
module type HasDestructivelySubstitutedPolyType = {  };
module type HasDestructivelySubstitutedSubPolyModule =
  { module X: HasDestructivelySubstitutedPolyType; };
module type HasSubPolyModule = { module X: HasPolyType; };
module EmbedsSubPolyModule: HasSubPolyModule;
module InliningSig: { let x: int; let y: int; };
module MyFunctor:
  (M : HasTT) => { type reexportedTT = M.tt; let someValue: int; };
module MyFunctorResult: { type reexportedTT = string; let someValue: int; };
module type ASig = { let a: int; };
module type BSig = { let b: int; };
module CurriedSugar: (A : ASig) => (B : BSig) => { let result: int; };
type withThreeFields = { name: string, age: int, occupation: string, };
let testRecord: withThreeFields;
let makeRecordBase: (unit) => withThreeFields;
type t = A | B(int) | C(int, int) | D((int, int));
class aClass :
  ('a) =>
  {
    pub a1: int;
    pub a2: (unit) => int;
    pub a3: (int, int) => int;
    pub a4: (int, int) => int
  };
```


fixes #1453



