### PR TITLE
MyConstructor({x: reallyLong, y: anotherReallyLongThing}) -> hug ({ and })

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/mlVariants.re
+++ b/formatTest/typeCheckedTests/expected_output/mlVariants.re
@@ -4,9 +4,9 @@ type polyVariantsInMl = [
   | `StillAnIntTuple(int, int)
 ];
 
-let intTuple = `IntTuple(1, 2);
+let intTuple = `IntTuple((1, 2));
 
-let stillAnIntTuple = `StillAnIntTuple(4, 5);
+let stillAnIntTuple = `StillAnIntTuple((4, 5));
 
 let sumThem =
   fun

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -162,19 +162,23 @@ let acceptsClosedAnonObjAsArg =
   o#x + o#y;
 
 let res =
-  acceptsOpenAnonObjAsArg(
-    {pub x = 0; pub y = 10}
-  );
+  acceptsOpenAnonObjAsArg({
+    pub x = 0;
+    pub y = 10
+  });
 
 let res =
-  acceptsOpenAnonObjAsArg(
-    {pub x = 0; pub y = 10; pub z = 10}
-  );
+  acceptsOpenAnonObjAsArg({
+    pub x = 0;
+    pub y = 10;
+    pub z = 10
+  });
 
 let res =
-  acceptsClosedAnonObjAsArg(
-    {pub x = 0; pub y = 10}
-  );
+  acceptsClosedAnonObjAsArg({
+    pub x = 0;
+    pub y = 10
+  });
 
 /* TODO: Unify class constructor return values with function return values */
 class myClassWithAnnotatedReturnType

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -332,20 +332,20 @@ let res =
   };
 
 /* FIXME type somePolyVariant = [ `Purple int | `Yellow int]; */
-let ylw = `Yellow(100, 100);
+let ylw = `Yellow((100, 100));
 
-let prp = `Purple(101, 100);
+let prp = `Purple((101, 100));
 
 let res =
   switch (ylw, prp) {
   | (`Yellow(y, y2), `Purple(p, p2)) =>
-    `Yellow(p + y, 0)
+    `Yellow((p + y, 0))
   | (`Purple(p, p2), `Yellow(y, y2)) =>
-    `Purple(y + p, 0)
+    `Purple((y + p, 0))
   | (`Purple(p, p2), `Purple(y, y2)) =>
-    `Yellow(y + p, 0)
+    `Yellow((y + p, 0))
   | (`Yellow(p, p2), `Yellow(y, y2)) =>
-    `Purple(y + p, 0)
+    `Purple((y + p, 0))
   };
 
 let ylw = `Yellow(100);
@@ -378,20 +378,20 @@ let res =
  *
  * Though, I'm not sure this will even work.
  */
-let ylw = `Yellow(100, 100);
+let ylw = `Yellow((100, 100));
 
-let prp = `Purple(101, 101);
+let prp = `Purple((101, 101));
 
 let res =
   switch (ylw, prp) {
   | (`Yellow(y, y2), `Purple(p, p2)) =>
-    `Yellow(p + y, 0)
+    `Yellow((p + y, 0))
   | (`Purple(p, p2), `Yellow(y, y2)) =>
-    `Purple(y + p, 0)
+    `Purple((y + p, 0))
   | (`Purple(p, p2), `Purple(y, y2)) =>
-    `Yellow(y + p, 0)
+    `Yellow((y + p, 0))
   | (`Yellow(p, p2), `Yellow(y, y2)) =>
-    `Purple(y + p, 0)
+    `Purple((y + p, 0))
   };
 
 let rec atLeastOneFlushableChildAndNoWipNoPending =
@@ -440,12 +440,12 @@ let rec atLeastOneFlushableChildAndNoWipNoPending =
 /*
  * When pretty printed, this appears to be multi-argument constructors.
  */
-let prp = `Purple(101, 101);
+let prp = `Purple((101, 101));
 
 let res =
   switch prp {
-  | `Yellow(y, y2) => `Yellow(y2 + y, 0)
-  | `Purple(p, p2) => `Purple(p2 + p, 0)
+  | `Yellow(y, y2) => `Yellow((y2 + y, 0))
+  | `Purple(p, p2) => `Purple((p2 + p, 0))
   };
 
 /*
@@ -561,3 +561,76 @@ type Graph.node +=
   | Atom = Expr.Atom;
 
 MyConstructorWithSingleUnitArg();
+
+/* #1510: keep ({ and }) together on the same line when breaking */
+Delete({
+  uuid:
+    json |> Util.member("uuid") |> Util.to_string
+});
+
+Delete((
+  someLongStuf,
+  someOtherLongStuff,
+  okokokok
+));
+
+Delete([
+  someLongStuf,
+  someOtherLongStuff,
+  okokokok
+]);
+
+Delete([|
+  someLongStuf,
+  someOtherLongStuff,
+  okokokok
+|]);
+
+Delete([
+  someLongStuf,
+  someOtherLongStuff,
+  okokokok,
+  ...veryES6
+]);
+
+Delete({
+  pub x = methodOne;
+  pub y = methodTwo;
+  pub z = methodThisBreaks
+});
+
+`Delete({
+  uuid:
+    json |> Util.member("uuid") |> Util.to_string
+});
+
+`Delete((
+  someLongStuf,
+  someOtherLongStuff,
+  okokokok
+));
+
+`Delete([
+  someLongStuf,
+  someOtherLongStuff,
+  okokokok
+]);
+
+`Delete([|
+  someLongStuf,
+  someOtherLongStuff,
+  okokokok
+|]);
+
+`Delete([
+  someLongStuf,
+  someOtherLongStuff,
+  okokokok,
+  ...veryES6
+]);
+
+`Delete({
+  pub x = methodOne;
+  pub y = methodTwo;
+  pub z = methodThisBreaks
+});

--- a/formatTest/unit_tests/input/variants.re
+++ b/formatTest/unit_tests/input/variants.re
@@ -380,3 +380,18 @@ type Graph.node += pri Node = Expr.Node;
 type Graph.node += pri | Node = Expr.Node | Atom = Expr.Atom;
 
 MyConstructorWithSingleUnitArg(());
+
+/* #1510: keep ({ and }) together on the same line when breaking */
+Delete({ uuid: json |> Util.member("uuid") |> Util.to_string });
+Delete((someLongStuf, someOtherLongStuff, okokokok));
+Delete([someLongStuf, someOtherLongStuff, okokokok]);
+Delete([|someLongStuf, someOtherLongStuff, okokokok|]);
+Delete([someLongStuf, someOtherLongStuff, okokokok, ...veryES6]);
+Delete({pub x = methodOne; pub y = methodTwo; pub z = methodThisBreaks});
+
+`Delete({ uuid: json |> Util.member("uuid") |> Util.to_string });
+`Delete((someLongStuf, someOtherLongStuff, okokokok));
+`Delete([someLongStuf, someOtherLongStuff, okokokok]);
+`Delete([|someLongStuf, someOtherLongStuff, okokokok|]);
+`Delete([someLongStuf, someOtherLongStuff, okokokok, ...veryES6]);
+`Delete({pub x = methodOne; pub y = methodTwo; pub z = methodThisBreaks});

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -2801,7 +2801,12 @@ simple_expr_template_constructor:
     }
   | name_tag
     mark_position_exp
-      ( non_labeled_argument_list   { mkexp (Pexp_tuple($1)) }
+      ( non_labeled_argument_list
+        { (* only wrap in a tuple if there are more than one arguments *)
+          match $1 with
+          | [x] -> x
+          | l -> mkexp (Pexp_tuple(l))
+        }
       | simple_expr_direct_argument { $1 }
       )
     { mkexp(Pexp_variant($1, Some $2)) }

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2392,6 +2392,28 @@ let is_direct_pattern x = x.ppat_attributes = [] && match x.ppat_desc with
   | Ppat_construct ( {txt= Lident"()"}, None)
   | Ppat_construct ( {txt= Lident"::"}, Some _) -> true
   | _ -> false
+
+(* Some cases require special formatting when there's a function application
+ * with a single argument containing some kind of structure with braces/parens/brackets.
+ * Example: `foo({a: 1, b: 2})` needs to be formatted as
+ *  foo({
+ *    a: 1,
+ *    b: 2
+ *  })
+ *  when the line length dictates breaking. Notice how `({` and `})` 'hug'.
+ *  Also applies to (poly)variants because they can be seen as a form of "function application".
+ *  This function says if a list of expressions fulfills the need to be formatted like
+ *  the example above. *)
+let isSingleArgParenApplication = function
+  | [{pexp_attributes = []; pexp_desc = Pexp_record _}]
+  | [{pexp_attributes = []; pexp_desc = Pexp_tuple _}]
+  | [{pexp_attributes = []; pexp_desc = Pexp_array _}]
+  | [{pexp_attributes = []; pexp_desc = Pexp_object _}] -> true
+  | [{pexp_attributes = []; pexp_desc = Pexp_extension (s, _)}] when s.txt = "bs.obj" -> true
+  | [({pexp_attributes = []; pexp_desc} as exp)] when (is_simple_list_expr exp) -> true
+  | _ -> false
+
+
 (* Flattens a resolvedRule into a list of infixChain nodes.
  * When foo |> f |> z gets parsed, we get the following tree:
  *         |>
@@ -4672,11 +4694,18 @@ class printer  ()= object(self:'self)
       (* special printing: MyConstructor(()) -> MyConstructor() *)
       | Pexp_tuple l when is_single_unit_construct l ->
           (false, atom "()")
+      | Pexp_tuple l when polyVariant == true ->
+          (false, self#unparseSequence ~wrap:("(", ")") ~construct:`Tuple l)
       | Pexp_tuple l ->
         (* There is no ambiguity when the number of tuple components is 1.
              We don't need put implicit_arity in that case *)
-        (List.length l > 1 && not arityIsClear,
-         makeTup (List.map self#unparseConstraintExpr l))
+        (match l with
+        | exprList when isSingleArgParenApplication exprList ->
+            (false, self#singleArgParenApplication exprList)
+        | exprList ->
+            (not arityIsClear, makeTup (List.map self#unparseConstraintExpr l)))
+      | _ when isSingleArgParenApplication [eo] ->
+          (false, self#singleArgParenApplication [eo])
       | _ -> (false, makeTup [self#unparseConstraintExpr eo])
     in
     let construction =
@@ -5124,16 +5153,7 @@ class printer  ()= object(self:'self)
           | Some simpleGet -> Some simpleGet
           | None -> None
         )
-        | Pexp_object cs ->
-          let obj =
-            makeList
-              ~sep:";"
-              ~wrap:("{", "}")
-              ~break:IfNeed
-              ~postSpace:true
-              ~inline:(true, false)
-              (self#class_self_pattern_and_structure cs) in
-          Some obj
+        | Pexp_object cs -> Some (self#classStructure cs)
         | Pexp_override l -> (* FIXME *)
           let string_x_expression (s, e) =
             label ~space:true (atom (s.txt ^ ":")) (self#unparseExpr e)
@@ -5814,6 +5834,17 @@ class printer  ()= object(self:'self)
       | Pcl_let _
       | Pcl_structure _ -> self#simple_class_expr x;
 
+  method classStructure ?(wrap=("", "")) cs =
+    let (left, right) = wrap in
+    let wrap = (left ^ "{", "}" ^ right) in
+    makeList
+      ~sep:";"
+      ~wrap
+      ~break:IfNeed
+      ~postSpace:true
+      ~inline:(true, false)
+      (self#class_self_pattern_and_structure cs)
+
   method signature signatureItems =
     let signatureItems = List.filter self#shouldDisplaySigItem signatureItems in
     if List.length signatureItems == 0 then
@@ -6382,6 +6413,37 @@ class printer  ()= object(self:'self)
     in
     (List.map case_row l)
 
+  (* Formats a list of a single expr param in such a way that the parens of the function or
+   * (poly)-variant application and the wrapping of the param stick together when the layout breaks.
+   *  Example: `foo({a: 1, b: 2})` needs to be formatted as
+   *  foo({
+   *    a: 1,
+   *    b: 2
+   *  })
+   *  when the line length dictates breaking. Notice how `({` and `})` 'hug'.
+   *  Also see "isSingleArgParenApplication" which determines if 
+   *  this kind of formatting should happen. *)
+  method singleArgParenApplication = function
+    | [{pexp_attributes = []; pexp_desc = Pexp_record (l, eo)}] ->
+      self#unparseRecord ~wrap:("(", ")") l eo
+    | [{pexp_attributes = []; pexp_desc = Pexp_tuple l}] ->
+      self#unparseSequence ~wrap:("(", ")") ~construct:`Tuple l
+    | [{pexp_attributes = []; pexp_desc = Pexp_array l}] ->
+      self#unparseSequence ~wrap:("(", ")") ~construct:`Array l
+    | [{pexp_attributes = []; pexp_desc = Pexp_object cs}] ->
+      self#classStructure ~wrap:("(", ")") cs
+    | [{pexp_attributes = []; pexp_desc = Pexp_extension (s, p)}] when s.txt = "bs.obj" ->
+      self#formatBsObjExtensionSugar ~wrap:("(", ")") p
+    | [({pexp_attributes = []; pexp_desc} as exp)] when (is_simple_list_expr exp) ->
+          (match view_expr exp with
+          | `list xs ->
+              self#unparseSequence ~construct:`List ~wrap:("(", ")") xs
+          | `cons xs ->
+              self#unparseSequence ~construct:`ES6List ~wrap:("(", ")") xs
+          | _ -> assert false)
+    | _ -> assert false
+
+
   method label_x_expression_param (l, e) =
     let term = self#unparseConstraintExpr e in
     let param = match l with
@@ -6413,22 +6475,8 @@ class printer  ()= object(self:'self)
        *  })
        *  when the line-length indicates breaking.
        *)
-      | [(Nolabel, ({pexp_attributes = []; pexp_desc = Pexp_record (l, eo)}))] ->
-          [self#unparseRecord ~wrap:("(", ")") l eo]
-      | [(Nolabel, ({pexp_attributes = []; pexp_desc = Pexp_extension (s, p)}))] when s.txt = "bs.obj" ->
-          [self#formatBsObjExtensionSugar ~wrap:("(", ")") p]
-      | [(Nolabel, ({pexp_attributes = []; pexp_desc = Pexp_tuple l}))] ->
-          [self#unparseSequence ~wrap:("(", ")") ~construct:`Tuple l]
-      | [(Nolabel, ({pexp_attributes = []; pexp_desc = Pexp_array l}))] ->
-          [self#unparseSequence ~wrap:("(", ")") ~construct:`Array  l]
-      | [(Nolabel, ({pexp_attributes = []; pexp_desc} as exp))] when (is_simple_list_expr exp) ->
-          (match view_expr exp with
-          | `list xs ->
-              [self#unparseSequence ~construct:`List ~wrap:("(", ")") xs]
-          | `cons xs ->
-              [self#unparseSequence ~construct:`ES6List ~wrap:("(", ")") xs]
-          | _ -> assert false)
-
+      | [(Nolabel, exp)] when isSingleArgParenApplication [exp] ->
+          [self#singleArgParenApplication [exp]]
       | params ->
           [makeTup (List.map self#label_x_expression_param params)])
     in


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/1510

Parser:

```reason
`Assoc(1)
```
is now parsed as
```
[
  structure_item (x.re[1,0+0]..[1,0+10])
    Pstr_eval
    expression (x.re[1,0+0]..[1,0+9])
      Pexp_variant "Assoc"
      Some
        expression (x.re[1,0+6]..[1,0+9])
          Pexp_constant PConst_int (1,None)
]
```
Unnecessary tuple is gone & matches the previous parser's behaviour.

Printer:

```reason
/* before */
Delete(
  { 
    uuid: imagineSomethingReallyLong 
  }
);
`Delete(
  { 
    uuid: imagineSomethingReallyLong 
  }
);

/* after*/
Delete({
  uuid: imagineSomethingReallyLong
});

`Delete({
  uuid: imagineSomethingReallyLong
});
```
This happens for tuples, lists, spread lists, arrays, bs obj sugar and objects.
Both variants and poly-variants are covered in this PR.

There was another issue with regular function application with a single object which formatted pretty ugly, has also been fixed.
```reason
/* before */
let res =
  acceptsOpenAnonObjAsArg(
    {pub x = 0; pub y = 10}
  );

/* after */
let res =
  acceptsOpenAnonObjAsArg({
    pub x = 0;
    pub y = 10
  });

```