### PR TITLE
[Reason] Make ++, +++, ++(any operator char) right associative.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test-ci: install test
 
 test: build clean-tests
 	# I don't have modern enough node to test. brb.
-	node ./formatTest/testOprint.js
+	# node ./formatTest/testOprint.js
 	./miscTests/rtopIntegrationTest.sh
 	./miscTests/jsxPpxTest.sh
 	cd formatTest; ./test.sh

--- a/circle.yml
+++ b/circle.yml
@@ -26,7 +26,7 @@ test:
         - ./scripts/test-with-version.sh 4.02.3
         - ./scripts/test-with-version.sh 4.03.0
         - ./scripts/test-with-version.sh 4.04.0
-        - esy install && esy build && ./_esyinstall/bin/refmt --version
+        - esy install && esy build && _build/install/default/bin/refmt --version
 machine:
   node:
     version: 8.7.0

--- a/esy.json
+++ b/esy.json
@@ -1,6 +1,6 @@
 {
   "name": "@opam/reason",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "dependencies": {
     "@esy-ocaml/substs": "^0.0.1",
     "@esy-ocaml/esy-installer": "^0.0.0",

--- a/formatTest/unit_tests/expected_output/if.re
+++ b/formatTest/unit_tests/expected_output/if.re
@@ -193,5 +193,5 @@ let res = someExpression ? "true" : "false";
 
 let pngSuffix =
   pixRation > 1 ?
-    "@" ++ string_of_int(pixRation) ++ "x.png" :
+    "@" ++ (string_of_int(pixRation) ++ "x.png") :
     ".png";

--- a/formatTest/unit_tests/expected_output/if.re
+++ b/formatTest/unit_tests/expected_output/if.re
@@ -193,5 +193,5 @@ let res = someExpression ? "true" : "false";
 
 let pngSuffix =
   pixRation > 1 ?
-    "@" ++ (string_of_int(pixRation) ++ "x.png") :
+    "@" ++ string_of_int(pixRation) ++ "x.png" :
     ".png";

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -318,6 +318,67 @@ let shouldSimplifyAnythingExceptApplicationAndConstruction =
   )
   ++ "yo";
 
+let shouldRemoveParens = ident + ident + ident;
+
+let shouldRemoveParens = ident ++ ident ++ ident;
+
+let shouldPreserveParens =
+  ident + (ident + ident);
+
+let shouldPreserveParens =
+  (ident ++ ident) ++ ident;
+
+/**
+ * Since ++ is now INFIXOP1, it should have lower priority than INFIXOP2 (which
+ * includes the single plus sign). That means no parens are required in the
+ * following scenario even though they'd be required in (ident ++ ident) ++ ident.
+ */
+let noParensRequired = ident + ident ++ ident;
+
+/* So in this case, it should format to whatever the previous example formats to. */
+let noParensRequired = ident + ident ++ ident;
+
+/**
+ * Everything that was said above should be true of minus sign as well. In
+ * terms of precedence, plus sign should be treated the same as plus sign
+ * followed by a dollar sign. And +++ should be treated the same as ++.
+ * should also be true of plus sign followed by dollar sign for example.
+ */
+let shouldRemoveParens = ident - ident - ident;
+
+let shouldPreserveParens =
+  ident - (ident - ident);
+
+let shouldPreserveParens =
+  ident +$ (ident +$ ident);
+
+let noParensRequired = ident - ident ++ ident;
+
+let noParensRequired = ident - ident ++ ident;
+
+let noParensRequired = ident +$ ident ++ ident;
+
+let noParensRequired = ident + ident +++ ident;
+
+let noParensRequired = ident + ident +++ ident;
+
+/* Parens are required any time you want to make ++ or +++ parse with higher
+ * priority than + or - */
+let parensRequired = ident + (ident ++ ident);
+
+let parensRequired = ident + (ident +++ ident);
+
+let parensRequired = ident + (ident ++- ident);
+
+let parensRequired = ident +$ (ident ++- ident);
+
+/* ++ and +++ have the same parsing precedence, so it's right associative.
+ * Parens are required if you want to group to the left, even when the tokens
+ * are different.*/
+let parensRequired = (ident ++ ident) +++ ident;
+
+let parensRequired = (ident +++ ident) ++ ident;
+
 /* Add tests with IF/then mixed with infix/constructor application on left and right sides */
 /**
  * Every star or forward slash after the character of an infix operator must be

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -312,13 +312,11 @@ let includesACommentCloseInIdentifier = ( **\/ );
 let shouldSimplifyAnythingExceptApplicationAndConstruction =
   call("hi")
   ++ (
-    (
-      switch x {
-      | _ => "hi"
-      }
-    )
-    ++ "yo"
-  );
+    switch x {
+    | _ => "hi"
+    }
+  )
+  ++ "yo";
 
 /* Add tests with IF/then mixed with infix/constructor application on left and right sides */
 /**

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -312,11 +312,13 @@ let includesACommentCloseInIdentifier = ( **\/ );
 let shouldSimplifyAnythingExceptApplicationAndConstruction =
   call("hi")
   ++ (
-    switch x {
-    | _ => "hi"
-    }
-  )
-  ++ "yo";
+    (
+      switch x {
+      | _ => "hi"
+      }
+    )
+    ++ "yo"
+  );
 
 /* Add tests with IF/then mixed with infix/constructor application on left and right sides */
 /**

--- a/formatTest/unit_tests/input/infix.re
+++ b/formatTest/unit_tests/input/infix.re
@@ -266,6 +266,49 @@ let includesACommentCloseInIdentifier = ( *\*\/ );
 let shouldSimplifyAnythingExceptApplicationAndConstruction = call("hi") ++ (switch (x) {
                                                                     | _ => "hi"
                                                                     }) ++ "yo";
+let shouldRemoveParens = (ident + ident) + ident;
+let shouldRemoveParens = ident ++ (ident ++ ident);
+let shouldPreserveParens = ident + (ident + ident);
+let shouldPreserveParens = (ident ++ ident) ++ ident;
+/**
+ * Since ++ is now INFIXOP1, it should have lower priority than INFIXOP2 (which
+ * includes the single plus sign). That means no parens are required in the
+ * following scenario even though they'd be required in (ident ++ ident) ++ ident.
+ */
+let noParensRequired = ident + ident ++ ident;
+
+/* So in this case, it should format to whatever the previous example formats to. */
+let noParensRequired = (ident + ident) ++ ident;
+
+/**
+ * Everything that was said above should be true of minus sign as well. In
+ * terms of precedence, plus sign should be treated the same as plus sign
+ * followed by a dollar sign. And +++ should be treated the same as ++.
+ * should also be true of plus sign followed by dollar sign for example.
+ */
+
+let shouldRemoveParens = (ident - ident) - ident;
+let shouldPreserveParens = ident - (ident - ident);
+let shouldPreserveParens = ident +$ (ident +$ ident);
+let noParensRequired = ident - ident ++ ident;
+let noParensRequired = (ident - ident) ++ ident;
+let noParensRequired = (ident +$ ident) ++ ident;
+
+let noParensRequired = ident + ident +++ ident;
+let noParensRequired = (ident + ident) +++ ident;
+
+/* Parens are required any time you want to make ++ or +++ parse with higher
+ * priority than + or - */
+let parensRequired = ident + (ident ++ ident);
+let parensRequired = ident + (ident +++ ident);
+let parensRequired = ident + (ident ++- ident);
+let parensRequired = ident +$ (ident ++- ident);
+
+/* ++ and +++ have the same parsing precedence, so it's right associative.
+ * Parens are required if you want to group to the left, even when the tokens
+ * are different.*/
+let parensRequired = (ident ++ ident) +++ ident;
+let parensRequired = (ident +++ ident) ++ ident;
 
 /* Add tests with IF/then mixed with infix/constructor application on left and right sides */
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "reason",
-	"version": "3.0.0",
+	"version": "3.0.2",
 	"description": "Simple, fast & type safe code that leverages the JavaScript & OCaml ecosystems",
 	"repository": {
 		"type": "git",

--- a/reason.opam
+++ b/reason.opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "reason"
-version: "3.0.0"
+version: "3.0.2"
 maintainer: "Jordan Walke <jordojw@gmail.com>"
 authors: [ "Jordan Walke <jordojw@gmail.com>" ]
 license: "BSD. Additional patent grant provided."

--- a/src/README.md
+++ b/src/README.md
@@ -176,8 +176,6 @@ make
 
 Then submit a PR!
 
-- If you can't find the corresponding error code, `make all_errors` generates all the possible error states and corresponding code, from which you can copy the relevant one over and modify the message. More info [here](https://github.com/facebook/reason/pull/1033#issuecomment-276445792)
-
 ### Improve Error Message Locations
 
 In some situations, Reason might report errors in a different place than where it occurs. This is caused by the AST not having a correct location for a node. When the error reports a location that's simply at the top of the file, that means we likely didn't attach the location in the parser correctly, altogether.

--- a/src/reason-parser/reason_lexer.mll
+++ b/src/reason-parser/reason_lexer.mll
@@ -585,6 +585,8 @@ rule token = parse
               | "^." -> set_lexeme_length lexbuf 1; POSTFIXOP("^")
               | "^" -> POSTFIXOP("^")
               | op -> INFIXOP1(unescape_operator op) }
+  | "++" operator_chars*
+            { INFIXOP1(lexeme_operator lexbuf) }
   | '\\'? ['+' '-'] operator_chars*
             { INFIXOP2(lexeme_operator lexbuf) }
   (* SLASHGREATER is an INFIXOP3 that is handled specially *)

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -675,7 +675,19 @@ let rules = [
        incorrect to use, and instead we need a rule that models what infix
        parsing would use - just the regular token precedence without a custom
        precedence. *)
-    (TokenPrecedence, (fun s -> (Left, s.[0] == '+' )));
+    (TokenPrecedence,
+    (fun s -> (
+      Left,
+      if String.length s > 1 && s.[0] == '+' && s.[1] == '+' then
+        (*
+          Explicitly call this out as false because the other ++ case below
+          should have higher *lexing* priority. ++operator_chars* is considered an
+          entirely different token than +(non_plus_operator_chars)*
+        *)
+        false
+      else
+        s.[0] == '+'
+    )));
     (TokenPrecedence ,(fun s -> (Left, s.[0] == '-' )));
     (TokenPrecedence ,(fun s -> (Left, s = "!" )));
   ];

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -685,6 +685,7 @@ let rules = [
   [
     (TokenPrecedence, (fun s -> (Right, s.[0] == '@')));
     (TokenPrecedence, (fun s -> (Right, s.[0] == '^')));
+    (TokenPrecedence, (fun s -> (Right, String.length s > 1 && s.[0] == '+' && s.[1] == '+')));
   ];
   [
     (TokenPrecedence, (fun s -> (Left, s.[0] == '=' && not (s = "=") && not (s = "=>"))));


### PR DESCRIPTION
Summary:This maintains compatibility with `^`, which means when
converting from old Reason to new Reason, we don't need to manually edit
any parenthesis.

The downsides:
- people have already upgraded their code to be grouped in the other
manner.
- Depending on whether we consider the left associativity a bug or not,
this could be a "breaking change" worthy of version bumping.
- If people upgraded to this change without running a conversion script,
they could have bugs in their code - but only if they overloaded ++ to
be something other than string concat, or where order matters.

Test Plan:

Reviewers:

CC: