### PR TITLE
WIP: fixing #1559, doc comments inside record

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -371,3 +371,8 @@ let fun_def_comment_newline = () => {/* */};
 let fun_def_comment_long = () => {
   /* longer comment inside empty function body */
 };
+
+type record_with_doc_comment = {
+  /** doc comment **/
+  foo: string
+};

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -372,7 +372,14 @@ let fun_def_comment_long = () => {
   /* longer comment inside empty function body */
 };
 
-type record_with_doc_comment = {
-  /** doc comment **/
+/** Problems with docstrings in records.
+ * See https://github.com/facebook/reason/issues/1559
+ */
+type record_with_docstring_on_label= {
+  /** docstring */
   foo: string
+};
+
+type record_with_docstring_before_expression = {
+  bar: /** docstring */ int
 };

--- a/formatTest/typeCheckedTests/input/reasonComments.re
+++ b/formatTest/typeCheckedTests/input/reasonComments.re
@@ -365,3 +365,8 @@ let fun_def_comment_newline = () => {
 };
 
 let fun_def_comment_long = () => { /* longer comment inside empty function body */};
+
+type record_with_doc_comment = {
+  /** doc comment **/
+  foo: string
+};

--- a/formatTest/typeCheckedTests/input/reasonComments.re
+++ b/formatTest/typeCheckedTests/input/reasonComments.re
@@ -366,7 +366,14 @@ let fun_def_comment_newline = () => {
 
 let fun_def_comment_long = () => { /* longer comment inside empty function body */};
 
-type record_with_doc_comment = {
-  /** doc comment **/
+/** Problems with docstrings in records.
+ * See https://github.com/facebook/reason/issues/1559
+ */
+type record_with_docstring_on_label= {
+  /** docstring */
   foo: string
+};
+
+type record_with_docstring_before_expression = {
+  bar: /** docstring */ int
 };

--- a/src/reason-parser/reason_lexer.mll
+++ b/src/reason-parser/reason_lexer.mll
@@ -642,7 +642,7 @@ rule token = parse
   (* The second star must be escaped so that the precedence assumptions for
    * printing match those of parsing. (Imagine what could happen if the other
    * rule beginning with * picked up */*, and we internally escaped it to **.
-   * Whe printing, we have an understanding of the precedence of "**", which
+   * When printing, we have an understanding of the precedence of "**", which
    * enables us to safely print/group it, but that understanding would not
    * match the *actual* precedence that it was parsed at thanks to the *other*
    * rule beginning with *, picking it up instead of the special double ** rule
@@ -670,7 +670,7 @@ rule token = parse
 and enter_comment = parse
   | "/*" ("*" "*"+)?
       { set_lexeme_length lexbuf 2;
-        let start_loc = Location.curr lexbuf  in
+        let start_loc = Location.curr lexbuf in
         comment_start_loc := [start_loc];
         reset_string_buffer ();
         let {Location. loc_end; _} = comment lexbuf in
@@ -692,7 +692,7 @@ and enter_comment = parse
   | "/**/"
       { DOCSTRING "" }
   | "/*/"
-      { let loc = Location.curr lexbuf  in
+      { let loc = Location.curr lexbuf in
         if !print_warnings then
           Location.prerr_warning loc Warnings.Comment_start;
         comment_start_loc := [loc];
@@ -874,7 +874,7 @@ and skip_sharp_bang = parse
 
 {
 
-  (* Filter commnets *)
+  (* Filter comments *)
 
   let token_with_comments lexbuf =
     match !preprocessor with

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -3111,15 +3111,21 @@ expr_optional_constraint:
 record_expr:
   | DOTDOTDOT expr_optional_constraint lnonempty_list(preceded(COMMA,lbl_expr))
     { (Some $2, $3) }
-  | as_loc(label_longident) COLON expr
-    { (None, [($1, $3)]) }
+  | attribute as_loc(label_longident) COLON expr
+    { let rec_expr = {$4 with pexp_attributes = [$1] @ $4.pexp_attributes} in
+      (None, [($2, rec_expr)])
+    }
   | lseparated_two_or_more(COMMA, lbl_expr) COMMA?
     { (None, $1) }
 ;
 
 lbl_expr:
-  | as_loc(label_longident) COLON expr { ($1, $3) }
-  | as_loc(label_longident)            { ($1, exp_of_label $1) }
+  | attribute as_loc(label_longident) COLON expr
+    { ($2, {$4 with pexp_attributes = [$1] @ $4.pexp_attributes} ) }
+  | attribute as_loc(label_longident)
+    { let exp = exp_of_label $2 in
+      ($2, {exp with pexp_attributes = [$1] @ exp.pexp_attributes})
+    }
 ;
 
 record_expr_with_string_keys:


### PR DESCRIPTION
Adds a test which triggers #1559, doc comments inside a record.