### PR TITLE
change print-width default from 100 to 80

### DIFF
--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -1121,7 +1121,7 @@ let defaultSettings = {
 
   *)
   funcCurriedPatternStyle = NeverWrapFinalItem;
-  width = 100;
+  width = 80;
   assumeExplicitArity = false;
   constructorLists = [];
 }

--- a/src/refmt/refmt_args.ml
+++ b/src/refmt/refmt_args.ml
@@ -42,7 +42,7 @@ let print =
 let print_width =
   let docv = "COLS" in
   let doc = "wrapping width for printing the AST" in
-  Arg.(value & opt (int) (100) & info ["w"; "print-width"] ~docv ~doc)
+  Arg.(value & opt (int) (80) & info ["w"; "print-width"] ~docv ~doc)
 
 let heuristics_file =
   let doc =


### PR DESCRIPTION
This PR will change the default print-width of refmt to be 80 columns. This matches prettiers print-width default. 

cc @IwanKaramazow 