### PR TITLE
pun record destructuring with renaming

### DIFF
--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1058,3 +1058,8 @@ let registerEventHandlers =
          )=?,
       ()
     ) => 1;
+
+/* #1320: record destrucuring + renaming */
+let x = ({state as prevState}) => 1;
+
+let x = ({ReasonReact.state as prevState}) => 1;

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -876,3 +876,7 @@ let registerEventHandlers =
           option(((~button: Events.buttonStateT, ~state: Events.stateT, ~x: int, ~y: int) => unit))=?,
       ()
     ) => 1;
+
+/* #1320: record destrucuring + renaming */
+let x = ({state: state as prevState}) => 1;
+let x = ({ReasonReact.state: state as prevState}) => 1;

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -3347,6 +3347,11 @@ lbl_pattern_list:
 lbl_pattern:
   | as_loc(label_longident) COLON pattern { ($1,$3) }
   | as_loc(label_longident)               { ($1, pat_of_label $1) }
+  | as_loc(label_longident) AS as_loc(val_ident)
+    { (* punning with alias eg. {ReasonReact.state as prevState}
+       *  -> {ReasonReact.state: state as prevState} *)
+      ($1, mkpat(Ppat_alias(pat_of_label $1, $3)))
+    }
 ;
 
 /* Primitive declarations */

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -3316,6 +3316,12 @@ class printer  ()= object(self:'self)
                     (* record field punning when destructuring. {x: x, y: y} becomes {x, y} *)
                     (* works with module prefix too: {MyModule.x: x, y: y} becomes {MyModule.x, y} *)
                       self#longident_loc li
+                  | ({txt = ident},
+                     Ppat_alias ({ppat_desc = (Ppat_var {txt = ident2}) }, {txt = aliasIdent}))
+                     when Longident.last ident = ident2 ->
+                    (* record field punning when destructuring with renaming. {state: state as prevState} becomes {state as prevState *)
+                    (* works with module prefix too: {ReasonReact.state: state as prevState} becomes {ReasonReact.state as prevState *)
+                      makeList ~sep:" " [self#longident_loc li; atom "as"; atom aliasIdent]
                   | _ ->
                       label ~space:true (makeList [self#longident_loc li; atom ":"]) (self#pattern p)
               in


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/1320

```reason
/* before */
let x = ({ReasonReact.state: state as prevState}) => 1;
let x = ({state: state as prevState}) => 1;

/* after */
let x = ({ReasonReact.state as prevState}) => 1;
let x = ({state as prevState}) => 1;
```