### PR TITLE
Fix build instructions

### DIFF
--- a/reason.opam
+++ b/reason.opam
@@ -10,8 +10,9 @@ bug-reports: "https://github.com/facebook/reason/issues"
 dev-repo: "git://github.com/facebook/reason.git"
 tags: [ "syntax" ]
 build: [
-  ["jbuilder" "build"]
+  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "jbuilder"                {build}
   "ocamlfind"               {build}

--- a/reason.opam.in
+++ b/reason.opam.in
@@ -10,8 +10,9 @@ bug-reports: "https://github.com/facebook/reason/issues"
 dev-repo: "git://github.com/facebook/reason.git"
 tags: [ "syntax" ]
 build: [
-  ["jbuilder" "build"]
+  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "jbuilder"                {build}
   "ocamlfind"               {build}


### PR DESCRIPTION
This will make them resilient against adding multiple opam packages to the repo.
And also, it will use the number of jobs as set by OPAM.