### PR TITLE
parser/pprint_ast: force parentheses around switch (...)/try (...)

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -518,7 +518,7 @@ external debounce :
 let x = "hi";
 
 let res =
-  switch x {
+  switch (x) {
   | _ =>
     [@attr]
     {
@@ -530,7 +530,7 @@ let res =
   };
 
 let res =
-  switch x {
+  switch (x) {
   | _ => [@attr] String.(Array.(concat))
   };
 

--- a/formatTest/typeCheckedTests/expected_output/comments.re
+++ b/formatTest/typeCheckedTests/expected_output/comments.re
@@ -82,7 +82,7 @@ let result =
   };
 
 let result =
-  switch None {
+  switch (None) {
   | Some({fieldOne: 20}) =>
     /* Where does this comment go? */
     let tmp = 0;

--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -101,7 +101,7 @@ module Namespace = {
 
 module Optional1 = {
   let createElement = (~required, ~children, ()) =>
-    switch required {
+    switch (required) {
     | Some(a) => {displayName: a}
     | None => {displayName: "nope"}
     };
@@ -110,7 +110,7 @@ module Optional1 = {
 module Optional2 = {
   let createElement =
       (~optional=?, ~children, ()) =>
-    switch optional {
+    switch (optional) {
     | Some(a) => {displayName: a}
     | None => {displayName: "nope"}
     };
@@ -119,7 +119,7 @@ module Optional2 = {
 module DefaultArg = {
   let createElement =
       (~default=Some("foo"), ~children, ()) =>
-    switch default {
+    switch (default) {
     | Some(a) => {displayName: a}
     | None => {displayName: "nope"}
     };

--- a/formatTest/typeCheckedTests/expected_output/mlSyntax.re
+++ b/formatTest/typeCheckedTests/expected_output/mlSyntax.re
@@ -53,7 +53,7 @@ type a =
   | A(bcd);
 
 let result =
-  switch B {
+  switch (B) {
   | B
   | C
   | D

--- a/formatTest/typeCheckedTests/expected_output/mlSyntax.re.4.02.3
+++ b/formatTest/typeCheckedTests/expected_output/mlSyntax.re.4.02.3
@@ -53,7 +53,7 @@ type a =
   | A(bcd);
 
 let result =
-  switch B {
+  switch (B) {
   | B
   | C
   | D

--- a/formatTest/typeCheckedTests/expected_output/mutation.re
+++ b/formatTest/typeCheckedTests/expected_output/mutation.re
@@ -31,7 +31,7 @@ holdsABool.contents = holdsAnInt.contents == 100;
 
 let numberToSwitchOn = 100;
 
-switch numberToSwitchOn {
+switch (numberToSwitchOn) {
 | (-3)
 | (-2)
 | (-1) => ()

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -7,7 +7,7 @@ class virtual stack ('a) (init) = {
   val mutable v: list('a) = init;
   pub virtual implementMe: int => int;
   pub pop =
-    switch v {
+    switch (v) {
     | [hd, ...tl] =>
       v = tl;
       Some(hd);
@@ -43,7 +43,7 @@ class virtual stackWithAttributes ('a) (init) = {
   val mutable v: list('a) = init;
   pub virtual implementMe: int => int;
   pub pop =
-    switch v {
+    switch (v) {
     | [hd, ...tl] =>
       v = tl;
       Some(hd);

--- a/formatTest/typeCheckedTests/expected_output/patternMatching.re
+++ b/formatTest/typeCheckedTests/expected_output/patternMatching.re
@@ -189,7 +189,7 @@ switch (Some(1)) {
 };
 
 /* with parens around direct list pattern in constructor pattern */
-switch None {
+switch (None) {
 | Some([]) => ()
 | Some([_]) when true => ()
 | Some([x]) => ()
@@ -199,7 +199,7 @@ switch None {
 };
 
 /* no parens around direct list pattern in constructor pattern (sugar) */
-switch None {
+switch (None) {
 | Some([]) => ()
 | Some([_]) when true => ()
 | Some([x]) => ()
@@ -209,7 +209,7 @@ switch None {
 };
 
 /* with parens around direct array pattern in constructor pattern */
-switch None {
+switch (None) {
 | Some([||]) => "empty"
 | Some([|_|]) when true => "one any"
 | Some([|a|]) => "one"
@@ -218,7 +218,7 @@ switch None {
 };
 
 /* no parens around direct array pattern in constructor pattern (sugar) */
-switch None {
+switch (None) {
 | Some([||]) => "empty"
 | Some([|_|]) when true => "one any"
 | Some([|a|]) => "one"
@@ -227,20 +227,20 @@ switch None {
 };
 
 /* parens around direct record pattern in constructor pattern */
-switch None {
+switch (None) {
 | Some({x}) when true => ()
 | Some({x, y}) => ()
 | _ => ()
 };
 
 /* no parens around direct record pattern in constructor pattern (sugar) */
-switch None {
+switch (None) {
 | Some({x}) when true => ()
 | Some({x, y}) => ()
 | _ => ()
 };
 
-switch None {
+switch (None) {
 | Some([|
     someSuperLongString,
     thisShouldBreakTheLine
@@ -249,7 +249,7 @@ switch None {
 | _ => ()
 };
 
-switch None {
+switch (None) {
 | Some((
     someSuperLongString,
     thisShouldBreakTheLine
@@ -258,7 +258,7 @@ switch None {
 | _ => ()
 };
 
-switch None {
+switch (None) {
 | Some([
     someSuperLongString,
     thisShouldBreakTheLine

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -217,7 +217,7 @@ and y2 = {
 };
 
 let result =
-  switch None {
+  switch (None) {
   | Some({fieldOne: 20, fieldA: a}) =>
     /* Where does this comment go? */
     let tmp = 0;
@@ -242,7 +242,7 @@ let res =
  * Now these end of line comments *should* be retained.
  */
 let result =
-  switch None {
+  switch (None) {
   | Some({
       fieldOne: 20, /* end of line */
       fieldA:

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -373,7 +373,7 @@ external debounce : int => ([@bs.meth] (unit => unit)) => ([@bs.meth] (unit => [
 
 let x = "hi";
 
-let res = switch x {
+let res = switch (x) {
 | _ =>
   [@attr]
   {
@@ -384,7 +384,7 @@ let res = switch x {
   }
 };
 
-let res = switch x {
+let res = switch (x) {
 | _ =>
   [@attr]
   {

--- a/formatTest/typeCheckedTests/input/patternMatching.re
+++ b/formatTest/typeCheckedTests/input/patternMatching.re
@@ -155,7 +155,7 @@ switch (Some(1)) {
 };
 
 /* with parens around direct list pattern in constructor pattern */
-switch None {
+switch (None) {
 | Some([]) => ()
 | Some([_]) when true => ()
 | Some([x]) => ()
@@ -165,7 +165,7 @@ switch None {
 };
 
 /* no parens around direct list pattern in constructor pattern (sugar) */
-switch None {
+switch (None) {
 | Some [] => ()
 | Some [_] when true => ()
 | Some [x] => ()
@@ -175,7 +175,7 @@ switch None {
 };
 
 /* with parens around direct array pattern in constructor pattern */
-switch None {
+switch (None) {
 | Some([| |]) => "empty"
 | Some([| _ |]) when true => "one any"
 | Some([| a |]) => "one"
@@ -184,7 +184,7 @@ switch None {
 };
 
 /* no parens around direct array pattern in constructor pattern (sugar) */
-switch None {
+switch (None) {
 | Some [||] => "empty"
 | Some [|_|] when true => "one any"
 | Some [|a|] => "one"
@@ -193,30 +193,30 @@ switch None {
 };
 
 /* parens around direct record pattern in constructor pattern */
-switch None {
+switch (None) {
 | Some({x}) when true => ()
 | Some({x, y}) => ()
 | _ => ()
 };
 
 /* no parens around direct record pattern in constructor pattern (sugar) */
-switch None {
+switch (None) {
 | Some {x} when true => ()
 | Some {x, y} => ()
 | _ => ()
 };
 
-switch None {
+switch (None) {
 | Some([|someSuperLongString, thisShouldBreakTheLine|]) => ()
 | _ => ()
 };
 
-switch None {
+switch (None) {
 | Some((someSuperLongString, thisShouldBreakTheLine)) => ()
 | _ => ()
 };
 
-switch None {
+switch (None) {
 | Some([someSuperLongString, thisShouldBreakTheLine]) => ()
 | Some([someSuperLongString, ...es6ListSugarLikeSyntaxWhichIsSuperLong]) when true === true => ()
 | Some([someSuperLongString, ...es6ListSugarLikeSyntaxWhichIsSuperLong]) => ()

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -409,16 +409,16 @@ let rec size =
 
 /* Optimize for tail recursion */
 let rec size = (soFar, lst) =>
-  switch lst {
+  switch (lst) {
   | [] => 0
   | [hd, ...tl] => size(soFar + 1, tl)
   };
 
 let nestedMatch = lstLst =>
-  switch lstLst {
+  switch (lstLst) {
   | [hd, ...tl] when false => 10
   | [hd, ...tl] =>
-    switch tl {
+    switch (tl) {
     | [] => 0 + 0
     | [tlHd, ...tlTl] => 0 + 1
     }
@@ -426,10 +426,10 @@ let nestedMatch = lstLst =>
   };
 
 let nestedMatchWithWhen = lstLst =>
-  switch lstLst {
+  switch (lstLst) {
   | [hd, ...tl] when false => 10
   | [hd, ...tl] when true =>
-    switch tl {
+    switch (tl) {
     | [] when false => 0 + 0
     | [] when true => 0 + 0
     | [tlHd, ...tlTl] => 0 + 1
@@ -764,7 +764,7 @@ let bar = {Foo.foo, Bar.bar};
 
 ({M.x, y}) => 1;
 
-switch foo {
+switch (foo) {
 | {y: 1, M.x} => 2
 };
 

--- a/formatTest/unit_tests/expected_output/extensions.re
+++ b/formatTest/unit_tests/expected_output/extensions.re
@@ -22,7 +22,7 @@ let x = {
 
 let x = {
   if%extend (true) {1} else {2};
-  switch%extend None {
+  switch%extend (None) {
   | Some(x) => assert false
   | None => ()
   };
@@ -35,7 +35,7 @@ let x = {
 let x = if%extend (true) {1} else {2};
 
 let x =
-  switch%extend None {
+  switch%extend (None) {
   | Some(x) => assert false
   | None => ()
   };

--- a/formatTest/unit_tests/expected_output/features403.re
+++ b/formatTest/unit_tests/expected_output/features403.re
@@ -27,7 +27,7 @@ type expr('a) =
 
 let rec eval: type a. expr(a) => a =
   e =>
-    switch e {
+    switch (e) {
     | Is0({test}) => eval(test) == 0
     | Val({value}) => value
     | Add({left, right}) =>

--- a/formatTest/unit_tests/expected_output/if.re
+++ b/formatTest/unit_tests/expected_output/if.re
@@ -163,7 +163,7 @@ let result =
  * Try shouldn't be aliased as ternary!
  */
 let res =
-  try something {
+  try (something) {
   | true => "hi"
   | false => "bye"
   };

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -312,7 +312,7 @@ let includesACommentCloseInIdentifier = ( **\/ );
 let shouldSimplifyAnythingExceptApplicationAndConstruction =
   call("hi")
   ++ (
-    switch x {
+    switch (x) {
     | _ => "hi"
     }
   )

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -113,7 +113,7 @@ let tuples =
 let icon =
   <Icon
     name=(
-      switch state.volume {
+      switch (state.volume) {
       | v when v < 0.1 => "sound-off"
       | v when v < 0.11 => "sound-min"
       | v when v < 0.51 => "sound-med"

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -17,7 +17,7 @@ TestUtils.printSection("General Syntax");
 /*   | `Other x => (print_string "matched other x"); x;; */
 /*  */
 let matchingFunc = a =>
-  switch a {
+  switch (a) {
   | `Thingy(x) =>
     print_string("matched thingy x");
     let zz = 10;
@@ -428,7 +428,7 @@ Printf.printf(
 
 /* Pattern matching */
 let blah = arg =>
-  switch arg {
+  switch (arg) {
   /* Comment before Bar */
   | /* Comment between bar/pattern */ Red(_) => 1
   /* Comment Before non-first bar */
@@ -571,7 +571,7 @@ let myFun =
   firstArg + x;
 
 let matchesWithWhen = a =>
-  switch a {
+  switch (a) {
   | Red(x) when 1 > 0 => 10
   | Red(_) => 10
   | Black(x) => 10

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -61,14 +61,14 @@ type threeForms =
   | FormThree;
 
 let doesntCareWhichForm = x =>
-  switch x {
+  switch (x) {
   | FormOne(q)
   | FormTwo(q) => 10
   | FormThree => 20
   };
 
 let doesntCareWhichFormAs = x =>
-  switch x {
+  switch (x) {
   | FormOne(q) as ppp
   | FormTwo(q) as ppp => 10
   | FormThree => 20
@@ -108,13 +108,13 @@ let accessDeeplyWithArg =
 
 /* Destructured matching *not* at function definition */
 let accessDeeply = x =>
-  switch x {
+  switch (x) {
   | LocalModule.AccessedThroughModule => 10
   | _ => 0
   };
 
 let accessDeeplyWithArg = x =>
-  switch x {
+  switch (x) {
   | LocalModule.AccessedThroughModuleWith(x) => 10
   | _ => 0
   };
@@ -128,12 +128,12 @@ let accessDeeplyWithArg = x =>
  *   let myFunc x = function | `Blah p as retVal -> retVal`
  */
 let accessDeeply = x =>
-  switch x {
+  switch (x) {
   | LocalModule.AccessedThroughModule as ppp => 1
   };
 
 let accessDeeplyWithArg = x =>
-  switch x {
+  switch (x) {
   | LocalModule.AccessedThroughModuleWith(
       x as retVal
     ) =>
@@ -147,7 +147,7 @@ let accessDeeplyWithArg = x =>
 
 /* Just to show that by default `as` captures much less aggresively */
 let rec accessDeeplyWithArgRecursive = (x, count) =>
-  switch x {
+  switch (x) {
   | LocalModule.AccessedThroughModuleWith(x) as entirePattern =>
     /* It captures the whole pattern */
     if (count > 0) {
@@ -201,7 +201,7 @@ let howWouldWeMatchFunctionArgs =
   x + y;
 
 let matchingTwoCurriedConstructorsInTuple = x =>
-  switch x {
+  switch (x) {
   | (
       HeresTwoConstructorArguments(x, y),
       HeresTwoConstructorArguments(a, b)
@@ -217,7 +217,7 @@ type twoCurriedConstructors =
 
 let matchingTwoCurriedConstructorInConstructor =
     x =>
-  switch x {
+  switch (x) {
   | TwoCombos(
       HeresTwoConstructorArguments(x, y),
       HeresTwoConstructorArguments(a, b)
@@ -254,7 +254,7 @@ let rec commentPolymorphicCases:
   | None => 0;
 
 let thisWontCompileButLetsSeeHowItFormats =
-  switch something {
+  switch (something) {
   | Zero
   | One => 10
   };
@@ -284,7 +284,7 @@ let rec eval: type a. term(a) => a =
 
 let rec eval: type a. term(a) => a =
   x =>
-    switch x {
+    switch (x) {
     | Int(n) => n
     /* a = int */
     | Add => ((x, y) => x + y)
@@ -318,14 +318,14 @@ type tuples =
 let myTuple = OneTuple(20, 30);
 
 let res =
-  switch myTuple {
+  switch (myTuple) {
   | Two(x, y) =>
     try (Two(x, y)) {
     | One => "hi"
     | Two => "bye"
     }
   | One =>
-    switch One {
+    switch (One) {
     | One => "hi"
     | _ => "bye"
     }
@@ -396,10 +396,10 @@ let res =
 
 let rec atLeastOneFlushableChildAndNoWipNoPending =
         (composition, atPriority) =>
-  switch composition {
+  switch (composition) {
   | [] => false
   | [hd, ...tl] =>
-    switch hd {
+    switch (hd) {
     | OpaqueGraph({lifecycle: Reconciled(_, [])}) =>
       atLeastOneFlushableChildAndNoWipNoPending(
         tl,
@@ -443,7 +443,7 @@ let rec atLeastOneFlushableChildAndNoWipNoPending =
 let prp = `Purple((101, 101));
 
 let res =
-  switch prp {
+  switch (prp) {
   | `Yellow(y, y2) => `Yellow((y2 + y, 0))
   | `Purple(p, p2) => `Purple((p2 + p, 0))
   };
@@ -478,7 +478,7 @@ let rec map = f =>
 let myFunc = (x, y, LongModule.Path.None) => "asdf";
 
 let listPatternMembersNeedntBeSimple = x =>
-  switch x {
+  switch (x) {
   | [] => ()
   | [Blah(x, y), Foo(a, b), ...rest] => ()
   | [Blah(x, y), Bar(a, b), ...rest] => ()
@@ -486,7 +486,7 @@ let listPatternMembersNeedntBeSimple = x =>
   };
 
 let listTailPatternNeedntBeSimple = x =>
-  switch x {
+  switch (x) {
   | [] => ()
   /* Although this would never typecheck! */
   | [Blah(x, y), Foo(a, b), ...Something(x)] =>
@@ -495,7 +495,7 @@ let listTailPatternNeedntBeSimple = x =>
   };
 
 let listPatternMayEvenIncludeAliases = x =>
-  switch x {
+  switch (x) {
   | [] => ()
   /* Although this would never typecheck! */
   | [

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -430,7 +430,7 @@ let myList = [
 let myList = [3, 4, 5];
 
 let simpleListPattern = x =>
-  switch x {
+  switch (x) {
   | [1, 2, 3] => 0
   | _ => 0
   };
@@ -2439,7 +2439,7 @@ type colors =
   | Green(int);
 
 let blah = arg =>
-  switch arg {
+  switch (arg) {
   /* Comment before Bar */
   | /* Comment between bar/pattern */ Red(_) => 1
   /* Comment Before non-first bar */
@@ -2470,7 +2470,7 @@ type reallyLongVariantNames =
   | AnotherReallyLongVariantName2(int, int, int);
 
 let howDoLongMultiBarPatternsWrap = x =>
-  switch x {
+  switch (x) {
   | AnotherReallyLongVariantName(_, _, _) => 0
   | AnotherReallyLongVariantName2(_, _, _) => 0
   | ReallyLongVariantName({
@@ -2480,7 +2480,7 @@ let howDoLongMultiBarPatternsWrap = x =>
   };
 
 let letsCombineTwoLongPatternsIntoOneCase = x =>
-  switch x {
+  switch (x) {
   | AnotherReallyLongVariantName(_, _, _)
   | AnotherReallyLongVariantName2(_, _, _) => 0
   | ReallyLongVariantName({
@@ -2490,7 +2490,7 @@ let letsCombineTwoLongPatternsIntoOneCase = x =>
   };
 
 let letsPutAWhereClauseOnTheFirstTwo = x =>
-  switch x {
+  switch (x) {
   | AnotherReallyLongVariantName(_, _, _)
   | AnotherReallyLongVariantName2(_, _, _)
       when true => 0
@@ -2501,7 +2501,7 @@ let letsPutAWhereClauseOnTheFirstTwo = x =>
   };
 
 let letsPutAWhereClauseOnTheLast = x =>
-  switch x {
+  switch (x) {
   | AnotherReallyLongVariantName(_, _, _)
   | AnotherReallyLongVariantName2(_, _, _) => 0
   | ReallyLongVariantName({

--- a/formatTest/unit_tests/input/extensions.re
+++ b/formatTest/unit_tests/input/extensions.re
@@ -29,7 +29,7 @@ let x = {
   %extend
   if (true) { 1 } else { 2 };
   %extend
-  switch None {
+  switch (None) {
     | Some(x) => assert(false)
     | None => ()
   };
@@ -49,7 +49,7 @@ let x = {
 
 let x = {
   %extend
-  switch None {
+  switch (None) {
     | Some(x) => assert(false)
     | None => ()
   };

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -2544,13 +2544,13 @@ mark_position_exp
    */
   | FUN optional_expr_extension match_cases(expr) %prec below_BAR
     { $2 (mkexp (Pexp_function $3)) }
-  | SWITCH optional_expr_extension simple_expr_no_constructor
+  | SWITCH optional_expr_extension parenthesized_expr
     LBRACE match_cases(seq_expr) RBRACE
     { $2 (mkexp (Pexp_match ($3, $5))) }
-  | TRY optional_expr_extension simple_expr_no_constructor
+  | TRY optional_expr_extension parenthesized_expr
     LBRACE match_cases(seq_expr) RBRACE
     { $2 (mkexp (Pexp_try ($3, $5))) }
-  | TRY optional_expr_extension simple_expr_no_constructor WITH error
+  | TRY optional_expr_extension parenthesized_expr WITH error
     { syntax_error_exp (mklocation $startpos($5) $endpos($5)) "Invalid try with"}
   | IF optional_expr_extension parenthesized_expr
        simple_expr ioption(preceded(ELSE,expr))
@@ -2677,6 +2677,23 @@ parenthesized_expr:
   | constant              { mkexp (Pexp_constant $1) }
   | jsx                   { $1 }
   | simple_expr_direct_argument { $1 }
+  | as_loc(constr_longident)
+    mark_position_exp
+      ( non_labeled_argument_list   { mkexp (Pexp_tuple($1)) }
+      | simple_expr_direct_argument { $1 }
+      )
+    { mkExplicitArityTupleExp (Pexp_construct($1, Some $2)) }
+  | name_tag
+    mark_position_exp
+      ( non_labeled_argument_list
+        { (* only wrap in a tuple if there are more than one arguments *)
+          match $1 with
+          | [x] -> x
+          | l -> mkexp (Pexp_tuple(l))
+        }
+      | simple_expr_direct_argument { $1 }
+      )
+    { mkexp(Pexp_variant($1, Some $2)) }
   | LBRACKETBAR expr_list BARRBRACKET
     { mkexp (Pexp_array $2) }
   | as_loc(LBRACKETBAR) expr_list as_loc(error)
@@ -2784,40 +2801,8 @@ parenthesized_expr:
 
 %inline simple_expr: simple_expr_call { mkexp_app_rev $startpos $endpos $1 };
 
-simple_expr_no_constructor:
-  mark_position_exp(simple_expr_template(simple_expr_no_constructor)) { $1 };
-
-simple_expr_template_constructor:
-  | as_loc(constr_longident)
-    mark_position_exp
-      ( non_labeled_argument_list   { mkexp (Pexp_tuple($1)) }
-      | simple_expr_direct_argument { $1 }
-      )
-    { (*if List.mem (string_of_longident $1.txt)
-         built_in_explicit_arity_constructors then
-        (* unboxing the inner tupple *)
-        match $2 with
-          | [inner] -> mkexp (Pexp_construct($1, Some inner))
-          | _ -> assert false
-      else*)
-      mkExplicitArityTupleExp (Pexp_construct($1, Some $2))
-    }
-  | name_tag
-    mark_position_exp
-      ( non_labeled_argument_list
-        { (* only wrap in a tuple if there are more than one arguments *)
-          match $1 with
-          | [x] -> x
-          | l -> mkexp (Pexp_tuple(l))
-        }
-      | simple_expr_direct_argument { $1 }
-      )
-    { mkexp(Pexp_variant($1, Some $2)) }
-;
-
 simple_expr_no_call:
-  | mark_position_exp(simple_expr_template(simple_expr_no_call)) { $1 }
-  | simple_expr_template_constructor { $1 }
+  mark_position_exp(simple_expr_template(simple_expr_no_call)) { $1 }
 ;
 
 simple_expr_call:
@@ -2829,7 +2814,6 @@ simple_expr_call:
       let loc = mklocation $startpos($2) $endpos($2) in
       (make_real_exp (mktailexp_extension loc seq ext_opt), [])
     }
-  | simple_expr_template_constructor { ($1, []) }
 ;
 
 simple_expr_direct_argument:


### PR DESCRIPTION
This PR force scrutinees in `switch` and `try` expressions to be wrapped with parentheses: `switch (a) { | None => ... }`.