### PR TITLE
Bump topkg requirements

### DIFF
--- a/opam
+++ b/opam
@@ -25,7 +25,7 @@ depends: [
   "utop"                    {>= "1.17"}
   "merlin-extend"           {>= "0.3"}
   "result"                  {=  "1.2"}
-  "topkg"                   {>=  "0.8.1"}
+  "topkg"                   {>=  "0.9.1"}
   "ocaml-migrate-parsetree"
 ]
 depopts: [

--- a/opam.in
+++ b/opam.in
@@ -24,7 +24,7 @@ depends: [
   "utop"                    {>= "1.17"}
   "merlin-extend"           {>= "0.3"}
   "result"                  {=  "1.2"}
-  "topkg"                   {>=  "0.8.1"}
+  "topkg"                   {>=  "0.9.1"}
   "ocaml-migrate-parsetree"
 ]
 depopts: [


### PR DESCRIPTION
@let-def's #1541 seems to require a newer version of topkg that provides
a `-r` flag