### PR TITLE
[WIP] Implement different treatment for empty children and disallowed children

### DIFF
--- a/miscTests/reactjs_jsx_ppx_tests/expected_v2_1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v2_1.re
@@ -27,6 +27,8 @@ let divRef = ReactDOMRe.createElement("div", [||]);
 
 ReactDOMRe.createElement("div", [||]);
 
+ReactDOMRe.createElement("div", [||]);
+
 ReactDOMRe.createElement("div", ~props=ReactDOMRe.props(~className="hello", ()), [||]);
 
 ReactDOMRe.createElement(
@@ -40,15 +42,14 @@ ReactDOMRe.createElement(
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
   [|
     ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
-    ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
+    ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]))
   |]
 );
 
 ReactDOMRe.createElement(
   "div",
-  ~props=
-    ReactDOMRe.props(~className="hello", ~comp=ReasonReact.element(Foo.make(~bar=1, [||])), ()),
-  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(~bar=2, [||]))|]
+  ~props=ReactDOMRe.props(~className="hello", ~comp=ReasonReact.element(Foo.make(~bar=1, ())), ()),
+  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(~bar=2, ()))|]
 );
 
 ReactDOMRe.createElement(
@@ -56,42 +57,46 @@ ReactDOMRe.createElement(
   ~props=
     ReactDOMRe.props(
       ~className="hello",
-      ~compCallback=() => ReasonReact.element(Foo.make(~bar=1, [||])),
+      ~compCallback=() => ReasonReact.element(Foo.make(~bar=1, ())),
       ()
     ),
-  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(~bar=2, [||])))()|]
+  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(~bar=2, ())))()|]
 );
 
 "=== Custom component ===";
+
+ReasonReact.element(Foo.make());
 
 ReasonReact.element(Foo.make([||]));
 
 ReasonReact.element(Foo.make([|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]));
 
 ReasonReact.element(
-  Foo.make([|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|])
+  Foo.make([|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make())|])
 );
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
+
+ReasonReact.element(Foo.make(~className="hello", ()));
 
 ReasonReact.element(Foo.make(~className="hello", [||]));
 
 ReasonReact.element(Foo.make(~className="hello", [|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make(~className="hello", [|ReasonReact.element(Bar.make())|]));
 
 ReasonReact.element(
   Foo.make(
     ~className="hello",
-    [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|]
+    [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make())|]
   )
 );
 
 ReasonReact.element(Foo.make(~className="hello", [|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(~className="hello", ~width="10", [||]));
+ReasonReact.element(Foo.make(~className="hello", ~width="10", ()));
 
 ReasonReact.element(
   Foo.make(
@@ -99,7 +104,7 @@ ReasonReact.element(
     ~width="10",
     [|
       ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
-      ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
+      ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]))
     |]
   )
 );
@@ -107,8 +112,8 @@ ReasonReact.element(
 ReasonReact.element(
   Foo.make(
     ~className="hello",
-    ~comp=ReasonReact.element(Bar.make(~bar=1, [||])),
-    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(~bar=2, [||]))|]
+    ~comp=ReasonReact.element(Bar.make(~bar=1, ())),
+    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(~bar=2, ()))|]
   )
 );
 
@@ -130,7 +135,7 @@ ReasonReact.element(
 
 ReasonReact.element(Foo.make(() => 1));
 
-ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make([||]))));
+ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make())));
 
 ReasonReact.element(Foo.make((1, 2)));
 
@@ -144,7 +149,7 @@ ReasonReact.element(Foo.make(divRef));
 
 ReasonReact.element(Foo.make(ReactDOMRe.createElement("div", [||])));
 
-ReasonReact.element(Foo.make(ReasonReact.element(Bar.make([||]))));
+ReasonReact.element(Foo.make(ReasonReact.element(Bar.make())));
 
 ReasonReact.element(Foo.make(~className="hello", () => 1));
 
@@ -166,16 +171,16 @@ ReactDOMRe.createElement(
 
 "=== With ref/key ===";
 
-ReasonReact.element(~key="someKey", Foo.make(~className="hello", [||]));
+ReasonReact.element(~key="someKey", Foo.make(~className="hello", ()));
 
-ReasonReact.element(~key=Some("someKey"), ~ref=Some(ref), Foo.make(~className="hello", [||]));
+ReasonReact.element(~key=Some("someKey"), ~ref=Some(ref), Foo.make(~className="hello", ()));
 
-ReasonReact.element(~key=?Some("someKey"), ~ref=?Some(ref), Foo.make(~className="hello", [||]));
+ReasonReact.element(~key=?Some("someKey"), ~ref=?Some(ref), Foo.make(~className="hello", ()));
 
 ReasonReact.element(
   ~key="someKey",
   ~ref=Some(ref),
-  Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|])
+  Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make())|])
 );
 
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v2_2.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v2_2.re
@@ -29,6 +29,8 @@ let divRef = ReactDOMRe.createElement("div", [||]);
 
 ReactDOMRe.createElement("div", [||]);
 
+ReactDOMRe.createElement("div", [||]);
+
 ReactDOMRe.createElement("div", ~props=ReactDOMRe.props(~className="hello", ()), [||]);
 
 ReactDOMRe.createElement(
@@ -42,15 +44,14 @@ ReactDOMRe.createElement(
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
   [|
     ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
-    ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
+    ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]))
   |]
 );
 
 ReactDOMRe.createElement(
   "div",
-  ~props=
-    ReactDOMRe.props(~className="hello", ~comp=ReasonReact.element(Foo.make(~bar=1, [||])), ()),
-  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(~bar=2, [||]))|]
+  ~props=ReactDOMRe.props(~className="hello", ~comp=ReasonReact.element(Foo.make(~bar=1, ())), ()),
+  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(~bar=2, ()))|]
 );
 
 ReactDOMRe.createElement(
@@ -58,42 +59,46 @@ ReactDOMRe.createElement(
   ~props=
     ReactDOMRe.props(
       ~className="hello",
-      ~compCallback=() => ReasonReact.element(Foo.make(~bar=1, [||])),
+      ~compCallback=() => ReasonReact.element(Foo.make(~bar=1, ())),
       ()
     ),
-  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(~bar=2, [||])))()|]
+  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(~bar=2, ())))()|]
 );
 
 "=== Custom component ===";
+
+ReasonReact.element(Foo.make());
 
 ReasonReact.element(Foo.make([||]));
 
 ReasonReact.element(Foo.make([|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]));
 
 ReasonReact.element(
-  Foo.make([|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|])
+  Foo.make([|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make())|])
 );
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
+
+ReasonReact.element(Foo.make(~className="hello", ()));
 
 ReasonReact.element(Foo.make(~className="hello", [||]));
 
 ReasonReact.element(Foo.make(~className="hello", [|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make(~className="hello", [|ReasonReact.element(Bar.make())|]));
 
 ReasonReact.element(
   Foo.make(
     ~className="hello",
-    [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|]
+    [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make())|]
   )
 );
 
 ReasonReact.element(Foo.make(~className="hello", [|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(~className="hello", ~width="10", [||]));
+ReasonReact.element(Foo.make(~className="hello", ~width="10", ()));
 
 ReasonReact.element(
   Foo.make(
@@ -101,7 +106,7 @@ ReasonReact.element(
     ~width="10",
     [|
       ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
-      ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
+      ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]))
     |]
   )
 );
@@ -109,8 +114,8 @@ ReasonReact.element(
 ReasonReact.element(
   Foo.make(
     ~className="hello",
-    ~comp=ReasonReact.element(Bar.make(~bar=1, [||])),
-    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(~bar=2, [||]))|]
+    ~comp=ReasonReact.element(Bar.make(~bar=1, ())),
+    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(~bar=2, ()))|]
   )
 );
 
@@ -132,7 +137,7 @@ ReasonReact.element(
 
 ReasonReact.element(Foo.make(() => 1));
 
-ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make([||]))));
+ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make())));
 
 ReasonReact.element(Foo.make((1, 2)));
 
@@ -146,7 +151,7 @@ ReasonReact.element(Foo.make(divRef));
 
 ReasonReact.element(Foo.make(ReactDOMRe.createElement("div", [||])));
 
-ReasonReact.element(Foo.make(ReasonReact.element(Bar.make([||]))));
+ReasonReact.element(Foo.make(ReasonReact.element(Bar.make())));
 
 ReasonReact.element(Foo.make(~className="hello", () => 1));
 
@@ -168,16 +173,16 @@ ReactDOMRe.createElement(
 
 "=== With ref/key ===";
 
-ReasonReact.element(~key="someKey", Foo.make(~className="hello", [||]));
+ReasonReact.element(~key="someKey", Foo.make(~className="hello", ()));
 
-ReasonReact.element(~key=Some("someKey"), ~ref=Some(ref), Foo.make(~className="hello", [||]));
+ReasonReact.element(~key=Some("someKey"), ~ref=Some(ref), Foo.make(~className="hello", ()));
 
-ReasonReact.element(~key=?Some("someKey"), ~ref=?Some(ref), Foo.make(~className="hello", [||]));
+ReasonReact.element(~key=?Some("someKey"), ~ref=?Some(ref), Foo.make(~className="hello", ()));
 
 ReasonReact.element(
   ~key="someKey",
   ~ref=Some(ref),
-  Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|])
+  Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make())|])
 );
 
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v2_3.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v2_3.re
@@ -29,6 +29,8 @@ let divRef = ReactDOMRe.createElement("div", [||]);
 
 ReactDOMRe.createElement("div", [||]);
 
+ReactDOMRe.createElement("div", [||]);
+
 ReactDOMRe.createElement("div", ~props=ReactDOMRe.props(~className="hello", ()), [||]);
 
 ReactDOMRe.createElement(
@@ -42,15 +44,14 @@ ReactDOMRe.createElement(
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
   [|
     ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
-    ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
+    ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]))
   |]
 );
 
 ReactDOMRe.createElement(
   "div",
-  ~props=
-    ReactDOMRe.props(~className="hello", ~comp=ReasonReact.element(Foo.make(~bar=1, [||])), ()),
-  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(~bar=2, [||]))|]
+  ~props=ReactDOMRe.props(~className="hello", ~comp=ReasonReact.element(Foo.make(~bar=1, ())), ()),
+  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(~bar=2, ()))|]
 );
 
 ReactDOMRe.createElement(
@@ -58,42 +59,46 @@ ReactDOMRe.createElement(
   ~props=
     ReactDOMRe.props(
       ~className="hello",
-      ~compCallback=() => ReasonReact.element(Foo.make(~bar=1, [||])),
+      ~compCallback=() => ReasonReact.element(Foo.make(~bar=1, ())),
       ()
     ),
-  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(~bar=2, [||])))()|]
+  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(~bar=2, ())))()|]
 );
 
 "=== Custom component ===";
+
+ReasonReact.element(Foo.make());
 
 ReasonReact.element(Foo.make([||]));
 
 ReasonReact.element(Foo.make([|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]));
 
 ReasonReact.element(
-  Foo.make([|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|])
+  Foo.make([|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make())|])
 );
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
+
+ReasonReact.element(Foo.make(~className="hello", ()));
 
 ReasonReact.element(Foo.make(~className="hello", [||]));
 
 ReasonReact.element(Foo.make(~className="hello", [|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make(~className="hello", [|ReasonReact.element(Bar.make())|]));
 
 ReasonReact.element(
   Foo.make(
     ~className="hello",
-    [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|]
+    [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make())|]
   )
 );
 
 ReasonReact.element(Foo.make(~className="hello", [|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(~className="hello", ~width="10", [||]));
+ReasonReact.element(Foo.make(~className="hello", ~width="10", ()));
 
 ReasonReact.element(
   Foo.make(
@@ -101,7 +106,7 @@ ReasonReact.element(
     ~width="10",
     [|
       ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
-      ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
+      ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]))
     |]
   )
 );
@@ -109,8 +114,8 @@ ReasonReact.element(
 ReasonReact.element(
   Foo.make(
     ~className="hello",
-    ~comp=ReasonReact.element(Bar.make(~bar=1, [||])),
-    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(~bar=2, [||]))|]
+    ~comp=ReasonReact.element(Bar.make(~bar=1, ())),
+    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(~bar=2, ()))|]
   )
 );
 
@@ -132,7 +137,7 @@ ReasonReact.element(
 
 ReasonReact.element(Foo.make(() => 1));
 
-ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make([||]))));
+ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make())));
 
 ReasonReact.element(Foo.make((1, 2)));
 
@@ -146,7 +151,7 @@ ReasonReact.element(Foo.make(divRef));
 
 ReasonReact.element(Foo.make(ReactDOMRe.createElement("div", [||])));
 
-ReasonReact.element(Foo.make(ReasonReact.element(Bar.make([||]))));
+ReasonReact.element(Foo.make(ReasonReact.element(Bar.make())));
 
 ReasonReact.element(Foo.make(~className="hello", () => 1));
 
@@ -168,16 +173,16 @@ ReactDOMRe.createElement(
 
 "=== With ref/key ===";
 
-ReasonReact.element(~key="someKey", Foo.make(~className="hello", [||]));
+ReasonReact.element(~key="someKey", Foo.make(~className="hello", ()));
 
-ReasonReact.element(~key=Some("someKey"), ~ref=Some(ref), Foo.make(~className="hello", [||]));
+ReasonReact.element(~key=Some("someKey"), ~ref=Some(ref), Foo.make(~className="hello", ()));
 
-ReasonReact.element(~key=?Some("someKey"), ~ref=?Some(ref), Foo.make(~className="hello", [||]));
+ReasonReact.element(~key=?Some("someKey"), ~ref=?Some(ref), Foo.make(~className="hello", ()));
 
 ReasonReact.element(
   ~key="someKey",
   ~ref=Some(ref),
-  Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|])
+  Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make())|])
 );
 
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v3_1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v3_1.re
@@ -27,6 +27,8 @@ let divRef = ReactDOMRe.createElement("div", [||]);
 
 ReactDOMRe.createElement("div", [||]);
 
+ReactDOMRe.createElement("div", [||]);
+
 ReactDOMRe.createElement("div", ~props=ReactDOMRe.props(~className="hello", ()), [||]);
 
 ReactDOMRe.createElement(
@@ -40,15 +42,14 @@ ReactDOMRe.createElement(
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
   [|
     ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
-    ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
+    ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]))
   |]
 );
 
 ReactDOMRe.createElement(
   "div",
-  ~props=
-    ReactDOMRe.props(~className="hello", ~comp=ReasonReact.element(Foo.make(~bar=1, [||])), ()),
-  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(~bar=2, [||]))|]
+  ~props=ReactDOMRe.props(~className="hello", ~comp=ReasonReact.element(Foo.make(~bar=1, ())), ()),
+  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(~bar=2, ()))|]
 );
 
 ReactDOMRe.createElement(
@@ -56,42 +57,46 @@ ReactDOMRe.createElement(
   ~props=
     ReactDOMRe.props(
       ~className="hello",
-      ~compCallback=() => ReasonReact.element(Foo.make(~bar=1, [||])),
+      ~compCallback=() => ReasonReact.element(Foo.make(~bar=1, ())),
       ()
     ),
-  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(~bar=2, [||])))()|]
+  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(~bar=2, ())))()|]
 );
 
 "=== Custom component ===";
+
+ReasonReact.element(Foo.make());
 
 ReasonReact.element(Foo.make([||]));
 
 ReasonReact.element(Foo.make([|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]));
 
 ReasonReact.element(
-  Foo.make([|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|])
+  Foo.make([|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make())|])
 );
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
+
+ReasonReact.element(Foo.make(~className="hello", ()));
 
 ReasonReact.element(Foo.make(~className="hello", [||]));
 
 ReasonReact.element(Foo.make(~className="hello", [|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make(~className="hello", [|ReasonReact.element(Bar.make())|]));
 
 ReasonReact.element(
   Foo.make(
     ~className="hello",
-    [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|]
+    [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make())|]
   )
 );
 
 ReasonReact.element(Foo.make(~className="hello", [|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(~className="hello", ~width="10", [||]));
+ReasonReact.element(Foo.make(~className="hello", ~width="10", ()));
 
 ReasonReact.element(
   Foo.make(
@@ -99,7 +104,7 @@ ReasonReact.element(
     ~width="10",
     [|
       ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
-      ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
+      ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]))
     |]
   )
 );
@@ -107,8 +112,8 @@ ReasonReact.element(
 ReasonReact.element(
   Foo.make(
     ~className="hello",
-    ~comp=ReasonReact.element(Bar.make(~bar=1, [||])),
-    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(~bar=2, [||]))|]
+    ~comp=ReasonReact.element(Bar.make(~bar=1, ())),
+    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(~bar=2, ()))|]
   )
 );
 
@@ -130,7 +135,7 @@ ReasonReact.element(
 
 ReasonReact.element(Foo.make(() => 1));
 
-ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make([||]))));
+ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make())));
 
 ReasonReact.element(Foo.make((1, 2)));
 
@@ -144,7 +149,7 @@ ReasonReact.element(Foo.make(divRef));
 
 ReasonReact.element(Foo.make(ReactDOMRe.createElement("div", [||])));
 
-ReasonReact.element(Foo.make(ReasonReact.element(Bar.make([||]))));
+ReasonReact.element(Foo.make(ReasonReact.element(Bar.make())));
 
 ReasonReact.element(Foo.make(~className="hello", () => 1));
 
@@ -166,16 +171,16 @@ ReactDOMRe.createElement(
 
 "=== With ref/key ===";
 
-ReasonReact.element(~key="someKey", Foo.make(~className="hello", [||]));
+ReasonReact.element(~key="someKey", Foo.make(~className="hello", ()));
 
-ReasonReact.element(~key=Some("someKey"), ~ref=Some(ref), Foo.make(~className="hello", [||]));
+ReasonReact.element(~key=Some("someKey"), ~ref=Some(ref), Foo.make(~className="hello", ()));
 
-ReasonReact.element(~key=?Some("someKey"), ~ref=?Some(ref), Foo.make(~className="hello", [||]));
+ReasonReact.element(~key=?Some("someKey"), ~ref=?Some(ref), Foo.make(~className="hello", ()));
 
 ReasonReact.element(
   ~key="someKey",
   ~ref=Some(ref),
-  Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|])
+  Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make())|])
 );
 
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v3_2.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v3_2.re
@@ -29,6 +29,8 @@ let divRef = ReactDOMRe.createElement("div", [||]);
 
 ReactDOMRe.createElement("div", [||]);
 
+ReactDOMRe.createElement("div", [||]);
+
 ReactDOMRe.createElement("div", ~props=ReactDOMRe.props(~className="hello", ()), [||]);
 
 ReactDOMRe.createElement(
@@ -42,15 +44,14 @@ ReactDOMRe.createElement(
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
   [|
     ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
-    ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
+    ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]))
   |]
 );
 
 ReactDOMRe.createElement(
   "div",
-  ~props=
-    ReactDOMRe.props(~className="hello", ~comp=ReasonReact.element(Foo.make(~bar=1, [||])), ()),
-  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(~bar=2, [||]))|]
+  ~props=ReactDOMRe.props(~className="hello", ~comp=ReasonReact.element(Foo.make(~bar=1, ())), ()),
+  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(~bar=2, ()))|]
 );
 
 ReactDOMRe.createElement(
@@ -58,42 +59,46 @@ ReactDOMRe.createElement(
   ~props=
     ReactDOMRe.props(
       ~className="hello",
-      ~compCallback=() => ReasonReact.element(Foo.make(~bar=1, [||])),
+      ~compCallback=() => ReasonReact.element(Foo.make(~bar=1, ())),
       ()
     ),
-  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(~bar=2, [||])))()|]
+  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(~bar=2, ())))()|]
 );
 
 "=== Custom component ===";
+
+ReasonReact.element(Foo.make());
 
 ReasonReact.element(Foo.make([||]));
 
 ReasonReact.element(Foo.make([|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]));
 
 ReasonReact.element(
-  Foo.make([|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|])
+  Foo.make([|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make())|])
 );
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
+
+ReasonReact.element(Foo.make(~className="hello", ()));
 
 ReasonReact.element(Foo.make(~className="hello", [||]));
 
 ReasonReact.element(Foo.make(~className="hello", [|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make(~className="hello", [|ReasonReact.element(Bar.make())|]));
 
 ReasonReact.element(
   Foo.make(
     ~className="hello",
-    [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|]
+    [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make())|]
   )
 );
 
 ReasonReact.element(Foo.make(~className="hello", [|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(~className="hello", ~width="10", [||]));
+ReasonReact.element(Foo.make(~className="hello", ~width="10", ()));
 
 ReasonReact.element(
   Foo.make(
@@ -101,7 +106,7 @@ ReasonReact.element(
     ~width="10",
     [|
       ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
-      ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
+      ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]))
     |]
   )
 );
@@ -109,8 +114,8 @@ ReasonReact.element(
 ReasonReact.element(
   Foo.make(
     ~className="hello",
-    ~comp=ReasonReact.element(Bar.make(~bar=1, [||])),
-    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(~bar=2, [||]))|]
+    ~comp=ReasonReact.element(Bar.make(~bar=1, ())),
+    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(~bar=2, ()))|]
   )
 );
 
@@ -132,7 +137,7 @@ ReasonReact.element(
 
 ReasonReact.element(Foo.make(() => 1));
 
-ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make([||]))));
+ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make())));
 
 ReasonReact.element(Foo.make((1, 2)));
 
@@ -146,7 +151,7 @@ ReasonReact.element(Foo.make(divRef));
 
 ReasonReact.element(Foo.make(ReactDOMRe.createElement("div", [||])));
 
-ReasonReact.element(Foo.make(ReasonReact.element(Bar.make([||]))));
+ReasonReact.element(Foo.make(ReasonReact.element(Bar.make())));
 
 ReasonReact.element(Foo.make(~className="hello", () => 1));
 
@@ -168,16 +173,16 @@ ReactDOMRe.createElement(
 
 "=== With ref/key ===";
 
-ReasonReact.element(~key="someKey", Foo.make(~className="hello", [||]));
+ReasonReact.element(~key="someKey", Foo.make(~className="hello", ()));
 
-ReasonReact.element(~key=Some("someKey"), ~ref=Some(ref), Foo.make(~className="hello", [||]));
+ReasonReact.element(~key=Some("someKey"), ~ref=Some(ref), Foo.make(~className="hello", ()));
 
-ReasonReact.element(~key=?Some("someKey"), ~ref=?Some(ref), Foo.make(~className="hello", [||]));
+ReasonReact.element(~key=?Some("someKey"), ~ref=?Some(ref), Foo.make(~className="hello", ()));
 
 ReasonReact.element(
   ~key="someKey",
   ~ref=Some(ref),
-  Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|])
+  Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make())|])
 );
 
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v3_3.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v3_3.re
@@ -29,6 +29,8 @@ let divRef = ReactDOMRe.createElement("div", [||]);
 
 ReactDOMRe.createElement("div", [||]);
 
+ReactDOMRe.createElement("div", [||]);
+
 ReactDOMRe.createElement("div", ~props=ReactDOMRe.props(~className="hello", ()), [||]);
 
 ReactDOMRe.createElement(
@@ -42,15 +44,14 @@ ReactDOMRe.createElement(
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
   [|
     ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
-    ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
+    ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]))
   |]
 );
 
 ReactDOMRe.createElement(
   "div",
-  ~props=
-    ReactDOMRe.props(~className="hello", ~comp=ReasonReact.element(Foo.make(~bar=1, [||])), ()),
-  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(~bar=2, [||]))|]
+  ~props=ReactDOMRe.props(~className="hello", ~comp=ReasonReact.element(Foo.make(~bar=1, ())), ()),
+  [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Foo.make(~bar=2, ()))|]
 );
 
 ReactDOMRe.createElement(
@@ -58,42 +59,46 @@ ReactDOMRe.createElement(
   ~props=
     ReactDOMRe.props(
       ~className="hello",
-      ~compCallback=() => ReasonReact.element(Foo.make(~bar=1, [||])),
+      ~compCallback=() => ReasonReact.element(Foo.make(~bar=1, ())),
       ()
     ),
-  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(~bar=2, [||])))()|]
+  [|ReactDOMRe.createElement("li", [||]), (() => ReasonReact.element(Foo.make(~bar=2, ())))()|]
 );
 
 "=== Custom component ===";
+
+ReasonReact.element(Foo.make());
 
 ReasonReact.element(Foo.make([||]));
 
 ReasonReact.element(Foo.make([|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]));
 
 ReasonReact.element(
-  Foo.make([|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|])
+  Foo.make([|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make())|])
 );
 
 ReasonReact.element(Foo.make([|divRef, divRef|]));
+
+ReasonReact.element(Foo.make(~className="hello", ()));
 
 ReasonReact.element(Foo.make(~className="hello", [||]));
 
 ReasonReact.element(Foo.make(~className="hello", [|ReactDOMRe.createElement("div", [||])|]));
 
-ReasonReact.element(Foo.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]));
+ReasonReact.element(Foo.make(~className="hello", [|ReasonReact.element(Bar.make())|]));
 
 ReasonReact.element(
   Foo.make(
     ~className="hello",
-    [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make([||]))|]
+    [|ReactDOMRe.createElement("div", [||]), ReasonReact.element(Bar.make())|]
   )
 );
 
 ReasonReact.element(Foo.make(~className="hello", [|divRef, divRef|]));
 
-ReasonReact.element(Foo.make(~className="hello", ~width="10", [||]));
+ReasonReact.element(Foo.make(~className="hello", ~width="10", ()));
 
 ReasonReact.element(
   Foo.make(
@@ -101,7 +106,7 @@ ReasonReact.element(
     ~width="10",
     [|
       ReactDOMRe.createElement("li", [|ReactDOMRe.createElement("p", [||])|]),
-      ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]))
+      ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make())|]))
     |]
   )
 );
@@ -109,8 +114,8 @@ ReasonReact.element(
 ReasonReact.element(
   Foo.make(
     ~className="hello",
-    ~comp=ReasonReact.element(Bar.make(~bar=1, [||])),
-    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(~bar=2, [||]))|]
+    ~comp=ReasonReact.element(Bar.make(~bar=1, ())),
+    [|ReactDOMRe.createElement("li", [||]), ReasonReact.element(Bar.make(~bar=2, ()))|]
   )
 );
 
@@ -132,7 +137,7 @@ ReasonReact.element(
 
 ReasonReact.element(Foo.make(() => 1));
 
-ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make([||]))));
+ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make())));
 
 ReasonReact.element(Foo.make((1, 2)));
 
@@ -146,7 +151,7 @@ ReasonReact.element(Foo.make(divRef));
 
 ReasonReact.element(Foo.make(ReactDOMRe.createElement("div", [||])));
 
-ReasonReact.element(Foo.make(ReasonReact.element(Bar.make([||]))));
+ReasonReact.element(Foo.make(ReasonReact.element(Bar.make())));
 
 ReasonReact.element(Foo.make(~className="hello", () => 1));
 
@@ -168,16 +173,16 @@ ReactDOMRe.createElement(
 
 "=== With ref/key ===";
 
-ReasonReact.element(~key="someKey", Foo.make(~className="hello", [||]));
+ReasonReact.element(~key="someKey", Foo.make(~className="hello", ()));
 
-ReasonReact.element(~key=Some("someKey"), ~ref=Some(ref), Foo.make(~className="hello", [||]));
+ReasonReact.element(~key=Some("someKey"), ~ref=Some(ref), Foo.make(~className="hello", ()));
 
-ReasonReact.element(~key=?Some("someKey"), ~ref=?Some(ref), Foo.make(~className="hello", [||]));
+ReasonReact.element(~key=?Some("someKey"), ~ref=?Some(ref), Foo.make(~className="hello", ()));
 
 ReasonReact.element(
   ~key="someKey",
   ~ref=Some(ref),
-  Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|])
+  Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make())|])
 );
 
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/test1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test1.re
@@ -29,6 +29,8 @@ let divRef = <div />;
 
 <div />;
 
+<div> </div>;
+
 <div className="hello" />;
 
 <div className="hello" width="10" />;
@@ -39,9 +41,12 @@ let divRef = <div />;
 
 <div className="hello" compCallback=(fun () => <Foo bar=1 />)> <li /> ((fun () => <Foo bar=2 />) ()) </div>;
 
+
 "=== Custom component ===";
 
 <Foo />;
+
+<Foo> </Foo>;
 
 <Foo> <div /> </Foo>;
 
@@ -52,6 +57,8 @@ let divRef = <div />;
 <Foo> divRef divRef </Foo>;
 
 <Foo className="hello" />;
+
+<Foo className="hello"> </Foo>;
 
 <Foo className="hello"> <div /> </Foo>;
 
@@ -118,3 +125,4 @@ let divRef = <div />;
   correct ReasonReact-specific call */
 
 ([@JSX] Foo.make(~children=[], ()));
+

--- a/miscTests/reactjs_jsx_ppx_tests/test2.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test2.re
@@ -25,9 +25,12 @@ module ReasonReact = {
 
 let divRef = <div />;
 
+
 "=== DOM component ===";
 
 <div />;
+
+<div> </div>;
 
 <div className="hello" />;
 
@@ -39,9 +42,12 @@ let divRef = <div />;
 
 <div className="hello" compCallback=(fun () => <Foo bar=1 />)> <li /> ((fun () => <Foo bar=2 />) ()) </div>;
 
+
 "=== Custom component ===";
 
 <Foo />;
+
+<Foo> </Foo>;
 
 <Foo> <div /> </Foo>;
 
@@ -52,6 +58,8 @@ let divRef = <div />;
 <Foo> divRef divRef </Foo>;
 
 <Foo className="hello" />;
+
+<Foo className="hello"> </Foo>;
 
 <Foo className="hello"> <div /> </Foo>;
 
@@ -118,3 +126,4 @@ let divRef = <div />;
   correct ReasonReact-specific call */
 
 ([@JSX] Foo.make(~children=[], ()));
+

--- a/miscTests/reactjs_jsx_ppx_tests/test3.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test3.re
@@ -25,9 +25,12 @@ module ReasonReact = {
 
 let divRef = <div />;
 
+
 "=== DOM component ===";
 
 <div />;
+
+<div> </div>;
 
 <div className="hello" />;
 
@@ -39,9 +42,12 @@ let divRef = <div />;
 
 <div className="hello" compCallback=(fun () => <Foo bar=1 />)> <li /> ((fun () => <Foo bar=2 />) ()) </div>;
 
+
 "=== Custom component ===";
 
 <Foo />;
+
+<Foo> </Foo>;
 
 <Foo> <div /> </Foo>;
 
@@ -52,6 +58,8 @@ let divRef = <div />;
 <Foo> divRef divRef </Foo>;
 
 <Foo className="hello" />;
+
+<Foo className="hello"> </Foo>;
 
 <Foo className="hello"> <div /> </Foo>;
 
@@ -118,3 +126,4 @@ let divRef = <div />;
   correct ReasonReact-specific call */
 
 ([@JSX] Foo.make(~children=[], ()));
+

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4021,8 +4021,14 @@ class printer  ()= object(self:'self)
   method formatJSXComponent componentName args =
     let rec processArguments arguments processedAttrs children =
       match arguments with
-      | (Labelled "children", {pexp_desc = Pexp_construct (_, None)}) :: tail ->
+      | (Labelled "children", {pexp_desc = Pexp_construct ({txt = Lident"()"}, None )}) :: tail ->
         processArguments tail processedAttrs None
+      | (Labelled "children", {pexp_desc = Pexp_construct (_, None)}) :: tail ->
+        let children = if componentName = String.capitalize componentName then 
+          (Some []) 
+        else 
+          None in
+        processArguments tail processedAttrs children
       | (Labelled "children", {pexp_desc = Pexp_construct ({txt = Lident"::"}, Some {pexp_desc = Pexp_tuple(components)} )}) :: tail ->
         processArguments tail processedAttrs (self#formatChildren components [])
       | (Labelled "children", expr) :: tail ->


### PR DESCRIPTION
This PR is work in progress. It will be finished if you like the idea. The remaining part is `typeCheckedTests/expected_output/jsx.re` test.

It just shows an idea how to make components which disallow children compatible with JSX.

I'm waiting for feedback 👍.

The behaviour has only changed for upper cased components:

`<Div> </Div>` is pretty printed as `<Div> </Div>`. And after desugaring it becomes `((Div.createElement ~children:[] ())[@JSX ])`.

However, `<Div />` is desugared as `((Div.createElement ~children:() ())[@JSX ])` (take a look at `children` arg)