### PR TITLE
Always break object def with two or more rows

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -116,12 +116,24 @@ let (>>) = (a, b) => a > b;
 
 let bigger = 3 >> 2;
 
-type typeDefForClosedObj = {. x: int, y: int};
+type typeDefForClosedObj = {
+  .
+  x: int,
+  y: int
+};
 
 type typeDefForOpenObj('a) =
-  {.. x: int, y: int} as 'a;
+  {
+    ..
+    x: int,
+    y: int
+  } as 'a;
 
-let anonClosedObject: {. x: int, y: int} = {
+let anonClosedObject: {
+  .
+  x: int,
+  y: int
+} = {
   pub x = 0;
   pub y = 0
 };
@@ -135,7 +147,11 @@ let xs: list({. x: int}) = [
 
 let constrainedAndCoerced = (
   [anonClosedObject, anonClosedObject]:
-    list({. x: int, y: int}) :>
+    list({
+      .
+      x: int,
+      y: int
+    }) :>
     list({. x: int})
 );
 
@@ -154,11 +170,23 @@ let coercedReturn = {
 };
 
 let acceptsOpenAnonObjAsArg =
-    (o: {.. x: int, y: int}) =>
+    (
+      o: {
+        ..
+        x: int,
+        y: int
+      }
+    ) =>
   o#x + o#y;
 
 let acceptsClosedAnonObjAsArg =
-    (o: {. x: int, y: int}) =>
+    (
+      o: {
+        .
+        x: int,
+        y: int
+      }
+    ) =>
   o#x + o#y;
 
 let res =

--- a/formatTest/unit_tests/expected_output/object.re
+++ b/formatTest/unit_tests/expected_output/object.re
@@ -1,7 +1,11 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 type t = {.};
 
-type t = {. u: int, v: int};
+type t = {
+  .
+  u: int,
+  v: int
+};
 
 type t = {.. u: int};
 
@@ -15,10 +19,31 @@ let (<..>) = (a, b) => a + b;
 
 let five = 2 <..> 3;
 
-type closedObjSugar = {. "foo": bar, "baz": int};
+type closedObjSugar = {
+  .
+  "foo": bar,
+  "baz": int
+};
 
-type openObjSugar = {.. "x": int, "y": int};
+type openObjSugar = {
+  ..
+  "x": int,
+  "y": int
+};
 
 type x = Js.t({.});
 
 type y = Js.t({..});
+
+/* #1595: always break object rows (>= 2) for readability */
+type o = {
+  .
+  a: int,
+  b: int
+};
+
+type o2 = {
+  ..
+  a: int,
+  b: int
+};

--- a/formatTest/unit_tests/input/object.re
+++ b/formatTest/unit_tests/input/object.re
@@ -28,3 +28,16 @@ type openObjSugar = Js.t({.. x: int, y: int});
 type x = Js.t({.});
 
 type y = Js.t({..});
+
+/* #1595: always break object rows (>= 2) for readability */
+type o = {
+  .
+  a: int,
+  b: int
+};
+
+type o2 = {
+  ..
+  a: int,
+  b: int
+};


### PR DESCRIPTION
Fixes #1595 
```reason
/* before */
type length_same = {. title: string, render: unit => ReasonReact.reactElement};

/* after */
type length_same = {
  .
  title: string,
  render: unit => ReasonReact.reactElement
};
```