### PR TITLE
Add all-supported-ocaml-versions target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,9 @@ release: release_check pre_release
 	./scripts/opam-release.sh
 
 .PHONY: release
+
+all-supported-ocaml-versions:
+# the --dev flag has been omitted here but should be re-introduced eventually
+	jbuilder build @install @runtest --workspace jbuild-workspace.dev --root .
+
+.PHONY: all-supported-ocaml-versions

--- a/jbuild-workspace.dev
+++ b/jbuild-workspace.dev
@@ -1,0 +1,5 @@
+;; This file is used by `make all-supported-ocaml-versions`
+(context ((switch 4.02.3)))
+(context ((switch 4.03.0)))
+(context ((switch 4.04.2)))
+(context ((switch 4.05.0)))


### PR DESCRIPTION
This target will build & test the entire project against a workspace that
defines a set of switches where reason is supported.

We use this little trick to make sure that jbuilder works on every version of OCaml. I think you might find it useful too.