### PR TITLE
Make exponentiation operator print with right associativity.

### DIFF
--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -1148,3 +1148,9 @@ let result = x =</> b;
 let z = x =</> b;
 
 let z = x =</> b;
+
+/* #1676: Exponentiation should be right-associative */
+let foo =
+  (100. /. 2.) ** 2. +. (200. /. 2.) ** 2.;
+
+let foo = 100. /. 2. ** 2. +. 200. /. 2. ** 2.;

--- a/formatTest/unit_tests/input/infix.re
+++ b/formatTest/unit_tests/input/infix.re
@@ -898,3 +898,7 @@ b;
 let z = x =</>
 
 b;
+
+/* #1676: Exponentiation should be right-associative */
+let foo = (100. /. 2.) ** 2. +. (200. /. 2.) ** 2.;
+let foo = 100. /. 2. ** 2. +. 200. /. 2. ** 2.;

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -662,6 +662,7 @@ let rules = [
   ];
   (* Note the special case for "*\*", BARBAR, and LESSMINUS, AMPERSAND(s) *)
   [
+    (TokenPrecedence, (fun s -> (Right, s = "**")));
     (TokenPrecedence, (fun s -> (Right, String.length s > 1 && s.[0] == '*' && s.[1] == '\\' && s.[2] == '*')));
     (TokenPrecedence, (fun s -> (Right, s = "lsl")));
     (TokenPrecedence, (fun s -> (Right, s = "lsr")));


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/1676

The exponentiation operator should be printed with right associativity.
```reason
let foo = (100. /. 2.) ** 2. +. (200. /. 2.) ** 2.;
let foo = 100. /. 2. ** 2. +. (200. /. 2.) ** 2.;
let foo = 100. /. 2. ** 2. +. 200. /. 2. ** 2.;
```
now compiles into 
```javascript
Math.pow(100 / 2, 2) + Math.pow(200 / 2, 2);
100 / Math.pow(2, 2) + Math.pow(200 / 2, 2);
var foo = 100 / Math.pow(2, 2) + 200 / Math.pow(2, 2);
```
with bucklescript, which is the correct output.