### PR TITLE
Re-enable Pexp_letception tests disabled in #1531

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.4.04.0.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.4.04.0.re
@@ -1,0 +1,6 @@
+/* Pexp_letexception with attributes */
+let () = {
+  [@attribute]
+  exception E;
+  raise(E)
+};

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -497,8 +497,10 @@ external debounce :
   ) =>
   [@bs.meth] (unit => unit) =
   "";
-/* Pexp_letexception with attributes, TODO enable on 4.04.2 and higher */
-/* let () = { */
-/* [@attribute] exception E; */
-/* raise(E) */
-/* }; */
+
+/* Pexp_letexception with attributes */
+let () = {
+  [@attribute]
+  exception E;
+  raise(E)
+};

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -497,10 +497,3 @@ external debounce :
   ) =>
   [@bs.meth] (unit => unit) =
   "";
-
-/* Pexp_letexception with attributes */
-let () = {
-  [@attribute]
-  exception E;
-  raise(E)
-};

--- a/formatTest/typeCheckedTests/input/attributes.4.04.0.re
+++ b/formatTest/typeCheckedTests/input/attributes.4.04.0.re
@@ -1,0 +1,5 @@
+/* Pexp_letexception with attributes */
+let () = {
+  [@attribute] exception E;
+  raise(E)
+};

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -358,9 +358,3 @@ external debounce : int => ([@bs.meth] (unit => unit)) => ([@bs.meth] (unit => u
 external debounce : int => ([@bs.meth] (unit => unit)) => ([@bs.meth] (unit => unit)) => ([@bs.meth] (unit => unit)) = "";
 
 external debounce : int => ([@bs.meth] (unit => unit)) => ([@bs.meth] (unit => [@bs.meth] (unit => unit))) => ([@bs.meth] (unit => unit)) = "";
-
-/* Pexp_letexception with attributes */
-let () = {
-  [@attribute] exception E;
-  raise(E)
-};

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -359,8 +359,8 @@ external debounce : int => ([@bs.meth] (unit => unit)) => ([@bs.meth] (unit => u
 
 external debounce : int => ([@bs.meth] (unit => unit)) => ([@bs.meth] (unit => [@bs.meth] (unit => unit))) => ([@bs.meth] (unit => unit)) = "";
 
-/* Pexp_letexception with attributes, TODO enable on 4.04.2 and higher */
-/* let () = { */
-  /* [@attribute] exception E; */
-  /* raise(E) */
-/* }; */
+/* Pexp_letexception with attributes */
+let () = {
+  [@attribute] exception E;
+  raise(E)
+};


### PR DESCRIPTION
Re-enables tests that were disabled because this feature was not available on 4.03 and earlier.

Fixes #1535.

Introduces a convention for naming typecheck tests to only run them on the OCaml compiler version in their name or later.