### PR TITLE
Fix outcome printer record value printing

### DIFF
--- a/formatTest/oprintTests/basic.re
+++ b/formatTest/oprintTests/basic.re
@@ -114,6 +114,8 @@ type t =
   | C(int, int)
   | D((int, int));
 
+type foo = {x:int};
+let result = Some {x:1};
 
 class aClass(x) {
   /* one value parameter x */

--- a/src/reason_oprint.ml
+++ b/src/reason_oprint.ml
@@ -212,7 +212,7 @@ let print_out_value ppf tree =
       [] -> ()
     | (name, tree) :: fields ->
         if not first then fprintf ppf ",@ ";
-        fprintf ppf "@[<1>%a@:@ %a@]" print_ident name (cautious (print_tree_1 false))
+        fprintf ppf "@[<1>%a:@ %a@]" print_ident name (cautious (print_tree_1 false))
           tree;
         print_fields false ppf fields
   and print_tree_list print_item sep ppf tree_list =


### PR DESCRIPTION
cc @hcarty @jaredly

Our oprint tests currently don't test value printing. This feels like
that time when a colleague put flow types everywhere then realize that
file wasn't flow typed, lol

Test:

in rtop, try this:

```
type foo = {x:int};
let bar = Some {x:1};
```

Make sure it prints correctly