### PR TITLE
Js.nullable syntax: `{. "x"?: int };`

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -379,6 +379,7 @@ let privacy = {pri x = (c) => 5 + c};
 
 module Js = {
   type t('a);
+  type nullable('a);
 };
 
 /* supports trailing comma */
@@ -386,3 +387,6 @@ type stream('a) = {
   .
   "observer": ('a => unit) => unit
 };
+
+/* #1451: Js.nullable(int) -> ?int  */
+type nullableObjSugar = {. "x": ?int};

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -376,17 +376,3 @@ module type T = {
 };
 
 let privacy = {pri x = (c) => 5 + c};
-
-module Js = {
-  type t('a);
-  type nullable('a);
-};
-
-/* supports trailing comma */
-type stream('a) = {
-  .
-  "observer": ('a => unit) => unit
-};
-
-/* #1451: Js.nullable(int) -> ?int  */
-type nullableObjSugar = {. "x": ?int};

--- a/formatTest/typeCheckedTests/input/oo.re
+++ b/formatTest/typeCheckedTests/input/oo.re
@@ -327,7 +327,11 @@ let privacy = {
 
 module Js = {
   type t('a);
+  type nullable('a);
 };
 
 /* supports trailing comma */
 type stream('a) = {. "observer": ('a => unit) => unit,};
+
+/* #1451: Js.nullable(int) -> ?int  */
+type nullableObjSugar = Js.t({. x: Js.nullable(int)});

--- a/formatTest/typeCheckedTests/input/oo.re
+++ b/formatTest/typeCheckedTests/input/oo.re
@@ -324,14 +324,3 @@ module type T = {
 let privacy = {
     pri x(c) = 5 + c;
 };
-
-module Js = {
-  type t('a);
-  type nullable('a);
-};
-
-/* supports trailing comma */
-type stream('a) = {. "observer": ('a => unit) => unit,};
-
-/* #1451: Js.nullable(int) -> ?int  */
-type nullableObjSugar = Js.t({. x: Js.nullable(int)});

--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -96,3 +96,18 @@ let isArrayPolyfill: [@bs] (int => bool) = [%bs.raw
 ];
 
 this#arrayInObject[count] = 1;
+
+/* supports trailing comma */
+type stream('a) = {
+  .
+  "observer": ('a => unit) => unit
+};
+
+/* #1451: Js.nullable(int) -> ?int  */
+type nullableObjSugar = {. "x"?: int};
+
+type x = {. "x"?: int};
+
+type y = {. "y"?: string};
+
+type z = {.. "a"?: foo, "x"?: bar, "z"?: crux};

--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -110,4 +110,4 @@ type x = {. "x"?: int};
 
 type y = {. "y"?: string};
 
-type z = {.. "a"?: foo, "x"?: bar, "z"?: crux};
+type z = {.. "a"?: foo, "x"?: bar, "z"?: baz};

--- a/formatTest/unit_tests/input/bucklescript.re
+++ b/formatTest/unit_tests/input/bucklescript.re
@@ -73,3 +73,15 @@ let isArrayPolyfill: [@bs] ((int) => bool) = [%bs.raw
 ];
 
 this#arrayInObject[count] = 1;
+
+/* supports trailing comma */
+type stream('a) = {. "observer": ('a => unit) => unit,};
+
+/* #1451: Js.nullable(int) -> ?int  */
+type nullableObjSugar = Js.t({. x: Js.nullable(int)});
+
+type x = {. "x" ? : int};
+
+type y = {. "y"?: string};
+
+type z = {.. "a"?: foo, "x"?: bar, "z": Js.nullable(baz)};

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -3547,7 +3547,7 @@ label_declaration:
   lseparated_nonempty_list(COMMA, string_literal_lbl) COMMA? { $1 };
 
 string_literal_lbl:
-  | STRING COLON poly_type
+  | STRING COLON nullable_poly_type
     {
       let loc = mklocation $symbolstartpos $endpos in
       let (s, _) = $1 in
@@ -3641,6 +3641,17 @@ with_constraint:
   | MODULE as_loc(UIDENT) COLONEQUAL as_loc(mod_ext_longident)
       { Pwith_modsubst ($2, $4) }
 ;
+
+(* #1451, use only with object types *)
+nullable_poly_type:
+  | poly_type
+    { $1 }
+  | QUESTION poly_type
+    (* {. "x": ?int } -> ?int, sugar for Js.nullable(int) *)
+    { let loc = mklocation $symbolstartpos $endpos in
+      let jsNullableCtr = { txt = Longident.parse "Js.nullable"; loc} in
+      mktyp ~loc (Ptyp_constr(jsNullableCtr, [$2])) }
+  ;
 
 /* Polymorphic types */
 


### PR DESCRIPTION
https://github.com/facebook/reason/issues/1451

Applies to object types only.
```
/* before */
type u = {. "x" : Js.nullable(int) };

/* after */
type u  = {. "x"?: int };
```

This will be pretty familiar for people coming from Flow.

Locations are as good as they can get.

Reopening this one because I magically wiped out everything in https://github.com/facebook/reason/pull/1477 