### PR TITLE
Make `Some ()` a valid pattern

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/patternMatching.re
+++ b/formatTest/typeCheckedTests/expected_output/patternMatching.re
@@ -125,3 +125,60 @@ let res =
       | None => 0
     )
   };
+
+/* test (), which is sugar for (()) */
+switch (Some()) {
+| Some () => 1
+};
+
+switch (Some()) {
+| Some () => 1
+};
+
+switch (Some()) {
+| Some () => 1
+};
+
+switch (Some()) {
+| Some () => 1
+};
+
+type foo =
+  | Foo(unit);
+
+switch (Foo()) {
+| Foo () => 1
+};
+
+switch (Foo()) {
+| Foo () => 1
+};
+
+switch (Foo()) {
+| Foo () => 1
+};
+
+switch (Foo()) {
+| Foo () => 1
+};
+
+switch () {
+| () => 1
+};
+
+switch () {
+| () => 1
+};
+
+switch () {
+| () => 1
+};
+
+switch () {
+| () => 1
+};
+
+switch (Some(1)) {
+| Some(1) => 1
+| None => 2
+};

--- a/formatTest/typeCheckedTests/input/patternMatching.re
+++ b/formatTest/typeCheckedTests/input/patternMatching.re
@@ -75,7 +75,7 @@ let res =
 
 /**
  * Ensure that nested Pexp_functions are correctly wrapped in parens.
- * 
+ *
  */
 let res =
   switch (TwoCombos(Unused,Unused)) {
@@ -103,4 +103,48 @@ let res =
             | None => 0));
   };
 
+/* test (), which is sugar for (()) */
+switch (Some(())) {
+| Some(()) => 1
+};
+switch (Some(())) {
+| Some() => 1
+};
+switch (Some()) {
+| Some(()) => 1
+};
+switch (Some()) {
+| Some() => 1
+};
 
+type foo = Foo(unit);
+switch (Foo(())) {
+| Foo(()) => 1
+};
+switch (Foo(())) {
+| Foo() => 1
+};
+switch (Foo()) {
+| Foo(()) => 1
+};
+switch (Foo()) {
+| Foo() => 1
+};
+
+switch (()) {
+| (()) => 1
+};
+switch (()) {
+| () => 1
+};
+switch () {
+| (()) => 1
+};
+switch () {
+| () => 1
+};
+
+switch (Some(1)) {
+| Some(1) => 1
+| None => 2
+};


### PR DESCRIPTION
Make `Some ()` a valid pattern

Fixes #1506

For posteriority, here's a code snippet of **values**:

```reason
Some(1);
Some(());
Foo(1);
Foo(());
```

The AST before this diff (with the previous syntax ofc):

```ocaml
[
  structure_item (foo.re[1,0+0]..[1,0+7])
    Pstr_eval
    expression (foo.re[1,0+0]..[1,0+6])
      Pexp_construct "Some" (foo.re[1,0+0]..[1,0+4])
      Some
        expression (foo.re[1,0+5]..[1,0+6])
          Pexp_constant Const_int 1
  structure_item (foo.re[2,8+0]..[2,8+8])
    Pstr_eval
    expression (foo.re[2,8+0]..[2,8+7])
      Pexp_construct "Some" (foo.re[2,8+0]..[2,8+4])
      Some
        expression (foo.re[2,8+5]..[2,8+7])
          Pexp_construct "()" (foo.re[2,8+5]..[2,8+7])
          None
  structure_item (foo.re[3,17+0]..[3,17+6])
    Pstr_eval
    expression (foo.re[3,17+0]..[3,17+5])
      attribute "explicit_arity"
        []
      Pexp_construct "Foo" (foo.re[3,17+0]..[3,17+3])
      Some
        expression (foo.re[3,17+4]..[3,17+5])
          Pexp_tuple
          [
            expression (foo.re[3,17+4]..[3,17+5])
              Pexp_constant Const_int 1
          ]
  structure_item (foo.re[4,24+0]..[4,24+7])
    Pstr_eval
    expression (foo.re[4,24+0]..[4,24+6])
      attribute "explicit_arity"
        []
      Pexp_construct "Foo" (foo.re[4,24+0]..[4,24+3])
      Some
        expression (foo.re[4,24+4]..[4,24+6])
          Pexp_tuple
          [
            expression (foo.re[4,24+4]..[4,24+6])
              Pexp_construct "()" (foo.re[4,24+4]..[4,24+6])
              None
          ]
]
```

After this diff:

```ocaml
[
  structure_item (foo.re[1,0+0]..[1,0+8])
    Pstr_eval
    expression (foo.re[1,0+0]..[1,0+7])
      attribute "explicit_arity"
        []
      Pexp_construct "Some" (foo.re[1,0+0]..[1,0+4])
      Some
        expression (foo.re[1,0+4]..[1,0+7])
          Pexp_tuple
          [
            expression (foo.re[1,0+5]..[1,0+6])
              Pexp_constant Const_int 1
          ]
  structure_item (foo.re[2,9+0]..[2,9+9])
    Pstr_eval
    expression (foo.re[2,9+0]..[2,9+8])
      attribute "explicit_arity"
        []
      Pexp_construct "Some" (foo.re[2,9+0]..[2,9+4])
      Some
        expression (foo.re[2,9+4]..[2,9+8])
          Pexp_tuple
          [
            expression (foo.re[2,9+5]..[2,9+7])
              Pexp_construct "()" (foo.re[2,9+5]..[2,9+7])
              None
          ]
  structure_item (foo.re[3,19+0]..[3,19+7])
    Pstr_eval
    expression (foo.re[3,19+0]..[3,19+6])
      attribute "explicit_arity"
        []
      Pexp_construct "Foo" (foo.re[3,19+0]..[3,19+3])
      Some
        expression (foo.re[3,19+3]..[3,19+6])
          Pexp_tuple
          [
            expression (foo.re[3,19+4]..[3,19+5])
              Pexp_constant Const_int 1
          ]
  structure_item (foo.re[4,27+0]..[4,27+8])
    Pstr_eval
    expression (foo.re[4,27+0]..[4,27+7])
      attribute "explicit_arity"
        []
      Pexp_construct "Foo" (foo.re[4,27+0]..[4,27+3])
      Some
        expression (foo.re[4,27+3]..[4,27+7])
          Pexp_tuple
          [
            expression (foo.re[4,27+4]..[4,27+6])
              Pexp_construct "()" (foo.re[4,27+4]..[4,27+6])
              None
          ]
]
```

This diff didn't change the above. They were already changed. Note `explicit_arity` everywhere now

And here's another snippet, of **patterns**:

```reason
switch a {
| Some(1) => 1
| Some() => 2
| Foo(1) => 3
| Foo() => 4
}
```

AST before this diff:

```ocaml
[
  structure_item (foo.re[1,0+0]..[6,67+1])
    Pstr_eval
    expression (foo.re[1,0+0]..[6,67+1])
      Pexp_match
      expression (foo.re[1,0+7]..[1,0+8])
        Pexp_ident "a" (foo.re[1,0+7]..[1,0+8])
      [
        <case>
          pattern (foo.re[2,11+2]..[2,11+8])
            attribute "explicit_arity"
              []
            Ppat_construct "Some" (foo.re[2,11+2]..[2,11+6])
            Some
              pattern (foo.re[2,11+2]..[2,11+8])
                Ppat_tuple
                [
                  pattern (foo.re[2,11+7]..[2,11+8])
                    Ppat_constant Const_int 1
                ]
          expression (foo.re[2,11+12]..[2,11+13])
            Pexp_constant Const_int 1
        <case>
          pattern (foo.re[3,25+2]..[3,25+9])
            attribute "explicit_arity"
              []
            Ppat_construct "Some" (foo.re[3,25+2]..[3,25+6])
            Some
              pattern (foo.re[3,25+2]..[3,25+9])
                Ppat_tuple
                [
                  pattern (foo.re[3,25+7]..[3,25+9])
                    Ppat_construct "()" (foo.re[3,25+7]..[3,25+9])
                    None
                ]
          expression (foo.re[3,25+13]..[3,25+14])
            Pexp_constant Const_int 2
        <case>
          pattern (foo.re[4,40+2]..[4,40+7])
            attribute "explicit_arity"
              []
            Ppat_construct "Foo" (foo.re[4,40+2]..[4,40+5])
            Some
              pattern (foo.re[4,40+2]..[4,40+7])
                Ppat_tuple
                [
                  pattern (foo.re[4,40+6]..[4,40+7])
                    Ppat_constant Const_int 1
                ]
          expression (foo.re[4,40+11]..[4,40+12])
            Pexp_constant Const_int 3
        <case>
          pattern (foo.re[5,53+2]..[5,53+8])
            attribute "explicit_arity"
              []
            Ppat_construct "Foo" (foo.re[5,53+2]..[5,53+5])
            Some
              pattern (foo.re[5,53+2]..[5,53+8])
                Ppat_tuple
                [
                  pattern (foo.re[5,53+6]..[5,53+8])
                    Ppat_construct "()" (foo.re[5,53+6]..[5,53+8])
                    None
                ]
          expression (foo.re[5,53+12]..[5,53+13])
            Pexp_constant Const_int 4
      ]
]
```

After this diff:

```ocaml
[
  structure_item (foo.re[1,0+0]..[6,67+1])
    Pstr_eval
    expression (foo.re[1,0+0]..[6,67+1])
      Pexp_match
      expression (foo.re[1,0+7]..[1,0+8])
        Pexp_ident "a" (foo.re[1,0+7]..[1,0+8])
      [
        <case>
          pattern (foo.re[2,11+2]..[2,11+9])
            attribute "explicit_arity"
              []
            Ppat_construct "Some" (foo.re[2,11+2]..[2,11+6])
            Some
              pattern (foo.re[2,11+2]..[2,11+9])
                Ppat_tuple
                [
                  pattern (foo.re[2,11+7]..[2,11+8])
                    Ppat_constant Const_int 1
                ]
          expression (foo.re[2,11+13]..[2,11+14])
            Pexp_constant Const_int 1
        <case>
          pattern (foo.re[3,26+2]..[3,26+8])
            Ppat_construct "Some" (foo.re[3,26+2]..[3,26+6])
            Some
              pattern (foo.re[3,26+2]..[3,26+8])
                Ppat_construct "()" (foo.re[3,26+2]..[3,26+8])
                None
          expression (foo.re[3,26+12]..[3,26+13])
            Pexp_constant Const_int 2
        <case>
          pattern (foo.re[4,40+2]..[4,40+8])
            attribute "explicit_arity"
              []
            Ppat_construct "Foo" (foo.re[4,40+2]..[4,40+5])
            Some
              pattern (foo.re[4,40+2]..[4,40+8])
                Ppat_tuple
                [
                  pattern (foo.re[4,40+6]..[4,40+7])
                    Ppat_constant Const_int 1
                ]
          expression (foo.re[4,40+12]..[4,40+13])
            Pexp_constant Const_int 3
        <case>
          pattern (foo.re[5,54+2]..[5,54+7])
            Ppat_construct "Foo" (foo.re[5,54+2]..[5,54+5])
            Some
              pattern (foo.re[5,54+2]..[5,54+7])
                Ppat_construct "()" (foo.re[5,54+2]..[5,54+7])
                None
          expression (foo.re[5,54+11]..[5,54+12])
            Pexp_constant Const_int 4
      ]
]
```

This diff does change the patterns. No more `explicit_arity` for `()` pattern