### PR TITLE
Fix PSig

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.4.04.0.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.4.04.0.re
@@ -4,3 +4,16 @@ let () = {
   exception E;
   raise(E);
 };
+
+/** Different payloads **/
+[@haha:]
+/* Empty signature */
+let x = 5;
+
+/* signature_item */
+[@haha: let x: option(int)]
+let x = 5;
+
+/* Signature */
+[@haha: type t; let x: option(t)]
+let x = 5;

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -538,3 +538,31 @@ let res =
 type value =
   | [@foo] VBool'(bool): [@bar] value
   | VInt'(int): value;
+
+/** Different payloads **/
+[@haha]
+/* Empty structure */
+let x = 5;
+
+/* Expression structure */
+[@haha "hello world"]
+let x = 5;
+
+/* structure_item */
+[@haha let x = 5]
+let x = 5;
+
+/* structure */
+[@haha
+  let x = 5;
+  module X = {}
+]
+let x = 5;
+
+/* Pattern */
+[@haha? Some(_)]
+let x = 5;
+
+/* Type */
+[@haha: option(int)]
+let x = 5;

--- a/formatTest/typeCheckedTests/expected_output/attributes.rei
+++ b/formatTest/typeCheckedTests/expected_output/attributes.rei
@@ -28,7 +28,7 @@ external createClassInternalHack :
   t('classSpec) => reactClass =
   "createClass";
 
-[@bs.send.pipe : array('a)]
+[@bs.send.pipe: array('a)]
 external map : [@bs] (('a => 'b) => array('b)) =
   "";
 

--- a/formatTest/typeCheckedTests/input/attributes.4.04.0.re
+++ b/formatTest/typeCheckedTests/input/attributes.4.04.0.re
@@ -3,3 +3,17 @@ let () = {
   [@attribute] exception E;
   raise(E)
 };
+
+/** Different payloads **/
+
+/* Empty signature */
+[@haha: ]
+let x = 5;
+
+/* signature_item */
+[@haha: let x : option(int)]
+let x = 5;
+
+/* Signature */
+[@haha: type t; let x : option(t)]
+let x = 5;

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -398,3 +398,29 @@ let res = switch (x) {
 type value =
 | [@foo] VBool'(bool): [@bar] value
 | VInt'(int): value;
+
+/** Different payloads **/
+
+/* Empty structure */
+[@haha]
+let x = 5;
+
+/* Expression structure */
+[@haha "hello world"]
+let x = 5;
+
+/* structure_item */
+[@haha let x = 5]
+let x = 5;
+
+/* structure */
+[@haha let x = 5; module X = {};]
+let x = 5;
+
+/* Pattern */
+[@haha? Some(_) ]
+let x = 5;
+
+/* Type */
+[@haha: option(int)]
+let x = 5;

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -4304,6 +4304,7 @@ item_extension:
 
 payload:
   | structure                       { PStr $1 }
+  | COLON signature                 { PSig $2 }
   | COLON only_core_type(core_type) { PTyp $2 }
   | QUESTION pattern                { PPat ($2, None) }
   | QUESTION pattern WHEN expr      { PPat ($2, Some $4) }


### PR DESCRIPTION
Just the PSig part of https://github.com/facebook/reason/pull/1719.

Add support for signatures in attribute payloads and update the printing of attributes (no more space between the attribute identifier and the token used to distinguish signatures and pattern cases).