### PR TITLE
Enforce parens in simple pattern match printing

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/comments.re
+++ b/formatTest/typeCheckedTests/expected_output/comments.re
@@ -83,11 +83,11 @@ let result =
 
 let result =
   switch None {
-  | Some {fieldOne: 20} =>
+  | Some({fieldOne: 20}) =>
     /* Where does this comment go? */
     let tmp = 0;
     2 + tmp
-  | Some {fieldOne: n} =>
+  | Some({fieldOne: n}) =>
     /* How about this one */
     let tmp = n;
     n + tmp

--- a/formatTest/typeCheckedTests/expected_output/patternMatching.re
+++ b/formatTest/typeCheckedTests/expected_output/patternMatching.re
@@ -185,50 +185,50 @@ switch (Some(1)) {
 
 /* with parens around direct list pattern in constructor pattern */
 switch None {
-| Some [] => ()
-| Some [_] => ()
-| Some [x] => ()
-| Some [x, ...xs] => ()
-| Some [x, y, z] => ()
+| Some([]) => ()
+| Some([_]) => ()
+| Some([x]) => ()
+| Some([x, ...xs]) => ()
+| Some([x, y, z]) => ()
 | _ => ()
 };
 
 /* no parens around direct list pattern in constructor pattern (sugar) */
 switch None {
-| Some [] => ()
-| Some [_] => ()
-| Some [x] => ()
-| Some [x, ...xs] => ()
-| Some [x, y, z] => ()
+| Some([]) => ()
+| Some([_]) => ()
+| Some([x]) => ()
+| Some([x, ...xs]) => ()
+| Some([x, y, z]) => ()
 | _ => ()
 };
 
 /* with parens around direct array pattern in constructor pattern */
 switch None {
-| Some [||] => "empty"
-| Some [|_|] => "one any"
-| Some [|a|] => "one"
-| Some [|a, b|] => "two"
+| Some([||]) => "empty"
+| Some([|_|]) => "one any"
+| Some([|a|]) => "one"
+| Some([|a, b|]) => "two"
 | _ => "many"
 };
 
 /* no parens around direct array pattern in constructor pattern (sugar) */
 switch None {
-| Some [||] => "empty"
-| Some [|_|] => "one any"
-| Some [|a|] => "one"
-| Some [|a, b|] => "two"
+| Some([||]) => "empty"
+| Some([|_|]) => "one any"
+| Some([|a|]) => "one"
+| Some([|a, b|]) => "two"
 | _ => "many"
 };
 
 /* parens around direct record pattern in constructor pattern */
 switch None {
-| Some {x} => ()
-| Some {x, y} => ()
+| Some({x}) => ()
+| Some({x, y}) => ()
 };
 
 /* no parens around direct record pattern in constructor pattern (sugar) */
 switch None {
-| Some {x} => ()
-| Some {x, y} => ()
+| Some({x}) => ()
+| Some({x, y}) => ()
 };

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -218,11 +218,11 @@ and y2 = {
 
 let result =
   switch None {
-  | Some {fieldOne: 20, fieldA: a} =>
+  | Some({fieldOne: 20, fieldA: a}) =>
     /* Where does this comment go? */
     let tmp = 0;
     2 + tmp
-  | Some {fieldOne: n, fieldA: a} =>
+  | Some({fieldOne: n, fieldA: a}) =>
     /* How about this one */
     let tmp = n;
     n + tmp
@@ -243,18 +243,22 @@ let res =
  */
 let result =
   switch None {
-  | Some {
-      fieldOne: 20, /* end of line */
-      fieldA:
-        a /* end of line */
-    } =>
+  | Some(
+      {
+        fieldOne: 20, /* end of line */
+        fieldA:
+          a /* end of line */
+      }
+    ) =>
     let tmp = 0;
     2 + tmp
-  | Some {
-      fieldOne: n, /* end of line */
-      fieldA:
-        a /* end of line */
-    } =>
+  | Some(
+      {
+        fieldOne: n, /* end of line */
+        fieldA:
+          a /* end of line */
+      }
+    ) =>
     let tmp = n;
     n + tmp
   | None => 20

--- a/formatTest/unit_tests/expected_output/features403.re
+++ b/formatTest/unit_tests/expected_output/features403.re
@@ -5,7 +5,7 @@ type t =
 let f =
   fun
   | B => 0
-  | A {a} => a;
+  | A({a}) => a;
 
 type nonrec u('a) =
   | Box('a);
@@ -28,11 +28,11 @@ type expr('a) =
 let rec eval: type a. expr(a) => a =
   (e) =>
     switch e {
-    | Is0 {test} => eval(test) == 0
-    | Val {value} => value
-    | Add {left, right} =>
+    | Is0({test}) => eval(test) == 0
+    | Val({value}) => value
+    | Add({left, right}) =>
       eval(left) + eval(right)
-    | If {pred, true_branch, false_branch} =>
+    | If({pred, true_branch, false_branch}) =>
       if (eval(pred)) {
         eval(true_branch)
       } else {

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -400,32 +400,36 @@ let rec atLeastOneFlushableChildAndNoWipNoPending =
   | [] => false
   | [hd, ...tl] =>
     switch hd {
-    | OpaqueGraph {lifecycle: Reconciled(_, [])} =>
+    | OpaqueGraph({lifecycle: Reconciled(_, [])}) =>
       atLeastOneFlushableChildAndNoWipNoPending(
         tl,
         atPriority
       )
-    | OpaqueGraph {
-        lifecycle:
-          ReconciledFlushable(
-            priority,
-            _,
-            _,
-            _,
-            _,
-            _
-          )
-      }
-    | OpaqueGraph {
-        lifecycle:
-          NeverReconciledFlushable(
-            priority,
-            _,
-            _,
-            _,
-            _
-          )
-      }
+    | OpaqueGraph(
+        {
+          lifecycle:
+            ReconciledFlushable(
+              priority,
+              _,
+              _,
+              _,
+              _,
+              _
+            )
+        }
+      )
+    | OpaqueGraph(
+        {
+          lifecycle:
+            NeverReconciledFlushable(
+              priority,
+              _,
+              _,
+              _,
+              _
+            )
+        }
+      )
         when priority == AtPriority =>
       noWipNoPending(tl, atPriority)
     | SuperLongNameThatWontBreakByItselfSoWhenWillHaveToBreak

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -2469,20 +2469,18 @@ let howDoLongMultiBarPatternsWrap = (x) =>
   switch x {
   | AnotherReallyLongVariantName(_, _, _) => 0
   | AnotherReallyLongVariantName2(_, _, _) => 0
-  | ReallyLongVariantName {
-      someField,
-      anotherField
-    } => 0
+  | ReallyLongVariantName(
+      {someField, anotherField}
+    ) => 0
   };
 
 let letsCombineTwoLongPatternsIntoOneCase = (x) =>
   switch x {
   | AnotherReallyLongVariantName(_, _, _)
   | AnotherReallyLongVariantName2(_, _, _) => 0
-  | ReallyLongVariantName {
-      someField,
-      anotherField
-    } => 0
+  | ReallyLongVariantName(
+      {someField, anotherField}
+    ) => 0
   };
 
 let letsPutAWhereClauseOnTheFirstTwo = (x) =>
@@ -2490,20 +2488,18 @@ let letsPutAWhereClauseOnTheFirstTwo = (x) =>
   | AnotherReallyLongVariantName(_, _, _)
   | AnotherReallyLongVariantName2(_, _, _)
       when true => 0
-  | ReallyLongVariantName {
-      someField,
-      anotherField
-    } => 0
+  | ReallyLongVariantName(
+      {someField, anotherField}
+    ) => 0
   };
 
 let letsPutAWhereClauseOnTheLast = (x) =>
   switch x {
   | AnotherReallyLongVariantName(_, _, _)
   | AnotherReallyLongVariantName2(_, _, _) => 0
-  | ReallyLongVariantName {
-      someField,
-      anotherField
-    }
+  | ReallyLongVariantName(
+      {someField, anotherField}
+    )
       when true => 0
   };
 

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2388,10 +2388,7 @@ let is_unit_pattern x = match x.ppat_desc with
   | _ -> false
 
 let is_direct_pattern x = x.ppat_attributes = [] && match x.ppat_desc with
-  | Ppat_array _ | Ppat_record _
-  | Ppat_construct ( {txt= Lident"()"}, None)
-  | Ppat_construct ( {txt= Lident"[]"}, None)
-  | Ppat_construct ( {txt= Lident"::"}, Some _) -> true
+  | Ppat_construct ( {txt= Lident"()"}, None) -> true
   | _ -> false
 
 (* Some cases require special formatting when there's a function application


### PR DESCRIPTION
This allows for simple pattern matches to be parsed, but will always print with the parens for more consistency with type constructors outside of pattern matches (and the rest of the new syntax).