### PR TITLE
Produce syntax error messages in some cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,15 +17,19 @@ precompile:
 	cp pkg/META.in pkg/META
 	ocamlbuild -use-ocamlfind -package topkg pkg/build.native
 
-build_without_utop: compile_error setup_convenient_bin_links precompile
+preprocess: precompile
+	./build.native build -r src/reason_parser.ml -r src/menhir_error_processor.native
+	./menhir_error_processor.native _build/src/reason_parser.cmly > src/reason_explain_error.ml
+
+build_without_utop: compile_error setup_convenient_bin_links preprocess
 	./build.native build --utop false
 	chmod +x $(shell pwd)/_build/src/*.sh
 
-build_with_outcome_test: compile_error setup_convenient_bin_links precompile
+build_with_outcome_test: compile_error setup_convenient_bin_links preprocess
 	./build.native build --utop true --outcome_test true
 	chmod +x $(shell pwd)/_build/src/*.sh
 
-build: compile_error setup_convenient_bin_links precompile
+build: compile_error setup_convenient_bin_links preprocess
 	./build.native build --utop true
 	chmod +x $(shell pwd)/_build/src/*.sh
 

--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,15 @@ preprocess: precompile
 	./build.native build -r src/reason_parser.ml -r src/menhir_error_processor.native
 	./menhir_error_processor.native _build/src/reason_parser.cmly > src/reason_parser_explain_raw.ml
 
-build_without_utop: compile_error setup_convenient_bin_links preprocess
+build_without_utop: compile_error setup_convenient_bin_links
 	./build.native build --utop false
 	chmod +x $(shell pwd)/_build/src/*.sh
 
-build_with_outcome_test: compile_error setup_convenient_bin_links preprocess
+build_with_outcome_test: compile_error setup_convenient_bin_links
 	./build.native build --utop true --outcome_test true
 	chmod +x $(shell pwd)/_build/src/*.sh
 
-build: compile_error setup_convenient_bin_links preprocess
+build: compile_error setup_convenient_bin_links
 	./build.native build --utop true
 	chmod +x $(shell pwd)/_build/src/*.sh
 
@@ -84,7 +84,7 @@ release: release_check pre_release
 
 # Compile error messages into ml file, checks if the error messages are complete and not redundent
 
-compile_error: update_error
+compile_error: update_error preprocess
 	menhir --explain --strict --unused-tokens src/reason_parser.mly --compile-errors src/reason_parser.messages > src/reason_parser_message.ml
 
 all_errors:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ precompile:
 
 preprocess: precompile
 	./build.native build -r src/reason_parser.ml -r src/menhir_error_processor.native
-	./menhir_error_processor.native _build/src/reason_parser.cmly > src/reason_explain_error.ml
+	./menhir_error_processor.native _build/src/reason_parser.cmly > src/reason_parser_explain_raw.ml
 
 build_without_utop: compile_error setup_convenient_bin_links preprocess
 	./build.native build --utop false

--- a/_tags
+++ b/_tags
@@ -8,4 +8,5 @@ true: warn(@5@8@10@11@12@14@23-24@26@29@40), bin_annot, safe_string, debug, thre
 "src": include
 <src/*>: package(menhirLib unix compiler-libs.common ocamlbuild findlib merlin_extend result dynlink findlib.dynload ocaml-migrate-parsetree)
 <src/reason_utop.*>: package(menhirLib utop)
+<src/menhir_error_processor.*>: package(menhirSdk)
 

--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -3,8 +3,8 @@
 open Topkg
 
 let menhir_options =
-  let trace = try let _ = Sys.getenv "trace" in "--trace" with | Not_found -> "" in
-  "menhir --strict --unused-tokens --fixed-exception --table " ^ trace
+  let trace = try let _ = Sys.getenv "trace" in " --trace" with | Not_found -> "" in
+  "menhir --strict --unused-tokens --fixed-exception --table --cmly" ^ trace
 
 let utop = Conf.(key "utop" bool ~absent:false)
 let native = Conf.(key "native" bool ~absent:false)

--- a/src/menhir_error_processor.ml
+++ b/src/menhir_error_processor.ml
@@ -10,34 +10,43 @@ let print fmt = Printf.ksprintf print_endline fmt
 (* We want to detect any state where an identifier is admissible.
    That way, we can assume that if a keyword is used and rejceted, the user was
    intending to put an identifier. *)
-let states_transitioning_on_ident =
-  (* A terminal is either "LIDENT" or "UIDENT" *)
-  let term_is_ident term = match Terminal.name term with
-    | "LIDENT" | "UIDENT" -> true
-    | _ -> false
-  in
-  let sym_is_ident = function
-    | T term -> term_is_ident term
-    | N _ -> false
-  in
+let states_transitioning_on pred =
   let keep_state lr1 =
     (* There are two kind of transitions (leading to SHIFT or REDUCE), detect
        those who accept identifiers *)
-    List.exists (fun (term, prod) -> term_is_ident term) (Lr1.reductions lr1) ||
-    List.exists (fun (sym, _) -> sym_is_ident sym) (Lr1.transitions lr1)
+    List.exists (fun (term, prod) -> pred (T term)) (Lr1.reductions lr1) ||
+    List.exists (fun (sym, _) -> pred sym) (Lr1.transitions lr1)
   in
   (* Now we filter the list of all states and keep the interesting ones *)
   G.Lr1.fold (fun lr1 acc -> if keep_state lr1 then lr1 :: acc else acc) []
 
-let () =
+let print_transitions_on name pred =
   (* Produce a function that will be linked into the reason parser to recognize
-     these states at runtime.
+     states at runtime.
      TODO: a more compact encoding could be used, for now we don't care and
      just pattern matches on states.
   *)
-  print "let transitions_on_ident = function";
-  List.iter
-    (fun lr1 -> print "  | %d" (Lr1.to_int lr1))
-    states_transitioning_on_ident;
-  print "      -> true";
+  print "let transitions_on_%s = function" name;
+  begin match states_transitioning_on pred with
+    | [] -> prerr_endline ("no states matches " ^ name ^ " predicate");
+    | states ->
+      List.iter (fun lr1 -> print "  | %d" (Lr1.to_int lr1)) states;
+      print "      -> true"
+  end;
   print "  | _ -> false"
+
+let terminal_find name =
+  match
+    Terminal.fold
+      (fun t default -> if Terminal.name t = name then Some t else default)
+      None
+  with
+  | Some term -> term
+  | None -> failwith ("Unkown terminal " ^ name)
+
+let () = (
+  let lident_term = terminal_find "LIDENT" in
+  let uident_term = terminal_find "UIDENT" in
+  print_transitions_on "lident" (fun t -> t = T lident_term);
+  print_transitions_on "uident" (fun t -> t = T uident_term);
+)

--- a/src/menhir_error_processor.ml
+++ b/src/menhir_error_processor.ml
@@ -1,0 +1,2 @@
+let () =
+  print_endline "let x = 5"

--- a/src/menhir_error_processor.ml
+++ b/src/menhir_error_processor.ml
@@ -1,2 +1,43 @@
+open MenhirSdk
+open Cmly_api
+open Printf
+
+module G = Cmly_read.Read(struct let filename = Sys.argv.(1) end)
+open G
+
+let print fmt = Printf.ksprintf print_endline fmt
+
+(* We want to detect any state where an identifier is admissible.
+   That way, we can assume that if a keyword is used and rejceted, the user was
+   intending to put an identifier. *)
+let states_transitioning_on_ident =
+  (* A terminal is either "LIDENT" or "UIDENT" *)
+  let term_is_ident term = match Terminal.name term with
+    | "LIDENT" | "UIDENT" -> true
+    | _ -> false
+  in
+  let sym_is_ident = function
+    | T term -> term_is_ident term
+    | N _ -> false
+  in
+  let keep_state lr1 =
+    (* There are two kind of transitions (leading to SHIFT or REDUCE), detect
+       those who accept identifiers *)
+    List.exists (fun (term, prod) -> term_is_ident term) (Lr1.reductions lr1) ||
+    List.exists (fun (sym, _) -> sym_is_ident sym) (Lr1.transitions lr1)
+  in
+  (* Now we filter the list of all states and keep the interesting ones *)
+  G.Lr1.fold (fun lr1 acc -> if keep_state lr1 then lr1 :: acc else acc) []
+
 let () =
-  print_endline "let x = 5"
+  (* Produce a function that will be linked into the reason parser to recognize
+     these states at runtime.
+     TODO: a more compact encoding could be used, for now we don't care and
+     just pattern matches on states.
+  *)
+  print "let transitions_on_ident = function";
+  List.iter
+    (fun lr1 -> print "  | %d" (Lr1.to_int lr1))
+    states_transitioning_on_ident;
+  print "      -> true";
+  print "  | _ -> false"

--- a/src/menhir_error_processor.ml
+++ b/src/menhir_error_processor.ml
@@ -46,7 +46,9 @@ let terminal_find name =
 
 let () = (
   let lident_term = terminal_find "LIDENT" in
-  let uident_term = terminal_find "UIDENT" in
   print_transitions_on "lident" (fun t -> t = T lident_term);
+  let uident_term = terminal_find "UIDENT" in
   print_transitions_on "uident" (fun t -> t = T uident_term);
+  let semi_term = terminal_find "SEMI" in
+  print_transitions_on "semi" (fun t -> t = T semi_term);
 )

--- a/src/reason_parser_explain.ml
+++ b/src/reason_parser_explain.ml
@@ -27,7 +27,7 @@ let keyword_confused_with_ident state token =
   match identlike_keywords token with
   | Some name when Raw.transitions_on_lident state
                 || Raw.transitions_on_uident state ->
-    (name ^ " is a reserved keyword, it cannot be used as an identifier")
+    (name ^ " is a reserved keyword, it cannot be used as an identifier. Try `" ^ name ^ "_' instead")
   | _ -> raise Not_found
 
 let uppercased_instead_of_lowercased state token =

--- a/src/reason_parser_explain.ml
+++ b/src/reason_parser_explain.ml
@@ -3,8 +3,10 @@ module Interp = Parser.MenhirInterpreter
 module Raw = Reason_parser_explain_raw
 
 let identlike_keywords = function
-  | Parser.SIG -> Some "sig"
+  | Parser.SIG    -> Some "sig"
   | Parser.MODULE -> Some "module"
+  | Parser.BEGIN  -> Some "begin"
+  | Parser.END    -> Some "end"
   | _ -> None
 
 let confused_with_ident state token =

--- a/src/reason_parser_explain.ml
+++ b/src/reason_parser_explain.ml
@@ -40,6 +40,13 @@ let uppercased_instead_of_lowercased state token =
       Printf.sprintf "variables and labels should be lowercased. Try `%s'" name
   | _ -> raise Not_found
 
+let semicolon_might_be_missing state _token =
+  (*let state = Interp.current_state_number env in*)
+  if Raw.transitions_on_semi state then
+    "syntax error, consider adding a `;' before"
+  else
+    raise Not_found
+
 let message env (token, startp, endp) =
   let state = Interp.current_state_number env in
   (* Is there a message for this specific state ? *)
@@ -50,6 +57,8 @@ let message env (token, startp, endp) =
   with Not_found ->
   (* Identify an uppercased identifier in a lowercase place *)
   try uppercased_instead_of_lowercased state token
+  with Not_found ->
+  try semicolon_might_be_missing state token
   with Not_found ->
     (* TODO: we don't know what to say *)
     "<UNKNOWN SYNTAX ERROR>"

--- a/src/reason_parser_explain.ml
+++ b/src/reason_parser_explain.ml
@@ -1,0 +1,25 @@
+module Parser = Reason_parser
+module Interp = Parser.MenhirInterpreter
+module Raw = Reason_parser_explain_raw
+
+let identlike_keywords = function
+  | Parser.SIG -> Some "sig"
+  | Parser.MODULE -> Some "module"
+  | _ -> None
+
+let confused_with_ident state token =
+  match identlike_keywords token with
+  | Some name when Raw.transitions_on_ident state ->
+    (name ^ " is a reserved keyword, it cannot be used as an identifier")
+  | _ -> raise Not_found
+
+let message env (token, startp, endp) =
+  let state = Interp.current_state_number env in
+  (* Is there a message for this specific state ? *)
+  try Reason_parser_message.message state
+  with Not_found ->
+    (* Identify a keyword used as an identifier *)
+    try confused_with_ident state token
+    with Not_found ->
+      (* TODO: we don't know what to say *)
+      "<UNKNOWN SYNTAX ERROR>"

--- a/src/reason_parser_explain.ml
+++ b/src/reason_parser_explain.ml
@@ -2,12 +2,26 @@ module Parser = Reason_parser
 module Interp = Parser.MenhirInterpreter
 module Raw = Reason_parser_explain_raw
 
-let identlike_keywords = function
+let identlike_keywords =
+  let reverse_table = lazy (
+    let table = Hashtbl.create 7 in
+    Hashtbl.iter (fun k v -> Hashtbl.add table v k) Reason_lexer.keyword_table;
+    table
+  ) in
+  function
   | Parser.SIG    -> Some "sig"
   | Parser.MODULE -> Some "module"
   | Parser.BEGIN  -> Some "begin"
   | Parser.END    -> Some "end"
-  | _ -> None
+  | Parser.OBJECT -> Some "object"
+  | Parser.SWITCH -> Some "switch"
+  | Parser.TO     -> Some "to"
+  | Parser.THEN   -> Some "then"
+  | Parser.TYPE   -> Some "type"
+  | token ->
+    match Hashtbl.find (Lazy.force reverse_table) token with
+    | name -> Some name
+    | exception Not_found -> None
 
 let confused_with_ident state token =
   match identlike_keywords token with

--- a/src/reason_toolchain.ml
+++ b/src/reason_toolchain.ml
@@ -83,6 +83,8 @@ module To_current = Convert(OCaml_404)(OCaml_current)
 
 module S = MenhirLib.General (* Streams *)
 
+open Reason_explain_error
+
 let invalidLex = "invalidCharacter.orComment.orString"
 let syntax_error_str err loc =
     if !Reason_config.recoverable = false then

--- a/src/reasonparser.mllib
+++ b/src/reasonparser.mllib
@@ -6,3 +6,5 @@ Reason_config
 Syntax_util
 Reason_toolchain
 Reason_parser_message
+Reason_parser_explain
+Reason_parser_explain_raw


### PR DESCRIPTION
This PR extends the build process to analyse the parser at compile-time and produce informations that are used at runtime for generating error messages.

# Features

It detects use of keywords in place of identifiers, use of uppercase identifiers when lowercase is expected, and missing `;`.

```reason
let x = module;
```
```
File "test.re", line 1, characters 8-14:
Error: 1471: module is a reserved keyword, it cannot be used as an identifier. Try `module_' instead
```

```reason
let maker(~SomeModule) => SomeModule.make ();
```
```
File "test.re", line 1, characters 11-21:
Error: 504: variables and labels should be lowercased. Try `someModule'
```

```reason
let foo = (a) => 1

if (foo) { bar }
```
```
File "test.re", line 3, characters 0-2:
Error: 843: syntax error, consider adding a `;' before
```

# Implementation

This PR adds a build-time dependency on menhirSdk. This package is already part of Menhir, so it should not affect existing processes.
menhirSdk is used to process the grammar & parser:
- menhir is invoked with `--cmly` to produce a synthetic description of the grammar
- src/menhir_error_processor.ml extracts relevant informations from the grammar and produces src/reason_parser_explain_raw.ml
- src/reason_parser_explain.ml is linked to reason and is used to produce error messages by matching the parser state with the information stored in src/reason_parser_explain_raw.ml