### PR TITLE
Adding optional param to know when to wrap neg prefix symbol in parens

### DIFF
--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -198,7 +198,7 @@ let minusAndInteger = pred - 1;
 
 let passingMinusOneToFunction = pred(-1);
 
-let leadingMinusIsCorrectlyNeg = (-1) + 20;
+let leadingMinusIsCorrectlyNeg = -1 + 20;
 
 let leadingMinusIsCorrectlyNeg = 3 > (-1);
 
@@ -969,7 +969,7 @@ let containingObject = {
       [@attr] (- something(blah, blah));
     /* Attribute on the regular function application, not prefix */
     let res = [@attr] (- something(blah, blah));
-    let attrOnPrefix = [@ppxOnPrefixApp] (-1);
+    let attrOnPrefix = [@ppxOnPrefixApp] -1;
     let attrOnPrefix = 5 + (-1);
     let result =
       [@ppxAttributeOnSugarGetter] arr.[0];

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -198,7 +198,7 @@ let minusAndInteger = pred - 1;
 
 let passingMinusOneToFunction = pred(-1);
 
-let leadingMinusIsCorrectlyNeg = -1 + 20;
+let leadingMinusIsCorrectlyNeg = (-1) + 20;
 
 let leadingMinusIsCorrectlyNeg = 3 > (-1);
 
@@ -969,7 +969,7 @@ let containingObject = {
       [@attr] (- something(blah, blah));
     /* Attribute on the regular function application, not prefix */
     let res = [@attr] (- something(blah, blah));
-    let attrOnPrefix = [@ppxOnPrefixApp] -1;
+    let attrOnPrefix = [@ppxOnPrefixApp] (-1);
     let attrOnPrefix = 5 + (-1);
     let result =
       [@ppxAttributeOnSugarGetter] arr.[0];
@@ -1154,3 +1154,10 @@ let foo =
   (100. /. 2.) ** 2. +. (200. /. 2.) ** 2.;
 
 let foo = 100. /. 2. ** 2. +. 200. /. 2. ** 2.;
+
+/* Parens should not be added to negative constants, but should be added in expressions */
+let x = -5;
+
+let x = (-10, -10);
+
+let x = 1 + (-1) + 1;

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -404,7 +404,7 @@ module rec A: {
     | (Leaf(s1), Leaf(s2)) =>
       Pervasives.compare(s1, s2)
     | (Leaf(_), Node(_)) => 1
-    | (Node(_), Leaf(_)) => (-1)
+    | (Node(_), Leaf(_)) => -1
     | (Node(n1), Node(n2)) =>
       ASet.compare(n1, n2)
     };

--- a/formatTest/unit_tests/input/infix.re
+++ b/formatTest/unit_tests/input/infix.re
@@ -902,3 +902,10 @@ b;
 /* #1676: Exponentiation should be right-associative */
 let foo = (100. /. 2.) ** 2. +. (200. /. 2.) ** 2.;
 let foo = 100. /. 2. ** 2. +. 200. /. 2. ** 2.;
+
+/* Parens should not be added to negative constants, but should be added in expressions */
+let x = -5;
+
+let x = (-10, -10);
+
+let x = 1 + -1 + 1;

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3658,7 +3658,7 @@ class printer  ()= object(self:'self)
      a chance to reduce. This function would determine the minimum parens to
      ensure that. *)
   method ensureContainingRule ~withPrecedence ~reducesAfterRight () =
-    match self#unparseExprRecurse ~wrapNegPrefix:true reducesAfterRight with
+    match self#unparseExprRecurse reducesAfterRight with
     | SpecificInfixPrecedence ({reducePrecedence; shiftPrecedence}, rightRecurse)->
       if higherPrecedenceThan shiftPrecedence withPrecedence then begin
         rightRecurse
@@ -3702,7 +3702,7 @@ class printer  ()= object(self:'self)
       minimizing parenthesis.
   *)
   method unparseExpr x =
-    match self#unparseExprRecurse x with
+    match self#unparseExprRecurse ~parens:false x with
     | SpecificInfixPrecedence ({reducePrecedence; shiftPrecedence}, resolvedRule) ->
         self#unparseResolvedRule resolvedRule
     | FunctionApplication itms -> formatAttachmentApplication applicationFinalWrapping None (itms, Some x.pexp_loc)
@@ -3763,7 +3763,7 @@ class printer  ()= object(self:'self)
 
 
   method unparseExprApplicationItems x =
-    match self#unparseExprRecurse x with
+    match self#unparseExprRecurse ~parens:false x with
     | SpecificInfixPrecedence ({reducePrecedence; shiftPrecedence}, wrappedRule) ->
         let itm = self#unparseResolvedRule wrappedRule in
         ([itm], Some x.pexp_loc)
@@ -3772,7 +3772,7 @@ class printer  ()= object(self:'self)
     | Simple itm -> ([itm], Some x.pexp_loc)
 
 
-  method unparseExprRecurse ?(wrapNegPrefix=false) x =
+  method unparseExprRecurse ?(parens=true) x =
     (* If there are any attributes, render unary like `(~-) x [@ppx]`, and infix like `(+) x y [@attr]` *)
     let {arityAttrs; stdAttrs; jsxAttrs} = partitionAttributes x.pexp_attributes in
     (* If there's any attributes, recurse without them, then apply them to
@@ -3797,7 +3797,7 @@ class printer  ()= object(self:'self)
           (List.concat [attributesAsList; itms])
       ]
     else
-    match self#simplest_expression ~wrapNegPrefix x with
+    match self#simplest_expression ~parens x with
     | Some se -> Simple se
     | None ->
     match x.pexp_desc with
@@ -5349,7 +5349,7 @@ class printer  ()= object(self:'self)
       | _ -> raise (Invalid_argument "bs.obj only accepts a record. You've passed something else"))
     | _ -> assert false
 
-  method simplest_expression ?(wrapNegPrefix=false) x =
+  method simplest_expression ?(parens=true) x =
     let {stdAttrs; jsxAttrs} = partitionAttributes x.pexp_attributes in
     if stdAttrs <> [] then
       None
@@ -5410,7 +5410,7 @@ class printer  ()= object(self:'self)
             Some (ensureSingleTokenSticksToLabel (self#longident_loc li))
         | Pexp_constant c ->
             (* Constants shouldn't break when to the right of a label *)
-            Some (ensureSingleTokenSticksToLabel (self#constant ~parens:wrapNegPrefix c))
+            Some (ensureSingleTokenSticksToLabel (self#constant ~parens c))
         | Pexp_pack me ->
           Some (
             makeList


### PR DESCRIPTION
#1728

Passing along this extra parameter should allow the printer to know when it's correct to wrap a negative prefix. I found that this would work by backtracking what functions are called for these different cases.

  