### PR TITLE
don't print fun in record expressions with Pexp_fun values

### DIFF
--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -777,3 +777,6 @@ let () = {
   exception E;
   raise(E)
 };
+
+/* # 1587: don't print fun keyword when printing Pexp_fun in a record expression  */
+{contents: () => ((): unit)};

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -2227,7 +2227,7 @@ let df_locallyAbstractFuncAnnotated:
  * Ppat_constraint. In this case, they're not equal!
  */
 let df_locallyAbstractFuncAnnotated: 'figureMeOut =
-  fun (type a, type b) => (
+  (type a, type b) => (
     (input: a, input2: b) => (
       {inputIs: input},
       {inputIs: input2}

--- a/formatTest/unit_tests/input/basicStructures.re
+++ b/formatTest/unit_tests/input/basicStructures.re
@@ -633,3 +633,6 @@ let () = {
   exception E;
   raise(E)
 };
+
+/* # 1587: don't print fun keyword when printing Pexp_fun in a record expression  */
+{contents: fun () => ((): unit)};

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -5122,7 +5122,7 @@ class printer  ()= object(self:'self)
             let upToColon = makeList (maybeQuoteFirstElem li [atom ":"]) in
             let returnedAppTerms = self#unparseExprApplicationItems return in
             let labelExpr = self#wrapCurriedFunctionBinding
-                ~sweet ~attachTo:upToColon "fun" ~arrow:"=>"
+                ~sweet:true ~attachTo:upToColon "fun" ~arrow:"=>"
                 firstArg tl returnedAppTerms
             in
             if appendComma then makeList [labelExpr; comma] else labelExpr

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4273,7 +4273,7 @@ class printer  ()= object(self:'self)
         | Pexp_newtype (newtype,e) ->
           let sweet, args, ret = extract_args e in
           (sweet, `Type newtype :: args, ret)
-        | Pexp_constraint _ -> (false, [], xx)
+        | Pexp_constraint _ -> (true, [], xx)
         | _ -> (true, [], xx)
     in
     let prepare_arg = function
@@ -5122,7 +5122,7 @@ class printer  ()= object(self:'self)
             let upToColon = makeList (maybeQuoteFirstElem li [atom ":"]) in
             let returnedAppTerms = self#unparseExprApplicationItems return in
             let labelExpr = self#wrapCurriedFunctionBinding
-                ~sweet:true ~attachTo:upToColon "fun" ~arrow:"=>"
+                ~sweet ~attachTo:upToColon "fun" ~arrow:"=>"
                 firstArg tl returnedAppTerms
             in
             if appendComma then makeList [labelExpr; comma] else labelExpr


### PR DESCRIPTION
fixes #1587 

```reason
/* before */
{contents: fun () => (() : unit)};

/* after */
{contents: () => (() : unit)};
```