### PR TITLE
Allow parsing of constraint expressions without parens inside constructor expr

### DIFF
--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1063,3 +1063,12 @@ let registerEventHandlers =
 let x = ({state as prevState}) => 1;
 
 let x = ({ReasonReact.state as prevState}) => 1;
+
+/* 1567: optional parens around expr constraint in constructor expression */
+Some(x: int);
+
+Some(x: int);
+
+Some(x, y: int, b);
+
+Some(x, y: int, b);

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -880,3 +880,9 @@ let registerEventHandlers =
 /* #1320: record destrucuring + renaming */
 let x = ({state: state as prevState}) => 1;
 let x = ({ReasonReact.state: state as prevState}) => 1;
+
+/* 1567: optional parens around expr constraint in constructor expression */
+Some(x : int);
+Some((x : int));
+Some(x, y: int, b);
+Some(x, (y: int), b);

--- a/src/reason_parser.mly
+++ b/src/reason_parser.mly
@@ -2871,7 +2871,7 @@ simple_expr_direct_argument:
 ;
 
 non_labeled_argument_list:
-  | parenthesized(separated_list(COMMA, expr))
+  | parenthesized(separated_list(COMMA, expr_optional_constraint))
     { match $1 with
       | [] -> let loc = mklocation $startpos $endpos in
               [mkexp_constructor_unit loc loc]


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/1567

```reason
/* before */
Some((x: string), (y: int), (b: float));

/* after */
Some(x: string, y: int, b: float);
```
Parser didn't support the form without parens.
