### PR TITLE
Make identifier lambdas parenless

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -120,11 +120,11 @@ let x = [@attrEverything] (true && false);
 /**
  * How attribute parsings respond to other syntactic constructs.
  */
-let add = (a) => [@onRet] a;
+let add = a => [@onRet] a;
 
-let add = (a) => [@onRet] a;
+let add = a => [@onRet] a;
 
-let add = [@onEntireFunction] ((a) => a);
+let add = [@onEntireFunction] (a => a);
 
 let res =
   if (true) {false} else {[@onFalse] false};
@@ -140,7 +140,7 @@ let add = (a, b) =>
 
 let add = (a, b) => a + [@onB] b;
 
-let both = [@onEntireFunction] ((a) => a);
+let both = [@onEntireFunction] (a => a);
 
 let both = (a, b) =>
   [@onEverything] ([@onA] a && b);

--- a/formatTest/typeCheckedTests/expected_output/comments.re
+++ b/formatTest/typeCheckedTests/expected_output/comments.re
@@ -123,7 +123,7 @@ module Temp = {
   let logIt = (str, ()) => print_string(str);
 };
 
-let store_attributes = (arg) => {
+let store_attributes = arg => {
   let attributes_file = "test";
   let proc_name = attributes_file ++ ".proc";
   let should_write =

--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -205,7 +205,7 @@ let selfClosing3 =
     b="cause the entire thing to wrap"
   />;
 
-let a = <Foo> <Bar c=((a) => a + 2) /> </Foo>;
+let a = <Foo> <Bar c=(a => a + 2) /> </Foo>;
 
 let a3 = <So> <Much> <Nesting /> </Much> </So>;
 
@@ -268,7 +268,7 @@ let jsxInList7 = [<Foo />, <Foo />];
 
 let jsxInList8 = [<Foo />, <Foo />];
 
-let testFunc = (b) => b;
+let testFunc = b => b;
 
 let jsxInFnCall = testFunc(<Foo />);
 
@@ -622,7 +622,7 @@ let g = <Two ?foo />;
 /* https://github.com/facebook/reason/issues/1428 */
 <Foo> ...element </Foo>;
 
-<Foo> ...((a) => 1) </Foo>;
+<Foo> ...(a => 1) </Foo>;
 
 <Foo> ...<Foo2 /> </Foo>;
 

--- a/formatTest/typeCheckedTests/expected_output/knownMlIssues.re
+++ b/formatTest/typeCheckedTests/expected_output/knownMlIssues.re
@@ -7,7 +7,7 @@ type color =
   | Black(int) /* After black */
   | Green(int) /* Does not remain here */;
 
-let blahCurriedX = (x) =>
+let blahCurriedX = x =>
   fun
   | Red(10)
   | Black(20)

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -13,12 +13,12 @@ class virtual stack ('a) (init) = {
       Some(hd);
     | [] => None
     };
-  pub push = (hd) => v = [hd, ...v];
+  pub push = hd => v = [hd, ...v];
   initializer (
     print_string("initializing object")
   );
-  pub explicitOverrideTest = (a) => a + 1;
-  pri explicitOverrideTest2 = (a) => a + 1;
+  pub explicitOverrideTest = a => a + 1;
+  pri explicitOverrideTest2 = a => a + 1;
 };
 
 let tmp = {
@@ -49,7 +49,7 @@ class virtual stackWithAttributes ('a) (init) = {
       Some(hd);
     | [] => None
     };
-  pub push = (hd) => v = [hd, ...v];
+  pub push = hd => v = [hd, ...v];
   initializer (
     print_string("initializing object")
   );
@@ -58,7 +58,7 @@ class virtual stackWithAttributes ('a) (init) = {
 class extendedStack ('a) (init) = {
   inherit (class stack('a))(init);
   val dummy = ();
-  pub implementMe = (i) => i;
+  pub implementMe = i => i;
 };
 
 class extendedStackAcknowledgeOverride
@@ -66,9 +66,9 @@ class extendedStackAcknowledgeOverride
       (init) = {
   inherit (class stack('a))(init);
   val dummy = ();
-  pub implementMe = (i) => i + 1;
-  pub! explicitOverrideTest = (a) => a + 2;
-  pri! explicitOverrideTest2 = (a) => a + 2;
+  pub implementMe = i => i + 1;
+  pub! explicitOverrideTest = a => a + 2;
+  pri! explicitOverrideTest2 = a => a + 2;
 };
 
 let inst = (new extendedStack)([1, 2]);
@@ -407,7 +407,7 @@ module type T = {
   and cl2 : {};
 };
 
-let privacy = {pri x = (c) => 5 + c};
+let privacy = {pri x = c => 5 + c};
 
 module Js = {
   type t('a);

--- a/formatTest/typeCheckedTests/expected_output/patternMatching.re
+++ b/formatTest/typeCheckedTests/expected_output/patternMatching.re
@@ -3,7 +3,7 @@ type point = {
   y: int
 };
 
-let id = (x) => x;
+let id = x => x;
 
 type myVariant =
   | TwoCombos(inner, inner)

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -334,7 +334,7 @@ type color =
   | Black(int) /* After black end of line */
   | Green(int) /* After green end of line */; /* On next line after color type def */
 
-let blahCurriedX = (x) =>
+let blahCurriedX = x =>
   fun
   | Red(10)
   | Black(20)

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -133,7 +133,7 @@ let something =
     print_newline();
   };
 
-let logTapSuccess = (self) =>
+let logTapSuccess = self =>
   if (self.ext.logSuccess) {
     print_string("Did tap");
     print_newline();
@@ -141,7 +141,7 @@ let logTapSuccess = (self) =>
     ();
   };
 
-let logTapSuccess = (self) =>
+let logTapSuccess = self =>
   if (self.ext.logSuccess) {
     print_string("Did tap");
     print_newline();
@@ -334,7 +334,7 @@ let (tupleItem: int, withTypeConstraint: int) = (
 );
 
 /* To make sure that tuple field annotations are annotating the entire field */
-let _dummyFunc = (x) => 10;
+let _dummyFunc = x => 10;
 
 let annotatingFuncApplication = (
   _dummyFunc("a"): int,
@@ -414,7 +414,7 @@ let rec size = (soFar, lst) =>
   | [hd, ...tl] => size(soFar + 1, tl)
   };
 
-let nestedMatch = (lstLst) =>
+let nestedMatch = lstLst =>
   switch lstLst {
   | [hd, ...tl] when false => 10
   | [hd, ...tl] =>
@@ -425,7 +425,7 @@ let nestedMatch = (lstLst) =>
   | [] => 0
   };
 
-let nestedMatchWithWhen = (lstLst) =>
+let nestedMatchWithWhen = lstLst =>
   switch lstLst {
   | [hd, ...tl] when false => 10
   | [hd, ...tl] when true =>
@@ -543,7 +543,7 @@ let myFunction = (a: int, b: int) : int => a + b;
 let functionReturnValueType =
     (i: int, s: string)
     : (int => int) =>
-  (x) => x + 1;
+  x => x + 1;
 
 let curriedFormOne = (i: int, s: string) =>
   s ++ string_of_int(i);

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -829,3 +829,22 @@ let z = {
   },
   "f": g
 };
+
+/**
+ * Unnecessary parens should be removed.
+ */
+let unitLambda = () => ();
+
+let identifierLambda = a => ();
+
+it("should remove parens", a => {
+  print_string("did it work?");
+  print_string("did it work?")
+});
+
+/**
+ * Parens around "any" pattern in lambda should be kept.
+ * We should also support removing these parens too, but that requires a parser
+ * change.
+ */
+let keepTheseParens = (_) => ();

--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -84,15 +84,13 @@ let b = {
 let c = {
   "a": a,
   "b": b,
-  "func": (a) => a##c#=func(10)
+  "func": a => a##c#=func(10)
 };
 
 let d = {
   "a": a2,
   "b": b,
-  "func": (a) => {
-    "a": (arg1, arg2) => arg1 + arg2
-  }
+  "func": a => {"a": (arg1, arg2) => arg1 + arg2}
 };
 
 let a = {"/foo": 10};

--- a/formatTest/unit_tests/expected_output/features403.re
+++ b/formatTest/unit_tests/expected_output/features403.re
@@ -26,7 +26,7 @@ type expr('a) =
     : expr('a);
 
 let rec eval: type a. expr(a) => a =
-  (e) =>
+  e =>
     switch e {
     | Is0({test}) => eval(test) == 0
     | Val({value}) => value

--- a/formatTest/unit_tests/expected_output/fixme.re
+++ b/formatTest/unit_tests/expected_output/fixme.re
@@ -1,7 +1,7 @@
 /**
  * Problem: In thise example, the comment should have a space after it.
  */
-let store_attributes = (proc_attributes) => {
+let store_attributes = proc_attributes => {
   let should_write =
     /* only overwrite defined procedures */ proc_attributes.ProcAttributes.is_defined
     || ! DB.file_exists(attributes_file);

--- a/formatTest/unit_tests/expected_output/functionInfix.re
+++ b/formatTest/unit_tests/expected_output/functionInfix.re
@@ -19,42 +19,42 @@ fff >>= xx(yy) >>= aa(bb);
 fff >>= (xx(yy) >>= aa(bb));
 
 /** Parse tree */
-fff >>= (((xx) => 0) >>= ((aa) => 10));
+fff >>= ((xx => 0) >>= (aa => 10));
 
 /* Minimum parenthesis */
-fff >>= (((xx) => 0) >>= ((aa) => 10));
+fff >>= ((xx => 0) >>= (aa => 10));
 
 /* Actually printed parenthesis */
-fff >>= (((xx) => 0) >>= ((aa) => 10));
+fff >>= ((xx => 0) >>= (aa => 10));
 
 /** Parse tree */
-fff >>= ((xx) => 0) >>= ((aa) => 10);
+fff >>= (xx => 0) >>= (aa => 10);
 
 /* Minimum parenthesis */
 /* It is very difficult to actually achieve this. */
-fff >>= ((xx) => 0) >>= ((aa) => 10);
+fff >>= (xx => 0) >>= (aa => 10);
 
 /* Actually printed. */
-fff >>= ((xx) => 0) >>= ((aa) => 10);
+fff >>= (xx => 0) >>= (aa => 10);
 
 /** Parse tree */
-fff >>= ((xx) => 0 >>= ((aa, cc) => 10));
+fff >>= (xx => 0 >>= ((aa, cc) => 10));
 
 /* Minimum parens - grouping the zero */
 /* Difficult to achieve. */
-fff >>= ((xx) => 0 >>= ((aa, cc) => 10));
+fff >>= (xx => 0 >>= ((aa, cc) => 10));
 
 /* Actually printed parenthesis. */
-fff >>= ((xx) => 0) >>= ((aa, cc) => 10);
+fff >>= (xx => 0) >>= ((aa, cc) => 10);
 
 /* Another way you could also write it it */
-fff >>= ((xx) => 0) >>= ((aa, cc) => 10);
+fff >>= (xx => 0) >>= ((aa, cc) => 10);
 
 /** Parse tree */
-fff >>= ((xx) => 0);
+fff >>= (xx => 0);
 
 /* Minimum parens - grouping the zero */
-fff >>= ((xx) => 0);
+fff >>= (xx => 0);
 
 /* Printed parens - see how more are printed than necessary. */
-fff >>= ((xx) => 0);
+fff >>= (xx => 0);

--- a/formatTest/unit_tests/expected_output/if.re
+++ b/formatTest/unit_tests/expected_output/if.re
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
-let logTSuccess = (self) =>
+let logTSuccess = self =>
   if (self > other) {
     print_string("Did T");
     print_newline();
@@ -13,7 +13,7 @@ let something =
     print_newline();
   };
 
-let logTSuccess = (self) =>
+let logTSuccess = self =>
   if (self.ext.logSuccess) {
     print_string("Did T");
     print_newline();
@@ -144,7 +144,7 @@ let ternaryResult =
         /* The final parent don't need to be preserved */
         eeeeeee ? fffffff : x ? y : z;
 
-let addOne = (x) => x + 1;
+let addOne = x => x + 1;
 
 let result =
   addOne(0) + 0 > 1 ?

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -398,7 +398,7 @@ let ( !=/\* ) = (q, r) => q + r;
 
 let res = q(( !=/\* ), r);
 
-let ( ~* ) = (a) => a + 1;
+let ( ~* ) = a => a + 1;
 
 let res = ~*10;
 
@@ -1074,7 +1074,7 @@ let server = {
     body
     |> Cohttp_lwt_body.to_string
     >|= (
-      (body) =>
+      body =>
         Printf.sprintf(
           "okokok",
           uri,
@@ -1084,7 +1084,7 @@ let server = {
         )
     )
     >>= (
-      (body) =>
+      body =>
         Server.respond_string(~status, ~body, ())
     );
   };
@@ -1097,7 +1097,7 @@ let server = {
 let lijst =
   List.length @@
   List.map(
-    (s) => s ++ " example",
+    s => s ++ " example",
     [
       "one",
       "two",

--- a/formatTest/unit_tests/expected_output/polymorphism.re
+++ b/formatTest/unit_tests/expected_output/polymorphism.re
@@ -36,7 +36,7 @@ let myFunc =
 let myFunc =
     (a: int => int, b: int => int)
     : (myType(int) => myType(int)) =>
-  (lst) => lst;
+  lst => lst;
 
 let certainlyRequiresWrapping:
   (

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -16,7 +16,7 @@ TestUtils.printSection("General Syntax");
 /*   `Thingy x => (print_string "matched thingy x"); x */
 /*   | `Other x => (print_string "matched other x"); x;; */
 /*  */
-let matchingFunc = (a) =>
+let matchingFunc = a =>
   switch a {
   | `Thingy(x) =>
     print_string("matched thingy x");
@@ -351,9 +351,9 @@ let printPerson = (p: person) => {
 
 /* let dontParseMeBro x y:int = x = y;*/
 /* With this unification, anywhere eyou see `= fun` you can just ommit it */
-let blah = (a) => a; /* Done */
+let blah = a => a; /* Done */
 
-let blah = (a) => a; /* Done (almost) */
+let blah = a => a; /* Done (almost) */
 
 let blah = (a, b) => a; /* Done */
 
@@ -427,7 +427,7 @@ Printf.printf(
 );
 
 /* Pattern matching */
-let blah = (arg) =>
+let blah = arg =>
   switch arg {
   /* Comment before Bar */
   | /* Comment between bar/pattern */ Red(_) => 1
@@ -456,7 +456,7 @@ let blah =
 /*   | Black x => 0                       /* Allow us to drop any => fun.. Just need to make pattern matching */ */
 /*   | Green x => 0;                      /* Support that */ */
 /*  */
-let blahCurriedX = (x) =>
+let blahCurriedX = x =>
   fun
   | Red(x)
   | Black(x)
@@ -466,7 +466,7 @@ let blahCurriedX = (x) =>
   | Green(x) => 0; /* Support that */
 
 let sameThingInLocal = {
-  let blahCurriedX = (x) =>
+  let blahCurriedX = x =>
     fun
     | Red(x)
     | Black(x)
@@ -478,7 +478,7 @@ let sameThingInLocal = {
 };
 
 /* This should be parsed/printed exactly as the previous */
-let blahCurriedX = (x) =>
+let blahCurriedX = x =>
   fun
   | Red(x)
   | Black(x)
@@ -570,7 +570,7 @@ let myFun =
     (firstArg, Red(x) | Black(x) | Green(x)) =>
   firstArg + x;
 
-let matchesWithWhen = (a) =>
+let matchesWithWhen = a =>
   switch a {
   | Red(x) when 1 > 0 => 10
   | Red(_) => 10
@@ -640,7 +640,7 @@ let tupleInsideALetSequence = {
 /* We *require* that function return types be wrapped in
    parenthesis. In this example, there's no ambiguity */
 let makeIncrementer = (delta: int) : (int => int) =>
-  (a) => a + delta;
+  a => a + delta;
 
 /* We could even force that consistency with let bindings - it's allowed
       currently but not forced.

--- a/formatTest/unit_tests/expected_output/testUtils.re
+++ b/formatTest/unit_tests/expected_output/testUtils.re
@@ -1,8 +1,8 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
-let printSection = (s) => {
+let printSection = s => {
   print_string("\n");
   print_string(s);
   print_string("\n---------------------\n");
 };
 
-let printLn = (s) => print_string(s ++ "\n");
+let printLn = s => print_string(s ++ "\n");

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -60,14 +60,14 @@ type threeForms =
   | FormTwo(int)
   | FormThree;
 
-let doesntCareWhichForm = (x) =>
+let doesntCareWhichForm = x =>
   switch x {
   | FormOne(q)
   | FormTwo(q) => 10
   | FormThree => 20
   };
 
-let doesntCareWhichFormAs = (x) =>
+let doesntCareWhichFormAs = x =>
   switch x {
   | FormOne(q) as ppp
   | FormTwo(q) as ppp => 10
@@ -107,13 +107,13 @@ let accessDeeplyWithArg =
     ) => x;
 
 /* Destructured matching *not* at function definition */
-let accessDeeply = (x) =>
+let accessDeeply = x =>
   switch x {
   | LocalModule.AccessedThroughModule => 10
   | _ => 0
   };
 
-let accessDeeplyWithArg = (x) =>
+let accessDeeplyWithArg = x =>
   switch x {
   | LocalModule.AccessedThroughModuleWith(x) => 10
   | _ => 0
@@ -127,12 +127,12 @@ let accessDeeplyWithArg = (x) =>
  *
  *   let myFunc x = function | `Blah p as retVal -> retVal`
  */
-let accessDeeply = (x) =>
+let accessDeeply = x =>
   switch x {
   | LocalModule.AccessedThroughModule as ppp => 1
   };
 
-let accessDeeplyWithArg = (x) =>
+let accessDeeplyWithArg = x =>
   switch x {
   | LocalModule.AccessedThroughModuleWith(
       x as retVal
@@ -200,7 +200,7 @@ let howWouldWeMatchFunctionArgs =
     ) =>
   x + y;
 
-let matchingTwoCurriedConstructorsInTuple = (x) =>
+let matchingTwoCurriedConstructorsInTuple = x =>
   switch x {
   | (
       HeresTwoConstructorArguments(x, y),
@@ -216,7 +216,7 @@ type twoCurriedConstructors =
     );
 
 let matchingTwoCurriedConstructorInConstructor =
-    (x) =>
+    x =>
   switch x {
   | TwoCombos(
       HeresTwoConstructorArguments(x, y),
@@ -283,7 +283,7 @@ let rec eval: type a. term(a) => a =
   | App(f, x) => eval(f, eval(x));
 
 let rec eval: type a. term(a) => a =
-  (x) =>
+  x =>
     switch x {
     | Int(n) => n
     /* a = int */
@@ -451,7 +451,7 @@ let res =
 /*
  * Testing explicit arity.
  */
-let rec map = (f) =>
+let rec map = f =>
   fun
   | Node(None, m) => Node(None, M.map(map(f), m))
   | Node(LongModule.Path.None, m) =>
@@ -461,7 +461,7 @@ let rec map = (f) =>
 
 let myFunc = (x, y, None) => "asdf";
 
-let rec map = (f) =>
+let rec map = f =>
   fun
   | Node(None, m) => Node(None, M.map(map(f), m))
   | Node(LongModule.Path.None, m) =>
@@ -477,7 +477,7 @@ let rec map = (f) =>
 
 let myFunc = (x, y, LongModule.Path.None) => "asdf";
 
-let listPatternMembersNeedntBeSimple = (x) =>
+let listPatternMembersNeedntBeSimple = x =>
   switch x {
   | [] => ()
   | [Blah(x, y), Foo(a, b), ...rest] => ()
@@ -485,7 +485,7 @@ let listPatternMembersNeedntBeSimple = (x) =>
   | _ => ()
   };
 
-let listTailPatternNeedntBeSimple = (x) =>
+let listTailPatternNeedntBeSimple = x =>
   switch x {
   | [] => ()
   /* Although this would never typecheck! */
@@ -494,7 +494,7 @@ let listTailPatternNeedntBeSimple = (x) =>
   | _ => ()
   };
 
-let listPatternMayEvenIncludeAliases = (x) =>
+let listPatternMayEvenIncludeAliases = x =>
   switch x {
   | [] => ()
   /* Although this would never typecheck! */

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -429,7 +429,7 @@ let myList = [
 
 let myList = [3, 4, 5];
 
-let simpleListPattern = (x) =>
+let simpleListPattern = x =>
   switch x {
   | [1, 2, 3] => 0
   | _ => 0
@@ -461,14 +461,14 @@ type functionsInARecord = {
 };
 
 let myFunctionsInARecord = {
-  adder: (x) => x,
-  minuser: (x) => x
+  adder: x => x,
+  minuser: x => x
 };
 
 let myFunctionsInARecordThatMustWrap = {
   /* Desired wrapping */
-  adder: (reallyLongArgument) => reallyLongArgument,
-  minuser: (anotherReallyLongArgument) => anotherReallyLongArgument
+  adder: reallyLongArgument => reallyLongArgument,
+  minuser: anotherReallyLongArgument => anotherReallyLongArgument
   /* Comment at bottom of record */
 };
 
@@ -519,13 +519,13 @@ let myFunctionsInARecordThatMustWrap = {
 };
 
 let oneArgShouldWrapToAlignWith =
-    (theFunctionNameBinding) => theFunctionNameBinding;
+    theFunctionNameBinding => theFunctionNameBinding;
 
 let twoArgsShouldWrapToAlignWith =
     (firstArgHere, secondArgThere) => secondArgThere;
 
 let rec oneArgShouldWrapToAlignWith =
-        (theFunctionNameBinding) => theFunctionNameBinding;
+        theFunctionNameBinding => theFunctionNameBinding;
 
 let rec twoArgsShouldWrapToAlignWith =
         (firstArgHere, secondArgThere) => secondArgThere;
@@ -548,7 +548,7 @@ let result =
     reallyReallyLongVarName
   );
 
-let justReturn = (x) => x;
+let justReturn = x => x;
 
 /* With default formatting settings: Two arguments are special cased in
    function application "justReturn hasABunch" */
@@ -593,7 +593,7 @@ let reallyHowDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark =
     (x, y) =>
   x + y;
 
-let reallyLongFunctionNameThatJustConcats = (a) =>
+let reallyLongFunctionNameThatJustConcats = a =>
   String.concat("-", a);
 
 let seeHowLongValuesWrap = {
@@ -2121,9 +2121,9 @@ let (the, type_, and_, value, should, both, wrap): (
   "wrap"
 );
 
-let myPolyFunc: 'a .'a => 'a = (o) => o;
+let myPolyFunc: 'a .'a => 'a = o => o;
 
-let myNonPolyFunc: 'a => 'a = (o) => o;
+let myNonPolyFunc: 'a => 'a = o => o;
 
 let locallyAbstractFunc = (type a, input: a) => input;
 
@@ -2137,9 +2137,9 @@ let locallyAbstractFuncAnnotated: type a. a => a =
   Examples of how long versions of these should be wrapped: df stands for
   "desired formatting" when the function binding itself must wrap.
  */
-let df_myPolyFunc: 'a .'a => 'a = (o) => o;
+let df_myPolyFunc: 'a .'a => 'a = o => o;
 
-let df_myNonPolyFunc: 'a => 'a = (o) => o;
+let df_myNonPolyFunc: 'a => 'a = o => o;
 
 type nameBlahType = {nameBlah: int};
 
@@ -2262,9 +2262,9 @@ let theTupleTypeAnnotationShouldWrap: (
   "now these tuple values should wrap"
 );
 
-let rec mutuallyRecursiveOne = (x) =>
+let rec mutuallyRecursiveOne = x =>
   mutuallyRecursiveTwo(x + x)
-and mutuallyRecursiveTwo = (y) => print_int(y);
+and mutuallyRecursiveTwo = y => print_int(y);
 
 /* The only downside to this is that now you can't redeclare a binding. */
 /* let newMutualRecursionSyntax x => newMutuallyRecursiveTwo (x + x); */
@@ -2362,10 +2362,10 @@ let funcOnSomeRecord =
 type simpleTupleVariant =
   | SimpleActuallyATuple((int, int));
 
-let returnTheSimpleTupleVariant = (i) =>
+let returnTheSimpleTupleVariant = i =>
   SimpleActuallyATuple(i, i);
 
-let shouldWrapLike = (whenLongArg) =>
+let shouldWrapLike = whenLongArg =>
   SimpleActuallyATuple(whenLongArg, whenLongArg);
 
 type recordWithLong = {
@@ -2438,7 +2438,7 @@ type colors =
   | Black(int)
   | Green(int);
 
-let blah = (arg) =>
+let blah = arg =>
   switch arg {
   /* Comment before Bar */
   | /* Comment between bar/pattern */ Red(_) => 1
@@ -2453,7 +2453,7 @@ let blah =
   | Black(_) => 0
   | Green(_) => 1;
 
-let blahCurriedX = (x) =>
+let blahCurriedX = x =>
   fun
   /* Comment before first bar */
   /* Comment between first bar and OR pattern */
@@ -2469,7 +2469,7 @@ type reallyLongVariantNames =
   | AnotherReallyLongVariantName(int, int, int)
   | AnotherReallyLongVariantName2(int, int, int);
 
-let howDoLongMultiBarPatternsWrap = (x) =>
+let howDoLongMultiBarPatternsWrap = x =>
   switch x {
   | AnotherReallyLongVariantName(_, _, _) => 0
   | AnotherReallyLongVariantName2(_, _, _) => 0
@@ -2479,7 +2479,7 @@ let howDoLongMultiBarPatternsWrap = (x) =>
     }) => 0
   };
 
-let letsCombineTwoLongPatternsIntoOneCase = (x) =>
+let letsCombineTwoLongPatternsIntoOneCase = x =>
   switch x {
   | AnotherReallyLongVariantName(_, _, _)
   | AnotherReallyLongVariantName2(_, _, _) => 0
@@ -2489,7 +2489,7 @@ let letsCombineTwoLongPatternsIntoOneCase = (x) =>
     }) => 0
   };
 
-let letsPutAWhereClauseOnTheFirstTwo = (x) =>
+let letsPutAWhereClauseOnTheFirstTwo = x =>
   switch x {
   | AnotherReallyLongVariantName(_, _, _)
   | AnotherReallyLongVariantName2(_, _, _)
@@ -2500,7 +2500,7 @@ let letsPutAWhereClauseOnTheFirstTwo = (x) =>
     }) => 0
   };
 
-let letsPutAWhereClauseOnTheLast = (x) =>
+let letsPutAWhereClauseOnTheLast = x =>
   switch x {
   | AnotherReallyLongVariantName(_, _, _)
   | AnotherReallyLongVariantName2(_, _, _) => 0
@@ -2701,13 +2701,13 @@ let /*beforePattern2 */ commentingBeforePatternSpecial: withThreeFields = {
   occupation: "programmer"
 };
 
-let produceRecord /*commentBeforeArg*/ = (x) => {
+let produceRecord /*commentBeforeArg*/ = x => {
   name: "hello",
   age: 20,
   occupation: "programmer"
 };
 
-let produceRecord = (x) => /*commentAfterArg*/ {
+let produceRecord = x => /*commentAfterArg*/ {
   name: "hello",
   age: 20,
   occupation: "programmer"
@@ -2717,54 +2717,54 @@ let myPolyFuncCommentBeforeColon /*beforeColon */:
   'a .
   'a => 'a
  =
-  (o) => o;
+  o => o;
 
 let myPolyFuncCommentAfterColon: 'a .'a => 'a =
   /*afterColon */
-  (o) => o;
+  o => o;
 
 let myPolyFuncCommentBeforeArrow: 'a .'a => 'a =
   /*beforeArrow */
-  (o) => o;
+  o => o;
 
 let myPolyFuncCommentAfterArrow:
   'a .
   'a => /*afterArrow */ 'a
  =
-  (o) => o;
+  o => o;
 
 let myPolyFuncCommentBeforeEqual:
   'a .
   'a => 'a /*beforeEqual */
  =
-  (o) => o;
+  o => o;
 
 let myPolyFuncCommentAfterEqual: 'a .'a => 'a =
-  /*afterEqual */ (o) => o;
+  /*afterEqual */ o => o;
 
 let myNonPolyFuncCommentBeforeColon /*BeforeColon */:
   'a => 'a =
-  (o) => o;
+  o => o;
 
 let myNonPolyFuncCommentAfterColon:
   /*AfterColon */ 'a => 'a =
-  (o) => o;
+  o => o;
 
 let myNonPolyFuncCommentBeforeArrow:
   'a => /*BeforeArrow */
   'a =
-  (o) => o;
+  o => o;
 
 let myNonPolyFuncCommentAfterArrow:
   'a => /*AfterArrow */ 'a =
-  (o) => o;
+  o => o;
 
 let myNonPolyFuncCommentBeforeEqual:
   'a => 'a /*BeforeEqual */ =
-  (o) => o;
+  o => o;
 
 let myNonPolyFuncCommentAfterEqual: 'a => 'a =
-  /*AfterEqual */ (o) => o;
+  /*AfterEqual */ o => o;
 
 let lATCurrySugarCommentBeforeType /*BeforeType */ =
     (type a, input: a) => input;
@@ -2927,17 +2927,17 @@ let onlyDoingThisTopLevelLetToBypassTopLevelSequence = {
 };
 
 /* With this unification, anywhere eyou see `= fun` you can just ommit it */
-let blah = (a) => a; /* Done */
+let blah = a => a; /* Done */
 
-let blah = (a) => a; /* Done (almost) */
+let blah = a => a; /* Done (almost) */
 
 let blah = (a, b) => a; /* Done */
 
 let blah = (a, b) => a; /* Done (almost) */
 
 let tryingTheSameInLocalScope = {
-  let blah = (a) => a; /* Done */
-  let blah = (a) => a; /* Done (almost) */
+  let blah = a => a; /* Done */
+  let blah = a => a; /* Done (almost) */
   let blah = (a, b) => a; /* Done */
   let blah = (a, b) => a;
   (); /* Done (almost) */

--- a/formatTest/unit_tests/input/basicStructures.re
+++ b/formatTest/unit_tests/input/basicStructures.re
@@ -649,3 +649,21 @@ let z = {"a": {"b": c, "d": e}, "f": g};
 let z = {"a": {b: c, d: e}, "f": g};
 
 let z = {"a": {pub b = c; pub d = e}, "f": g};
+
+
+/**
+ * Unnecessary parens should be removed.
+ */
+let unitLambda = (()) => ();
+let identifierLambda = (a) => ();
+it("should remove parens", (a) => {
+  print_string("did it work?");
+  print_string("did it work?");
+});
+
+/**
+ * Parens around "any" pattern in lambda should be kept.
+ * We should also support removing these parens too, but that requires a parser
+ * change.
+ */
+let keepTheseParens = (_) => ();

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -6666,8 +6666,8 @@ class printer  ()= object(self:'self)
     let categorizeFunApplArgs args =
       let reverseArgs = List.rev args in
       match reverseArgs with
-      | ((_, {pexp_desc = Pexp_fun _}) as callback)::args 
-          when let otherCallbacks = 
+      | ((_, {pexp_desc = Pexp_fun _}) as callback)::args
+          when let otherCallbacks =
             List.filter (fun (_, e) -> match e.pexp_desc with Pexp_fun _ -> true | _ -> false) args
           in List.length otherCallbacks == 0
           (* default to normal formatting if there's more than one callback *)
@@ -6690,7 +6690,7 @@ class printer  ()= object(self:'self)
 
         let theFunc = SourceMap (funExpr.pexp_loc, makeList ~wrap:("", "(") [self#simplifyUnparseExpr funExpr]) in
         let formattedFunAppl = begin match self#letList retCb with
-        | [x] -> 
+        | [x] ->
           (* force breaks for test assertion style callbacks, e.g.
            *  describe("App", () => test("math", () => Expect.expect(1 + 2) |> toBe(3)));
            * should always break for readability of the tests:
@@ -6715,7 +6715,7 @@ class printer  ()= object(self:'self)
               argsWithCallbackArgs)
           in
           label left returnValueCallback
-        | xs -> 
+        | xs ->
               let printWidthExceeded = Reason_heuristics.funAppCallbackExceedsWidth ~printWidth:settings.width ~args ~funExpr () in
               if printWidthExceeded = false then
               (*
@@ -6777,7 +6777,7 @@ class printer  ()= object(self:'self)
         (*reset here only because [function,match,try,sequence] are lower priority*)
         let theArgs = self#reset#label_x_expression_params args in
         maybeJSXAttr @ [label theFunc theArgs]
-    end 
+    end
 end;;
 
 

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4323,29 +4323,28 @@ class printer  ()= object(self:'self)
   method curriedPatternsAndReturnVal x =
     let rec extract_args xx =
       if xx.pexp_attributes <> [] then
-        (true, [], xx)
+        ([], xx)
       else match xx.pexp_desc with
         (* label * expression option * pattern * expression *)
         | Pexp_fun (l, eo, p, e) ->
-          (* sweet determines whether es6 => sugar can be used or not *)
-          let sweet, args, ret = extract_args e in
-          (sweet, `Value (l,eo,p) :: args, ret)
+          let args, ret = extract_args e in
+          (`Value (l,eo,p) :: args, ret)
         | Pexp_newtype (newtype,e) ->
-          let sweet, args, ret = extract_args e in
-          (sweet, `Type newtype :: args, ret)
-        | Pexp_constraint _ -> (true, [], xx)
-        | _ -> (true, [], xx)
+          let args, ret = extract_args e in
+          (`Type newtype :: args, ret)
+        | Pexp_constraint _ -> ([], xx)
+        | _ -> ([], xx)
     in
     let prepare_arg = function
       | `Value (l,eo,p) -> SourceMap (p.ppat_loc, self#label_exp l eo p)
       | `Type nt -> atom ("type " ^ nt)
     in
     match extract_args x with
-    | (sweet, [], ret) -> (sweet, [], ret)
-    | (sweet, [`Value (Nolabel, None, p) as arg], ret) when is_unit_pattern p ->
-      (sweet, [prepare_arg arg], ret)
-    | (sweet, args, ret) ->
-      (sweet, [makeTup (List.map prepare_arg args)], ret)
+    | ([], ret) -> ([], ret)
+    | ([`Value (Nolabel, None, p) as arg], ret) when is_unit_pattern p ->
+      ([prepare_arg arg], ret)
+    | (args, ret) ->
+      ([makeTup (List.map prepare_arg args)], ret)
 
   (* Returns the (curriedModule, returnStructure) for a functor *)
   method curriedFunctorPatternsAndReturnStruct = function
@@ -4451,7 +4450,7 @@ class printer  ()= object(self:'self)
          }
    *)
   method wrappedBinding prefixText ~arrow pattern patternAux expr =
-    let (_sweet, argsList, return) = self#curriedPatternsAndReturnVal expr in
+    let (argsList, return) = self#curriedPatternsAndReturnVal expr in
     let patternList = match patternAux with
       | [] -> pattern
       | _::_ -> makeList ~postSpace:true ~inline:(true, true) ~break:IfNeed (pattern::patternAux)
@@ -4873,7 +4872,7 @@ class printer  ()= object(self:'self)
         let itm = match x.pexp_desc with
           | Pexp_fun _
           | Pexp_newtype _ ->
-            let (sweet, args, ret) = self#curriedPatternsAndReturnVal x in
+            let (args, ret) = self#curriedPatternsAndReturnVal x in
             ( match args with
               | [] -> raise (NotPossible ("no arrow args in unparse "))
               | firstArg::tl ->
@@ -4900,7 +4899,7 @@ class printer  ()= object(self:'self)
                    needed, should we even print them with the minimum amount?  We can
                    instead model everything as "infix" with ranked precedences.  *)
                 let retValUnparsed = self#unparseExprApplicationItems ret in
-                Some (self#wrapCurriedFunctionBinding ~sweet "fun" ~arrow:"=>" firstArg tl retValUnparsed)
+                Some (self#wrapCurriedFunctionBinding ~sweet:true "fun" ~arrow:"=>" firstArg tl retValUnparsed)
             )
           | Pexp_try (e, l) ->
             let estimatedBracePoint = {
@@ -5172,7 +5171,7 @@ class printer  ()= object(self:'self)
             let row = label ~space:true keyWithColon value in
             if appendComma then makeList [row; comma] else row
         | _ ->
-          let (sweet, argsList, return) = self#curriedPatternsAndReturnVal e in
+          let (argsList, return) = self#curriedPatternsAndReturnVal e in
           match argsList with
           | [] ->
             let appTerms = self#unparseExprApplicationItems e in
@@ -5185,7 +5184,7 @@ class printer  ()= object(self:'self)
             let upToColon = makeList (maybeQuoteFirstElem li [atom ":"]) in
             let returnedAppTerms = self#unparseExprApplicationItems return in
             let labelExpr = self#wrapCurriedFunctionBinding
-                ~sweet ~attachTo:upToColon "fun" ~arrow:"=>"
+                ~sweet:true ~attachTo:upToColon "fun" ~arrow:"=>"
                 firstArg tl returnedAppTerms
             in
             if appendComma then makeList [labelExpr; comma] else labelExpr
@@ -6678,7 +6677,7 @@ class printer  ()= object(self:'self)
          *   MyModuleBlah.toList(argument)
          *)
         let (argLbl, cb) = callbackArg in
-        let (_sweet, cbArgs, retCb) = self#curriedPatternsAndReturnVal cb in
+        let (cbArgs, retCb) = self#curriedPatternsAndReturnVal cb in
         let theCallbackArg = match argLbl with
           | Optional s -> makeList ([atom namedArgSym; atom s; atom "=?"]@cbArgs)
           | Labelled s -> makeList ([atom namedArgSym; atom s; atom "="]@cbArgs)

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -2421,6 +2421,10 @@ let is_unit_pattern x = match x.ppat_desc with
   | Ppat_construct ( {txt= Lident"()"}, None) -> true
   | _ -> false
 
+let is_ident_pattern x = match x.ppat_desc with
+  | Ppat_var _ -> true
+  | _ -> false
+
 let is_direct_pattern x = x.ppat_attributes = [] && match x.ppat_desc with
   | Ppat_construct ( {txt= Lident"()"}, None) -> true
   | _ -> false
@@ -4341,7 +4345,7 @@ class printer  ()= object(self:'self)
     in
     match extract_args x with
     | ([], ret) -> ([], ret)
-    | ([`Value (Nolabel, None, p) as arg], ret) when is_unit_pattern p ->
+    | ([`Value (Nolabel, None, p) as arg], ret) when is_unit_pattern p || is_ident_pattern p ->
       ([prepare_arg arg], ret)
     | (args, ret) ->
       ([makeTup (List.map prepare_arg args)], ret)


### PR DESCRIPTION
This partially addresses the issue that @bobzhang and @glennsl brought up about the new syntax having too many parens. I tried formatting a large project and noticed that the most jarring use of parens was:

- Single identifiers in lambdas that had parens included.
- Records arguments to lambdas that had parens included.

We can't really remove the parens around record arguments to lambdas at the moment because then it opens up this precedent which we cannot uphold for tuples.
But still, single identifier lambda arguments were the biggest offender of paren-fatigue in my example project.

cc @IwanKaramazow @chenglou @rickyvetter 