### PR TITLE
Missing parens when pattern matching on Ppat_construct containing a list

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/patternMatching.re
+++ b/formatTest/typeCheckedTests/expected_output/patternMatching.re
@@ -182,3 +182,12 @@ switch (Some(1)) {
 | Some(1) => 1
 | None => 2
 };
+
+switch None {
+| Some([]) => ()
+| Some([_]) => ()
+| Some([x]) => ()
+| Some([x, ...xs]) => ()
+| Some([x, y, z]) => ()
+| _ => ()
+};

--- a/formatTest/typeCheckedTests/input/patternMatching.re
+++ b/formatTest/typeCheckedTests/input/patternMatching.re
@@ -148,3 +148,12 @@ switch (Some(1)) {
 | Some(1) => 1
 | None => 2
 };
+
+switch None {
+| Some([]) => ()
+| Some([_]) => ()
+| Some([x]) => ()
+| Some([x, ...xs]) => ()
+| Some([x, y, z]) => ()
+| _ => ()
+};

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2389,8 +2389,7 @@ let is_unit_pattern x = match x.ppat_desc with
 
 let is_direct_pattern x = x.ppat_attributes = [] && match x.ppat_desc with
   | Ppat_array _ | Ppat_record _
-  | Ppat_construct ( {txt= Lident"()"}, None)
-  | Ppat_construct ( {txt= Lident"::"}, Some _) -> true
+  | Ppat_construct ( {txt= Lident"()"}, None) -> true
   | _ -> false
 
 (* Some cases require special formatting when there's a function application
@@ -3250,7 +3249,6 @@ class printer  ()= object(self:'self)
                 self#constructor_pattern ~arityIsClear liSourceMapped xx
             | None ->
                 liSourceMapped
-
           in
             SourceMap (x.ppat_loc, formattedConstruction)
       | _ -> self#simple_pattern x
@@ -4741,8 +4739,8 @@ class printer  ()= object(self:'self)
       | _ -> (false, [po])
     in
     let space, arguments = match arguments with
-      | [x] when is_direct_pattern x -> true, self#simple_pattern x
-      | xs -> false, makeTup (List.map self#pattern xs)
+      | [x] when is_direct_pattern x -> (true, self#simple_pattern x)
+      | xs -> (false, makeTup (List.map self#pattern xs))
     in
     let construction = label ~space ctor arguments in
     if implicit_arity && (not polyVariant) then


### PR DESCRIPTION
Fixes #1525 

```
/* before */
  switch x {
  | Some([]) => ()
  | Some [_] => () /* Not good, parens missing */
  | Some [x] => () /* Not good, parens missing */
  | Some [x, y, z] => () /* Not good, parens missing */
  | Some [x, ...xs] => () /* Not good, parens missing */
  };

/* after */
  switch x {
  | Some([]) => ()
  | Some([_]) => ()
  | Some([x]) => ()
  | Some([x, y, z]) => ()
  | Some([x, ...xs]) => ()
  };
```