### PR TITLE
Fix outcome printer for class type and variant values

### DIFF
--- a/formatTest/oprintTests/basic.re
+++ b/formatTest/oprintTests/basic.re
@@ -17,6 +17,11 @@ type t2 = (a, b) => c;
 type t3 = ((a, b)) => c;
 type t4 = (~x: int, ~y: string) => c;
 type t5 = (~x: a=?) => b;
+type tf = (int => int) => string;
+type tNested2 = ((int => int)) => string;
+type tNested3 = ((int => int) => int) => string;
+type tNested4 = (int, int) => string;
+type tNested5 = ((int, int)) => string;
 
 type t6 = int;
 type t7('a) = list('a);
@@ -116,20 +121,3 @@ type t =
 
 type foo = {x:int};
 let result = Some {x:1};
-
-class aClass(x) {
-  /* one value parameter x */
-  pub a1 = 0;
-  pub a2() = 0;
-  pub a3(x,y) = x + y;
-  pub a4(x,y) {
-    let result = x + y;
-    print_endline(" x + y = " ++ string_of_int(x) ++ " + " ++ string_of_int(y) ++ " = " ++ string_of_int(result));
-    result
-  };
-};
-
-
-
-
-

--- a/formatTest/oprintTests/class.re
+++ b/formatTest/oprintTests/class.re
@@ -1,0 +1,36 @@
+class aClass1(x) {
+  /* one value parameter x */
+  pub a1 = 0;
+  pub a2() = 0;
+  pub a3(x,y) = x + y;
+  pub a4(x,y) {
+    let result = x + y;
+    print_endline(" x + y = " ++ string_of_int(x) ++ " + " ++ string_of_int(y) ++ " = " ++ string_of_int(result));
+    result
+  };
+};
+class aClass2(x) {
+};
+class aClass3(x: (int => int)) {
+};
+class aClass4(x: (int => int => int)) {
+};
+class aClass5(x: (int => (int => int))) {
+};
+class aClass6(x: ((int => int) => int)) {
+};
+class aClass7(x: ((int, int) => int)) {
+};
+
+class labeledClass1(~x) {
+};
+class labeledClass2(~x: ((~y:int) => int)) {
+};
+class labeledClass3(~x: ((~y:int) => int => int)) {
+};
+class labeledClass4(~x: ((~y:int) => (int => int))) {
+};
+class labeledClass5(~x: (((~y:int) => int) => int)) {
+};
+class labeledClass6(~x: ((~y:(int, int)) => int)) {
+};

--- a/formatTest/testOprint.js
+++ b/formatTest/testOprint.js
@@ -42,7 +42,6 @@ const refmtInterface = (sourceFile) => {
 }
 
 const checkResult = (text) => new Promise((res, rej) => {
-  const cmd = `echo `
   const proc = spawn(refmt, ['--parse', 're', '-i', 'true', '--print', 're'])
 
   let stdout = ''

--- a/src/README.md
+++ b/src/README.md
@@ -84,6 +84,8 @@ Our lexer & parser use [Menhir](http://gallium.inria.fr/~fpottier/menhir/), a li
 
 - `reactjs_jsx_ppx_v2.ml/v3.ml`: our ReactJS interop that translates [Reason JSX](https://reasonml.github.io/guide/language/jsx) into something that ReactJS understands. See the comments in the file and the description in [ReasonReact](https://reasonml.github.io/reason-react/#reason-react-jsx).
 
+- `testOprint.ml`: unit tests for the outcome printer mentioned above. See the file for more info on how outcome printing is tested.
+
 ## Working With Parser
 
 Here's a recommended workflow:

--- a/src/testOprint.ml
+++ b/src/testOprint.ml
@@ -3,7 +3,7 @@
 (**
  * See `testOprint.js` for how this gets run.
  *
- * In order to test our outcome printer, we parse & typecheck the code provided on stin.
+ * In order to test our outcome printer, we parse & typecheck the code provided on stdin.
  * That gives us a `Typedtree` (like an AST but with all the types included), which includes
  * the `signature` type of the module we just processed.
  * From there, `Printtyp` will helpfully convert the `signature` into something that our


### PR DESCRIPTION
For class type: see comment.
For variant values: they weren't updated to the new syntax. We'll put test for them in #1548