### PR TITLE
Not throw Location.Error in the parser

### DIFF
--- a/FUTURE.md
+++ b/FUTURE.md
@@ -1,3 +1,3 @@
 ## 3.0.5
 
-- Just cut a release. Nothing here yet!
+- Better error report when refmt is used programmatically (#1695)

--- a/bspacks/refmtJsApi.ml
+++ b/bspacks/refmtJsApi.ml
@@ -47,7 +47,7 @@ let parseWith f code =
     |> Lexing.from_string
     |> f)
   with
-  (* from ocaml *)
+  (* from ocaml and reason *)
   | Syntaxerr.Error err ->
     let location = Syntaxerr.location_of_error err in
     let jsLocation = locationToJsObj location in

--- a/bspacks/testRefmtJs.js
+++ b/bspacks/testRefmtJs.js
@@ -17,4 +17,10 @@ try {
   console.log(e)
 }
 
+try {
+  refmt.parseRE(`type X = Foo`)
+} catch (e) {
+  console.log(e)
+}
+
 console.log("=============== we're good! ===============")


### PR DESCRIPTION
Fixes #1691

This is because our public API says we only ever throw Syntaxerr.Error or Syntax_utils.Error. This caused https://github.com/facebook/reason/blob/731e605870e22fdcb3d37f3f963d346f18a072cc/bspacks/refmtJsApi.ml#L49 not to catch the extra Location.Error correctly and failing to massage the data structure before using it in the browser.