### PR TITLE
Move rebuild to own opam package

### DIFF
--- a/rebuild.opam
+++ b/rebuild.opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Jordan Walke <jordojw@gmail.com>"
+authors: [ "Jordan Walke <jordojw@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/facebook/reason"
+doc: "http://reasonml.github.io/"
+bug-reports: "https://github.com/facebook/reason/issues"
+dev-repo: "git://github.com/facebook/reason.git"
+tags: [ "syntax" ]
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder"                {build}
+  "ocamlbuild"
+]
+available: [ ocaml-version >= "4.02" & ocaml-version < "4.07" ]

--- a/src/reasonbuild/jbuild
+++ b/src/reasonbuild/jbuild
@@ -7,6 +7,7 @@
 
 (install
  ((section bin)
+  (package rebuild)
   ; This is a nested _build directory that running
   ; ocamlbuild -just-plugin generates.
   (files ((myocamlbuild as rebuild)))))

--- a/src/rtop/jbuild
+++ b/src/rtop/jbuild
@@ -2,6 +2,7 @@
 
 (install
  ((section bin)
+  (package reason)
   (files (rtop_init.ml))))
 
 (library


### PR DESCRIPTION
FIrst step in slimming down the dependency code for people who just want to build reason code.