### PR TITLE
implement Pexp_letexception

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -497,10 +497,8 @@ external debounce :
   ) =>
   [@bs.meth] (unit => unit) =
   "";
-
-/* Pexp_letexception with attributes */
-let () = {
-  [@attribute]
-  exception E;
-  raise(E)
-};
+/* Pexp_letexception with attributes, TODO enable on 4.04.2 and higher */
+/* let () = { */
+/* [@attribute] exception E; */
+/* raise(E) */
+/* }; */

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -497,3 +497,10 @@ external debounce :
   ) =>
   [@bs.meth] (unit => unit) =
   "";
+
+/* Pexp_letexception with attributes */
+let () = {
+  [@attribute]
+  exception E;
+  raise(E)
+};

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -358,3 +358,9 @@ external debounce : int => ([@bs.meth] (unit => unit)) => ([@bs.meth] (unit => u
 external debounce : int => ([@bs.meth] (unit => unit)) => ([@bs.meth] (unit => unit)) => ([@bs.meth] (unit => unit)) = "";
 
 external debounce : int => ([@bs.meth] (unit => unit)) => ([@bs.meth] (unit => [@bs.meth] (unit => unit))) => ([@bs.meth] (unit => unit)) = "";
+
+/* Pexp_letexception with attributes */
+let () = {
+  [@attribute] exception E;
+  raise(E)
+};

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -359,8 +359,8 @@ external debounce : int => ([@bs.meth] (unit => unit)) => ([@bs.meth] (unit => u
 
 external debounce : int => ([@bs.meth] (unit => unit)) => ([@bs.meth] (unit => [@bs.meth] (unit => unit))) => ([@bs.meth] (unit => unit)) = "";
 
-/* Pexp_letexception with attributes */
-let () = {
-  [@attribute] exception E;
-  raise(E)
-};
+/* Pexp_letexception with attributes, TODO enable on 4.04.2 and higher */
+/* let () = { */
+  /* [@attribute] exception E; */
+  /* raise(E) */
+/* }; */

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -771,3 +771,9 @@ switch foo {
 /* Requested in #566 */
 let break_after_equal =
   no_break_from_here(some_call(to_here));
+
+/* Pexp_letexception */
+let () = {
+  exception E;
+  raise(E)
+};

--- a/formatTest/unit_tests/input/basicStructures.re
+++ b/formatTest/unit_tests/input/basicStructures.re
@@ -627,3 +627,9 @@ switch (foo) {
 
 /* Requested in #566 */
 let break_after_equal = no_break_from_here(some_call(to_here));
+
+/* Pexp_letexception */
+let () = {
+  exception E;
+  raise(E)
+};

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -2291,11 +2291,11 @@ mark_position_exp
     { mkexp (Pexp_letmodule($2, $3, $5)) }
   | LET? OPEN override_flag as_loc(mod_longident) SEMI semi_terminated_seq_expr
     { mkexp (Pexp_open($3, $4, $6)) }
+  | str_exception_declaration SEMI semi_terminated_seq_expr {
+     mkexp (Pexp_letexception ($1, $3)) }
   | expr SEMI semi_terminated_seq_expr
     { mkexp (Pexp_sequence($1, $3)) }
   ) {$1};
-
-
 
 /*
 

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -4674,6 +4674,9 @@ class printer  ()= object(self:'self)
            * brace {} in the let sequence. *)
           let letModuleSourceMapped = SourceMap (letModuleLoc, letModuleLayout) in
            letModuleSourceMapped::(self#letList e)
+      | ([], Pexp_letexception (extensionConstructor, expr)) ->
+          let exc = self#exception_declaration extensionConstructor in
+          exc::(self#letList expr)
       | ([], Pexp_sequence (({pexp_desc=Pexp_sequence _ }) as e1, e2))
       | ([], Pexp_sequence (({pexp_desc=Pexp_let _      }) as e1, e2))
       | ([], Pexp_sequence (({pexp_desc=Pexp_open _     }) as e1, e2))
@@ -5243,6 +5246,8 @@ class printer  ()= object(self:'self)
         | Pexp_let (rf, l, e) ->
             Some (makeLetSequence (self#letList x))
         | Pexp_letmodule (s, me, e) ->
+            Some (makeLetSequence (self#letList x))
+        | Pexp_letexception _ ->
             Some (makeLetSequence (self#letList x))
         | Pexp_open (ovf, lid, e) ->
             let letItems = (self#letList x) in


### PR DESCRIPTION
https://github.com/facebook/reason/issues/1424

Adds support for `Pexp_letexception`.

Ocaml:
```ocaml
let () = let exception E in raise E

```
resulting in parse tree:
```

(* parse tree *)
[
  structure_item (exc.ml[1,0+0]..[1,0+35])
    Pstr_value Nonrec
    [
      <def>
        pattern (exc.ml[1,0+4]..[1,0+6])
          Ppat_construct "()" (exc.ml[1,0+4]..[1,0+6])
          None
        expression (exc.ml[1,0+9]..[1,0+35])
          Pexp_letexception
          extension_constructor (exc.ml[1,0+23]..[1,0+24])
            pext_name = "E"
            pext_kind =
              Pext_decl
                []
                None
          expression (exc.ml[1,0+28]..[1,0+35])
            Pexp_apply
            expression (exc.ml[1,0+28]..[1,0+33])
              Pexp_ident "raise" (exc.ml[1,0+28]..[1,0+33])
            [
              <arg>
              Nolabel
                expression (exc.ml[1,0+34]..[1,0+35])
                  Pexp_construct "E" (exc.ml[1,0+34]..[1,0+35])
                  None
            ]
    ]
]
```

Becomes in Reason:
```reason
let () = {
  exception E;
  raise(E);
};
```
resulting in parse tree:
```
[
  structure_item (local.re[1,0+0]..[4,39+2])
    Pstr_value Nonrec
    [
      <def>
        pattern (local.re[1,0+4]..[1,0+6])
          Ppat_construct "()" (local.re[1,0+4]..[1,0+6])
          None
        expression (local.re[1,0+9]..[4,39+1])
          Pexp_letexception
          extension_constructor (local.re[2,11+12]..[2,11+13])
            pext_name = "E"
            pext_kind =
              Pext_decl
                []
                None
          expression (local.re[3,26+2]..[3,26+11])
            Pexp_apply
            expression (local.re[3,26+2]..[3,26+7])
              Pexp_ident "raise" (local.re[3,26+2]..[3,26+7])
            [
              <arg>
              Nolabel
                expression (local.re[3,26+8]..[3,26+9])
                  Pexp_construct "E" (local.re[3,26+8]..[3,26+9])
                  None
            ]
    ]
]
```

