### PR TITLE
Print`foo(()) as `foo() + update parser

### DIFF
--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -560,7 +560,17 @@ type Graph.node +=
   | Node = Expr.Node
   | Atom = Expr.Atom;
 
+/* without single unit arg sugar */
 MyConstructorWithSingleUnitArg();
+
+/* with single unit arg sugar */
+MyConstructorWithSingleUnitArg();
+
+/* without single unit arg sugar */
+`polyVariantWithSingleUnitArg();
+
+/* with single unit arg sugar */
+`polyVariantWithSingleUnitArg();
 
 /* #1510: keep ({ and }) together on the same line when breaking */
 Delete({

--- a/formatTest/unit_tests/input/variants.re
+++ b/formatTest/unit_tests/input/variants.re
@@ -379,7 +379,14 @@ type Graph.node += pri Node = Expr.Node;
 
 type Graph.node += pri | Node = Expr.Node | Atom = Expr.Atom;
 
+/* without single unit arg sugar */
 MyConstructorWithSingleUnitArg(());
+/* with single unit arg sugar */
+MyConstructorWithSingleUnitArg();
+/* without single unit arg sugar */
+`polyVariantWithSingleUnitArg(());
+/* with single unit arg sugar */
+`polyVariantWithSingleUnitArg();
 
 /* #1510: keep ({ and }) together on the same line when breaking */
 Delete({ uuid: json |> Util.member("uuid") |> Util.to_string });

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -2871,12 +2871,10 @@ simple_expr_direct_argument:
 ;
 
 non_labeled_argument_list:
-  | parenthesized(separated_list(COMMA, expr))
-    { match $1 with
-      | [] -> let loc = mklocation $startpos $endpos in
-              [mkexp_constructor_unit loc loc]
-      | xs -> xs
-    }
+  | parenthesized(separated_nonempty_list(COMMA, expr)) { $1 }
+  | LPAREN RPAREN
+    { let loc = mklocation $startpos $endpos in
+      [mkexp_constructor_unit loc loc] }
 ;
 
 labeled_arguments:

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -4702,6 +4702,10 @@ class printer  ()= object(self:'self)
   method constructor_expression ?(polyVariant=false) ~arityIsClear stdAttrs ctor eo =
     let (implicit_arity, arguments) =
       match eo.pexp_desc with
+      | Pexp_construct ( {txt= Lident "()"},_) ->
+          (* `foo() is a polymorphic variant that contains a single unit construct as expression
+           * This requires special formatting: `foo(()) -> `foo() *)
+          (false, atom "()")
       (* special printing: MyConstructor(()) -> MyConstructor() *)
       | Pexp_tuple l when is_single_unit_construct l ->
           (false, atom "()")


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/1550