### PR TITLE
Callback printing

### DIFF
--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1133,7 +1133,23 @@ foo(
 /* Smooth formatting of functions with callbacks as arguments */
 funWithCb("text", () => doStuff());
 
+funWithCb(~text="text", ~f=() => doStuff());
+
+funWithCb(~text="text", ~f=?() => doStuff());
+
 test("my test", () => {
+  let x = a + b;
+  let y = z + c;
+  x + y
+});
+
+test(~desc="my test", ~f=() => {
+  let x = a + b;
+  let y = z + c;
+  x + y
+});
+
+test(~desc=?"my test", ~f=?() => {
   let x = a + b;
   let y = z + c;
   x + y
@@ -1145,7 +1161,27 @@ describe("App", () =>
   )
 );
 
+describe(~text="App", ~f=() =>
+  test(~text="math", ~f=() =>
+    Expect.expect(1 + 2) |> toBe(3)
+  )
+);
+
+describe(~text=?"App", ~f=?() =>
+  test(~text=?"math", ~f=?() =>
+    Expect.expect(1 + 2) |> toBe(3)
+  )
+);
+
 Thing.map(foo, bar, baz, (abc, z) =>
+  MyModuleBlah.toList(argument)
+);
+
+Thing.map(~a=foo, ~b=bar, ~c=?baz, ~f=(abc, z) =>
+  MyModuleBlah.toList(argument)
+);
+
+Thing.map(~a=foo, ~b=bar, ~c=?baz, ~f=?(abc, z) =>
   MyModuleBlah.toList(argument)
 );
 
@@ -1160,4 +1196,38 @@ Thing.map(
     let x = 1;
     MyModuleBlah.toList(x, argument);
   }
+);
+
+Thing.map(
+  ~a=foo,
+  ~b=bar,
+  ~c=baz,
+  ~d=foo2,
+  ~e=bakjlksjdf,
+  ~f=okokokok,
+  ~cb=(abc, z) => {
+    let x = 1;
+    MyModuleBlah.toList(x, argument);
+  }
+);
+
+Thing.map(
+  ~a=?foo,
+  ~b=?bar,
+  ~c=?baz,
+  ~d=?foo2,
+  ~e=?bakjlksjdf,
+  ~f=?okokokok,
+  ~cb=?(abc, z) => {
+    let x = 1;
+    MyModuleBlah.toList(x, argument);
+  }
+);
+
+Thing.map(
+  foo,
+  bar,
+  baz,
+  (abc, z) => MyModuleBlah.toList(argument),
+  (abc, z) => MyModuleBlah.toList(argument)
 );

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1129,3 +1129,35 @@ foo(
   ~y=[@foo] -0.1n,
   ~z=[@foo] -0.1p
 );
+
+/* Smooth formatting of functions with callbacks as arguments */
+funWithCb("text", () => doStuff());
+
+test("my test", () => {
+  let x = a + b;
+  let y = z + c;
+  x + y
+});
+
+describe("App", () =>
+  test("math", () =>
+    Expect.expect(1 + 2) |> toBe(3)
+  )
+);
+
+Thing.map(foo, bar, baz, (abc, z) =>
+  MyModuleBlah.toList(argument)
+);
+
+Thing.map(
+  foo,
+  bar,
+  baz,
+  foo2,
+  bakjlksjdf,
+  okokokok,
+  (abc, z) => {
+    let x = 1;
+    MyModuleBlah.toList(x, argument);
+  }
+);

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -766,7 +766,8 @@ echoTheEchoer(
       o,
       p
     )
-  ) => (
+  ) =>
+  (
     a,
     b,
     c,

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -918,10 +918,27 @@ foo(~x=[@foo] (-0.1m), ~y=[@foo] (-0.1n), ~z=[@foo] (-0.1p));
 /* Smooth formatting of functions with callbacks as arguments */
 funWithCb("text", () => doStuff());
 
+funWithCb(~text="text", ~f=() => doStuff());
+
+funWithCb(~text="text", ~f=?() => doStuff());
+
 test("my test", () => {
  let x = a + b;
  let y = z + c;
  x + y
+});
+
+test(~desc="my test", ~f=() => {
+ let x = a + b;
+ let y = z + c;
+ x + y
+});
+
+
+test(~desc=?"my test", ~f=?() => {
+  let x = a + b;
+  let y = z + c;
+  x + y
 });
 
 describe("App", () => {
@@ -930,7 +947,27 @@ describe("App", () => {
   });
 });
 
+describe(~text="App", ~f=() =>
+  test(~text="math", ~f=() =>
+    Expect.expect(1 + 2) |> toBe(3)
+  )
+);
+
+describe(~text=?"App", ~f=?() =>
+  test(~text=?"math", ~f=?() =>
+    Expect.expect(1 + 2) |> toBe(3)
+  )
+);
+
 Thing.map(foo, bar, baz, (abc, z) =>
+  MyModuleBlah.toList(argument)
+);
+
+Thing.map(~a=foo, ~b=bar, ~c=?baz, ~f=(abc, z) =>
+  MyModuleBlah.toList(argument)
+);
+
+Thing.map(~a=foo, ~b=bar, ~c=?baz, ~f=?(abc, z) =>
   MyModuleBlah.toList(argument)
 );
 
@@ -945,4 +982,38 @@ Thing.map(
     let x = 1;
     MyModuleBlah.toList(x, argument);
   }
+);
+
+Thing.map(
+  ~a=foo,
+  ~b=bar,
+  ~c=baz,
+  ~d=foo2,
+  ~e=bakjlksjdf,
+  ~f=okokokok,
+  ~cb=(abc, z) => {
+    let x = 1;
+    MyModuleBlah.toList(x, argument);
+  }
+);
+
+Thing.map(
+  ~a=?foo,
+  ~b=?bar,
+  ~c=?baz,
+  ~d=?foo2,
+  ~e=?bakjlksjdf,
+  ~f=?okokokok,
+  ~cb=?(abc, z) => {
+    let x = 1;
+    MyModuleBlah.toList(x, argument);
+  }
+);
+
+Thing.map(
+  foo, 
+  bar, 
+  baz, 
+  (abc, z) => MyModuleBlah.toList(argument), 
+  (abc, z) => MyModuleBlah.toList(argument)
 );

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -914,3 +914,35 @@ foo(~x=[@foo] (-1), ~y=[@foo] (-1), ~z=[@foo] (-1));
 foo(~x=[@foo] (-1z), ~y=[@foo] (-1z), ~z=[@foo] (-1z));
 foo(~x=[@foo] (-0.1), ~y=[@foo] (-0.1), ~z=[@foo] (-0.1));
 foo(~x=[@foo] (-0.1m), ~y=[@foo] (-0.1n), ~z=[@foo] (-0.1p));
+
+/* Smooth formatting of functions with callbacks as arguments */
+funWithCb("text", () => doStuff());
+
+test("my test", () => {
+ let x = a + b;
+ let y = z + c;
+ x + y
+});
+
+describe("App", () => {
+  test("math", () => {
+    Expect.expect(1+2) |> toBe(3)
+  });
+});
+
+Thing.map(foo, bar, baz, (abc, z) =>
+  MyModuleBlah.toList(argument)
+);
+
+Thing.map(
+  foo,
+  bar,
+  baz,
+  foo2,
+  bakjlksjdf,
+  okokokok,
+  (abc, z) => {
+    let x = 1;
+    MyModuleBlah.toList(x, argument);
+  }
+);

--- a/src/reason-parser/jbuild
+++ b/src/reason-parser/jbuild
@@ -48,6 +48,7 @@
   (wrapped false)
   (modules
    (syntax_util
+    reason_heuristics
     reason_toolchain
     reason_config
     reason_pprint_ast

--- a/src/reason-parser/reason_heuristics.ml
+++ b/src/reason-parser/reason_heuristics.ml
@@ -1,4 +1,4 @@
-let is_punned_labelled_expression e lbl = 
+let is_punned_labelled_expression e lbl =
   let open Ast_404.Parsetree in
   match e.pexp_desc with
   | Pexp_ident { txt; _ }
@@ -7,7 +7,14 @@ let is_punned_labelled_expression e lbl =
     -> txt = Longident.parse lbl
   | _ -> false
 
-let estimateLineLengthForCallback ~args ~funExpr () =
+(* We manually check the length of `Thing.map(foo, bar, baz`,
+ * in `Thing.map(foo, bar, baz, (a) => doStuff(a))`
+ * because Easyformat doesn't have a hook to change printing when a list breaks
+ *
+ * we check if all arguments aside from the final one are either strings or identifiers,
+ * where the sum of the string contents and identifier names are less than the print width
+ *)
+let funAppCallbackExceedsWidth ~printWidth ~args ~funExpr () =
   let open Ast_404.Parsetree in
   let open Ast_404.Asttypes in
   let funLen = begin match funExpr.pexp_desc with
@@ -17,28 +24,41 @@ let estimateLineLengthForCallback ~args ~funExpr () =
        let len = List.fold_left (fun acc curr ->
          acc + (String.length curr)) lengthOfDots identList in
        len
-    | _ -> -1 
+    | _ -> -1
   end in
+  (* eats an argument & substract its length from the printWidth
+   * as soon as the print width reaches a sub-zero value,
+   * we know the print width is exceeded & returns *)
   let rec aux len = function
-    | [] -> len
-    | _ when len < 0 -> len
-    | arg::args -> 
+    | _ when len < 0 -> true
+    | [] -> false
+    | arg::args ->
       begin match arg with
       | (label, ({ pexp_desc = Pexp_ident ident } as e)) ->
         let identLen = List.fold_left (fun acc curr ->
           acc + (String.length curr)
         ) len (Longident.flatten ident.txt) in
         begin match label with
-        | Nolabel -> aux (len + identLen) args
-        | Labelled s  when is_punned_labelled_expression e s ->   
-            aux (len + identLen + 1) args
-        | _ ->
-         -1 
+        | Nolabel -> aux (len - identLen) args
+        | Labelled s when is_punned_labelled_expression e s ->
+            aux (len - (identLen + 1)) args
+        | Labelled s ->
+            aux (len - (identLen + 2 + String.length s)) args
+        | Optional s ->
+            aux (len - (identLen + 3 + String.length s)) args
         end
-      | (_, {pexp_desc = Pexp_constant (Pconst_string (str, _))}) ->
-        aux (len + (String.length str)) args
-      | _ -> aux (-1) args
+      | (label, {pexp_desc = Pexp_constant (Pconst_string (str, _))}) ->
+        let strLen = String.length str in
+        begin match label with
+        | Nolabel -> aux (len - strLen) args
+        | Labelled s ->
+            aux (len - (strLen + 2 + String.length s)) args
+        | Optional s ->
+            aux (len - (strLen + 3 + String.length s)) args
+        end
+      | _ ->
+        (* if we encounter a non-string or non-identifier argument exit *)
+          true
     end
   in
-  aux funLen args
-
+  aux (printWidth - funLen) args

--- a/src/reason-parser/reason_heuristics.ml
+++ b/src/reason-parser/reason_heuristics.ml
@@ -1,0 +1,44 @@
+let is_punned_labelled_expression e lbl = 
+  let open Ast_404.Parsetree in
+  match e.pexp_desc with
+  | Pexp_ident { txt; _ }
+  | Pexp_constraint ({pexp_desc = Pexp_ident { txt; _ }; _}, _)
+  | Pexp_coerce ({pexp_desc = Pexp_ident { txt; _ }; _}, _, _)
+    -> txt = Longident.parse lbl
+  | _ -> false
+
+let estimateLineLengthForCallback ~args ~funExpr () =
+  let open Ast_404.Parsetree in
+  let open Ast_404.Asttypes in
+  let funLen = begin match funExpr.pexp_desc with
+    | Pexp_ident ident ->
+       let identList = Longident.flatten ident.txt in
+       let lengthOfDots = List.length identList - 1 in
+       let len = List.fold_left (fun acc curr ->
+         acc + (String.length curr)) lengthOfDots identList in
+       len
+    | _ -> -1 
+  end in
+  let rec aux len = function
+    | [] -> len
+    | _ when len < 0 -> len
+    | arg::args -> 
+      begin match arg with
+      | (label, ({ pexp_desc = Pexp_ident ident } as e)) ->
+        let identLen = List.fold_left (fun acc curr ->
+          acc + (String.length curr)
+        ) len (Longident.flatten ident.txt) in
+        begin match label with
+        | Nolabel -> aux (len + identLen) args
+        | Labelled s  when is_punned_labelled_expression e s ->   
+            aux (len + identLen + 1) args
+        | _ ->
+         -1 
+        end
+      | (_, {pexp_desc = Pexp_constant (Pconst_string (str, _))}) ->
+        aux (len + (String.length str)) args
+      | _ -> aux (-1) args
+    end
+  in
+  aux funLen args
+

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -6683,9 +6683,6 @@ class printer  ()= object(self:'self)
           | Labelled s -> makeList ([atom namedArgSym; atom s; atom "="]@cbArgs)
           | Nolabel -> makeList cbArgs
         in
-        (* major hack; we manually check the length of `Thing.map(foo, bar,baz`,
-         * because Easyformat doesn't have a hook to change printing when a list breaks *)
-        let estimatedLineLength = Reason_heuristics.estimateLineLengthForCallback ~args ~funExpr () in
 
         let theFunc = SourceMap (funExpr.pexp_loc, makeList ~wrap:("", "(") [self#simplifyUnparseExpr funExpr]) in
         let formattedFunAppl = begin match self#letList retCb with
@@ -6715,30 +6712,27 @@ class printer  ()= object(self:'self)
           in
           label left returnValueCallback
         | xs -> 
-            if estimatedLineLength > 0 && estimatedLineLength < settings.width then
-            (*
-             * Thing.map(foo, bar, baz, (abc, z) =>
-             *   MyModuleBlah.toList(argument)
-             * )
-             *
-             * To get this kind of formatting we need to construct the following tree:
-             * <Label>
-             * <left>Thing.map(foo, bar, baz, (abc, z)</left><right>=>
-             *   MyModuleBlah.toList(argument)
-             * )</right>
-             * </Label>
-             *
-             * where left is
-             * <Label><left>Thing.map(</left></right>foo, bar, baz, (abc, z) </right></Label>
-             *
-             * The <right> part of that label could be a <List> with wrap:("", " ") break:IfNeed inline:(true, true)
-             * with items: "foo", "bar", "baz", "(abc, z)", separated by commas.
-             *)
-              (* heuristic
-               * if all arguments aside from the final one are either strings or identifiers,
-               * where the sum of the string contents and identifier names are less than the print width
+              let printWidthExceeded = Reason_heuristics.funAppCallbackExceedsWidth ~printWidth:settings.width ~args ~funExpr () in
+              if printWidthExceeded = false then
+              (*
+               * Thing.map(foo, bar, baz, (abc, z) =>
+               *   MyModuleBlah.toList(argument)
+               * )
                *
-               * this is necessary to achieve the following formatting where }) hugs :
+               * To get this kind of formatting we need to construct the following tree:
+               * <Label>
+               * <left>Thing.map(foo, bar, baz, (abc, z)</left><right>=>
+               *   MyModuleBlah.toList(argument)
+               * )</right>
+               * </Label>
+               *
+               * where left is
+               * <Label><left>Thing.map(</left></right>foo, bar, baz, (abc, z) </right></Label>
+               *
+               * The <right> part of that label could be a <List> with wrap:("", " ") break:IfNeed inline:(true, true)
+               * with items: "foo", "bar", "baz", "(abc, z)", separated by commas.
+               *
+               * this is also necessary to achieve the following formatting where }) hugs :
                * test("my test", () => {
                *   let x = a + b;
                *   let y = z + c;

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -60,7 +60,6 @@ open Easy_format
 open Syntax_util
 open Ast_mapper
 
-
 type commentCategory =
   | EndOfLine
   | SingleLine
@@ -6663,55 +6662,30 @@ class printer  ()= object(self:'self)
     let categorizeFunApplArgs args =
       let reverseArgs = List.rev args in
       match reverseArgs with
-      | (Nolabel, {pexp_desc = Pexp_fun _})::_ -> `LastArgIsCallback reverseArgs
+      | ((_, {pexp_desc = Pexp_fun _}) as callback)::args 
+          when let otherCallbacks = 
+            List.filter (fun (_, e) -> match e.pexp_desc with Pexp_fun _ -> true | _ -> false) args
+          in List.length otherCallbacks == 0
+          (* default to normal formatting if there's more than one callback *)
+          -> `LastArgIsCallback(callback, List.rev args)
       | _ -> `NormalFunAppl args
     in
     begin match categorizeFunApplArgs args with
-    | `LastArgIsCallback reverseArgs ->
+    | `LastArgIsCallback(callbackArg, args) ->
         (* This is the following case:
          * Thing.map(foo, bar, baz, (abc, z) =>
          *   MyModuleBlah.toList(argument)
          *)
-        let (args, callbackArg) = begin match reverseArgs with
-        | callback::args -> (List.rev args, callback)
-        | [] -> raise (NotPossible "can't partition 0 function expression args")
-        end in
-        (* callback isn't a labelled argument *)
-        let (_, cb) = callbackArg in
+        let (argLbl, cb) = callbackArg in
         let (_sweet, cbArgs, retCb) = self#curriedPatternsAndReturnVal cb in
-
+        let theCallbackArg = match argLbl with
+          | Optional s -> makeList ([atom namedArgSym; atom s; atom "=?"]@cbArgs)
+          | Labelled s -> makeList ([atom namedArgSym; atom s; atom "="]@cbArgs)
+          | Nolabel -> makeList cbArgs
+        in
         (* major hack; we manually check the length of `Thing.map(foo, bar,baz`,
          * because Easyformat doesn't have a hook to change printing when a list breaks *)
-        let estimatedLineLength =
-          let funLen = begin match funExpr.pexp_desc with
-           | Pexp_ident ident ->
-               let identList = Longident.flatten ident.txt in
-               let lengthOfDots = List.length identList - 1 in
-               let len = List.fold_left (fun acc curr ->
-                 acc + (String.length curr)) lengthOfDots identList in
-               len
-           | _ -> 0
-          end in
-          let argsLength = List.fold_left (fun acc curr ->
-            match acc with
-            | None -> None
-            | Some len ->
-              let (_, argExpr) = curr in
-              begin match argExpr with
-              | {pexp_desc = Pexp_ident ident } ->
-                  let identLen = List.fold_left (fun acc curr ->
-                    acc + (String.length curr)
-                  ) len (Longident.flatten ident.txt) in
-                  Some identLen
-              | {pexp_desc = Pexp_constant (Pconst_string (str, _))} ->
-                  Some (len + (String.length str))
-              | _ -> None
-              end
-          ) (Some (((List.length args) - 1) * 2)) args in
-          match argsLength with
-          | Some len -> Some (funLen + len)
-          | None -> None
-         in
+        let estimatedLineLength = Reason_heuristics.estimateLineLengthForCallback ~args ~funExpr () in
 
         let theFunc = SourceMap (funExpr.pexp_loc, makeList ~wrap:("", "(") [self#simplifyUnparseExpr funExpr]) in
         let formattedFunAppl = begin match self#letList retCb with
@@ -6732,15 +6706,16 @@ class printer  ()= object(self:'self)
           | _ -> false
           in
           let returnValueCallback = makeList ~break:(if forceBreak then Always else IfNeed) ~wrap:("=> ", ")") [x] in
-          let argsWithCallbackArgs = List.concat [(List.map self#label_x_expression_param args); cbArgs] in
+
+          let argsWithCallbackArgs = List.concat [(List.map self#label_x_expression_param args); [theCallbackArg]] in
           let left = label
             theFunc
             (makeList ~wrap:("", " ") ~break:IfNeed ~inline:(true, true) ~sep:"," ~postSpace:true
               argsWithCallbackArgs)
           in
           label left returnValueCallback
-        | xs -> begin match estimatedLineLength with
-            | Some len when len < settings.width ->
+        | xs -> 
+            if estimatedLineLength > 0 && estimatedLineLength < settings.width then
             (*
              * Thing.map(foo, bar, baz, (abc, z) =>
              *   MyModuleBlah.toList(argument)
@@ -6771,14 +6746,14 @@ class printer  ()= object(self:'self)
                * });
                *)
               let right = makeList ~break:Always_rec ~wrap:("=> {", "})") ~sep:";" xs in
-              let argsWithCallbackArgs = List.concat [(List.map self#label_x_expression_param args); cbArgs] in
+              let argsWithCallbackArgs = List.concat [(List.map self#label_x_expression_param args); [theCallbackArg]] in
               let left = label
                 theFunc
                 (makeList ~wrap:("", " ") ~break:IfNeed ~inline:(true, true) ~sep:"," ~postSpace:true
                   argsWithCallbackArgs)
               in
               label left right
-            | _ ->
+            else
               (* Since the heuristic says the line lenght is exceeded in this case,
                * we conveniently format everything as
                * <label><left>Thing.map(</left><right><list>
@@ -6794,10 +6769,9 @@ class printer  ()= object(self:'self)
                *)
               let args = makeList ~break:Always ~wrap:("", ")") ~sep:"," (
                 (List.map self#label_x_expression_param args)
-                @([label ~space:true (makeList ~wrap:("", " =>") cbArgs) (makeLetSequence xs)])
+                @([label ~space:true (makeList ~wrap:("", " =>") [theCallbackArg]) (makeLetSequence xs)])
               ) in
               label theFunc args
-            end
         end in
         maybeJSXAttr @ [formattedFunAppl]
     | `NormalFunAppl args ->


### PR DESCRIPTION
fixes https://github.com/facebook/reason/issues/1373

Example:
```reason
test("my test", () => {
  let x = a + b;
  let y = z + c;
  x + y
});

describe("App", () => {
  let x = 1;
  test("math", () => {
    let y = 1;
    Expect.expect(1 + 2) |> toBe(3)
  })
});

describe("App", () =>
  test("math", () =>
    Expect.expect(1 + 2) |> toBe(3)
  )
);

Thing.map(foo, bar, baz, (abc, z) =>
  MyModuleBlah.toList(argument)
);

Thing.map(
  foo,
  bar,
  baz,
  foo2,
  bakjlksjdf,
  okokokok,
  (abc, z) => {
    let x = 1;
    MyModuleBlah.toList(argument);
  }
);
```
