### PR TITLE
Allow parsing & printing of attributes after the bar on type extensions

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -393,25 +393,34 @@ type attr = ..;
 
 [@block]
 type attr +=
-  [@tag1] [@tag2] | Str
-  [@tag3] | Float;
+  | [@tag1] [@tag2] Str
+  | [@tag3] Float;
 
 type reconciler('props) = ..;
 
 [@onVariantType]
 type reconciler('props) +=
-  | Foo (int) : [@onFirstRow] reconciler(int)
-  | Bar ([@onInt] int) : [@onSecondRow]
-                         reconciler(unit)
-  [@baz] | Baz : [@onThirdRow]
-                 reconciler([@onUnit] unit);
+  | Foo(int): [@onFirstRow] reconciler(int)
+  | Bar([@onInt] int): [@onSecondRow]
+                       reconciler(unit)
+  | [@baz]
+    Baz: [@onThirdRow] reconciler([@onUnit] unit);
 
 type water = ..;
 
 type water +=
   pri
-  [@foo] | MineralWater
+  | [@foo] [@foo2] MineralWater
   | SpringWater;
+
+type cloud = string;
+
+type water +=
+  pri
+  | [@h2o] PreparedWater
+  | [@nature] RainWater(cloud)
+  | [@toxic]
+    MeltedSnowWaterFromNuclearWastelandWithALineBreakBecauseTheNameIsSoLong;
 
 /* reasonreact */
 type element;

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -308,7 +308,12 @@ type reconciler('props) +=
 
 type water = ..;
 
-type water += pri [@foo] | MineralWater | SpringWater;
+type water += pri [@foo] | [@foo2] MineralWater | SpringWater;
+
+type cloud = string;
+
+type water += pri | [@h2o] PreparedWater | [@nature] RainWater(cloud) | [@toxic] MeltedSnowWaterFromNuclearWastelandWithALineBreakBecauseTheNameIsSoLong;
+
 
 /* reasonreact */
 type element;

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -514,22 +514,22 @@ type attr = ..;
 
 /* `of` is optional */
 type attr +=
-  | Str (string);
+  | Str(string);
 
 type attr +=
-  | Point (int, int);
+  | Point(int, int);
 
 type attr +=
-  | Float (float)
-  | Char (char);
+  | Float(float)
+  | Char(char);
 
 type tag('props) = ..;
 
 type titleProps = {title: string};
 
 type tag('props) +=
-  | Title : tag(titleProps)
-  | Count (int) : tag(int);
+  | Title: tag(titleProps)
+  | Count(int): tag(int);
 
 module Graph = {
   type node = ..;

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -3643,7 +3643,15 @@ sig_type_extension:
 ;
 
 %inline attributed_ext_constructor(X):
-  item_attributes BAR X { {$3 with pext_attributes = $1 @ $3.pext_attributes} }
+  item_attributes BAR item_attributes X { {$4 with pext_attributes = List.concat [$1; $3; $4.pext_attributes]} }
+  /* Why is item_attributes duplicated?
+     To be consistent with attributes on (poly)variants/gadts.
+     So we can place the attribute after the BAR.
+     Example:
+      type water +=
+        pri
+        | [@foo] MineralWater;
+  */
 ;
 
 attributed_ext_constructors(X):


### PR DESCRIPTION
fixes https://github.com/facebook/reason/issues/1672

```reason
type water +=
  pri
  | [@H2O] MineralWater;
```