### PR TITLE
Implement paren hugging for patterns.

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/patternMatching.re
+++ b/formatTest/typeCheckedTests/expected_output/patternMatching.re
@@ -239,3 +239,41 @@ switch None {
 | Some({x, y}) => ()
 | _ => ()
 };
+
+switch None {
+| Some([|
+    someSuperLongString,
+    thisShouldBreakTheLine
+  |]) =>
+  ()
+| _ => ()
+};
+
+switch None {
+| Some((
+    someSuperLongString,
+    thisShouldBreakTheLine
+  )) =>
+  ()
+| _ => ()
+};
+
+switch None {
+| Some([
+    someSuperLongString,
+    thisShouldBreakTheLine
+  ]) =>
+  ()
+| Some([
+    someSuperLongString,
+    ...es6ListSugarLikeSyntaxWhichIsSuperLong
+  ])
+    when true === true =>
+  ()
+| Some([
+    someSuperLongString,
+    ...es6ListSugarLikeSyntaxWhichIsSuperLong
+  ]) =>
+  ()
+| _ => ()
+};

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -243,22 +243,18 @@ let res =
  */
 let result =
   switch None {
-  | Some(
-      {
-        fieldOne: 20, /* end of line */
-        fieldA:
-          a /* end of line */
-      }
-    ) =>
+  | Some({
+      fieldOne: 20, /* end of line */
+      fieldA:
+        a /* end of line */
+    }) =>
     let tmp = 0;
     2 + tmp
-  | Some(
-      {
-        fieldOne: n, /* end of line */
-        fieldA:
-          a /* end of line */
-      }
-    ) =>
+  | Some({
+      fieldOne: n, /* end of line */
+      fieldA:
+        a /* end of line */
+    }) =>
     let tmp = n;
     n + tmp
   | None => 20

--- a/formatTest/typeCheckedTests/input/patternMatching.re
+++ b/formatTest/typeCheckedTests/input/patternMatching.re
@@ -205,3 +205,20 @@ switch None {
 | Some {x, y} => ()
 | _ => ()
 };
+
+switch None {
+| Some([|someSuperLongString, thisShouldBreakTheLine|]) => ()
+| _ => ()
+};
+
+switch None {
+| Some((someSuperLongString, thisShouldBreakTheLine)) => ()
+| _ => ()
+};
+
+switch None {
+| Some([someSuperLongString, thisShouldBreakTheLine]) => ()
+| Some([someSuperLongString, ...es6ListSugarLikeSyntaxWhichIsSuperLong]) when true === true => ()
+| Some([someSuperLongString, ...es6ListSugarLikeSyntaxWhichIsSuperLong]) => ()
+| _ => ()
+}

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -405,31 +405,27 @@ let rec atLeastOneFlushableChildAndNoWipNoPending =
         tl,
         atPriority
       )
-    | OpaqueGraph(
-        {
-          lifecycle:
-            ReconciledFlushable(
-              priority,
-              _,
-              _,
-              _,
-              _,
-              _
-            )
-        }
-      )
-    | OpaqueGraph(
-        {
-          lifecycle:
-            NeverReconciledFlushable(
-              priority,
-              _,
-              _,
-              _,
-              _
-            )
-        }
-      )
+    | OpaqueGraph({
+        lifecycle:
+          ReconciledFlushable(
+            priority,
+            _,
+            _,
+            _,
+            _,
+            _
+          )
+      })
+    | OpaqueGraph({
+        lifecycle:
+          NeverReconciledFlushable(
+            priority,
+            _,
+            _,
+            _,
+            _
+          )
+      })
         when priority == AtPriority =>
       noWipNoPending(tl, atPriority)
     | SuperLongNameThatWontBreakByItselfSoWhenWillHaveToBreak

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -2469,18 +2469,20 @@ let howDoLongMultiBarPatternsWrap = (x) =>
   switch x {
   | AnotherReallyLongVariantName(_, _, _) => 0
   | AnotherReallyLongVariantName2(_, _, _) => 0
-  | ReallyLongVariantName(
-      {someField, anotherField}
-    ) => 0
+  | ReallyLongVariantName({
+      someField,
+      anotherField
+    }) => 0
   };
 
 let letsCombineTwoLongPatternsIntoOneCase = (x) =>
   switch x {
   | AnotherReallyLongVariantName(_, _, _)
   | AnotherReallyLongVariantName2(_, _, _) => 0
-  | ReallyLongVariantName(
-      {someField, anotherField}
-    ) => 0
+  | ReallyLongVariantName({
+      someField,
+      anotherField
+    }) => 0
   };
 
 let letsPutAWhereClauseOnTheFirstTwo = (x) =>
@@ -2488,18 +2490,20 @@ let letsPutAWhereClauseOnTheFirstTwo = (x) =>
   | AnotherReallyLongVariantName(_, _, _)
   | AnotherReallyLongVariantName2(_, _, _)
       when true => 0
-  | ReallyLongVariantName(
-      {someField, anotherField}
-    ) => 0
+  | ReallyLongVariantName({
+      someField,
+      anotherField
+    }) => 0
   };
 
 let letsPutAWhereClauseOnTheLast = (x) =>
   switch x {
   | AnotherReallyLongVariantName(_, _, _)
   | AnotherReallyLongVariantName2(_, _, _) => 0
-  | ReallyLongVariantName(
-      {someField, anotherField}
-    )
+  | ReallyLongVariantName({
+      someField,
+      anotherField
+    })
       when true => 0
   };
 


### PR DESCRIPTION
Fixes #1540
Implements paren hugging for pattern matching on a constructor expression with a single argument.

Example:
```
switch x {
| Some({
    a,
    b,
  }) => ...
}
```

Notice how `({` and `})` stick together.

A few additional printing improvements can be made when printing pattern matches, but they are for a separate PR.

