### PR TITLE
Enforce final semicolon for sequences.

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -18,7 +18,7 @@
   },
   "HOW-TO-TEST-OCAML-4.04": [
     "To test with OCaml 4.04:",
-    "1. Change the OCaml devDependency to: esy-ocaml/ocaml#4.4.2+esy instead of ~4.2.3000",
+    "1. Change the OCaml devDependency to: ~4.4.2 instead of ~4.2.3000",
     "2. Rerun esy install",
     "3. Rerun esy build"
   ],

--- a/esy.json
+++ b/esy.json
@@ -16,6 +16,12 @@
   "peerDependencies": {
     "ocaml": " >= 4.2.0  < 4.6.0"
   },
+  "HOW-TO-TEST-OCAML-4.04": [
+    "To test with OCaml 4.04:",
+    "1. Change the OCaml devDependency to: esy-ocaml/ocaml#4.4.2+esy instead of ~4.2.3000",
+    "2. Rerun esy install",
+    "3. Rerun esy build"
+  ],
   "devDependencies": {
     "@opam/merlin": "2.5.4",
     "ocaml": "~4.2.3000"

--- a/formatTest/test.sh
+++ b/formatTest/test.sh
@@ -187,6 +187,9 @@ function unit_test() {
         info "  ${INFO}$OUTPUT/$FILE${RESET}"
         info "  doesn't match expected output"
         info "  ${INFO}$EXPECTED_OUTPUT/$OFILE${RESET}"
+        info ""
+        info "  To approve the changes run:"
+        info "    cp $OUTPUT/$FILE $EXPECTED_OUTPUT/$OFILE"
         echo ""
         return 1
     fi
@@ -345,6 +348,9 @@ function error_test() {
         info "  ${INFO}$OUTPUT/$FILE${RESET}"
         info "  doesn't match expected output"
         info "  ${INFO}$EXPECTED_OUTPUT/$FILE${RESET}"
+        info ""
+        info "  To approve the changes run:"
+        info "    cp $OUTPUT/$FILE $EXPECTED_OUTPUT/$FILE"
         echo ""
         return 1
     fi

--- a/formatTest/typeCheckedTests/expected_output/attributes.4.04.0.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.4.04.0.re
@@ -2,5 +2,5 @@
 let () = {
   [@attribute]
   exception E;
-  raise(E)
+  raise(E);
 };

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -242,8 +242,8 @@ let showLets = () =>
     [@onFinalLet]
     {
       let tmpTmp = tmp + tmp;
-      tmpTmp + tmpTmp
-    }
+      tmpTmp + tmpTmp;
+    };
   };
 
 /**
@@ -507,7 +507,7 @@ let res =
       open String;
       open Array;
       concat;
-      index_from
+      index_from;
     }
   };
 

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -496,3 +496,22 @@ external debounce :
   ) =>
   [@bs.meth] (unit => unit) =
   "";
+
+let x = "hi";
+
+let res =
+  switch x {
+  | _ =>
+    [@attr]
+    {
+      open String;
+      open Array;
+      concat;
+      index_from
+    }
+  };
+
+let res =
+  switch x {
+  | _ => [@attr] String.(Array.(concat))
+  };

--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -17,7 +17,7 @@ let reasonBarAs =
   fun
   | ((Y(_) | Z(_)) as t, _) => {
       let _ = t;
-      true
+      true;
     }
   | _ => false;
 

--- a/formatTest/typeCheckedTests/expected_output/comments.re
+++ b/formatTest/typeCheckedTests/expected_output/comments.re
@@ -74,11 +74,11 @@ let result =
   | X(x) =>
     /* Where does this comment go? */
     let tmp = x;
-    x + tmp
+    x + tmp;
   | Y(x) =>
     /* How about this one */
     let tmp = x;
-    x + tmp
+    x + tmp;
   };
 
 let result =
@@ -86,11 +86,11 @@ let result =
   | Some({fieldOne: 20}) =>
     /* Where does this comment go? */
     let tmp = 0;
-    2 + tmp
+    2 + tmp;
   | Some({fieldOne: n}) =>
     /* How about this one */
     let tmp = n;
-    n + tmp
+    n + tmp;
   | None => 20
   };
 
@@ -130,6 +130,6 @@ let store_attributes = (arg) => {
     /* only overwrite defined procedures */
     Temp.v || ! Temp.v;
   if (should_write) {
-    Temp.logIt(proc_name, ())
-  }
+    Temp.logIt(proc_name, ());
+  };
 };

--- a/formatTest/typeCheckedTests/expected_output/imperative.re
+++ b/formatTest/typeCheckedTests/expected_output/imperative.re
@@ -6,7 +6,7 @@
  */
 switch (
   while (true) {
-    ()
+    ();
   }
 ) {
 | _ => ()
@@ -14,7 +14,7 @@ switch (
 
 try (
   while (true) {
-    ()
+    ();
   }
 ) {
 | _ => ()
@@ -22,7 +22,7 @@ try (
 
 switch (
   for (i in 0 to 10) {
-    ()
+    ();
   }
 ) {
 | _ => ()
@@ -30,7 +30,7 @@ switch (
 
 try (
   for (i in 0 to 10) {
-    ()
+    ();
   }
 ) {
 | _ => ()
@@ -38,9 +38,9 @@ try (
 
 switch (
   if (true) {
-    print_string("switching on true")
+    print_string("switching on true");
   } else {
-    print_string("switching on false")
+    print_string("switching on false");
   }
 ) {
 | _ => ()
@@ -48,7 +48,7 @@ switch (
 
 try (
   for (i in 0 to 10) {
-    ()
+    ();
   }
 ) {
 | _ => ()
@@ -57,7 +57,7 @@ try (
 let result =
   (
     while (false) {
-      ()
+      ();
     }
   )
   == () ?
@@ -79,16 +79,16 @@ let shouldStillLoop = {contents: false};
 
 while (shouldStillLoop.contents) {
   print_string("You're in a while loop");
-  print_newline()
+  print_newline();
 };
 
 while ({
          shouldStillLoop.contents = false;
-         shouldStillLoop.contents
+         shouldStillLoop.contents;
        }) {
-  print_string("Will never loop")
+  print_string("Will never loop");
 };
 
 while ((shouldStillLoop := false) == ()) {
-  print_string("Forever in the loop")
+  print_string("Forever in the loop");
 };

--- a/formatTest/typeCheckedTests/expected_output/lazy.re
+++ b/formatTest/typeCheckedTests/expected_output/lazy.re
@@ -2,14 +2,14 @@ let myComputation =
   lazy {
     let tmp = 10;
     let tmp2 = 20;
-    tmp + tmp2
+    tmp + tmp2;
   };
 
 type myRecord = {myRecordField: int};
 
 let operateOnLazyValue = (lazy {myRecordField}) => {
   let tmp = myRecordField;
-  tmp + tmp
+  tmp + tmp;
 };
 
 let result =

--- a/formatTest/typeCheckedTests/expected_output/mlSyntax.re
+++ b/formatTest/typeCheckedTests/expected_output/mlSyntax.re
@@ -81,9 +81,9 @@ let referentialInequality = 2 !== 2;
 
 let equalityInIf =
   if (1 == 1) {
-    true
+    true;
   } else {
-    false
+    false;
   };
 
 let equalityWithIdentifiers =

--- a/formatTest/typeCheckedTests/expected_output/mlSyntax.re.4.02.3
+++ b/formatTest/typeCheckedTests/expected_output/mlSyntax.re.4.02.3
@@ -81,9 +81,9 @@ let referentialInequality = 2 !== 2;
 
 let equalityInIf =
   if (1 == 1) {
-    true
+    true;
   } else {
-    false
+    false;
   };
 
 let equalityWithIdentifiers =

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -10,7 +10,7 @@ class virtual stack ('a) (init) = {
     switch v {
     | [hd, ...tl] =>
       v = tl;
-      Some(hd)
+      Some(hd);
     | [] => None
     };
   pub push = (hd) => v = [hd, ...v];
@@ -46,7 +46,7 @@ class virtual stackWithAttributes ('a) (init) = {
     switch v {
     | [hd, ...tl] =>
       v = tl;
-      Some(hd)
+      Some(hd);
     | [] => None
     };
   pub push = (hd) => v = [hd, ...v];
@@ -166,7 +166,7 @@ let xs: ref({. x: int}) = {
 
 let coercedReturn = {
   let tmp = anonClosedObject;
-  (tmp :> {. x: int})
+  (tmp :> {. x: int});
 };
 
 let acceptsOpenAnonObjAsArg =
@@ -337,7 +337,7 @@ let incrementMyClassInstance:
   #tupleClass(int, int) =
   (i, inst) => {
     let (x, y) = inst#pr;
-    {pub pr = (x + i, y + i)}
+    {pub pr = (x + i, y + i)};
   };
 
 class myClassWithNoTypeParams = {};

--- a/formatTest/typeCheckedTests/expected_output/patternMatching.re
+++ b/formatTest/typeCheckedTests/expected_output/patternMatching.re
@@ -63,20 +63,20 @@ let res =
       HeresTwoConstructorArguments(a, b)
     ) =>
     let ret = (x, y, a, b);
-    ret
+    ret;
   | TwoCombos(_, _) =>
     /**
      * See, no braces required - saves indentation as well!
      */
     let ret = (0, 0, 0, 0);
-    ret
+    ret;
   | Short
   | AlsoHasARecord(300, _, _) =>
     /**
      * And no final semicolon is required.
      */
     let ret = (100000, 100000, 100000, 100000);
-    ret
+    ret;
   | AlsoHasARecord(firstItem, two, {x, y}) =>
     computeTuple(
       firstItem,
@@ -110,7 +110,7 @@ let res =
       | Some(x) => x + 1
       | None => 0
     );
-    x
+    x;
   | Short
   | AlsoHasARecord(300, _, _) =>
     id(

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -221,11 +221,11 @@ let result =
   | Some({fieldOne: 20, fieldA: a}) =>
     /* Where does this comment go? */
     let tmp = 0;
-    2 + tmp
+    2 + tmp;
   | Some({fieldOne: n, fieldA: a}) =>
     /* How about this one */
     let tmp = n;
-    n + tmp
+    n + tmp;
   | None => 20
   };
 
@@ -249,14 +249,14 @@ let result =
         a /* end of line */
     }) =>
     let tmp = 0;
-    2 + tmp
+    2 + tmp;
   | Some({
       fieldOne: n, /* end of line */
       fieldA:
         a /* end of line */
     }) =>
     let tmp = n;
-    n + tmp
+    n + tmp;
   | None => 20
   };
 
@@ -321,7 +321,7 @@ let a = ();
 
 for (i in 0 to 10) {
   /* bla  */
-  a
+  a;
 };
 
 if (true) {

--- a/formatTest/typeCheckedTests/expected_output/sequences.re
+++ b/formatTest/typeCheckedTests/expected_output/sequences.re
@@ -5,13 +5,13 @@
 let result = {
   let twenty = 20;
   let result = twenty;
-  result
+  result;
 };
 
 /* Final semicolon is not required */
 let result = {
   let twenty = result;
-  twenty
+  twenty;
 };
 
 let anInt = result + 20;
@@ -37,15 +37,15 @@ let unitValue = ();
  * it's not required.
  */
 while (false) {
-  unitValue
+  unitValue;
 };
 
 while (false) {
-  print_string("test")
+  print_string("test");
 };
 
 while (false) {
-  print_string("test")
+  print_string("test");
 };
 
 type myRecord = {number: int};

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -358,3 +358,27 @@ external debounce : int => ([@bs.meth] (unit => unit)) => ([@bs.meth] (unit => u
 external debounce : int => ([@bs.meth] (unit => unit)) => ([@bs.meth] (unit => unit)) => ([@bs.meth] (unit => unit)) = "";
 
 external debounce : int => ([@bs.meth] (unit => unit)) => ([@bs.meth] (unit => [@bs.meth] (unit => unit))) => ([@bs.meth] (unit => unit)) = "";
+
+
+let x = "hi";
+
+let res = switch x {
+| _ =>
+  [@attr]
+  {
+    open String;
+    open Array;
+    concat;
+    index_from;
+  }
+};
+
+let res = switch x {
+| _ =>
+  [@attr]
+  {
+    open String;
+    open Array;
+    concat;
+  }
+};

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -4,7 +4,7 @@ let run = () =>
 
 while (something) {
   print_string("You're in a while loop");
-  print_newline()
+  print_newline();
 };
 
 for (i in 0 to 5) {
@@ -14,8 +14,8 @@ for (i in 0 to 5) {
     print_string(
       "Counting in reverse direction"
     );
-    print_newline()
-  }
+    print_newline();
+  };
 };
 
 for (i in
@@ -29,8 +29,8 @@ for (i in
     print_string(
       "Counting in reverse direction"
     );
-    print_newline()
-  }
+    print_newline();
+  };
 };
 
 let x = foo^ ^.bar^;
@@ -130,21 +130,21 @@ let x = arr^[0] = 1;
 let something =
   if (self.ext.logSuccess) {
     print_string("Did tap");
-    print_newline()
+    print_newline();
   };
 
 let logTapSuccess = (self) =>
   if (self.ext.logSuccess) {
     print_string("Did tap");
-    print_newline()
+    print_newline();
   } else {
-    ()
+    ();
   };
 
 let logTapSuccess = (self) =>
   if (self.ext.logSuccess) {
     print_string("Did tap");
-    print_newline()
+    print_newline();
   };
 
 (! data).field = true;
@@ -161,47 +161,47 @@ let loop = (appTime, frameTime) => {
   if (hasSetup.contents) {
     setupScene();
     renderIntoTop();
-    hasSetup.contents = true
+    hasSetup.contents = true;
   };
-  process(appTime, frameTime)
+  process(appTime, frameTime);
 };
 
 /* These parens should be kept around the entire last if/then/else */
 if (something) {
-  if (somethingElse) {()} else {"blah"}
+  if (somethingElse) {()} else {"blah"};
 };
 
 /* These parens should be kept around just the last if/then*/
 if (something) {
-  if (somethingElse) {()} else {"blah"}
+  if (somethingElse) {()} else {"blah"};
 };
 
 /* Parens should be generated to wrap the entire final if then else.
  * To test that it's being parsed correclty, should print "one". */
 if (true) {
   if (true) {
-    print_string("one")
+    print_string("one");
   } else {
-    print_string("two")
-  }
+    print_string("two");
+  };
 };
 
 /* Should print two */
 if (true) {
   if (false) {
-    print_string("one")
+    print_string("one");
   } else {
-    print_string("two")
-  }
+    print_string("two");
+  };
 };
 
 /* Should not print */
 if (false) {
   if (true) {
-    print_string("one")
+    print_string("one");
   } else {
-    print_string("two")
-  }
+    print_string("two");
+  };
 };
 
 /* Should wrap (if a > b then a else b).
@@ -213,20 +213,20 @@ let result =
   if (printIfFirstArgGreater) {
     (a, b) =>
       if (a > b) {
-        print_string("a > b")
+        print_string("a > b");
       } else {
-        print_string("b >= a")
-      }
+        print_string("b >= a");
+      };
   } else if ((a, b) =>
                if (a > b) {
-                 print_string("b < a")
+                 print_string("b < a");
                } else {
-                 print_string("a <= b")
+                 print_string("a <= b");
                }) {
     print_string(
       "That could never possibly type check"
     );
-    print_newline()
+    print_newline();
   };
 
 let myRecord = {
@@ -238,9 +238,9 @@ let myRecord = {
             instaComp.relativeRect,
             displayRect
           )) {
-        IoEligible
+        IoEligible;
       } else {
-        IoInelibleButTryComposition
+        IoInelibleButTryComposition;
       }
   }
 };
@@ -248,61 +248,61 @@ let myRecord = {
 if (printIfFirstArgGreater) {
   (a, b) =>
     if (a > b) {
-      print_string("a > b")
-    }
+      print_string("a > b");
+    };
 } else {
   (a, b) =>
     if (a > b) {
-      print_string("b < a")
-    }
+      print_string("b < a");
+    };
 };
 
 /* Should Be Parsed As: Cleary a type error, but at least the parsing makes that clear */
 if (printIfFirstArgGreater) {
   (a, b) =>
     if (a > b) {
-      print_string("a > b")
+      print_string("a > b");
     } else {
       (a, b) =>
         if (a > b) {
-          print_string("b < a")
-        }
-    }
+          print_string("b < a");
+        };
+    };
 };
 
 (a, b) =>
   if (a > b) {
-    print_string("a > b")
+    print_string("a > b");
   };
 
 /* What you probably wanted was: */
 if (printIfFirstArgGreater) {
   (a, b) =>
     if (a > b) {
-      print_string("a > b")
-    }
+      print_string("a > b");
+    };
 } else {
   (a, b) =>
     if (a > b) {
-      print_string("b < a")
-    }
+      print_string("b < a");
+    };
 };
 
 /* Mutative if statement: Not used to evaluate to something. */
 if (10 < 100) {
   let msg = "If there was any doubt, 10 is in fact less than 100.";
-  print_string(msg)
+  print_string(msg);
 } else {
   let msg = "All bets are off.";
-  print_string(msg)
+  print_string(msg);
 };
 
 if (10 < 100) {
   print_string(
     "If there was any doubt, 10 is in fact less than 100."
-  )
+  );
 } else {
-  print_string("All bets are off.")
+  print_string("All bets are off.");
 };
 
 /**                            TYPE CONSTRAINTS
@@ -355,7 +355,7 @@ let annotatingSingleFuncApplication = {
    * This demonstrates why named arguments cannot simply have the form (func
    * arg:val) - it is indistinguishable from a type constraint.
    */
-  2 + (_dummyFunc(a): int)
+  2 + (_dummyFunc(a): int);
 };
 
 let (
@@ -775,7 +775,7 @@ let break_after_equal =
 /* Pexp_letexception */
 let () = {
   exception E;
-  raise(E)
+  raise(E);
 };
 
 /* # 1587: don't print fun keyword when printing Pexp_fun in a record expression  */

--- a/formatTest/unit_tests/expected_output/features403.re
+++ b/formatTest/unit_tests/expected_output/features403.re
@@ -34,9 +34,9 @@ let rec eval: type a. expr(a) => a =
       eval(left) + eval(right)
     | If({pred, true_branch, false_branch}) =>
       if (eval(pred)) {
-        eval(true_branch)
+        eval(true_branch);
       } else {
-        eval(false_branch)
+        eval(false_branch);
       }
     };
 

--- a/formatTest/unit_tests/expected_output/fixme.re
+++ b/formatTest/unit_tests/expected_output/fixme.re
@@ -5,5 +5,5 @@ let store_attributes = (proc_attributes) => {
   let should_write =
     /* only overwrite defined procedures */ proc_attributes.ProcAttributes.is_defined
     || ! DB.file_exists(attributes_file);
-  should_write
+  should_write;
 };

--- a/formatTest/unit_tests/expected_output/if.re
+++ b/formatTest/unit_tests/expected_output/if.re
@@ -2,55 +2,55 @@
 let logTSuccess = (self) =>
   if (self > other) {
     print_string("Did T");
-    print_newline()
+    print_newline();
   } else {
-    ()
+    ();
   };
 
 let something =
   if (self.ext.logSuccess) {
     print_string("Did T");
-    print_newline()
+    print_newline();
   };
 
 let logTSuccess = (self) =>
   if (self.ext.logSuccess) {
     print_string("Did T");
-    print_newline()
+    print_newline();
   } else {
-    ()
+    ();
   };
 
 if (if (x) {true} else {false}) {
-  true
+  true;
 } else {
-  false
+  false;
 };
 
 /* Parens are required around if if it's an argument - this is the same as before. */
 if (callSomeFunction(
       if (true) {true} else {false}
     )) {
-  true
+  true;
 } else {
-  false
+  false;
 };
 
 /* Notice that to do something strange, your code must *look* strange. */
 /* That's generally a good thing */
 if (callSomeFunction) {
-  if (true) {true}
+  if (true) {true};
 } else {
-  false
+  false;
 };
 
 if (callSomeFunction(
       {
         thisIsAnArgument;
-        notTheControlFlow
+        notTheControlFlow;
       }
     )) {
-  thisIsTheControlFlow
+  thisIsTheControlFlow;
 };
 
 /* The braces around the test conditions of if statements are not required.
@@ -64,15 +64,15 @@ if (callSomeFunction(
  *
  */
 if (printIfFirstArgGreater) {
-  simpleThen
+  simpleThen;
 } else {
-  thisDoesnt(even, have2, be, simple)
+  thisDoesnt(even, have2, be, simple);
 };
 
 if (if (x) {true} else {false}) {
-  ()
+  ();
 } else {
-  ()
+  ();
 };
 
 /**                            TERNARY
@@ -173,13 +173,13 @@ let res =
  */
 let result =
   if (something) {
-    Console.log("First Branch")
+    Console.log("First Branch");
   } else if (anotherThing) {
-    Console.log("Second Branch")
+    Console.log("Second Branch");
   } else if (yetAnotherThing) {
-    Console.log("Third Branch")
+    Console.log("Third Branch");
   } else {
-    Console.log("Final Case")
+    Console.log("Final Case");
   };
 
 /*

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -1000,7 +1000,7 @@ let containingObject = {
     [@shouldBeRenderedOnEntireSetField]
     (something.contents = "newvalue");
     something.contents =
-      [@shouldBeRenderedOnString] "newvalue"
+      [@shouldBeRenderedOnString] "newvalue";
   }
 };
 
@@ -1086,12 +1086,12 @@ let server = {
     >>= (
       (body) =>
         Server.respond_string(~status, ~body, ())
-    )
+    );
   };
   Server.create(
     ~mode,
     Server.make(~callback, ())
-  )
+  );
 };
 
 let lijst =
@@ -1121,7 +1121,7 @@ let example =
 
 if (List.length(files) > 0
     && List.length(otherfiles) < 2) {
-  ()
+  ();
 };
 
 /* Don't clash with jsx edge cases */

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -35,7 +35,7 @@ let y =
                 ),
                 latestComponentBag,
                 ()
-              )
+              );
           },
           ()
         )

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -104,7 +104,7 @@ let opensAModuleLocally = {
     let y: someType = 20;
   };
   let tmp = MyLocalModule.x + 22;
-  tmp + 30
+  tmp + 30;
 };
 
 module type HasTT = {type tt;};
@@ -278,7 +278,7 @@ let letsTryThatSyntaxInLocalModuleBindings = () => {
       AMod,
       BMod
     );
-  TempModule.result + TempModule2.result
+  TempModule.result + TempModule2.result;
 };
 
 module type EmptySig = {};
@@ -534,7 +534,7 @@ module N = {
   let z = {
     open M;
     34;
-    35
+    35;
   };
   let z = M.(34, 35);
   let z = M.(34, 35);
@@ -550,41 +550,41 @@ module N = {
   let z = M.(M2.value);
   let z = {
     open! M;
-    34
+    34;
   };
   let z = {
     open! M;
     34;
-    35
+    35;
   };
   let z = {
     open! M;
-    {}
+    {};
   };
   let z = {
     open! M;
-    {x: 10}
+    {x: 10};
   };
   let z = {
     open! M;
-    [foo, bar]
+    [foo, bar];
   };
   let z = {
     open! M;
-    [foo, bar]
+    [foo, bar];
   };
   let z = {
     open! M;
-    {x: 10, y: 20}
+    {x: 10, y: 20};
   };
   let z = {
     open! M;
     open! M2;
-    value
+    value;
   };
   let z = {
     open! M;
-    M2.value
+    M2.value;
   };
   let y = 44;
 };

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -21,10 +21,10 @@ let matchingFunc = (a) =>
   | `Thingy(x) =>
     print_string("matched thingy x");
     let zz = 10;
-    zz
+    zz;
   | `Other(x) =>
     print_string("matched other x");
-    x
+    x;
   };
 
 type firstTwoShouldBeGroupedInParens =
@@ -285,7 +285,7 @@ let point3D: point3D = {
 
 let printPoint = (p: point) => {
   print_int(p.x);
-  print_int(p.y)
+  print_int(p.y);
 };
 
 let addPoints = (p1: point, p2: point) => {
@@ -346,7 +346,7 @@ let o: person = {name: "bob", age: 10};
 
 let printPerson = (p: person) => {
   let q: person = p;
-  p.name ++ p.name
+  p.name ++ p.name;
 };
 
 /* let dontParseMeBro x y:int = x = y;*/
@@ -385,22 +385,22 @@ module TryToExportTwice = {
 let onlyDoingThisTopLevelLetToBypassTopLevelSequence = {
   let x = {
     print_int(1);
-    print_int(20) /* Missing trailing SEMI */
+    print_int(20); /* Missing trailing SEMI */
   };
   let x = {
     print_int(1);
     print_int(
       20
     ); /* Ensure missing middle SEMI reported well */
-    print_int(20)
+    print_int(20);
   };
   let x = {
     print_int(1);
     print_int(20);
-    10
+    10;
     /* Comment in final position */
   }; /* Missing final SEMI */
-  x + x
+  x + x;
 };
 
 type hasA = {a: int};
@@ -474,7 +474,7 @@ let sameThingInLocal = {
       1 /* With some effort, we can ammend the sugar rule that would */
     | Black(x) => 0 /* Allow us to drop any => fun.. Just need to make pattern matching */
     | Green(x) => 0; /* Support that */
-  blahCurriedX
+  blahCurriedX;
 };
 
 /* This should be parsed/printed exactly as the previous */
@@ -503,9 +503,9 @@ let res = {
   {
     print_string(a);
     let a = 20;
-    print_int(a)
+    print_int(a);
   };
-  print_string(a)
+  print_string(a);
 };
 
 let res = {
@@ -513,14 +513,14 @@ let res = {
   let a = 20;
   print_int(a);
   print_int(a);
-  print_int(a)
+  print_int(a);
 };
 
 let res = {
   let a = "a is always a string";
   print_string(a);
   let b = 30;
-  print_int(b)
+  print_int(b);
 };
 
 /* let result = LyList.map((fun | [] => true | _ => false), []); */
@@ -543,16 +543,16 @@ let blah =
 /* let arrowFunc = fun a b => print_string "returning aplusb from arrow"; a + b;;  */
 let arrowFunc = (a, b) => {
   print_string("returning aplusb from arrow");
-  a + b
+  a + b;
 };
 
 let add = (a, b) => {
   let extra = {
     print_string("adding");
-    0
+    0;
   };
   let anotherExtra = 0;
-  extra + a + b + anotherExtra
+  extra + a + b + anotherExtra;
 };
 
 print_string(string_of_int(add(4, 34)));
@@ -626,7 +626,7 @@ let tupleInsideAParenSequence = {
     "look, a tuple inside a sequence"
   );
   let x = 10;
-  (x, x)
+  (x, x);
 };
 
 let tupleInsideALetSequence = {
@@ -634,7 +634,7 @@ let tupleInsideALetSequence = {
     "look, a tuple inside a sequence"
   );
   let x = 10;
-  (x, x)
+  (x, x);
 };
 
 /* We *require* that function return types be wrapped in
@@ -852,22 +852,22 @@ let explictlyPassedAnnotated: int =
 
 let nestedLet = {
   let _ = 1;
-  ()
+  ();
 };
 
 let nestedLet = {
   let _ = 1;
-  ()
+  ();
 };
 
 let nestedLet = {
   let _ = 1;
-  ()
+  ();
 };
 
 let nestedLet = {
   let _ = 1;
-  2
+  2;
 };
 
 /*
@@ -909,14 +909,16 @@ let x =
 
 let res = {
   (constraintedSequenceItem: string);
-  (dontKnowWheYoudWantToActuallyDoThis: string)
+  (dontKnowWheYoudWantToActuallyDoThis: string);
 };
 
 let res = {
   (
     butTheyWillBePrintedWithAppropriateSpacing: string
   );
-  (soAsToInstillBestDevelopmentPractices: string)
+  (
+    soAsToInstillBestDevelopmentPractices: string
+  );
 };
 
 let x = [

--- a/formatTest/unit_tests/expected_output/testUtils.re
+++ b/formatTest/unit_tests/expected_output/testUtils.re
@@ -2,7 +2,7 @@
 let printSection = (s) => {
   print_string("\n");
   print_string(s);
-  print_string("\n---------------------\n")
+  print_string("\n---------------------\n");
 };
 
 let printLn = (s) => print_string(s ++ "\n");

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -151,12 +151,12 @@ let rec accessDeeplyWithArgRecursive = (x, count) =>
   | LocalModule.AccessedThroughModuleWith(x) as entirePattern =>
     /* It captures the whole pattern */
     if (count > 0) {
-      0
+      0;
     } else {
       accessDeeplyWithArgRecursive(
         entirePattern,
         count - 1
-      )
+      );
     }
   | LocalModule.AccessedThroughModuleWithTwo(
       x,
@@ -164,12 +164,12 @@ let rec accessDeeplyWithArgRecursive = (x, count) =>
     ) as entirePattern =>
     /* It captures the whole pattern */
     if (count > 0) {
-      0
+      0;
     } else {
       accessDeeplyWithArgRecursive(
         entirePattern,
         count - 1
-      )
+      );
     }
   };
 
@@ -180,7 +180,7 @@ accessDeeplyWithArgRecursive(
 
 let run = () => {
   TestUtils.printSection("Variants");
-  Printf.printf("%d %d \n", x, y)
+  Printf.printf("%d %d \n", x, y);
 };
 
 type combination('a) =

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -2903,26 +2903,26 @@ let x =
 let onlyDoingThisTopLevelLetToBypassTopLevelSequence = {
   let x = {
     print_int(1);
-    print_int(20) /* Missing trailing SEMI */
+    print_int(20); /* Missing trailing SEMI */
   };
   let x = {
     print_int(1);
     print_int(
       20
     ); /* Ensure missing middle SEMI reported well */
-    print_int(20)
+    print_int(20);
   };
   let x = {
     print_int(1);
     print_int(20);
-    10
+    10;
   }; /* Missing final SEMI */
   let x = {
     print_int(1);
     print_int(20);
-    10
+    10;
   };
-  x + x /* Final item */
+  x + x; /* Final item */
 };
 
 /* With this unification, anywhere eyou see `= fun` you can just ommit it */
@@ -2939,7 +2939,7 @@ let tryingTheSameInLocalScope = {
   let blah = (a) => a; /* Done (almost) */
   let blah = (a, b) => a; /* Done */
   let blah = (a, b) => a;
-  () /* Done (almost) */
+  (); /* Done (almost) */
 };
 
 reallyLongFunctionNameWithArrayThatBreaks([|

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -2150,7 +2150,7 @@ let makeLetSequence letItems =
     ~newlinesAboveComments:0
     ~newlinesAboveItems:0
     ~newlinesAboveDocComments:1
-    ~renderFinalSep:false
+    ~renderFinalSep:true
     ~postSpace:true
     ~sep:";"
     letItems
@@ -2181,7 +2181,7 @@ let makeUnguardedLetSequence letItems =
     ~indent:0
     ~newlinesAboveItems:0
     ~newlinesAboveDocComments:1
-    ~renderFinalSep:false
+    ~renderFinalSep:true
     ~postSpace:true
     ~sep:";"
     letItems
@@ -5462,7 +5462,7 @@ class printer  ()= object(self:'self)
       | PStr [itm] -> makeList ~break ~wrap ~pad [self#structure_item itm]
       | PStr (_::_ as items) ->
         let rows = (List.map (self#structure_item) items) in
-        makeList ~wrap ~break ~pad ~postSpace ~sep rows
+        makeList ~wrap ~break ~pad ~postSpace ~sep ~renderFinalSep:false rows
       | PTyp x ->
         makeList ~wrap ~break ~pad [label ~space:true (atom ":") (self#core_type x)]
       (* Signatures in attributes were added recently *)


### PR DESCRIPTION
Summary:

First step:  Simplify detection of M.(P.(foo)).
Second step: Enforce the final semicolon for multi-line statements/sequences. (First step doesn't have much to do with it, but it helped me understand what was going on).

Reviewers:chenglou, iwankaramazow
