### PR TITLE
Fix subtle jsx parsing issues.

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -629,3 +629,10 @@ let g = <Two ?foo />;
 <Foo> ...[|a|] </Foo>;
 
 <Foo> ...(1, 2) </Foo>;
+
+module Foo3 = {
+  let createElement = (~bar, ~children, ()) =>
+    ();
+};
+
+<Foo3 bar=<Foo /> />;

--- a/formatTest/typeCheckedTests/input/jsx.re
+++ b/formatTest/typeCheckedTests/input/jsx.re
@@ -423,3 +423,9 @@ let g = <Two ?foo />;
 <Foo> ...[|a|] </Foo>;
 
 <Foo> ...(1, 2) </Foo>;
+
+module Foo3 = {
+  let createElement = (~bar, ~children, ()) => ();
+};
+
+<Foo3 bar=<Foo /> />;

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -1140,3 +1140,11 @@ let result = x ></ b;
 let z = x ></ b;
 
 let z = x ></ b;
+
+let (=</>) = (a, b) => a + b;
+
+let result = x =</> b;
+
+let z = x =</> b;
+
+let z = x =</> b;

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -1123,3 +1123,20 @@ if (List.length(files) > 0
     && List.length(otherfiles) < 2) {
   ()
 };
+
+/* Don't clash with jsx edge cases */
+let (=<) = (a, b) => a + b;
+
+let result = x =< y;
+
+let z = x =< y;
+
+let z = x =< y;
+
+let (></) = (a, b) => a - b;
+
+let result = x ></ b;
+
+let z = x ></ b;
+
+let z = x ></ b;

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -141,3 +141,25 @@ let icon =
 
 /* don't pun explicitly passed optional with module identifier */
 <Foo bar=?Baz.bar />;
+
+let x = <div />;
+
+<div asd=1 />;
+
+foo#=<bar />;
+
+foo#=<bar />;
+
+let x = [|<div />|];
+
+let x = [|
+  <Button onClick=handleStaleClick />,
+  <Button onClick=handleStaleClick />
+|];
+
+let z = <div />;
+
+let z = (
+  <Button onClick=handleStaleClick />,
+  <Button onClick=handleStaleClick />
+);

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -163,3 +163,10 @@ let z = (
   <Button onClick=handleStaleClick />,
   <Button onClick=handleStaleClick />
 );
+
+let y = [<div />, <div />];
+
+let y = [
+  <Button onClick=handleStaleClick />,
+  <Button onClick=handleStaleClick />
+];

--- a/formatTest/unit_tests/input/infix.re
+++ b/formatTest/unit_tests/input/infix.re
@@ -869,3 +869,23 @@ if (List.length(files)
     < 2) {
   ()
 };
+
+/* Don't clash with jsx edge cases */
+let (=<) = (a, b) => a + b;
+let result = x =< y;
+let z = x =<
+y;
+
+let z = x =<
+
+
+y;
+
+let (></) = (a, b) => a - b;
+let result = x ></ b;
+let z = x ></
+b;
+
+let z = x ></
+
+b;

--- a/formatTest/unit_tests/input/infix.re
+++ b/formatTest/unit_tests/input/infix.re
@@ -889,3 +889,12 @@ b;
 let z = x ></
 
 b;
+
+let (=</>) = (a, b) => a + b;
+let result = x =</> b;
+let z = x =</>
+b;
+
+let z = x =</>
+
+b;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -121,3 +121,7 @@ let x = [|<Button onClick=handleStaleClick />, <Button onClick=handleStaleClick 
 let z = (<div />);
 
 let z = (<Button onClick=handleStaleClick />, <Button onClick=handleStaleClick />);
+
+let y = [<div />, <div />];
+
+let y = [<Button onClick=handleStaleClick />, <Button onClick=handleStaleClick />];

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -105,3 +105,19 @@ let icon = <Icon
 
 /* don't pun explicitly passed optional with module identifier */
 <Foo bar=?Baz.bar />;
+
+let x = <div />;
+
+<div asd=1></div>;
+
+foo#=(<bar />);
+
+foo#=<bar />;
+
+let x =[|<div />|];
+
+let x = [|<Button onClick=handleStaleClick />, <Button onClick=handleStaleClick />|];
+
+let z = (<div />);
+
+let z = (<Button onClick=handleStaleClick />, <Button onClick=handleStaleClick />);

--- a/src/reason-parser/reason_lexer.mll
+++ b/src/reason-parser/reason_lexer.mll
@@ -442,27 +442,6 @@ let hex_float_literal =
 
 let literal_modifier = ['G'-'Z' 'g'-'z']
 
-(* In some situations the lexing/parsing of jsx conflicts
- * with infix operators. Example:
- * let x =<div />;
- * The author of this code clearly intends to bind
- * the div-jsx to x. The lexer interprets this as infix operator however.
- * I.e. you get `let` `x` `=<`, which is not what we want in this case.
- * To disambiguate the jsx from the infix operator we introduce the
- * following convention: if an ambigous case like `=<` (is it a infix op
- * or jsx ?), occurs we say that is categorized as infix operator if it's
- * followed by a whitespace or newline.
- * So in let result =< a + b, =< is interpreted as infix op (due to the whitespace).
- *
- * The following pattern helps to disambiguate the jsx from the infix op case
- *)
-let is_jsx_not_infix_operator =
-  [^
-   '\013' '\010' (* newline *)
-   ' ' '\009' '\012' (* whitespace *)
-   ')' (* let (=<) = (a, b) => a + b;, represents right paren after `=<` *)
-  ]
-
 rule token = parse
   | "\\" newline {
       match !preprocessor with
@@ -608,7 +587,7 @@ rule token = parse
   *)
   | "}"  { RBRACE }
   | ">}" { GREATERRBRACE }
-  | "=<" is_jsx_not_infix_operator  {
+  | "=<" uppercase_or_lowercase+ {
     (* allow `let x=<div />;` *)
     set_lexeme_length lexbuf 1;
     EQUAL

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -2439,8 +2439,11 @@ jsx_start_tag_and_args:
 ;
 
 jsx_start_tag_and_args_without_leading_less:
-  mod_longident jsx_arguments
-  { (jsx_component $1 $2, $1) }
+    mod_longident jsx_arguments
+    { (jsx_component $1 $2, $1) }
+  | LIDENT jsx_arguments
+    { let lident = Longident.Lident $1 in
+      (jsx_component lident $2, lident) }
 ;
 
 jsx:

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -939,7 +939,6 @@ let doc_attr text loc =
 
 /* Tokens */
 
-%token <string> LIDENTCOLONCOLON
 %token AMPERAMPER
 %token AMPERSAND
 %token AND
@@ -973,7 +972,6 @@ let doc_attr text loc =
 %token EXTERNAL
 %token FALSE
 %token <string * char option> FLOAT
-%token <string> COLONCOLONLIDENT
 %token FOR
 %token FUN ES6_FUN
 %token FUNCTION
@@ -1008,13 +1006,11 @@ let doc_attr text loc =
 %token LESSGREATER
 %token LESSSLASHGREATER
 %token LESSDOTDOTGREATER
-%token LESSMINUS
 %token EQUALGREATER
 %token LET
 %token <string> LIDENT
 %token LPAREN
 %token LBRACKETAT
-%token LESSSLASH
 %token OF
 %token PRI
 %token SWITCH


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/856 https://github.com/facebook/reason/issues/904 https://github.com/facebook/reason/issues/1181 https://github.com/facebook/reason/issues/1263 https://github.com/facebook/reason/issues/1292

Allow parsing of following "problematic jsx":
```reason
let listy = [<div />, <div />];
let x =[|<div />|];
let x=<div />;
let y = (<div />, <div />);
<Foo bar=<Baz /> />;
foo#=<bar />;
<div asd=1></div>;
```