### PR TITLE
Add support for simple pattern direct argument with array, list & record.

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/patternMatching.re
+++ b/formatTest/typeCheckedTests/expected_output/patternMatching.re
@@ -183,11 +183,52 @@ switch (Some(1)) {
 | None => 2
 };
 
+/* with parens around direct list pattern in constructor pattern */
 switch None {
-| Some([]) => ()
-| Some([_]) => ()
-| Some([x]) => ()
-| Some([x, ...xs]) => ()
-| Some([x, y, z]) => ()
+| Some [] => ()
+| Some [_] => ()
+| Some [x] => ()
+| Some [x, ...xs] => ()
+| Some [x, y, z] => ()
 | _ => ()
+};
+
+/* no parens around direct list pattern in constructor pattern (sugar) */
+switch None {
+| Some [] => ()
+| Some [_] => ()
+| Some [x] => ()
+| Some [x, ...xs] => ()
+| Some [x, y, z] => ()
+| _ => ()
+};
+
+/* with parens around direct array pattern in constructor pattern */
+switch None {
+| Some [||] => "empty"
+| Some [|_|] => "one any"
+| Some [|a|] => "one"
+| Some [|a, b|] => "two"
+| _ => "many"
+};
+
+/* no parens around direct array pattern in constructor pattern (sugar) */
+switch None {
+| Some [||] => "empty"
+| Some [|_|] => "one any"
+| Some [|a|] => "one"
+| Some [|a, b|] => "two"
+| _ => "many"
+};
+
+/* parens around direct record pattern in constructor pattern */
+switch None {
+| Some {x} => ()
+| Some {x, y} => ()
+};
+
+/* no parens around direct record pattern in constructor pattern (sugar) */
+switch None {
+| Some {x} => ()
+| Some {x, y} => ()
 };

--- a/formatTest/typeCheckedTests/input/patternMatching.re
+++ b/formatTest/typeCheckedTests/input/patternMatching.re
@@ -149,6 +149,7 @@ switch (Some(1)) {
 | None => 2
 };
 
+/* with parens around direct list pattern in constructor pattern */
 switch None {
 | Some([]) => ()
 | Some([_]) => ()
@@ -156,4 +157,44 @@ switch None {
 | Some([x, ...xs]) => ()
 | Some([x, y, z]) => ()
 | _ => ()
+};
+
+/* no parens around direct list pattern in constructor pattern (sugar) */
+switch None {
+| Some [] => ()
+| Some [_] => ()
+| Some [x] => ()
+| Some [x, ...xs] => ()
+| Some [x, y, z] => ()
+| _ => ()
+};
+
+/* with parens around direct array pattern in constructor pattern */
+switch None {
+| Some([| |]) => "empty"
+| Some([| _ |]) => "one any"
+| Some([| a |]) => "one"
+| Some([| a, b |]) => "two"
+| _ => "many"
+};
+
+/* no parens around direct array pattern in constructor pattern (sugar) */
+switch None {
+| Some [||] => "empty"
+| Some [|_|] => "one any"
+| Some [|a|] => "one"
+| Some [|a, b|] => "two"
+| _ => "many"
+};
+
+/* parens around direct record pattern in constructor pattern */
+switch None {
+| Some({x}) => ()
+| Some({x, y}) => ()
+};
+
+/* no parens around direct record pattern in constructor pattern (sugar) */
+switch None {
+| Some {x} => ()
+| Some {x, y} => ()
 };

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2389,7 +2389,9 @@ let is_unit_pattern x = match x.ppat_desc with
 
 let is_direct_pattern x = x.ppat_attributes = [] && match x.ppat_desc with
   | Ppat_array _ | Ppat_record _
-  | Ppat_construct ( {txt= Lident"()"}, None) -> true
+  | Ppat_construct ( {txt= Lident"()"}, None)
+  | Ppat_construct ( {txt= Lident"[]"}, None)
+  | Ppat_construct ( {txt= Lident"::"}, Some _) -> true
   | _ -> false
 
 (* Some cases require special formatting when there's a function application


### PR DESCRIPTION
https://github.com/facebook/reason/pull/1527#issuecomment-338124733

This PR streamlines  all "sugar" around `simple_pattern_direct_argument`:
```reason
/* you don't need to surround the constructor's arg with parens */
switch v {
| Foo () => ...
| Foo [a] => ...
| Foo [||] => ...
| Foo {a} => ...
};
```