### PR TITLE
Pretty print extensions

### DIFF
--- a/formatTest/unit_tests/expected_output/extensions.re
+++ b/formatTest/unit_tests/expected_output/extensions.re
@@ -22,3 +22,34 @@ let x = {
   %extend
   return("hi");
 };
+
+let x = {
+  %extend
+  if (true) {1} else {2};
+  %extend
+  switch None {
+  | Some(x) => assert false
+  | None => ()
+  };
+  %extend
+  try (raise(Not_found)) {
+  | Not_found => ()
+  | Invalid_argument(msg) => prerr_endline(msg)
+  };
+};
+
+let x = [%extend if (true) {1} else {2}];
+
+let x = [%extend
+  switch None {
+  | Some(x) => assert false
+  | None => ()
+  }
+];
+
+let x = [%extend
+  try (raise(Not_found)) {
+  | Not_found => ()
+  | Invalid_argument(msg) => prerr_endline(msg)
+  }
+];

--- a/formatTest/unit_tests/expected_output/extensions.re
+++ b/formatTest/unit_tests/expected_output/extensions.re
@@ -8,48 +8,40 @@ module M = {};
 %extend
 module type M = {};
 
-%extend
-let x = "hi";
+let%extend x = "hi";
 
 let x = {
-  %extend
-  let x = ();
+  let%extend x = ();
   ignore();
   %extend
   ignore();
-  %extend
-  let x = ();
+  let%extend x = ();
   %extend
   return("hi");
 };
 
 let x = {
-  %extend
-  if (true) {1} else {2};
-  %extend
-  switch None {
+  if%extend (true) {1} else {2};
+  switch%extend None {
   | Some(x) => assert false
   | None => ()
   };
-  %extend
-  try (raise(Not_found)) {
+  try%extend (raise(Not_found)) {
   | Not_found => ()
   | Invalid_argument(msg) => prerr_endline(msg)
   };
 };
 
-let x = [%extend if (true) {1} else {2}];
+let x = if%extend (true) {1} else {2};
 
-let x = [%extend
-  switch None {
+let x =
+  switch%extend None {
   | Some(x) => assert false
   | None => ()
-  }
-];
+  };
 
-let x = [%extend
-  try (raise(Not_found)) {
+let x =
+  try%extend (raise(Not_found)) {
   | Not_found => ()
   | Invalid_argument(msg) => prerr_endline(msg)
-  }
-];
+  };

--- a/formatTest/unit_tests/expected_output/extensions.re
+++ b/formatTest/unit_tests/expected_output/extensions.re
@@ -1,0 +1,24 @@
+/* Extension sugar */
+%extend
+open M;
+
+%extend
+module M = {};
+
+%extend
+module type M = {};
+
+%extend
+let x = "hi";
+
+let x = {
+  %extend
+  let x = ();
+  ignore();
+  %extend
+  ignore();
+  %extend
+  let x = ();
+  %extend
+  return("hi");
+};

--- a/formatTest/unit_tests/expected_output/extensions.re
+++ b/formatTest/unit_tests/expected_output/extensions.re
@@ -45,3 +45,266 @@ let x =
   | Not_found => ()
   | Invalid_argument(msg) => prerr_endline(msg)
   };
+
+/* At structure level */
+try%extend () {
+| _ => ()
+};
+
+switch%extend () {
+| _ => ()
+};
+
+if%extend (true) {1} else {2};
+
+for%extend (i in 1 to 10) {
+  ();
+};
+
+while%extend (false) {
+  ();
+};
+
+fun%extend () => ();
+
+fun%extend
+| None => ()
+| Some(1) => ();
+
+/* In a top-level binding */
+let x =
+  try%extend () {
+  | _ => ()
+  };
+
+let x =
+  switch%extend () {
+  | _ => ()
+  };
+
+let x = if%extend (true) {1} else {2};
+
+let x =
+  for%extend (i in 1 to 10) {
+    ();
+  };
+
+let x =
+  while%extend (false) {
+    ();
+  };
+
+let x = fun%extend () => ();
+
+let x =
+  fun%extend
+  | None => ()
+  | Some(1) => ();
+
+/* With two extensions, alone */
+let x = [%extend1
+  try%extend2 () {
+  | _ => ()
+  }
+];
+
+let x = [%extend1
+  switch%extend2 () {
+  | _ => ()
+  }
+];
+
+let x = [%extend1
+  if%extend2 (true) {1} else {2}
+];
+
+let x = [%extend1
+  for%extend2 (i in 1 to 10) {
+    ();
+  }
+];
+
+let x = [%extend1
+  while%extend2 (false) {
+    ();
+  }
+];
+
+let x = [%extend1 fun%extend2 () => ()];
+
+let x = [%extend1
+  fun%extend2
+  | None => ()
+  | Some(1) => ()
+];
+
+/* With two extensions, first in sequence */
+let x = {
+  %extend1
+  try%extend2 () {
+  | _ => ()
+  };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  switch%extend2 () {
+  | _ => ()
+  };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  if%extend2 (true) {1} else {2};
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  for%extend2 (i in 1 to 10) {
+    ();
+  };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  while%extend2 (false) {
+    ();
+  };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  fun%extend2 () => ();
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  fun%extend2
+  | None => ()
+  | Some(1) => ();
+};
+
+/* With two extensions, in sequence */
+let x = {
+  ignore();
+  %extend1
+  try%extend2 () {
+  | _ => ()
+  };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  switch%extend2 () {
+  | _ => ()
+  };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  if%extend2 (true) {1} else {2};
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  for%extend2 (i in 1 to 10) {
+    ();
+  };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  while%extend2 (false) {
+    ();
+  };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  fun%extend2 () => ();
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  fun%extend2
+  | None => ()
+  | Some(1) => ();
+  ignore();
+};
+
+/* With two extensions, second in sequence */
+let x = {
+  ignore();
+  %extend1
+  try%extend2 () {
+  | _ => ()
+  };
+};
+
+let x = {
+  ignore();
+  %extend1
+  switch%extend2 () {
+  | _ => ()
+  };
+};
+
+let x = {
+  ignore();
+  %extend1
+  if%extend2 (true) {1} else {2};
+};
+
+let x = {
+  ignore();
+  %extend1
+  for%extend2 (i in 1 to 10) {
+    ();
+  };
+};
+
+let x = {
+  ignore();
+  %extend1
+  while%extend2 (false) {
+    ();
+  };
+};
+
+let x = {
+  ignore();
+  %extend1
+  fun%extend2 () => ();
+};
+
+let x = {
+  ignore();
+  %extend1
+  fun%extend2
+  | None => ()
+  | Some(1) => ();
+};

--- a/formatTest/unit_tests/input/extensions.re
+++ b/formatTest/unit_tests/input/extensions.re
@@ -64,3 +64,228 @@ let x = {
     | Invalid_argument(msg) => prerr_endline(msg)
   }
 };
+
+/* At structure level */
+
+try%extend () { | _ => () };
+
+switch%extend () { | _ => () };
+
+if%extend (true) { 1 } else { 2 };
+
+for%extend (i in 1 to 10) { () };
+
+while%extend (false) { () };
+
+fun%extend () => ();
+
+fun%extend
+ | None => ()
+ | Some(1) => ();
+
+ /* In a top-level binding */
+
+let x = try%extend () { | _ => () };
+
+let x = switch%extend () { | _ => () };
+
+let x = if%extend (true) { 1 } else { 2 };
+
+let x = for%extend (i in 1 to 10) { () };
+
+let x = while%extend (false) { () };
+
+let x = fun%extend () => ();
+
+let x = fun%extend
+  | None => ()
+  | Some(1) => ();
+
+ /* With two extensions, alone */
+
+let x = { 
+  %extend1
+  try%extend2 () { | _ => () };
+};
+
+let x = {
+  %extend1
+  switch%extend2 () { | _ => () };
+};
+
+let x = {
+  %extend1
+  if%extend2 (true) { 1 } else { 2 };
+};
+
+let x = {
+  %extend1
+  for%extend2 (i in 1 to 10) { () };
+};
+
+let x = {
+  %extend1
+  while%extend2 (false) { () };
+};
+
+let x = {
+  %extend1
+  fun%extend2 () => ();
+};
+
+let x = {
+  %extend1
+  fun%extend2
+    | None => ()
+    | Some(1) => ();
+};
+
+ /* With two extensions, first in sequence */
+
+let x = { 
+  %extend1
+  try%extend2 () { | _ => () };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  switch%extend2 () { | _ => () };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  if%extend2 (true) { 1 } else { 2 };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  for%extend2 (i in 1 to 10) { () };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  while%extend2 (false) { () };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  fun%extend2 () => ();
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  fun%extend2
+    | None => ()
+    | Some(1) => ();
+};
+
+ /* With two extensions, in sequence */
+
+let x = { 
+  ignore();
+  %extend1
+  try%extend2 () { | _ => () };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  switch%extend2 () { | _ => () };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  if%extend2 (true) { 1 } else { 2 };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  for%extend2 (i in 1 to 10) { () };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  while%extend2 (false) { () };
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  fun%extend2 () => ();
+  ignore();
+};
+
+let x = {
+  ignore();
+  %extend1
+  fun%extend2
+    | None => ()
+    | Some(1) => ();
+  ignore();
+};
+
+ /* With two extensions, second in sequence */
+
+let x = { 
+  ignore();
+  %extend1
+  try%extend2 () { | _ => () };
+};
+
+let x = {
+  ignore();
+  %extend1
+  switch%extend2 () { | _ => () };
+};
+
+let x = {
+  ignore();
+  %extend1
+  if%extend2 (true) { 1 } else { 2 };
+};
+
+let x = {
+  ignore();
+  %extend1
+  for%extend2 (i in 1 to 10) { () };
+};
+
+let x = {
+  ignore();
+  %extend1
+  while%extend2 (false) { () };
+};
+
+let x = {
+  ignore();
+  %extend1
+  fun%extend2 () => ();
+};
+
+let x = {
+  ignore();
+  %extend1
+  fun%extend2
+    | None => ()
+    | Some(1) => ();
+};

--- a/formatTest/unit_tests/input/extensions.re
+++ b/formatTest/unit_tests/input/extensions.re
@@ -25,3 +25,42 @@ let x = {
   return("hi");
 };
 
+let x = {
+  %extend
+  if (true) { 1 } else { 2 };
+  %extend
+  switch None {
+    | Some(x) => assert(false)
+    | None => ()
+  };
+  %extend
+  try {
+    raise(Not_found)
+  } {
+    | Not_found => ()
+    | Invalid_argument(msg) => prerr_endline(msg)
+  }
+};
+
+let x = {
+  %extend
+  if (true) { 1 } else { 2 }
+};
+
+let x = {
+  %extend
+  switch None {
+    | Some(x) => assert(false)
+    | None => ()
+  };
+};
+
+let x = {
+  %extend
+  try {
+    raise(Not_found)
+  } {
+    | Not_found => ()
+    | Invalid_argument(msg) => prerr_endline(msg)
+  }
+};

--- a/formatTest/unit_tests/input/extensions.re
+++ b/formatTest/unit_tests/input/extensions.re
@@ -1,0 +1,27 @@
+
+/* Extension sugar */
+
+%extend
+open M;
+
+%extend
+module M = {};
+
+%extend
+module type M = {};
+
+%extend
+let x = "hi";
+
+let x = {
+  %extend
+  let x = ();
+  ignore();
+  %extend
+  ignore();
+  %extend
+  let x = ();
+  %extend
+  return("hi");
+};
+

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -680,7 +680,7 @@ let wrap_type_annotation newtypes core_type body =
 let struct_item_extension (ext_attrs, ext_id) structure_items =
   mkstr ~ghost:true (Pstr_extension ((ext_id, PStr structure_items), ext_attrs))
 
-let extension_expression (ext_attrs, ext_id) item_expr =
+let expression_extension (ext_attrs, ext_id) item_expr =
   mkexp ~ghost:true ~attrs:ext_attrs (Pexp_extension (ext_id, PStr [mkstrexp item_expr []]))
 
 (* There's no more need for these functions - this was for the following:
@@ -726,13 +726,7 @@ type let_binding =
 type let_bindings =
   { lbs_bindings: let_binding list;
     lbs_rec: rec_flag;
-    lbs_extension: string Asttypes.loc option;
-    (* In Reason, we use this field to represent
-       extension attributes attached to the extension on a series of "let/and"
-       bindings As in: let [@extAttrs ] [%id] [@attribute] x = ...; It only
-       makes sense to have [lbs_attributes] when there is an [lbs_extension].
-     *)
-    lbs_attributes: attributes;
+    lbs_extension: (attributes * string Asttypes.loc) option;
     lbs_loc: Location.t }
 
 let mklb (p, e) attrs loc =
@@ -743,11 +737,10 @@ let mklb (p, e) attrs loc =
     lb_attributes = attrs;
     lb_loc = loc; }
 
-let mklbs (extAttrs, extId) rf lb loc =
+let mklbs ext rf lb loc =
   { lbs_bindings = [lb];
     lbs_rec = rf;
-    lbs_extension = extId ;
-    lbs_attributes = extAttrs;
+    lbs_extension = ext;
     lbs_loc = loc; }
 
 let addlbs lbs lbs' =
@@ -763,12 +756,10 @@ let val_of_let_bindings lbs =
            lb.lb_pattern lb.lb_expression)
       lbs.lbs_bindings
   in
-  let str = mkstr(Pstr_value(lbs.lbs_rec, bindings)) in
-  (* Note that for value bindings, when there's an extension, the
-   * lbs_attributes are attributes on the extension *)
-  match (lbs.lbs_extension) with
-    | None -> str
-    | Some ext_id -> struct_item_extension (lbs.lbs_attributes, ext_id) [str]
+  let str = mkstr (Pstr_value(lbs.lbs_rec, bindings)) in
+  match lbs.lbs_extension with
+  | None -> str
+  | Some ext -> struct_item_extension ext [str]
 
 let expr_of_let_bindings lbs body =
   let bindings =
@@ -783,11 +774,9 @@ let expr_of_let_bindings lbs body =
   (* The location of this expression unfortunately includes the entire rule,
    * which will include any preceeding extensions. *)
   let item_expr = mkexp (Pexp_let(lbs.lbs_rec, bindings, body)) in
-  (* Note that for let expression bindings, when there's an extension, the
-   * lbs_attributes are attributes on the entire [let ..in x] expression. *)
   match lbs.lbs_extension with
-    | None -> item_expr
-    | Some ext_id -> extension_expression (lbs.lbs_attributes, ext_id) item_expr
+  | None -> item_expr
+  | Some ext -> expression_extension ext item_expr
 
 let class_of_let_bindings lbs body =
   let bindings =
@@ -800,8 +789,6 @@ let class_of_let_bindings lbs body =
   in
     if lbs.lbs_extension <> None then
       raise Syntaxerr.(Error(Not_expecting(lbs.lbs_loc, "extension")));
-    if lbs.lbs_attributes <> [] then
-      raise Syntaxerr.(Error(Not_expecting(lbs.lbs_loc, "attributes")));
     mkclass(Pcl_let (lbs.lbs_rec, bindings, body))
 
 (*
@@ -2266,7 +2253,7 @@ mark_position_exp
 seq_expr:
 mark_position_exp
   ( item_extension_sugar seq_expr
-    { extension_expression $1 $2 }
+    { expression_extension $1 $2 }
   | expr SEMI? { $1 }
   | opt_LET_MODULE as_loc(UIDENT) module_binding_body SEMI seq_expr
     { mkexp (Pexp_letmodule($2, $3, $5)) }
@@ -2517,6 +2504,11 @@ jsx_without_leading_less:
   }
 ;
 
+optional_expr_extension:
+  | (* empty *) { fun exp -> exp }
+  | item_extension_sugar { fun exp -> expression_extension $1 exp  }
+;
+
 /*
  * Parsing of expressions is quite involved as it depends on context.
  * At the top-level of a structure, expressions can't have attributes
@@ -2531,8 +2523,8 @@ jsx_without_leading_less:
 mark_position_exp
   ( simple_expr
     { $1 }
-  | FUN fun_def(EQUALGREATER,non_arrowed_core_type)
-    { $2 }
+  | FUN optional_expr_extension fun_def(EQUALGREATER,non_arrowed_core_type)
+    { $2 $3 }
   | ES6_FUN es6_parameters EQUALGREATER expr
     { List.fold_right mkexp_fun $2 $4 }
   | ES6_FUN es6_parameters COLON only_core_type(non_arrowed_core_type) EQUALGREATER expr
@@ -2541,20 +2533,24 @@ mark_position_exp
   /* List style rules like this often need a special precendence
      such as below_BAR in order to let the entire list "build up"
    */
-  | FUN match_cases(expr) %prec below_BAR
-    { mkexp (Pexp_function $2) }
-  | SWITCH simple_expr_no_constructor LBRACE match_cases(seq_expr) RBRACE
-    { mkexp (Pexp_match ($2, $4)) }
-  | TRY simple_expr_no_constructor LBRACE match_cases(seq_expr) RBRACE
-    { mkexp (Pexp_try ($2, $4)) }
-  | TRY simple_expr_no_constructor WITH error
-    { syntax_error_exp (mklocation $startpos($4) $endpos($4)) "Invalid try with"}
-  | IF parenthesized_expr simple_expr ioption(preceded(ELSE,expr))
-    { mkexp(Pexp_ifthenelse($2, $3, $4)) }
-  | WHILE parenthesized_expr simple_expr
-    { mkexp (Pexp_while($2, $3)) }
-  | FOR LPAREN pattern IN expr direction_flag expr RPAREN simple_expr
-    { mkexp(Pexp_for($3, $5, $7, $6, $9)) }
+  | FUN optional_expr_extension match_cases(expr) %prec below_BAR
+    { $2 (mkexp (Pexp_function $3)) }
+  | SWITCH optional_expr_extension simple_expr_no_constructor
+    LBRACE match_cases(seq_expr) RBRACE
+    { $2 (mkexp (Pexp_match ($3, $5))) }
+  | TRY optional_expr_extension simple_expr_no_constructor
+    LBRACE match_cases(seq_expr) RBRACE
+    { $2 (mkexp (Pexp_try ($3, $5))) }
+  | TRY optional_expr_extension simple_expr_no_constructor WITH error
+    { syntax_error_exp (mklocation $startpos($5) $endpos($5)) "Invalid try with"}
+  | IF optional_expr_extension parenthesized_expr
+       simple_expr ioption(preceded(ELSE,expr))
+    { $2 (mkexp (Pexp_ifthenelse($3, $4, $5))) }
+  | WHILE optional_expr_extension parenthesized_expr simple_expr
+    { $2 (mkexp (Pexp_while($3, $4))) }
+  | FOR optional_expr_extension LPAREN pattern IN expr direction_flag expr RPAREN
+    simple_expr
+    { $2 (mkexp (Pexp_for($4, $6, $8, $7, $10))) }
   | LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr RPAREN
     { let loc_colon = mklocation $startpos($2) $endpos($2) in
       let loc = mklocation $symbolstartpos $endpos in
@@ -2935,13 +2931,8 @@ let_bindings: let_binding and_let_binding* { addlbs $1 $2 };
 let_binding:
   /* Form with item extension sugar */
   item_attributes LET item_extension_sugar? rec_flag let_binding_body
-  { let (ext_attrs, ext_id) = match $3 with
-      | Some (ext_attrs, ext_id) -> (ext_attrs, Some ext_id)
-      | None -> ([], None)
-    in
-    let loc = mklocation $symbolstartpos $endpos in
-    mklbs (ext_attrs, ext_id) $4 (mklb $5 $1 loc) loc
-  }
+  { let loc = mklocation $symbolstartpos $endpos in
+    mklbs $3 $4 (mklb $5 $1 loc) loc }
 ;
 
 let_binding_body:

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -241,6 +241,32 @@ type infixChain =
   | InfixToken of string
   | Layout of layoutNode
 
+let expression_extension_sugar x =
+  if x.pexp_attributes <> [] then None
+  else match x.pexp_desc with
+    | Pexp_extension (name, PStr [{pstr_desc = Pstr_eval(expr, [])}]) ->
+      Some (name, expr)
+    | _ -> None
+
+let expression_immediate_extension_sugar x =
+  match expression_extension_sugar x with
+  | None -> (None, x)
+  | Some (name, expr) ->
+    match expr.pexp_desc with
+    | Pexp_for _ | Pexp_while _ | Pexp_ifthenelse _
+    | Pexp_fun _ | Pexp_function _ | Pexp_newtype _
+    | Pexp_try _ | Pexp_match _ ->
+      (Some name, expr)
+    | _ -> (None, x)
+
+let expression_not_immediate_extension_sugar x =
+  match expression_immediate_extension_sugar x with
+  | (Some _, _) -> None
+  | (None, _) -> expression_extension_sugar x
+
+let add_extension_sugar keyword = function
+  | None -> keyword
+  | Some str -> keyword ^ "%" ^ str.txt
 
 let print_comment_type = function
   | Regular -> "Regular"
@@ -4637,14 +4663,15 @@ class printer  ()= object(self:'self)
       loc_ghost = false
     }
 
-  method bindings (rf, l) =
+  method bindings ?extension (rf, l) =
     let first, rest = match l with
       | [] -> raise (NotPossible "no bindings supplied")
       | x :: xs -> x, xs
     in
+    let label = add_extension_sugar "let" extension in
     let label = match rf with
-      | Nonrecursive -> "let"
-      | Recursive -> "let rec"
+      | Nonrecursive -> label
+      | Recursive -> label ^ " rec"
     in
     let first = self#binding label first in
     match rest with
@@ -4657,27 +4684,20 @@ class printer  ()= object(self:'self)
         ~inline:(true, true)
         (first :: List.map (self#binding "and") rest)
 
-  method item_extension_sugar exprTerm =
-    if exprTerm.pexp_attributes <> [] then None
-    else match exprTerm.pexp_desc with
-      | Pexp_extension (name, PStr [{ pstr_desc = Pstr_eval (expr, [])}]) ->
-        Some (name, expr)
-      | _ -> None
-
-  method letList exprTerm =
-    match (exprTerm.pexp_attributes, exprTerm.pexp_desc) with
+  method letList expr =
+    match (expr.pexp_attributes, expr.pexp_desc) with
       | ([], Pexp_let (rf, l, e)) ->
         (* For "letList" bindings, the start/end isn't as simple as with
          * module value bindings. For "let lists", the sequences were formed
          * within braces {}. The parser relocates the first let binding to the
          * first brace. *)
-         let bindingsLayout = (self#bindings (rf, l)) in
+         let bindingsLayout = self#bindings (rf, l) in
          let bindingsLoc = self#bindingsLocationRange l in
          let bindingsSourceMapped = SourceMap (bindingsLoc, bindingsLayout) in
          bindingsSourceMapped::(self#letList e)
       | ([], Pexp_open (ovf, lid, e))
           (* Add this when check to make sure these are handled as regular "simple expressions" *)
-          when not (self#isSeriesOfOpensFollowedByNonSequencyExpression exprTerm) ->
+          when not (self#isSeriesOfOpensFollowedByNonSequencyExpression expr) ->
         let overrideStr = match ovf with | Override -> "!" | Fresh -> "" in
         let openLayout = label ~space:true
           (atom ("open" ^ overrideStr))
@@ -4712,28 +4732,34 @@ class printer  ()= object(self:'self)
       | ([], Pexp_sequence (({pexp_desc=Pexp_open _     }) as e1, e2))
       | ([], Pexp_sequence (({pexp_desc=Pexp_letmodule _}) as e1, e2))
       | ([], Pexp_sequence (e1, e2)) ->
-          let e1Layout = (self#unparseExpr e1) in
+          let e1Layout = match expression_not_immediate_extension_sugar e1 with
+            | Some (extension, expr) ->
+              self#attach_std_item_attrs ~extension [] (self#unparseExpr expr)
+            | None ->self#unparseExpr e1
+          in
           (* It's kind of difficult to synthesize a location here in the case
            * where this is the first expression in the braces. We could consider
            * deeply inspecting the leftmost token/term in the expression. *)
           let e1SourceMapped = SourceMap (e1.pexp_loc, e1Layout) in
-          e1SourceMapped::(self#letList e2)
+          (e1SourceMapped :: self#letList e2)
       | _ ->
-        match self#item_extension_sugar exprTerm with
+        match expression_not_immediate_extension_sugar expr with
+        | Some (extension, {pexp_attributes = []; pexp_desc = Pexp_let (rf, l, e)}) ->
+          let bindingsLayout = self#bindings ~extension (rf, l) in
+          let bindingsLoc = self#bindingsLocationRange l in
+          let bindingsSourceMapped = SourceMap (bindingsLoc, bindingsLayout) in
+          bindingsSourceMapped::(self#letList e)
+        | Some (extension, expr) ->
+          [self#attach_std_item_attrs ~extension [] (self#unparseExpr expr)]
         | None ->
           (* Should really do something to prevent infinite loops here. Never
              allowing a top level call into letList to recurse back to
              self#unparseExpr- top level calls into letList *must* be one of the
              special forms above whereas lower level recursive calls may be of
              any form. *)
-          let exprTermLayout = (self#unparseExpr exprTerm) in
-          let exprTermSourceMapped = SourceMap (exprTerm.pexp_loc, exprTermLayout) in
+          let exprTermLayout = self#unparseExpr expr in
+          let exprTermSourceMapped = SourceMap (expr.pexp_loc, exprTermLayout) in
           [exprTermSourceMapped]
-        | Some (extension, expr) ->
-          match self#letList expr with
-          | [] -> []
-          | e1 :: es ->
-            self#attach_std_item_attrs ~extension [] e1 :: es
 
   method constructor_expression ?(polyVariant=false) ~arityIsClear stdAttrs ctor eo =
     let (implicit_arity, arguments) =
@@ -4858,7 +4884,7 @@ class printer  ()= object(self:'self)
     let wrap = (left ^ "{", "}" ^ right) in
     makeList ~wrap ~break:IfNeed ~sep:"," ~postSpace:true rows
 
-  method patternFunction loc l =
+  method patternFunction ?extension loc l =
     let estimatedFunLocation = {
         loc_start = loc.loc_start;
         loc_end = {loc.loc_start with pos_cnum = loc.loc_start.Lexing.pos_cnum + 3};
@@ -4869,18 +4895,19 @@ class printer  ()= object(self:'self)
       ~break:IfNeed
       ~inline:(true, true)
       ~pad:(false, false)
-      ((atom ~loc:estimatedFunLocation "fun") :: (self#case_list l))
+      ((atom ~loc:estimatedFunLocation (add_extension_sugar "fun" extension)) :: (self#case_list l))
 
   (* Expressions requiring parens, in most contexts such as separated by infix *)
   method expression_requiring_parens_in_infix x =
     let {stdAttrs} = partitionAttributes x.pexp_attributes in
     assert (stdAttrs == []);
+    let extension, x = expression_immediate_extension_sugar x in
     match x.pexp_desc with
       (* The only reason Pexp_fun must also be wrapped in parens when under
          pipe, is that its => token will be confused with the match token.
          Simple expression will also invoke `#reset`. *)
       | Pexp_function _ when pipe || semi -> None (* Would be rendered as simplest_expression  *)
-      | Pexp_function l -> Some (self#patternFunction x.pexp_loc l)
+      | Pexp_function l -> Some (self#patternFunction ?extension x.pexp_loc l)
       | _ ->
         (* The Pexp_function cases above don't use location because comment printing
           breaks for them. *)
@@ -4914,7 +4941,10 @@ class printer  ()= object(self:'self)
                    needed, should we even print them with the minimum amount?  We can
                    instead model everything as "infix" with ranked precedences.  *)
                 let retValUnparsed = self#unparseExprApplicationItems ret in
-                Some (self#wrapCurriedFunctionBinding ~sweet:true "fun" ~arrow:"=>" firstArg tl retValUnparsed)
+                Some (self#wrapCurriedFunctionBinding
+                        ~sweet:(extension = None)
+                        (add_extension_sugar "fun" extension)
+                        ~arrow:"=>" firstArg tl retValUnparsed)
             )
           | Pexp_try (e, l) ->
             let estimatedBracePoint = {
@@ -4924,7 +4954,8 @@ class printer  ()= object(self:'self)
             }
             in
             let cases = (self#case_list ~allowUnguardedSequenceBodies:true l) in
-            let switchWith = label ~space:true (atom "try")
+            let switchWith = label ~space:true
+                (atom (add_extension_sugar "try" extension))
                 (self#reset#simplifyUnparseExpr e)
             in
             Some (
@@ -4947,7 +4978,7 @@ class printer  ()= object(self:'self)
              let cases = (self#case_list ~allowUnguardedSequenceBodies:true l) in
              let switchWith =
                let exp = self#reset#simplifyUnparseExpr e in
-               label ~space:true (atom "switch") exp in
+               label ~space:true (atom (add_extension_sugar "switch" extension)) exp in
              let lbl =
                label
                  ~space:true
@@ -5002,14 +5033,14 @@ class printer  ()= object(self:'self)
             let init =
               label
                 ~space:true
-                (SourceMap (e1.pexp_loc, (label ~space:true (atom "if") (makeList ~wrap:("(",")") [self#unparseExpr e1]))))
+                (SourceMap (e1.pexp_loc, (label ~space:true (atom (add_extension_sugar "if" extension)) (makeList ~wrap:("(",")") [self#unparseExpr e1]))))
                 (makeLetSequence (self#letList e2)) in
             Some (sequence init blocks)
           | Pexp_while (e1, e2) ->
             let lbl =
               label
                 ~space:true
-                (label ~space:true (atom "while") (makeList ~wrap:("(",")") [self#unparseExpr e1]))
+                (label ~space:true (atom (add_extension_sugar "while" extension)) (makeList ~wrap:("(",")") [self#unparseExpr e1]))
                 (makeLetSequence (self#letList e2)) in
             Some lbl
           | Pexp_for (s, e1, e2, df, e3) ->
@@ -5032,7 +5063,9 @@ class printer  ()= object(self:'self)
                   (self#unparseExpr e2);
                 ]
             in
-            let upToBody = makeList ~inline:(true, true) ~postSpace:true [atom "for"; dockedToFor] in
+            let upToBody = makeList ~inline:(true, true) ~postSpace:true
+                [atom (add_extension_sugar "for" extension); dockedToFor]
+            in
             Some (label ~space:true upToBody (makeLetSequence (self#letList e3)))
           | Pexp_new (li) ->
             Some (label ~space:true (atom "new") (self#longident_class_or_type_loc li))
@@ -5321,7 +5354,8 @@ class printer  ()= object(self:'self)
     if stdAttrs <> [] then
       None
     else
-      let item = match x.pexp_desc with
+      let item =
+        match x.pexp_desc with
         (* The only reason Pexp_fun must also be wrapped in parens is that its =>
            token will be confused with the match token. *)
         | Pexp_fun _ when pipe || semi -> Some (self#reset#simplifyUnparseExpr x)
@@ -5416,12 +5450,19 @@ class printer  ()= object(self:'self)
         | Pexp_letmodule _ | Pexp_letexception _ ->
           Some (makeLetSequence (self#letList x))
         | Pexp_extension e ->
-          begin match self#item_extension_sugar x with
-            | Some (_, { pexp_desc = Pexp_let _ | Pexp_sequence _ |
-                                     Pexp_letmodule _ | Pexp_letexception _
-                       }) ->
-              Some (makeLetSequence (self#letList x))
-            | _ -> Some (self#extension e)
+          begin match expression_immediate_extension_sugar x with
+            | (Some _, _) -> None
+            | (None, _) ->
+              match expression_extension_sugar x with
+              | None -> Some (self#extension e)
+              | Some (extension, x') ->
+                match x'.pexp_desc with
+                | Pexp_let _ ->
+                  Some (makeLetSequence (self#letList x))
+                | Pexp_function l when (pipe || semi) ->
+                  Some (formatPrecedence ~loc:x.pexp_loc
+                          (self#reset#patternFunction ~extension x'.pexp_loc l))
+                | _ -> Some (self#extension e)
           end
         | Pexp_open (ovf, lid, e) ->
             if self#isSeriesOfOpensFollowedByNonSequencyExpression x then
@@ -6473,13 +6514,11 @@ class printer  ()= object(self:'self)
             in
             makeNonIndentedBreakingList moduleBindings
         | Pstr_attribute a -> self#floating_attribute a
-        | Pstr_extension ((name,PStr [item] as e), a) ->
+        | Pstr_extension ((extension, PStr [item]), a) ->
           begin match item.pstr_desc with
-            | Pstr_extension _ ->
-              self#attach_std_item_attrs a (self#item_extension e)
-            | _ ->
-              self#attach_std_item_attrs ~extension:name a
-                (self#structure_item item)
+            | Pstr_value (rf, l) -> self#bindings ~extension (rf, l)
+            | _ -> self#attach_std_item_attrs ~extension a
+                     (self#structure_item item)
           end
         | Pstr_extension (e, a) ->
           (* Notice how extensions have attributes - but not every structure


### PR DESCRIPTION
With current version, Reason accepts:
```
%lwt
let x = Lwt.return(5);
```

But pretty print it as:
```
[%%lwt let x = Lwt.return(5)];
```

This PR implements pretty-printing for extension sugars (in structures and in expressions).