### PR TITLE
More liberal menhir version constraint.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 *.messages binary
-*.lock binary
 
 docs/highlightJs/** binary
 docs/vendor/** binary

--- a/esy.json
+++ b/esy.json
@@ -5,7 +5,7 @@
     "@esy-ocaml/substs": "^0.0.1",
     "@esy-ocaml/esy-installer": "^0.0.0",
     "@opam/ocamlfind": "",
-    "@opam/menhir": " >= 20170418.0.0  <= 20170712.0.0",
+    "@opam/menhir": " >= 20170418.0.0  <= 20171013.0.0",
     "@opam/utop": " >= 1.17.0",
     "@opam/merlin-extend": " >= 0.3.0",
     "@opam/result": "=1.2.0",

--- a/esy.lock
+++ b/esy.lock
@@ -55,15 +55,16 @@
     ocaml " >= 4.2.3"
 
 "@opam/camlp4@*":
-  version "4.6.0-1"
-  uid "8cb8cde01975178a4702ccb0146e3b69"
-  resolved "@opam/camlp4@4.6.0-1-8cb8cde01975178a4702ccb0146e3b69.tgz"
+  version "4.2.0-7"
+  uid d53806e26bd846f370dfcf737059c135
+  resolved "@opam/camlp4@4.2.0-7-d53806e26bd846f370dfcf737059c135.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
+    "@opam/conf-which" "*"
     "@opam/ocamlbuild" "*"
   peerDependencies:
-    ocaml " >= 4.6.0  < 4.7.0"
+    ocaml " >= 4.2.0  < 4.3.0"
 
 "@opam/camomile@ >= 0.8.0", "@opam/camomile@*":
   version "0.8.7"
@@ -182,10 +183,10 @@
   peerDependencies:
     ocaml "*"
 
-"@opam/menhir@ >= 20170418.0.0  <= 20170712.0.0":
-  version "20170712.0.0"
-  uid ba00c20e2ef9090560de7429e1d5b0dd
-  resolved "@opam/menhir@20170712.0.0-ba00c20e2ef9090560de7429e1d5b0dd.tgz"
+"@opam/menhir@ >= 20170418.0.0  <= 20171013.0.0":
+  version "20171013.0.0"
+  uid "5712b6580d0ab8d7b8d67d0a538fb2cb"
+  resolved "@opam/menhir@20171013.0.0-5712b6580d0ab8d7b8d67d0a538fb2cb.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
@@ -206,17 +207,17 @@
   peerDependencies:
     ocaml " >= 4.2.3"
 
-"@opam/merlin@3.0.5":
-  version "3.0.5"
-  uid "47ca3e74aba286394b143ec92343bea3"
-  resolved "@opam/merlin@3.0.5-47ca3e74aba286394b143ec92343bea3.tgz"
+"@opam/merlin@2.5.4":
+  version "2.5.4"
+  uid "12ad852acf4c42f710c19a298dc42880"
+  resolved "@opam/merlin@2.5.4-12ad852acf4c42f710c19a298dc42880.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
     "@opam/ocamlfind" " >= 1.5.2"
     "@opam/yojson" "*"
   peerDependencies:
-    ocaml " >= 4.2.1  < 4.7.0"
+    ocaml " >= 4.2.1  < 4.5.0"
 
 "@opam/ocaml-migrate-parsetree@ >= 0.7.0", "@opam/ocaml-migrate-parsetree@*":
   version "1.0.7"
@@ -232,14 +233,14 @@
     ocaml " >= 4.2.0"
 
 "@opam/ocamlbuild@*":
-  version "0.12.0"
-  uid "761c85d20275dc92caf736a38af02f51"
-  resolved "@opam/ocamlbuild@0.12.0-761c85d20275dc92caf736a38af02f51.tgz"
+  version "0.11.0"
+  uid b72309c383acb89aeac83e886afb586f
+  resolved "@opam/ocamlbuild@0.11.0-b72309c383acb89aeac83e886afb586f.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
   peerDependencies:
-    ocaml " >= 4.3.0"
+    ocaml "<4.3.0"
 
 "@opam/ocamlfind@", "@opam/ocamlfind@ >= 1.5.0", "@opam/ocamlfind@ >= 1.5.2", "@opam/ocamlfind@ >= 1.5.3", "@opam/ocamlfind@ >= 1.6.1", "@opam/ocamlfind@ >= 1.7.2", "@opam/ocamlfind@*":
   version "1.7.3"
@@ -348,6 +349,6 @@
   peerDependencies:
     ocaml " >= 4.2.3"
 
-ocaml@~4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/ocaml/-/ocaml-4.6.0.tgz#d3a19c79935ccdfccbc68fce4f6894771e139a5c"
+ocaml@~4.2.3000:
+  version "4.2.3001"
+  resolved "https://registry.yarnpkg.com/ocaml/-/ocaml-4.2.3001.tgz#4bb250b8a842fb357acb2ebf1a13a0c3fa753dd6"


### PR DESCRIPTION
The [opam release](https://github.com/ocaml/opam-repository/pull/10869)
was failing in a way that seemed related to Menhir. Only on linux though
- and it wasn't being caught in our own CI - only OPAM's. Must be for
some configuration we don't test. Making menhir dep more liberal to see
if it will fix our attempted release.

Creating pull request to see if CI passes.
