### PR TITLE
Percent less

### DIFF
--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -87,7 +87,7 @@ let x = [@attrEverything] (true && false);
 /**
  * How attribute parsings respond to other syntactic constructs.
  */
-let add(a) { [@onRet] a };
+let add = (a) => { [@onRet] a };
 let add = fun(a) => [@onRet] a;
 let add = [@onEntireFunction] (fun(a) => a);
 
@@ -95,13 +95,13 @@ let res = if (true) false else [@onFalse] false;
 let res = [@onEntireIf] (if (true) false else false);
 
 
-let add(a,b) = [@onEverything] ([@onA] a + b);
-let add(a,b) = [@onEverything] ([@onA]a + ([@onB]b));
+let add = (a,b) => [@onEverything] ([@onA] a + b);
+let add = (a,b) => [@onEverything] ([@onA]a + ([@onB]b));
 let add = (a,b) => a + [@onB]b;
 
 let both = [@onEntireFunction](fun(a) => a);
-let both(a,b) = [@onEverything]([@onA]a && b);
-let both(a,b) = [@onA] a && [@onB] ([@onB] b);
+let both = (a,b) => [@onEverything]([@onA]a && b);
+let both = (a,b) => [@onA] a && [@onB] ([@onB] b);
 let both = fun(a,b) => [@onEverything](a && b);
 
 let thisVal = 10;
@@ -111,7 +111,7 @@ let x = - [@onFunctionCall] add(thisVal,thisVal);
 let x = [@onEverything] (- add(thisVal,thisVal));
 
 
-let bothTrue(x,y) = {contents: x && y};
+let bothTrue = (x,y) => {contents: x && y};
 let something = [@onEverythingToRightOfEquals](bothTrue(true,true)^);
 let something = ([@onlyOnArgumentToBang]bothTrue(true,true))^;
 
@@ -168,7 +168,7 @@ and secondBinding = "second";
  * Let bindings.
  * ----------------------
  */
-let showLets () = [@onOuterLet] {
+let showLets  = () => [@onOuterLet] {
   let tmp = 20;
   [@onFinalLet] {
     let tmpTmp = tmp + tmp;

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -48,7 +48,7 @@ let expectedPrecendence = 1 + 1 \=== 1 + 1 && 1 + 1 \!== 1 + 1;
 let expectedPrecendence = 1 \+ 1 \=== 1 \+ 1 && 1 \+ 1 \!== 1 \+ 1;
 
 module X: {let x: (~x: unit=?, unit) => unit;} = {
-  let x(~x=(),()) = ();
+  let x = (~x=(),()) => ();
 };
 
-let display (~message=("hello": string), ~person: string="Reason", time: float) = 1;
+let display = (~message=("hello": string), ~person: string="Reason", time: float) => 1;

--- a/formatTest/typeCheckedTests/input/jsx.re
+++ b/formatTest/typeCheckedTests/input/jsx.re
@@ -1,66 +1,66 @@
 type component = {displayName: string};
 
 module Bar = {
-  let createElement(~c=?,~children,()) {displayName: "test"};
+  let createElement = (~c=?,~children,()) => {displayName: "test"};
 };
 
 module Nesting = {
-  let createElement(~children,()) {displayName: "test"};
+  let createElement = (~children,()) => {displayName: "test"};
 };
 
 module Much = {
-  let createElement(~children,()) {displayName: "test"};
+  let createElement = (~children,()) => {displayName: "test"};
 };
 
 module Foo = {
-    let createElement(~a=?,~b=?,~children,()) {displayName: "test"};
+    let createElement = (~a=?,~b=?,~children,()) => {displayName: "test"};
 };
 
 module One = {
-    let createElement(~test=?,~foo=?,~children,()) {displayName: "test"};
-    let createElementobvioustypo(~test,~children,()) {displayName: "test"};
+    let createElement = (~test=?,~foo=?,~children,()) => {displayName: "test"};
+    let createElementobvioustypo = (~test,~children,()) => {displayName: "test"};
 };
 
 module Two = {
-    let createElement(~foo=?,~children,()) {displayName: "test"};
+    let createElement = (~foo=?,~children,()) => {displayName: "test"};
 };
 
 module Sibling = {
-    let createElement(~foo=?,~children : list(component),()) = {displayName: "test"};
+    let createElement = (~foo=?,~children : list(component),()) => {displayName: "test"};
 };
 
 module Test = {
-    let createElement(~yo=?,~children,()) {displayName: "test"};
+    let createElement = (~yo=?,~children,()) => {displayName: "test"};
 };
 
 module So = {
-    let createElement(~children,()) {displayName: "test"};
+    let createElement = (~children,()) => {displayName: "test"};
 };
 
 module Foo2 = {
-    let createElement(~children,()) {displayName: "test"};
+    let createElement = (~children,()) => {displayName: "test"};
 };
 
 module Text = {
-    let createElement(~children,()) {displayName: "test"};
+    let createElement = (~children,()) => {displayName: "test"};
 };
 
 module Exp = {
-    let createElement(~children,()) {displayName: "test"};
+    let createElement = (~children,()) => {displayName: "test"};
 };
 
 module Pun = {
-    let createElement(~intended=?,~children,()) {displayName: "test"};
+    let createElement = (~intended=?,~children,()) => {displayName: "test"};
 };
 
 module Namespace = {
     module Foo = {
-        let createElement(~intended=?,~anotherOptional as x=100,~children,()) {displayName: "test"};
+        let createElement = (~intended=?,~anotherOptional as x=100,~children,()) => {displayName: "test"};
     };
 };
 
 module Optional1 = {
-    let createElement(~required,~children,()) {
+    let createElement = (~required,~children,()) => {
         switch (required) {
             | Some(a) => {displayName: a}
             | None => {displayName: "nope"}
@@ -69,7 +69,7 @@ module Optional1 = {
 };
 
 module Optional2 = {
-    let createElement(~optional=?,~children,()) {
+    let createElement = (~optional=?,~children,()) => {
         switch (optional) {
             | Some(a) => {displayName: a}
             | None => {displayName: "nope"}
@@ -78,7 +78,7 @@ module Optional2 = {
 };
 
 module DefaultArg = {
-    let createElement(~default=Some("foo"),~children,()) {
+    let createElement = (~default=Some("foo"),~children,()) => {
          switch (default) {
             | Some(a) => {displayName: a}
             | None => {displayName: "nope"}
@@ -88,41 +88,41 @@ module DefaultArg = {
 
 
 module LotsOfArguments = {
-    let createElement(~argument1=?,~argument2=?,~argument3=?,~argument4=?,~argument5=?,~argument6=?,~children,()) {displayName: "test"};
+    let createElement = (~argument1=?,~argument2=?,~argument3=?,~argument4=?,~argument5=?,~argument6=?,~children,()) => {displayName: "test"};
 };
 
-let div(~argument1=?,~children,()) {
+let div = (~argument1=?,~children,()) => {
     displayName: "test"
 };
 
 module List1 = {
-    let createElement(~children,()) {displayName: "test"};
+    let createElement = (~children,()) => {displayName: "test"};
 };
 
 module List2 = {
-    let createElement(~children,()) {displayName: "test"};
+    let createElement = (~children,()) => {displayName: "test"};
 };
 
 module List3 = {
-    let createElement(~children,()) {displayName: "test"};
+    let createElement = (~children,()) => {displayName: "test"};
 };
 
 module NotReallyJSX = {
-    let createElement(~foo,~bar,children) {displayName: "test"};
+    let createElement = (~foo,~bar,children) => {displayName: "test"};
 };
 
-let notReallyJSX(~foo,~bar,children) {
+let notReallyJSX = (~foo,~bar,children) => {
     displayName: "test"
 };
 
-let fakeRender (el:component) {
+let fakeRender  = (el:component) => {
     el.displayName
 };
 
 /* end of setup */
 
-let (/><)(a,b) = a + b;
-let (><)(a,b) = a + b;
+let (/><) = (a,b) => a + b;
+let (><) = (a,b) => a + b;
 let (/>) = fun(a,b) => a + b;
 let ( ><\/ ) = fun(a,b) => a + b;
 
@@ -170,7 +170,7 @@ let jsxInList5 = [ <Foo> </Foo>, <Foo> </Foo> ];
 let jsxInList6 = [ <Foo />, <Foo /> ];
 let jsxInList7 = [ <Foo> </Foo>, <Foo> </Foo>];
 let jsxInList8 = [ <Foo />, <Foo />];
-let testFunc(b) = b;
+let testFunc = (b) => b;
 let jsxInFnCall = testFunc (<Foo />);
 let lotsOfArguments = <LotsOfArguments argument1=1 argument2=2 argument3=3 argument4=4 argument5=5 argument6="test"> <Namespace.Foo /> </LotsOfArguments>;
 let lowerCase = <div argument1=1 />;
@@ -208,7 +208,7 @@ let listOfItems3 = <List3>fragment11 fragment11</List3>;
 /*
  * Several sequential simple jsx expressions must be separated with a space.
  */
-let thisIsRight(a,b) = ();
+let thisIsRight = (a,b) => ();
 let tagOne = fun(~children,()) => ();
 let tagTwo = fun(~children,()) => ();
 /* thisIsWrong <tagOne /><tagTwo />; */
@@ -276,17 +276,17 @@ type t('a) = [< thisType ] as 'a;
 let asd = [@JSX] [@foo] One.createElement(~test=true, ~foo=2, ~children=["a", "b"],());
 let asd2 = [@JSX] [@foo] One.createElementobvioustypo(~test=false, ~children=["a", "b"],());
 
-let span(~test : bool,~foo : int,~children,()) = 1;
+let span = (~test : bool,~foo : int,~children,()) => 1;
 let asd = [@JSX] [@foo] span(~test=true, ~foo=2, ~children=["a", "b"],());
 /* "video" call doesn't end with a list, so the expression isn't converted to JSX */
-let video(~test:  bool,children) = children;
+let video = (~test:  bool,children) => children;
 let asd2 = [@JSX] [@foo] video(~test=false,10);
 
 
-let div(~children) = 1;
+let div = (~children) => 1;
 ([@JSX] (((fun () => div) ())(~children=[])));
 
-let myFun () {
+let myFun  = () => {
   <>
         <Namespace.Foo intended=(true) anotherOptional=200 />
         <Namespace.Foo intended=(true) anotherOptional=200 />
@@ -303,12 +303,12 @@ let myFun () {
 
 };
 
-let myFun () {
+let myFun  = () => {
 <>
 </>;
 };
 
-let myFun () {
+let myFun  = () => {
   <>
         <Namespace.Foo intended=(true) anotherOptional=200 />
         <Namespace.Foo intended=(true) anotherOptional=200 />
@@ -378,7 +378,7 @@ module Metal = {
 };
 
 module OverEager = {
-  let createElement(~fiber,~children,()) {displayName: "test"};
+  let createElement = (~fiber,~children,()) => {displayName: "test"};
 };
 
 let element = <OverEager fiber=Metal.fiber />;
@@ -393,7 +393,7 @@ type style = {
 };
 
 module Window = {
-  let createElement(~style,~children,()) {displayName: "window"};
+  let createElement = (~style,~children,()) => {displayName: "window"};
 };
 
 let w =

--- a/formatTest/typeCheckedTests/input/knownReIssues.re
+++ b/formatTest/typeCheckedTests/input/knownReIssues.re
@@ -6,7 +6,7 @@
    The latter doesn't type-check with Error: Unbound value exc.
    Warning 11 (unused match case) is also triggered.
  */
-let f () = raise(Sys_error("error"));
+let f  = () => raise(Sys_error("error"));
 
 switch (f ()) {
 | x => ()
@@ -15,7 +15,7 @@ switch (f ()) {
 
 exception Foo(string);
 
-let g () = raise(Foo("bar errors"));
+let g  = () => raise(Foo("bar errors"));
 
 switch (g ()) {
 | x => ()

--- a/formatTest/typeCheckedTests/input/lazy.re
+++ b/formatTest/typeCheckedTests/input/lazy.re
@@ -6,7 +6,7 @@ let myComputation = lazy {
 
 type myRecord = {myRecordField: int};
 
-let operateOnLazyValue (lazy {myRecordField}) {
+let operateOnLazyValue = (lazy {myRecordField}) => {
    let tmp = myRecordField;
    tmp + tmp;
 };

--- a/formatTest/typeCheckedTests/input/oo.re
+++ b/formatTest/typeCheckedTests/input/oo.re
@@ -122,12 +122,12 @@ and secondRecursiveClass(init) {
 
 type closedObj = {.};
 
-let (<..>)(a,b) = a + b;
+let (<..>) = (a,b) => a + b;
 let five = 2 <..> 3;
 
 type nestedObj = {. bar : {. a: int}};
 
-let (>>)(a,b) = a > b;
+let (>>) = (a,b) => a > b;
 
 let bigger = 3 >> 2;
 
@@ -156,8 +156,8 @@ let coercedReturn = {
   (tmp :> {. x: int})
 };
 
-let acceptsOpenAnonObjAsArg (o: {.. x: int, y:int}) = o#x + o#y;
-let acceptsClosedAnonObjAsArg (o: {. x: int, y:int}) = o#x + o#y;
+let acceptsOpenAnonObjAsArg  = (o: {.. x: int, y:int}) => o#x + o#y;
+let acceptsClosedAnonObjAsArg  = (o: {. x: int, y:int}) => o#x + o#y;
 let res = acceptsOpenAnonObjAsArg {
   pub x = 0;
   pub y = 10;

--- a/formatTest/typeCheckedTests/input/patternMatching.re
+++ b/formatTest/typeCheckedTests/input/patternMatching.re
@@ -1,6 +1,6 @@
 type point = {x: int, y: int};
 
-let id(x) = x;
+let id = (x) => x;
 
 type myVariant =
   | TwoCombos(inner, inner)
@@ -10,7 +10,7 @@ and inner =
   | Unused
   | HeresTwoConstructorArguments(int, int);
 
-let computeTuple(a,b,c,d,e,f,g,h) = (
+let computeTuple = (a,b,c,d,e,f,g,h) => (
   a + b,
   c + d,
   e + f,

--- a/formatTest/typeCheckedTests/input/reasonComments.re
+++ b/formatTest/typeCheckedTests/input/reasonComments.re
@@ -94,11 +94,11 @@ let testingEndOfLineComments = [];/* Comment after entire let binding */
 /*   withFirstArg + andSecondArg /* before semi */ ; */
 /* }; */
 
-let myFunction
+let myFunction =
    (/* First arg */
     withFirstArg,
     /* Second Arg */
-    andSecondArg) {
+    andSecondArg) => {
   withFirstArg + andSecondArg
 }; /* After Semi */
 
@@ -331,7 +331,7 @@ type color =
   | Green(int) /* After green end of line */
 ; /* On next line after color type def */
 
-let blahCurriedX(x) =
+let blahCurriedX = (x) =>
   fun
   | Red(10)
   | Black(20)
@@ -341,17 +341,17 @@ let blahCurriedX(x) =
   | Green(x) => 0 /* After second green */
 ; /* On next line after blahCurriedX def */
 
-let name_equal(x,y) { x == y };
+let name_equal = (x,y) => { x == y };
 
-let equal(i1,i2) =
+let equal = (i1,i2) =>
   i1.contents === i2.contents && true; /* most unlikely first */
 
-let equal(i1,i2) =
+let equal = (i1,i2) =>
   compare(compare(0,0),compare(1,1)); /* END OF LINE HERE */
 
-let tuple_equal((i1, i2)) = i1 == i2;
+let tuple_equal = ((i1, i2)) => i1 == i2;
 
-let tuple_equal((csu, mgd)) =
+let tuple_equal = ((csu, mgd)) =>
   /* Some really long comments, see https://github.com/facebook/reason/issues/811 */
   tuple_equal((csu, mgd));
 

--- a/formatTest/unit_tests/expected_output/extensions.re
+++ b/formatTest/unit_tests/expected_output/extensions.re
@@ -8,60 +8,60 @@ module M = {};
 %extend
 module type M = {};
 
-let%extend x = "hi";
+let extend x = "hi";
 
 let x = {
-  let%extend x = ();
+  let extend x = ();
   ignore();
   %extend
   ignore();
-  let%extend x = ();
+  let extend x = ();
   %extend
   return("hi");
 };
 
 let x = {
-  if%extend (true) {1} else {2};
-  switch%extend (None) {
+  if extend (true) {1} else {2};
+  switch extend (None) {
   | Some(x) => assert false
   | None => ()
   };
-  try%extend (raise(Not_found)) {
+  try extend (raise(Not_found)) {
   | Not_found => ()
   | Invalid_argument(msg) => prerr_endline(msg)
   };
 };
 
-let x = if%extend (true) {1} else {2};
+let x = if extend (true) {1} else {2};
 
 let x =
-  switch%extend (None) {
+  switch extend (None) {
   | Some(x) => assert false
   | None => ()
   };
 
 let x =
-  try%extend (raise(Not_found)) {
+  try extend (raise(Not_found)) {
   | Not_found => ()
   | Invalid_argument(msg) => prerr_endline(msg)
   };
 
 /* At structure level */
-try%extend () {
+try extend () {
 | _ => ()
 };
 
-switch%extend () {
+switch extend () {
 | _ => ()
 };
 
-if%extend (true) {1} else {2};
+if extend (true) {1} else {2};
 
-for%extend (i in 1 to 10) {
+for extend (i in 1 to 10) {
   ();
 };
 
-while%extend (false) {
+while extend (false) {
   ();
 };
 
@@ -73,24 +73,24 @@ fun%extend
 
 /* In a top-level binding */
 let x =
-  try%extend () {
+  try extend () {
   | _ => ()
   };
 
 let x =
-  switch%extend () {
+  switch extend () {
   | _ => ()
   };
 
-let x = if%extend (true) {1} else {2};
+let x = if extend (true) {1} else {2};
 
 let x =
-  for%extend (i in 1 to 10) {
+  for extend (i in 1 to 10) {
     ();
   };
 
 let x =
-  while%extend (false) {
+  while extend (false) {
     ();
   };
 
@@ -103,29 +103,29 @@ let x =
 
 /* With two extensions, alone */
 let x = [%extend1
-  try%extend2 () {
+  try extend2 () {
   | _ => ()
   }
 ];
 
 let x = [%extend1
-  switch%extend2 () {
+  switch extend2 () {
   | _ => ()
   }
 ];
 
 let x = [%extend1
-  if%extend2 (true) {1} else {2}
+  if extend2 (true) {1} else {2}
 ];
 
 let x = [%extend1
-  for%extend2 (i in 1 to 10) {
+  for extend2 (i in 1 to 10) {
     ();
   }
 ];
 
 let x = [%extend1
-  while%extend2 (false) {
+  while extend2 (false) {
     ();
   }
 ];
@@ -141,7 +141,7 @@ let x = [%extend1
 /* With two extensions, first in sequence */
 let x = {
   %extend1
-  try%extend2 () {
+  try extend2 () {
   | _ => ()
   };
   ignore();
@@ -150,7 +150,7 @@ let x = {
 let x = {
   ignore();
   %extend1
-  switch%extend2 () {
+  switch extend2 () {
   | _ => ()
   };
   ignore();
@@ -159,14 +159,14 @@ let x = {
 let x = {
   ignore();
   %extend1
-  if%extend2 (true) {1} else {2};
+  if extend2 (true) {1} else {2};
   ignore();
 };
 
 let x = {
   ignore();
   %extend1
-  for%extend2 (i in 1 to 10) {
+  for extend2 (i in 1 to 10) {
     ();
   };
   ignore();
@@ -175,7 +175,7 @@ let x = {
 let x = {
   ignore();
   %extend1
-  while%extend2 (false) {
+  while extend2 (false) {
     ();
   };
   ignore();
@@ -200,7 +200,7 @@ let x = {
 let x = {
   ignore();
   %extend1
-  try%extend2 () {
+  try extend2 () {
   | _ => ()
   };
   ignore();
@@ -209,7 +209,7 @@ let x = {
 let x = {
   ignore();
   %extend1
-  switch%extend2 () {
+  switch extend2 () {
   | _ => ()
   };
   ignore();
@@ -218,14 +218,14 @@ let x = {
 let x = {
   ignore();
   %extend1
-  if%extend2 (true) {1} else {2};
+  if extend2 (true) {1} else {2};
   ignore();
 };
 
 let x = {
   ignore();
   %extend1
-  for%extend2 (i in 1 to 10) {
+  for extend2 (i in 1 to 10) {
     ();
   };
   ignore();
@@ -234,7 +234,7 @@ let x = {
 let x = {
   ignore();
   %extend1
-  while%extend2 (false) {
+  while extend2 (false) {
     ();
   };
   ignore();
@@ -260,7 +260,7 @@ let x = {
 let x = {
   ignore();
   %extend1
-  try%extend2 () {
+  try extend2 () {
   | _ => ()
   };
 };
@@ -268,7 +268,7 @@ let x = {
 let x = {
   ignore();
   %extend1
-  switch%extend2 () {
+  switch extend2 () {
   | _ => ()
   };
 };
@@ -276,13 +276,13 @@ let x = {
 let x = {
   ignore();
   %extend1
-  if%extend2 (true) {1} else {2};
+  if extend2 (true) {1} else {2};
 };
 
 let x = {
   ignore();
   %extend1
-  for%extend2 (i in 1 to 10) {
+  for extend2 (i in 1 to 10) {
     ();
   };
 };
@@ -290,7 +290,7 @@ let x = {
 let x = {
   ignore();
   %extend1
-  while%extend2 (false) {
+  while extend2 (false) {
     ();
   };
 };
@@ -305,6 +305,70 @@ let x = {
   ignore();
   %extend1
   fun%extend2
+  | None => ()
+  | Some(1) => ();
+};
+
+/* Complex attribute identifiers */
+let () = {
+  /* Uppercase */
+  try%Extend () {
+  | _ => ()
+  };
+  switch%Extend () {
+  | _ => ()
+  };
+  if%Extend (true) {1} else {2};
+  for%Extend (i in 1 to 10) {
+    ();
+  };
+  while%Extend (false) {
+    ();
+  };
+  fun%Extend () => ();
+  fun%Extend
+  | None => ()
+  | Some(1) => ();
+};
+
+let () = {
+  /* Path */
+  try%Extend.more () {
+  | _ => ()
+  };
+  switch%Extend.more () {
+  | _ => ()
+  };
+  if%Extend.more (true) {1} else {2};
+  for%Extend.more (i in 1 to 10) {
+    ();
+  };
+  while%Extend.more (false) {
+    ();
+  };
+  fun%Extend.more () => ();
+  fun%Extend.more
+  | None => ()
+  | Some(1) => ();
+};
+
+let () = {
+  /* Keyword */
+  try%rec () {
+  | _ => ()
+  };
+  switch%rec () {
+  | _ => ()
+  };
+  if%rec (true) {1} else {2};
+  for%rec (i in 1 to 10) {
+    ();
+  };
+  while%rec (false) {
+    ();
+  };
+  fun%rec () => ();
+  fun%rec
   | None => ()
   | Some(1) => ();
 };

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -709,7 +709,7 @@ type yourThing = myOtherThing(int, int);
 
    /* Currying */
    let lookES6Style = (`Red x) (`Black y) => { };
-   let lookES6Style (`Red x) (`Black y) => { };
+   let lookES6Style = (`Red x) (`Black y) => { };
 
    /* Matching the single argument */
    let lookES6Style = oneArg => match oneArg with

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -41,8 +41,8 @@ let simpleTupled: simpleTupleVariant =
   SimpleActuallyATuple(intTuple);
 
 /*Works! */
-let NotActuallyATuple(x, y) =
-  NotActuallyATuple(10, 20);
+let NotActuallyATuple =
+  (x, y) => NotActuallyATuple(10, 20);
 
 /* Doesn't work because we've correctly annotated parse tree nodes with explicit_arity! */
 /* let unfortunatelyThisStillWorks: simpleTupleVariant = SimpleActuallyATuple 10 10; */

--- a/formatTest/unit_tests/input/basicStructures.re
+++ b/formatTest/unit_tests/input/basicStructures.re
@@ -128,7 +128,7 @@ let logTapSuccess = fun(self) => if (self.ext.logSuccess) {
                             ();
                           };
 
-let logTapSuccess(self) = if (self.ext.logSuccess) {
+let logTapSuccess = (self) => if (self.ext.logSuccess) {
                             print_string("Did tap");
                             print_newline ();
                           };
@@ -139,7 +139,7 @@ let logTapSuccess(self) = if (self.ext.logSuccess) {
 ((!data).field1).field2 = true;
 (!(data.field1)).field2 = true;
 
-let loop(appTime,frameTime) = {
+let loop = (appTime,frameTime) => {
   if (hasSetup.contents) {
     setupScene ();
     renderIntoTop ();
@@ -276,7 +276,7 @@ let (letBindingWithTypeConstraint:int) = 10;
 let ((tupleItem:int), (withTypeConstraint:int)) = (10, 20);
 
 /* To make sure that tuple field annotations are annotating the entire field */
-let _dummyFunc(x) = 10;
+let _dummyFunc = (x) => 10;
 let annotatingFuncApplication = (_dummyFunc("a"):int, _dummyFunc("a"):int);
 
 /* Pretty printer might stick the [int] at the label. */
@@ -328,7 +328,7 @@ let rec size = fun(soFar,lst) => switch (lst) {
   | [hd, ...tl] => size(soFar + 1,tl)
 };
 
-let nestedMatch(lstLst) = switch (lstLst) {
+let nestedMatch = (lstLst) => switch (lstLst) {
   | [hd, ...tl] when false => 10
   | [hd, ...tl] => switch (tl) {
       | [] => 0 + 0
@@ -337,7 +337,7 @@ let nestedMatch(lstLst) = switch (lstLst) {
   | [] => 0
 };
 
-let nestedMatchWithWhen(lstLst) = switch (lstLst) {
+let nestedMatchWithWhen = (lstLst) => switch (lstLst) {
   | [hd, ...tl] when false => 10
   | [hd, ...tl] when true => switch (tl) {
       | [] when false => 0 + 0
@@ -452,14 +452,14 @@ let addValues = fun (a:int, b:int) => {
 
 let myFunction = fun (a : int, b : int) : int => a + b;
 
-let functionReturnValueType (i:int, s:string): (int) => int = fun(x) => x + 1;
+let functionReturnValueType = (i:int, s:string): ((int) => int) => fun(x) => x + 1;
 
-let curriedFormOne (i:int, s:string) = s ++ string_of_int(i);
+let curriedFormOne = (i:int, s:string) => s ++ string_of_int(i);
 
-let curriedFormTwo (i:int, x:int) :(int, int) = (i, x);
+let curriedFormTwo = (i:int, x:int) :(int, int) => (i, x);
 /* let nonCurriedFormTwo = fun (i:int, x:int) (:(int, int)) => (i, x); */
 
-let curriedFormThree (i:int, (a:int, b:int):(int, int)) :(int, int, int) = (i, a, b);
+let curriedFormThree = (i:int, (a:int, b:int):(int, int)) :(int, int, int) => (i, a, b);
 
 /* let nonCurriedFormThree = fun (i:int, (a:int, b:int):(int, int)) (:(int, int, int)) => (i, a, b);  */
 
@@ -474,7 +474,7 @@ type myFuncType = (int, int) => int;
 
 let myFunc: myFuncType = fun (a,b) => a + b;
 
-let funcWithTypeLocallyAbstractTypes (type atype, type btype, a, b, c: (atype, btype) => unit) = c(a,b);
+let funcWithTypeLocallyAbstractTypes = (type atype, type btype, a, b, c: (atype, btype) => unit) => c(a,b);
 
 /* Checks that function types aren't unnecessary wrapped */
 type a = ((unit => unit));
@@ -513,7 +513,7 @@ let anotherRecord = {
   age: testRecord.age + 10
 };
 
-let makeRecordBase () {name: "Joe", age: 30, occupation: "Engineer"};
+let makeRecordBase  = () => {name: "Joe", age: 30, occupation: "Engineer"};
 let anotherRecord = {
   /* These parens should be evaporated. */
   ...(makeRecordBase ()),

--- a/formatTest/unit_tests/input/extensions.re
+++ b/formatTest/unit_tests/input/extensions.re
@@ -1,4 +1,3 @@
-
 /* Extension sugar */
 
 %extend
@@ -288,4 +287,66 @@ let x = {
   fun%extend2
     | None => ()
     | Some(1) => ();
+};
+
+/* Complex attribute identifiers */
+
+let () = {
+  /* Uppercase */
+  try%Extend () { | _ => () };
+
+  switch%Extend () { | _ => () };
+
+  if%Extend (true) { 1 } else { 2 };
+
+  for%Extend (i in 1 to 10) { () };
+
+  while%Extend (false) { () };
+
+  fun%Extend () => ();
+
+  fun%Extend
+    | None => ()
+    | Some(1) => ();
+
+};
+
+let () = {
+  /* Path */
+  try%Extend.more () { | _ => () };
+
+  switch%Extend.more () { | _ => () };
+
+  if%Extend.more (true) { 1 } else { 2 };
+
+  for%Extend.more (i in 1 to 10) { () };
+
+  while%Extend.more (false) { () };
+
+  fun%Extend.more () => ();
+
+  fun%Extend.more
+    | None => ()
+    | Some(1) => ();
+
+};
+
+let () = {
+  /* Keyword */
+  try%rec () { | _ => () };
+
+  switch%rec () { | _ => () };
+
+  if%rec (true) { 1 } else { 2 };
+
+  for%rec (i in 1 to 10) { () };
+
+  while%rec (false) { () };
+
+  fun%rec () => ();
+
+  fun%rec
+    | None => ()
+    | Some(1) => ();
+
 };

--- a/formatTest/unit_tests/input/features403.re
+++ b/formatTest/unit_tests/input/features403.re
@@ -29,4 +29,4 @@ let rec eval: type a. (expr(a)) => a =
 type hlist =
   | [] : hlist;
 
-let foo (type a, type b) = 5;
+let foo = (type a, type b) => 5;

--- a/formatTest/unit_tests/input/fixme.re
+++ b/formatTest/unit_tests/input/fixme.re
@@ -1,7 +1,7 @@
 /**
  * Problem: In thise example, the comment should have a space after it.
  */
-let store_attributes(proc_attributes) {
+let store_attributes = (proc_attributes) => {
   let should_write =
     /* only overwrite defined procedures */proc_attributes.ProcAttributes.is_defined ||
       not (DB.file_exists(attributes_file));

--- a/formatTest/unit_tests/input/functionInfix.re
+++ b/formatTest/unit_tests/input/functionInfix.re
@@ -5,7 +5,7 @@ let all = ref(0);
 /*
  * >>= is left associative, and higher precedence than =>
  */
-let (>>=)(a,b) = b(a);
+let (>>=) = (a,b) => b(a);
 
 let fff = ();
 

--- a/formatTest/unit_tests/input/if.re
+++ b/formatTest/unit_tests/input/if.re
@@ -128,7 +128,7 @@ let ternaryResult =
   eeeeeee ? fffffff : (x ? y : z);
 
 
-let addOne(x) = x + 1;
+let addOne = (x) => x + 1;
 
 let result =
    addOne(0) + 0 > 1 ? print_string("this wont print") : print_string("this will");

--- a/formatTest/unit_tests/input/infix.re
+++ b/formatTest/unit_tests/input/infix.re
@@ -170,7 +170,7 @@ let leadingMinusIsCorrectlyNeg = (-1) + 20;
 let leadingMinusIsCorrectlyNeg = 3 > (-1);
 
 /* Custom infix without labeled args */
-let (|>)(first,second) = first + second;
+let (|>) = (first,second) => first + second;
 
 /* Should reformat to actually be placed infix */
 let res = first |> second;
@@ -179,7 +179,7 @@ let res = first |> second;
 let res = (|>)(first);
 
 /* Custom infix with labeled args */
-let (|>)(~first as first, ~second as second) = first + second;
+let (|>) = (~first as first, ~second as second) => first + second;
 
 /* Should NOT reformat named args to actually be placed infix */
 let res = (|>)(~first=first, ~second=second);
@@ -188,7 +188,7 @@ let res = (|>)(~first=first, ~second=second);
 let res = (|>)(~first=first);
 
 /* Custom infix accepting *three* without labeled args */
-let (|>)(firsfirst,second,third) = first + second + third;
+let (|>) = (firsfirst,second,third) => first + second + third;
 
 /* Should reformat to actually be placed infix if passed two args */
 let res = first |> second;
@@ -230,9 +230,9 @@ let res = blah && DataConstructor(10) && DataConstructor(10) + 10;
 /* Should be parsed as */
 let res = blah && DataConstructor(10) && DataConstructor(10) + 10;
 
-let (++)(~label as label,~label2 as label2) = label + label2;
+let (++) = (~label as label,~label2 as label2) => label + label2;
 
-let (++)(~label as label,~label2 as label2) = label + label2;
+let (++) = (~label as label,~label2 as label2) => label + label2;
 
 let (++) = (++);
 
@@ -244,9 +244,9 @@ let (++): int = int = (++);
 (++)(~label=20, ~label2=30) + 40;
 
 /* Great idea! */
-let (==)(a,b) = a < 0;
+let (==) = (a,b) => a < 0;
 
-let (==)(a,b) = a < 0;
+let (==) = (a,b) => a < 0;
 
 let (==) = (==);
 
@@ -315,21 +315,21 @@ let parensRequired = (ident +++ ident) ++ ident;
  * Every star or forward slash after the character of an infix operator must be
  * escaped.
  */
-let ( /\* )(a,b) = a + b;
+let ( /\* ) = (a,b) => a + b;
 
 let x = 12 /-\* 23 /-\* 12;
 
 let y = a /\* b;
 
-let ( !=\* )(q,r) = q + r;
+let ( !=\* ) = (q,r) => q + r;
 
 let res = q(( !=\* ),r);
 
-let ( !=\/\* )(q,r) = q + r;
+let ( !=\/\* ) = (q,r) => q + r;
 
 let res = q(( !=\/\* ),r);
 
-let ( ~\* )(a) = a + 1;
+let ( ~\* ) = (a) => a + 1;
 
 let res = ~\*10;
 
@@ -344,12 +344,12 @@ let res = f (- x);
 /**
  * Test using almost simple prefix as regular function.
  */
-let (!!)(a,b) = a + b;
+let (!!) = (a,b) => a + b;
 
 let res = (!!)(20,40);
 
 /* The semicolon should be attached to someType */
-let myFunc(aaaa,bbbb,cccc,dddd,aaaa,bbbb,cccc,dddd,aaaa) =
+let myFunc = (aaaa,bbbb,cccc,dddd,aaaa,bbbb,cccc,dddd,aaaa) =>
   [blah(aaaa,bbbb,cccc,dddd,aaaa,bbbb,cccc,dddd,aaaa), ...someType];
 
 /**
@@ -828,7 +828,7 @@ let code = JSCodegen.Code.(
 let code = JSCodegen.Code.(create |> render);
 
 let server = {
- let callback(_conn, req, body) = {
+ let callback = (_conn, req, body) => {
   let uri = req |> Request.uri |> Uri.to_string |> Code.string_of_uri |> Server.respond |> Request.uri;
   let meth = req |> Request.meth |> Code.string_of_method;
   let headers = req |> Request.headers |> Header.to_string;

--- a/formatTest/unit_tests/input/modules.re
+++ b/formatTest/unit_tests/input/modules.re
@@ -235,7 +235,7 @@ module CurriedNoSugar = fun (A:ASig) => fun (B:BSig) => {
   let result = A.a + B.b;
 };
 
-let letsTryThatSyntaxInLocalModuleBindings () {
+let letsTryThatSyntaxInLocalModuleBindings = () => {
   module CurriedSugarWithReturnType (A:ASig, B:BSig): SigResult = {
     let result = A.a + B.b;
   };
@@ -323,7 +323,7 @@ module rec A : {
   let compare: (t, t) => int;
 } = {
   type t = Leaf(string) | Node(ASet.t);
-  let compare(t1,t2) = switch (t1, t2) {
+  let compare = (t1,t2) => switch (t1, t2) {
     | (Leaf(s1), Leaf(s2)) => Pervasives.compare(s1, s2)
     | (Leaf(_), Node(_)) => 1
     | (Node(_), Leaf(_)) => -1
@@ -362,7 +362,7 @@ module Example2 (F:(Type)=>Type, X:Type) {
    *   let iso (a:(Compose Id F X).t): (F X).t => a;
    *
    */
-  let iso (a:Compose(Id,F,X).t): F(X).t = a;
+  let iso  = (a:Compose(Id,F,X).t): F(X).t => a;
 };
 
 Printf.printf("\nModules And Functors: %n\n", CurriedNoSugarFunctorResultInline.result);
@@ -386,7 +386,7 @@ Printf.printf("\nModules And Functors: %n\n", CurriedNoSugarFunctorResultInline.
 include YourLib.CreateComponent {
   type thing = blahblahblah;
   type state = unit;
-  let getInitialState(_)= ();
+  let getInitialState = (_) => ();
   let myValue = {
     recordField: "hello"
   };
@@ -401,9 +401,9 @@ let myFirstClass = (module MyModule : HasInt);
 
 let myFirstClassWillBeFormattedAs: (module HasInt) = (module MyModule);
 
-let acceptsAndUnpacksFirstClass ((module M : HasInt)) = M.x + M.x;
+let acceptsAndUnpacksFirstClass  = ((module M : HasInt)) => M.x + M.x;
 
-let acceptsAndUnpacksFirstClass ((module M) : (module HasInt)) = M.x + M.x;
+let acceptsAndUnpacksFirstClass  = ((module M) : (module HasInt)) => M.x + M.x;
 
 module SecondClass = (val myFirstClass);
 
@@ -466,6 +466,6 @@ module type T = (t with type t = a) => a;
 module X = [%test extension];
 module type T = [%test extension];
 
-let foo (type a, (module X): (module X_t with type t =a)) = X.a;
+let foo = (type a, (module X): (module X_t with type t =a)) => X.a;
 
 let f = ((module M): (module M with type x = x and type y = y)) => M.x;

--- a/formatTest/unit_tests/input/object.re
+++ b/formatTest/unit_tests/input/object.re
@@ -18,7 +18,7 @@ type t = {
 
 type t = {..};
 
-let (<..>)(a,b) = a + b;
+let (<..>) = (a,b) => a + b;
 let five = 2 <..> 3;
 
 type closedObjSugar = Js.t({. foo: bar, baz: int});

--- a/formatTest/unit_tests/input/polymorphism.re
+++ b/formatTest/unit_tests/input/polymorphism.re
@@ -27,10 +27,10 @@ type myType2 = (myTwoParamType(myType((int) => int), int)) => int;
 
                                      /* Confusing because => looks like part
                                      of the return type signature. */
-let myFunc (a:(int)=>int, b:(int)=>int) :myType(int) =
+let myFunc  = (a:(int)=>int, b:(int)=>int) :myType(int) =>
     [a(20) + b(30)];
 
-let myFunc (a:(int)=>int, b:(int)=>int) : ((myType(int)) => myType(int)) =
+let myFunc = (a:(int)=>int, b:(int)=>int) : ((myType(int)) => myType(int)) =>
     fun(lst) => lst;
 
 

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -12,7 +12,7 @@ TestUtils.printSection("General Syntax");
 /*   `Thingy x => (print_string "matched thingy x"); x */
 /*   | `Other x => (print_string "matched other x"); x;; */
 /*  */
-let matchingFunc(a) = switch (a) {
+let matchingFunc = (a) => switch (a) {
   | `Thingy x => {
     print_string("matched thingy x");
     let zz = 10;
@@ -199,10 +199,10 @@ let is
 pre-
 fix    /-function binding name---\
 |-\   / is coupled to prefix      \   */
-let desiredFormattingForWrappedSugar
+let desiredFormattingForWrappedSugar =
    (curriedArg,
     anotherArg,
-    lastArg) {
+    lastArg) => {
   nameBlah: 10
 };
 
@@ -211,10 +211,10 @@ let is
 pre-
 fix    /-function binding name---\
 |-\   / is coupled to prefix      \   */
-let desiredFormattingForWrappedSugarReturnOnNewLine
+let desiredFormattingForWrappedSugarReturnOnNewLine =
    (curriedArg,
     anotherArg,
-    lastArg)
+    lastArg) =>
 {
   nameBlah: 10
 };
@@ -239,12 +239,12 @@ let point3D:point3D = {
   z: 80,    /* Optional Comma */
 };
 
-let printPoint (p:point) {
+let printPoint = (p:point) => {
   print_int(p.x);
   print_int(p.y);
 };
 
-let addPoints (p1:point, p2:point) {
+let addPoints = (p1:point, p2:point) => {
   x: p1.x + p2.x,
   y: p1.y + p2.y
 };
@@ -285,7 +285,7 @@ let o: (person) = {name: "bob", age: 10};
 /* Parens needed? Nope! */
 let o: person = {name: "bob", age: 10};
 
-let printPerson (p: person) {
+let printPerson = (p: person) => {
   let q: person = p;
   p.name ++ p.name;
 };
@@ -294,15 +294,15 @@ let printPerson (p: person) {
 
 /* With this unification, anywhere eyou see `= fun` you can just ommit it */
 let blah = fun(a) => a;         /* Done */
-let blah (a) = a;               /* Done (almost) */
+let blah = (a) => a;               /* Done (almost) */
 
 let blah = fun(a,b) => a;       /* Done */
-let blah (a, b) = a;             /* Done (almost) */
+let blah = (a, b) => a;             /* Done (almost) */
 
 /* More than one consecutive pattern must have a single case */
 type blah = {blahBlah: int};
 let blah = fun (a, {blahBlah}) => a;
-let blah (a, {blahBlah}) = a;
+let blah = (a, {blahBlah}) => a;
 
 module TryToExportTwice = {
   let myVal = "hello";
@@ -344,9 +344,9 @@ let onlyDoingThisTopLevelLetToBypassTopLevelSequence = {
 
 type hasA = {a:int};
 let a = 10;
-let returnsASequenceExpressionWithASingleIdentifier () {a};
-let thisReturnsA () {a;};
-let thisReturnsAAsWell () = a;
+let returnsASequenceExpressionWithASingleIdentifier = () => {a};
+let thisReturnsA = () => {a;};
+let thisReturnsAAsWell = () => a;
 
 let recordVal:int = thisReturnsARecord().a;
 Printf.printf("\nproof that thisReturnsARecord: %n\n", recordVal);
@@ -387,7 +387,7 @@ let blah = fun
 /*   | Green x => 0;                      /* Support that */ */
 /*  */
 
-let blahCurriedX(x) =
+let blahCurriedX = (x) =>
   fun
   | Red(x)
   | Black(x)
@@ -396,7 +396,7 @@ let blahCurriedX(x) =
   | Green(x) => 0; /* Support that */
 
 let sameThingInLocal = {
-  let blahCurriedX(x) =
+  let blahCurriedX = (x) =>
     fun
     | Red(x)
     | Black(x)
@@ -408,7 +408,7 @@ let sameThingInLocal = {
 };
 
 /* This should be parsed/printed exactly as the previous */
-let blahCurriedX(x) = fun
+let blahCurriedX = (x) => fun
   | Red(x) | Black(x) | Green(x) => 1
   | Black(x) => 0
   | Green(x) => 0;
@@ -465,7 +465,7 @@ let res = {
 /* let blah a patt => 0 | anotherPatt => 1; */
 
                 /*simple pattern  EQUALGREATER      expr */
-let blah (    a,      {blahBlah})        =             a;
+let blah = (    a,      {blahBlah})        =>             a;
 
                /*            match_case             */
                /*     pattern EQUALGREATER  expr */
@@ -475,7 +475,7 @@ let blah = fun   |Red(_)          =>      1   |Black(_)=> 0 |Green(_)=> 0;
 /* Won't work! */
 /* let arrowFunc = fun a b => print_string "returning aplusb from arrow"; a + b;;  */
 let arrowFunc = fun(a,b)=> {print_string("returning aplusb from arrow"); a + b;};
-let add(a,b) {
+let add = (a,b) => {
   let extra = {print_string("adding"); 0;};
   let anotherExtra = 0;
   extra + a + b + anotherExtra;
@@ -483,15 +483,15 @@ let add(a,b) {
 
 (print_string (string_of_int (add(4,34))));
 
-let dummy(_) = 10;
+let dummy = (_) => 10;
 dummy(res1);
 dummy(res2);
 dummy(res3);
 
 
 /* Some edge cases */
-let myFun (firstArg, Red(x) | Black(x) | Green(x)) = firstArg + x;
-let matchesWithWhen(a) = switch (a) {
+let myFun = (firstArg, Red(x) | Black(x) | Green(x)) => firstArg + x;
+let matchesWithWhen = (a) => switch (a) {
   | Red(x) when 1 > 0 => 10
   | Red(_) => 10
   | Black(x) => 10
@@ -505,7 +505,7 @@ let matchesWithWhen = fun
   | Green(x) => 10;
 
 
-let matchesOne (`Red x) = 10;
+let matchesOne = (`Red x) => 10;
 
 
 /*
@@ -543,7 +543,7 @@ let tupleInsideALetSequence = {
 
 /* We *require* that function return types be wrapped in
   parenthesis. In this example, there's no ambiguity */
-let makeIncrementer (delta:int) : (int)=>int = (a) => a + delta;
+let makeIncrementer = (delta:int) : ((int)=>int) => (a) => a + delta;
 
 /* We could even force that consistency with let bindings - it's allowed
    currently but not forced.
@@ -564,13 +564,13 @@ class classWithNoArg {
   end;
 */
 
-let myFunc (a:int, b:int) : (int, int) = (a, b);
-let myFunc (a:int, b:int) : list(int) = [1];
-let myFunc (a:int, b:int) : point {
+let myFunc = (a:int, b:int) : (int, int) => (a, b);
+let myFunc = (a:int, b:int) : list(int) => [1];
+let myFunc = (a:int, b:int) : point => {
   x: a,
   y: b
 };
-let myFunc (a:int, b:int) : point {
+let myFunc = (a:int, b:int) : point => {
   x: a,
   y: b
 };
@@ -604,7 +604,7 @@ in an extra [], but it doesn't hurt */
 
   /* Currying */
   let lookES6Style = (`Red x) (`Black y) => { };
-  let lookES6Style (`Red x) (`Black y) => { };
+  let lookES6Style = (`Red x) (`Black y) => { };
 
   /* Matching the single argument */
   let lookES6Style = oneArg => match oneArg with
@@ -661,34 +661,34 @@ let a = 10;
 let b = 20;
 
 /*A*/
-let named                (~a as a,   ~b as b)   = a + b;
+let named                = (~a as a,   ~b as b)   => a + b;
 type named =             (~a: int, ~b: int) => int;
 /*B*/
-let namedAlias           (~a as aa,  ~b as bb)  = aa + bb;
-let namedAlias           (~a as aa,  ~b as bb)  = aa + bb;
+let namedAlias           = (~a as aa,  ~b as bb)  => aa + bb;
+let namedAlias           = (~a as aa,  ~b as bb)  => aa + bb;
 type namedAlias =        (~a: int, ~b: int) => int;
 /*C*/
-let namedAnnot           (~a :int, ~b :int)  = 20;
+let namedAnnot           = (~a :int, ~b :int)  => 20;
 /*D*/
-let namedAliasAnnot      (~a as aa:int,~b as bb:int) = 20;
+let namedAliasAnnot      = (~a as aa:int,~b as bb:int) => 20;
 /*E*/
-let myOptional           (~a=?,    ~b=?,      ()) = 10;
+let myOptional           = (~a=?,    ~b=?,      ()) => 10;
 type named =             (~a: int=?, ~b: int=?, unit) => int;
 /*F*/
-let optionalAlias        (~a as aa=?,  ~b as bb=?,  ()) = 10;
+let optionalAlias        = (~a as aa=?,  ~b as bb=?,  ()) => 10;
 /*G*/                       
-let optionalAnnot        (~a as a:int =?, ~b as b:int=?, ()) = 10;
+let optionalAnnot        = (~a as a:int =?, ~b as b:int=?, ()) => 10;
 /*H*/                       
-let optionalAliasAnnot   (~a as aa:int =?, ~b as bb:int=?, ()) = 10;
+let optionalAliasAnnot   = (~a as aa:int =?, ~b as bb:int=?, ()) => 10;
 /*I: */                     
-let defOptional          (~a as a=10, ~b as b=10, ()) = 10;
+let defOptional          = (~a as a=10, ~b as b=10, ()) => 10;
 type named =             (~a: int=?, ~b: int=?, unit) => int;
 /*J*/                       
-let defOptionalAlias     (~a as aa=10, ~b as bb=10, ()) = 10;
+let defOptionalAlias     = (~a as aa=10, ~b as bb=10, ()) => 10;
 /*K*/                       
-let defOptionalAnnot     (~a as a:int=10, ~b as b:int=10, ()) = 10;
+let defOptionalAnnot     = (~a as a:int=10, ~b as b:int=10, ()) => 10;
 /*L*/                       
-let defOptionalAliasAnnot(~a as aa:int=10, ~b as bb:int=10, ()) = 10;
+let defOptionalAliasAnnot = (~a as aa:int=10, ~b as bb:int=10, ()) => 10;
 
 /*M: Invoking them - Punned */
 let resNotAnnotated = named(~a=a,~b=b);
@@ -748,7 +748,7 @@ type typeWithNestedOptionalNamedArgs =
 type typeWithNestedOptionalNamedArgs =
     (~outerOne: list(string)=?, ~outerTwo: int=?) => int;
 
-let f(~tuple="long string to trigger line break") = ();
+let f = (~tuple="long string to trigger line break") => ();
 
 let x =
   callSomeFunction
@@ -862,7 +862,7 @@ let match = "match";
 
 let method = "method";
 
-let foo(x,~x as bar,~z,~foo as bar,~foo as z) {
+let foo = (x,~x as bar,~z,~foo as bar,~foo as z) => {
   bar + 2
 };
 

--- a/formatTest/unit_tests/input/testUtils.re
+++ b/formatTest/unit_tests/input/testUtils.re
@@ -1,9 +1,9 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
-let printSection(s) {
+let printSection = (s) => {
   print_string("\n");
   print_string(s);
   print_string("\n---------------------\n");
 };
 
-let printLn(s) = print_string(s ++ "\n");
+let printLn = (s) => print_string(s ++ "\n");

--- a/formatTest/unit_tests/input/variants.re
+++ b/formatTest/unit_tests/input/variants.re
@@ -77,8 +77,8 @@ type colorList = [<
 /* Destructured matching at function definition */
 let accessDeeply = (LocalModule.AccessedThroughModule) => 10;
 
-let accessDeeplyWithArg
-    (LocalModule.AccessedThroughModuleWith(x) | LocalModule.AccessedThroughModuleWithTwo(_,x)) = x;
+let accessDeeplyWithArg =
+    (LocalModule.AccessedThroughModuleWith(x) | LocalModule.AccessedThroughModuleWithTwo(_,x)) => x;
 
 /* Destructured matching *not* at function definition */
 let accessDeeply = (x) => switch (x) {

--- a/formatTest/unit_tests/input/variants.re
+++ b/formatTest/unit_tests/input/variants.re
@@ -20,7 +20,7 @@ let notTupled: notTupleVariant = NotActuallyATuple(10,10);
 
 /* Doesn't work because we've correctly annotated parse tree nodes with explicit_arity! */
 /* let notTupled: notTupleVariant = NotActuallyATuple (10, 10); */
-let funcOnNotActuallyATuple (NotActuallyATuple(x,y)) = x + y;
+let funcOnNotActuallyATuple  = (NotActuallyATuple(x,y)) => x + y;
 
 /* let funcOnNotActuallyATuple (NotActuallyATuple (x, y)) = x + y; */
 /* let notTupled: notTupleVariant = NotActuallyATuple intTuple; /*Doesn't work! */ */
@@ -31,7 +31,7 @@ let simpleTupled: simpleTupleVariant = SimpleActuallyATuple (10, 10);
 let simpleTupled: simpleTupleVariant = SimpleActuallyATuple (intTuple);
 
 /*Works! */
-let NotActuallyATuple(x,y) = NotActuallyATuple (10, 20);
+let NotActuallyATuple = (x,y) => NotActuallyATuple (10, 20);
 
 /* Doesn't work because we've correctly annotated parse tree nodes with explicit_arity! */
 /* let unfortunatelyThisStillWorks: simpleTupleVariant = SimpleActuallyATuple 10 10; */
@@ -43,13 +43,13 @@ let yesTupled: tupleVariant = ActuallyATuple (intTuple);
 
 type threeForms = | FormOne(int) | FormTwo(int) | FormThree;
 
-let doesntCareWhichForm(x) = switch (x) {
+let doesntCareWhichForm = (x) => switch (x) {
   | FormOne(q)
   | FormTwo(q) => 10
   | FormThree => 20
 };
 
-let doesntCareWhichFormAs(x) = switch (x) {
+let doesntCareWhichFormAs = (x) => switch (x) {
   | FormOne(q) as ppp
   | FormTwo(q) as ppp => 10
   | FormThree => 20
@@ -75,18 +75,18 @@ type colorList = [<
 1 + doesntCareWhichForm(FormThree);
 
 /* Destructured matching at function definition */
-let accessDeeply(LocalModule.AccessedThroughModule) = 10;
+let accessDeeply = (LocalModule.AccessedThroughModule) => 10;
 
 let accessDeeplyWithArg
     (LocalModule.AccessedThroughModuleWith(x) | LocalModule.AccessedThroughModuleWithTwo(_,x)) = x;
 
 /* Destructured matching *not* at function definition */
-let accessDeeply(x) = switch (x) {
+let accessDeeply = (x) => switch (x) {
   | LocalModule.AccessedThroughModule => 10
   | _ => 0
 };
 
-let accessDeeplyWithArg(x) = switch (x) {
+let accessDeeplyWithArg = (x) => switch (x) {
   | LocalModule.AccessedThroughModuleWith(x) => 10
   | _ => 0
 };
@@ -99,17 +99,17 @@ let accessDeeplyWithArg(x) = switch (x) {
  *
  *   let myFunc x = function | `Blah p as retVal -> retVal`
  */
-let accessDeeply(x) = switch (x) {
+let accessDeeply = (x) => switch (x) {
   | LocalModule.AccessedThroughModule as ppp => 1
 };
 
-let accessDeeplyWithArg(x) = switch (x) {
+let accessDeeplyWithArg = (x) => switch (x) {
   | LocalModule.AccessedThroughModuleWith (x as retVal) => retVal + 1
   | LocalModule.AccessedThroughModuleWithTwo((x as retVal1),(y as retVal2)) => retVal1 + retVal2 + 1
 };
 
 /* Just to show that by default `as` captures much less aggresively */
-let rec accessDeeplyWithArgRecursive(x,count) = switch (x) {
+let rec accessDeeplyWithArgRecursive = (x,count) => switch (x) {
   | LocalModule.AccessedThroughModuleWith(x) as entirePattern =>
       /* It captures the whole pattern */
       if (count > 0) {0;} else {accessDeeplyWithArgRecursive(entirePattern, count - 1);}
@@ -120,7 +120,7 @@ let rec accessDeeplyWithArgRecursive(x,count) = switch (x) {
 
 accessDeeplyWithArgRecursive (LocalModule.AccessedThroughModuleWith(10), 10);
 
-let run () {
+let run  = () => {
   TestUtils.printSection("Variants");
   Printf.printf("%d %d \n",x,y);
 };
@@ -129,18 +129,18 @@ type combination('a) = | HeresTwoConstructorArguments(int,int);
 
 /** But then how do we parse matches in function arguments? */
 /* We must require parenthesis around construction matching in function args only*/
-let howWouldWeMatchFunctionArgs (HeresTwoConstructorArguments(x,y)) = x + y;
+let howWouldWeMatchFunctionArgs  = (HeresTwoConstructorArguments(x,y)) => x + y;
 
 /* How would we annotate said arg? */
-let howWouldWeMatchFunctionArgs (HeresTwoConstructorArguments(x,y): combination('wat)) = x + y;
+let howWouldWeMatchFunctionArgs  = (HeresTwoConstructorArguments(x,y): combination('wat)) => x + y;
 
-let matchingTwoCurriedConstructorsInTuple(x) = switch (x) {
+let matchingTwoCurriedConstructorsInTuple = (x) => switch (x) {
   | (HeresTwoConstructorArguments(x,y), HeresTwoConstructorArguments(a,b)) => x + y + a + b
 };
 
 type twoCurriedConstructors = | TwoCombos (combination(int), combination(int));
 
-let matchingTwoCurriedConstructorInConstructor(x) = switch (x) {
+let matchingTwoCurriedConstructorInConstructor = (x) => switch (x) {
   | TwoCombos (HeresTwoConstructorArguments(x,y), HeresTwoConstructorArguments(a,b)) => a + b + x + y
 };
 
@@ -274,7 +274,7 @@ let res = switch (ylw, prp) {
   | (`Yellow (p, p2), `Yellow (y, y2)) => `Purple (y + p, 0)
 };
 
-let rec atLeastOneFlushableChildAndNoWipNoPending(composition,atPriority) = switch (composition) {
+let rec atLeastOneFlushableChildAndNoWipNoPending = (composition,atPriority) => switch (composition) {
   | [] => false
   | [hd, ...tl] =>
       switch (hd) {
@@ -304,36 +304,36 @@ let res = switch (prp) {
 /*
  * Testing explicit arity.
  */
-let rec map(f) =
+let rec map = (f) =>
   fun | Node(None,m) => Node(None, M.map(map(f),m))
       | Node(LongModule.Path.None,m) => Node(None, M.map(map(f),m))
       | Node(LongModule.Path.Some(v),m) => Node(Some(f(v)), M.map(map(f),m));
 
-let myFunc(x,y,None) = "asdf";
+let myFunc = (x,y,None) => "asdf";
 
-let rec map(f) =
+let rec map = (f) =>
   fun | Node(None,m) => Node(None, M.map(map(f),m))
       | Node(LongModule.Path.None,m) => LongModule.Path.Node(LongModule.Path.None, M.map(map(f),m))
       | Node(LongModule.Path.Some(v),m) =>
           LongModule.Path.Node(LongModule.Path.Some(f(v)), M.map(map(f),m));
 
-let myFunc(x,y,LongModule.Path.None) = "asdf";
+let myFunc = (x,y,LongModule.Path.None) => "asdf";
 
-let listPatternMembersNeedntBeSimple(x) = switch (x) {
+let listPatternMembersNeedntBeSimple = (x) => switch (x) {
   | [] => ()
   | [Blah(x,y), Foo(a,b), ...rest] => ()
   | [Blah(x,y), Bar(a,b), ...rest] => ()
   | _ => ()
 };
 
-let listTailPatternNeedntBeSimple(x) = switch (x) {
+let listTailPatternNeedntBeSimple = (x) => switch (x) {
   | [] => ()
   /* Although this would never typecheck! */
   | [Blah(x,y), Foo(a,b), ...Something(x)] => ()
   | _ => ()
 };
 
-let listPatternMayEvenIncludeAliases(x) = switch (x) {
+let listPatternMayEvenIncludeAliases = (x) => switch (x) {
   | [] => ()
   /* Although this would never typecheck! */
   | [Blah(x,y) as head, Foo(a,b) as head2, ...Something(x) as tail] => ()

--- a/formatTest/unit_tests/input/wrappingTest.re
+++ b/formatTest/unit_tests/input/wrappingTest.re
@@ -466,9 +466,9 @@ let justReturn = (x) => x;
 
 /* With default formatting settings: Two arguments are special cased in
    function application "justReturn hasABunch" */
-let acceptsTwoThings
+let acceptsTwoThings =
     (nameAge:nameAge,
-     hasABunch:hasABunch) = justReturn(hasABunch);
+     hasABunch:hasABunch) => justReturn(hasABunch);
 
 /*
   Ideally, we'd allow "acceptsTwoThings {age, name}" on the first line, then
@@ -520,9 +520,9 @@ let onlyReturnWraps  = ((a, b, c, d, e, f)) => (
   f
 );
 
-let bothArgsWrapAndIndent
+let bothArgsWrapAndIndent =
    ((a, b, c, d, e, f),
-    (h, i, j, k, l, m)) = (
+    (h, i, j, k, l, m)) => (
   a,
   b,
   c,
@@ -1456,9 +1456,9 @@ let funcOnSomeConstructorHi  = (
   SomeConstructorHi(x,y)
 ) => x + y;
 
-let funcOnSomeConstructorHi
+let funcOnSomeConstructorHi =
     (SomeConstructorHi(x,y),
-     secondArg) = x + y;
+     secondArg) => x + y;
 
 /* With two args */
 let funcOnSomeRecord  = ({
@@ -1466,8 +1466,8 @@ let funcOnSomeRecord  = ({
   secondField
 }) => firstFieldInRecord + secondField;
 
-let funcOnSomeRecord
-    ({firstFieldInRecord, secondField}, secondArg) =
+let funcOnSomeRecord =
+    ({firstFieldInRecord, secondField}, secondArg) =>
    firstFieldInRecord + secondField;
 
 
@@ -1477,20 +1477,20 @@ let funcOnSomeRecord
   terms in the binding/argument pattern list (the name, followed by one
   pattern).
 */
-let funcOnSomeConstructorHi
-    (SomeConstructorHi(x,y)) = x + y;
+let funcOnSomeConstructorHi =
+    (SomeConstructorHi(x,y)) => x + y;
 
-let funcOnSomeRecord
-    ({firstFieldInRecord, secondField}) =
+let funcOnSomeRecord =
+    ({firstFieldInRecord, secondField}) =>
  firstFieldInRecord + secondField;
 
 /* With two args */
-let funcOnSomeConstructorHi
-    (SomeConstructorHi(x,y), secondArg) = 
+let funcOnSomeConstructorHi =
+    (SomeConstructorHi(x,y), secondArg) =>
   x + y;
 
-let funcOnSomeRecord
-    ({firstFieldInRecord, secondField}, secondArg) =
+let funcOnSomeRecord =
+    ({firstFieldInRecord, secondField}, secondArg) =>
   firstFieldInRecord + secondField;
 
 
@@ -1687,13 +1687,13 @@ let testRecordCommented = {
 /*
  * Test comments near the arguments.
  */
-let callMeWithComments
+let callMeWithComments =
     /* Comment before first arg "a" */
     (a:int,
     /* Comment before second arg "b" */
      b:int)
     /* Comment before return type annotation "int" */
-    :int =
+    :int =>
   /* Comment above return value a + b + c */
   a + b + c;
 

--- a/formatTest/unit_tests/input/wrappingTest.re
+++ b/formatTest/unit_tests/input/wrappingTest.re
@@ -75,7 +75,7 @@ let testPrintingPrecedence =
     reallyLongIdent * (reallyLongIdent + andYetAnotherReallyLongIdent) +
     reallyLongIdent;
 
-let add(x,y) = x + y;
+let add = (x,y) => x + y;
 let testPrintingPrecedence =
   reallyLongIdent +
     /*
@@ -91,125 +91,125 @@ let testPrintingPrecedence =
 let a = 10;
 let b = 20;
 /*A*/
-let named
+let named =
     /* a::a */
    (~a as a,
     /* b::b */
-    ~b as b) =
+    ~b as b) =>
   /* a + b */
   a + b;
 
 /*B*/
-let namedAlias
+let namedAlias =
     /* a::aa */
    (~a as aa,
     /* b::bb */
-    ~b as bb) =
+    ~b as bb) =>
   /* aa + bb */
   aa + bb;
 
 /*C*/
-let namedAnnot
+let namedAnnot =
     /* ~a a: option(int) */
    (~a as a: option(int),
     /* ~b b: option(int) */
-    ~b as b: option(int)) =
+    ~b as b: option(int)) =>
   /* 20 */
   20;
 
 /*D*/
-let namedAliasAnnot
+let namedAliasAnnot =
     /* a::(aa: option int) */
    (~a as aa: option(int),
     /* b::(bb: option int) */
-    ~b as bb: option(int)) =
+    ~b as bb: option(int)) =>
   /* 20 */
   20;
 
 /*E*/
-let optional
+let optional =
     /* a::a=? */
    (~a as a=?,
     /* b::b=? */
     ~b as b=?,
     /* () */
-    ()) =
+    ()) =>
   /* 10 */
   10;
 
 /*F*/
-let optionalAlias
+let optionalAlias =
     /* a::aa */
    (~a as aa=?,
     /* ?b:bb */
     ~b as bb=?,
     /* () */
-    ()) =
+    ()) =>
   /* 10 */
   10;
 
 /*G*/
-let optionalAnnot
+let optionalAnnot =
     /* a::(a: option int)=? */
    (~a: option(int)=?,
     /* ?b:(b: option int) */
     ~b: option(int)=?,
     /* () */
-    ()) =
+    ()) =>
   /* 10 */
   10;
 
 /*H*/
-let optionalAliasAnnot
+let optionalAliasAnnot =
     /* a::(aa: option int)=? */
    (~a as aa: option(int)=?,
     /* b::(bb: option int)=? */
     ~b as bb: option(int)=?,
     /* () = */
-    ()) =
+    ()) =>
   /* 10 */
   10;
 /*I: This one is really annoying? Where's the visual label?*/
-let defOptional
+let defOptional =
     /* a::a=10 */
    (~a as a=10,
     /* b::b=10 */
     ~b as b=10,
     /* () = */
-    ()) =
+    ()) =>
   /* 10 */
   10;
 
 /*J*/
-let defOptionalAlias
+let defOptionalAlias =
     /* a::aa=10 */
    (~a as aa=10,
     /* b::bb=10 */
     ~b as bb=10,
     /* () = */
-    ()) =
+    ()) =>
   /* 10; */
   10;
 
 /*K*/
-let defOptionalAnnot
+let defOptionalAnnot =
     /* a::(a:int)=10 */
    (~a :int=10,
     /* b::(b:int)=10 */
     ~b :int=10,
     /* () = */
-    ()) =
+    ()) =>
   /* 10; */
   10;
 
 /*L*/
-let defOptionalAliasAnnot
+let defOptionalAliasAnnot =
     /* a::(aa:int)=10 */
    (~a as aa :int=10,
     /* b::(bb:int)=10 */
     ~b as bb :int=10,
     /* () = */
-    ()) =
+    ()) =>
   /* 10; */
   10;
 
@@ -265,7 +265,7 @@ let explictlyPassed =
       None);
 
 
-let complex_default(~callback as callback=(fun(k,d) => 4),x) = 3;
+let complex_default = (~callback as callback=(fun(k,d) => 4),x) => 3;
 
 
 let myList = /*CommentAfterEqualBeforeList */[1, 2, 3];
@@ -339,7 +339,7 @@ let myList = [
 let myList = [1, 2, 3, /*CommentAfterConsBeforeAppendedTo */...myList];
 let myList = [3, 4, 5];
 
-let simpleListPattern(x) = switch (x) {
+let simpleListPattern = (x) => switch (x) {
 | [1, 2, 3] => 0
 | _ => 0
 };
@@ -423,21 +423,21 @@ let myFunctionsInARecordThatMustWrap = {
       reallyLongArgument + anotherReallyLongArgument,
 };
 
-let oneArgShouldWrapToAlignWith
-   (theFunctionNameBinding) = theFunctionNameBinding;
+let oneArgShouldWrapToAlignWith =
+   (theFunctionNameBinding) => theFunctionNameBinding;
 
-let twoArgsShouldWrapToAlignWith
+let twoArgsShouldWrapToAlignWith =
    (firstArgHere,
-    secondArgThere) = secondArgThere;
+    secondArgThere) => secondArgThere;
 
-let rec oneArgShouldWrapToAlignWith
-       (theFunctionNameBinding) = theFunctionNameBinding;
+let rec oneArgShouldWrapToAlignWith =
+       (theFunctionNameBinding) => theFunctionNameBinding;
 
-let rec twoArgsShouldWrapToAlignWith
+let rec twoArgsShouldWrapToAlignWith =
        (firstArgHere,
-        secondArgThere) = secondArgThere;
+        secondArgThere) => secondArgThere;
 
-let secondArgShouldWrap (pointLess, (
+let secondArgShouldWrap = (pointLess, (
   a,
   b,
   c,
@@ -446,7 +446,7 @@ let secondArgShouldWrap (pointLess, (
   f,
   g,
   h
-)) = (
+)) => (
   pointLess + a + b + c + d + e
 );
 
@@ -462,7 +462,7 @@ let result =
     reallyReallyLongVarName);
 
 
-let justReturn(x) = x;
+let justReturn = (x) => x;
 
 /* With default formatting settings: Two arguments are special cased in
    function application "justReturn hasABunch" */
@@ -487,12 +487,12 @@ let result =
     fieldFour: {age: 20, name: "joe"}
   };
 
-let howDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark(x,y,z) = x + y + z;
-let howDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark(x,y) = x + y;
-let reallyHowDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark(x,y,z) = x + y + z;
-let reallyHowDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark(x,y) = x + y;
+let howDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark = (x,y,z) => x + y + z;
+let howDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark = (x,y) => x + y;
+let reallyHowDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark = (x,y,z) => x + y + z;
+let reallyHowDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark = (x,y) => x + y;
 
-let reallyLongFunctionNameThatJustConcats(a) = String.concat("-",a);
+let reallyLongFunctionNameThatJustConcats = (a) => String.concat("-",a);
 
 let seeHowLongValuesWrap = {
   age: 30,
@@ -511,7 +511,7 @@ let seeHowLongValuesWrap = {
 /--Everything up to the arrow is label left--\  /-The return is label right-\
                           /-append => to last-\
 /-----------------------\ /--------------------\ */
-let onlyReturnWraps ((a, b, c, d, e, f)) = (
+let onlyReturnWraps  = ((a, b, c, d, e, f)) => (
   a,
   b,
   c,
@@ -548,7 +548,7 @@ let result =
 type sixteenTuple = (int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int);
 
 /* Nothing annotated */
-let echoTuple ((
+let echoTuple = ((
   a,
   b,
   c,
@@ -565,7 +565,7 @@ let echoTuple ((
   n,
   o,
   p
-)) = (
+)) => (
   a,
   b,
   c,
@@ -604,7 +604,7 @@ let echoTuple = fun((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p)) => (
   p
 );
 
-let echoTheEchoer (x: (sixteenTuple) => sixteenTuple) : (sixteenTuple) => sixteenTuple = x;
+let echoTheEchoer = (x: (sixteenTuple) => sixteenTuple) : ((sixteenTuple) => sixteenTuple) => x;
 
 /* Nothing annotated fun, passed to func */
 echoTheEchoer (fun((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p)) => (
@@ -628,7 +628,7 @@ echoTheEchoer (fun((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p)) => (
 
 
 /* Argument annotated */
-let echoTuple ((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p):sixteenTuple) = (
+let echoTuple = ((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p):sixteenTuple) => (
   a,
   b,
   c,
@@ -668,7 +668,7 @@ let echoTuple = fun ((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p):sixteenTup
 );
 
 /* Argument annotated, return type annotated */
-let echoTuple ((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p):sixteenTuple) :sixteenTuple = (
+let echoTuple = ((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p):sixteenTuple) :sixteenTuple => (
   a,
   b,
   c,
@@ -688,7 +688,7 @@ let echoTuple ((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p):sixteenTuple) :s
 );
 
 /* Desired formatting if first line fits within margin */
-let makeTuple(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p) = (
+let makeTuple = (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p) => (
   a,
   b,
   c,
@@ -1275,7 +1275,7 @@ let (the, type_, and_, value, should, both, wrap): (string, string, string, stri
 let myPolyFunc: 'a . ('a) => 'a = fun(o) => o;
 let myNonPolyFunc: ('a) => 'a = fun(o) => o;
 
-let locallyAbstractFunc (type a, input:a) = input;
+let locallyAbstractFunc  = (type a, input:a) => input;
 let locallyAbstractFuncNotSugared = fun (type a, input:a) => input;
 let locallyAbstractFuncAnnotated: type a. (a) => a = fun (type a, input:a) => input;
 
@@ -1298,10 +1298,10 @@ let myFunc =
 type inputEchoRecord('a) = {
   inputIs: 'a
 };
-let df_locallyAbstractFunc
+let df_locallyAbstractFunc =
     (type a,
      type b,
-     input:a) {
+     input:a) => {
   inputIs: input
 };   /* With setting ReturnValOnSameLine */
 
@@ -1413,8 +1413,8 @@ let (theTupleTypeAnnotationShouldWrap: (
 );
 
 
-let rec mutuallyRecursiveOne(x) = mutuallyRecursiveTwo (x + x)
-and mutuallyRecursiveTwo(y) = print_int(y);
+let rec mutuallyRecursiveOne = (x) => mutuallyRecursiveTwo (x + x)
+and mutuallyRecursiveTwo = (y) => print_int(y);
 
 /* The only downside to this is that now you can't redeclare a binding. */
 /* let newMutualRecursionSyntax x => newMutuallyRecursiveTwo (x + x); */
@@ -1452,19 +1452,19 @@ type someRecord = {firstFieldInRecord: int, secondField: int};
   terms in the binding/argument pattern list (the name, followed by one
   pattern).
 */
-let funcOnSomeConstructorHi (
+let funcOnSomeConstructorHi  = (
   SomeConstructorHi(x,y)
-) = x + y;
+) => x + y;
 
 let funcOnSomeConstructorHi
     (SomeConstructorHi(x,y),
      secondArg) = x + y;
 
 /* With two args */
-let funcOnSomeRecord ({
+let funcOnSomeRecord  = ({
   firstFieldInRecord,
   secondField
-}) = firstFieldInRecord + secondField;
+}) => firstFieldInRecord + secondField;
 
 let funcOnSomeRecord
     ({firstFieldInRecord, secondField}, secondArg) =
@@ -1497,10 +1497,10 @@ let funcOnSomeRecord
 type simpleTupleVariant =
   SimpleActuallyATuple((int, int));
 
-let returnTheSimpleTupleVariant(i) =
+let returnTheSimpleTupleVariant = (i) =>
   SimpleActuallyATuple (i, i);
 
-let shouldWrapLike(whenLongArg) = SimpleActuallyATuple (
+let shouldWrapLike = (whenLongArg) => SimpleActuallyATuple (
   whenLongArg,
   whenLongArg
 );
@@ -1584,7 +1584,7 @@ let blah = fun
   | Black(_) => 0
   | Green(_) => 1;
 
-let blahCurriedX(x) = fun
+let blahCurriedX = (x) => fun
   /* Comment before first bar */
   | /* Comment between first bar and OR pattern */
     (Red(x) | Black(x) | Green(x)) => 1
@@ -1604,21 +1604,21 @@ let howDoLongMultiBarPatternsWrap = fun(x) => switch (x) {
   | ReallyLongVariantName {someField, anotherField} => 0
 };
 
-let letsCombineTwoLongPatternsIntoOneCase(x) =
+let letsCombineTwoLongPatternsIntoOneCase = (x) =>
   switch (x) {
     | AnotherReallyLongVariantName(_,_,_)
     | AnotherReallyLongVariantName2(_,_,_) => 0
     | ReallyLongVariantName {someField, anotherField} => 0
   };
 
-let letsPutAWhereClauseOnTheFirstTwo(x) =
+let letsPutAWhereClauseOnTheFirstTwo = (x) =>
   switch (x) {
     | AnotherReallyLongVariantName(_,_,_)
     | AnotherReallyLongVariantName2(_,_,_) when true => 0
     | ReallyLongVariantName {someField, anotherField} => 0
   };
 
-let letsPutAWhereClauseOnTheLast(x) =
+let letsPutAWhereClauseOnTheLast = (x) =>
   switch (x) {
     | AnotherReallyLongVariantName(_,_,_)
     | AnotherReallyLongVariantName2(_,_,_) => 0
@@ -1783,13 +1783,13 @@ let /*beforePattern*/ /*beforePattern2 */ commentingBeforePatternSpecial : withT
   occupation: "programmer"
 };
 
-let produceRecord /*commentBeforeArg*/(x) {
+let produceRecord /*commentBeforeArg*/ = (x) => {
   name: "hello",
   age: 20,
   occupation: "programmer"
 };
 
-let produceRecord(x) /*commentAfterArg*/ {
+let produceRecord = (x) => /*commentAfterArg*/ {
   name: "hello",
   age: 20,
   occupation: "programmer"
@@ -1811,11 +1811,11 @@ let myNonPolyFuncCommentAfterArrow: ('a) => /*AfterArrow */'a = fun(o) => o;
 let myNonPolyFuncCommentBeforeEqual: ('a) => 'a /*BeforeEqual */= fun(o) => o;
 let myNonPolyFuncCommentAfterEqual: ('a) => 'a = /*AfterEqual */ fun(o) => o;
 
-let lATCurrySugarCommentBeforeType /*BeforeType */ (type a, input:a) = input;
-let lATCurrySugarCommentAfterType /*AfterType */ (type a, input:a) = input;
-let lATCurrySugarCommentBeforeArg (type a, /*BeforeArg */ input:a) = input;
-let lATCurrySugarCommentAfterArg (type a, input:a) /*AfterArg */ = input;
-let lATCurrySugarCommentAfterArrow (type a, input:a) = /*AfterArrow */ input;
+let lATCurrySugarCommentBeforeType /*BeforeType */  = (type a, input:a) => input;
+let lATCurrySugarCommentAfterType /*AfterType */  = (type a, input:a) => input;
+let lATCurrySugarCommentBeforeArg  = (type a, /*BeforeArg */ input:a) => input;
+let lATCurrySugarCommentAfterArg  = (type a, input:a) /*AfterArg */ => input;
+let lATCurrySugarCommentAfterArrow  = (type a, input:a) => /*AfterArrow */ input;
 
 let lATNotSugaredCommentBeforeEqual /*BeforeEqual*/ = fun (type a, input:a) => input;
 let lATNotSugaredCommentAfterEqual = /*AfterEqual*/fun (type a, input:a) => input;
@@ -1851,7 +1851,7 @@ let ternaryResult =
     trailingTest ? /* before nested ifTrue */ true : /* before nested ifFalse */ false;
 
 
-let returningATernary(x,y) = x > y ? "hi" : "by";
+let returningATernary = (x,y) => x > y ? "hi" : "by";
 
 
 /** Testing some special comment alignment features */
@@ -1934,17 +1934,17 @@ let onlyDoingThisTopLevelLetToBypassTopLevelSequence = {
 
 /* With this unification, anywhere eyou see `= fun` you can just ommit it */
 let blah = fun(a)=> a;         /* Done */
-let blah(a) = a;               /* Done (almost) */
+let blah = (a) => a;               /* Done (almost) */
 
 let blah = fun(a,b) => a;       /* Done */
-let blah(a,b) = a;             /* Done (almost) */
+let blah = (a,b) => a;             /* Done (almost) */
 
 let tryingTheSameInLocalScope = {
   let blah = fun(a) => a;         /* Done */
-  let blah(a) = a;               /* Done (almost) */
+  let blah = (a) => a;               /* Done (almost) */
 
   let blah = fun(a,b) => a;       /* Done */
-  let blah(a,b) = a;             /* Done (almost) */
+  let blah = (a,b) => a;             /* Done (almost) */
 };
 
 reallyLongFunctionNameWithArrayThatBreaks([|

--- a/miscTests/reactjs_jsx_ppx_tests/test1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test1.re
@@ -3,23 +3,23 @@
 /* test setup dummy modules. These are here to make the transform pass the type checker. Also helps validating our transforms thanks to types */
 
 module ReactDOMRe = {
-  let createElement (tag, ~props=?, children) = 1;
-  let props (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) = 1;
+  let createElement = (tag, ~props=?, children) => 1;
+  let props = (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) => 1;
 };
 module Foo = {
-  let make (~className=?, ~width=?, ~comp=?, ~bar=?, children) = 1;
-  let createElement (~className=?, ~ref=?, ~key=?, ~width=?, ~comp=?, ~bar=?, ~children, ()) = 1;
+  let make = (~className=?, ~width=?, ~comp=?, ~bar=?, children) => 1;
+  let createElement = (~className=?, ~ref=?, ~key=?, ~width=?, ~comp=?, ~bar=?, ~children, ()) => 1;
   module Bar = {
-    let make (~className=?, children) = 1;
-    let createElement (~className=?, ~ref=?, ~key=?, ~children, ()) = 1;
+    let make = (~className=?, children) => 1;
+    let createElement = (~className=?, ~ref=?, ~key=?, ~children, ()) => 1;
   };
 };
 module Bar = {
-  let make (~bar=?, children) = 1;
-  let createElement (~bar=?, ~children, ()) = 1;
+  let make = (~bar=?, children) => 1;
+  let createElement = (~bar=?, ~children, ()) => 1;
 };
 module ReasonReact = {
-  let element (~key=?, ~ref=?, component) = 1;
+  let element = (~key=?, ~ref=?, component) => 1;
 };
 
 let divRef = <div />;

--- a/miscTests/reactjs_jsx_ppx_tests/test2.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test2.re
@@ -4,23 +4,23 @@
 /* test setup dummy modules. These are here to make the transform pass the type checker. Also helps validating our transforms thanks to types */
 
 module ReactDOMRe = {
-  let createElement (tag, ~props=?, children) = 1;
-  let props (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) = 1;
+  let createElement = (tag, ~props=?, children) => 1;
+  let props = (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) => 1;
 };
 module Foo = {
-  let make (~className=?, ~width=?, ~comp=?, ~bar=?, children) = 1;
-  let createElement (~className=?, ~ref=?, ~key=?, ~width=?, ~comp=?, ~bar=?, ~children, ()) = 1;
+  let make = (~className=?, ~width=?, ~comp=?, ~bar=?, children) => 1;
+  let createElement = (~className=?, ~ref=?, ~key=?, ~width=?, ~comp=?, ~bar=?, ~children, ()) => 1;
   module Bar = {
-    let make (~className=?, children) = 1;
-    let createElement (~className=?, ~ref=?, ~key=?, ~children, ()) = 1;
+    let make = (~className=?, children) => 1;
+    let createElement = (~className=?, ~ref=?, ~key=?, ~children, ()) => 1;
   };
 };
 module Bar = {
-  let make (~bar=?, children) = 1;
-  let createElement (~bar=?, ~children, ()) = 1;
+  let make = (~bar=?, children) => 1;
+  let createElement = (~bar=?, ~children, ()) => 1;
 };
 module ReasonReact = {
-  let element (~key=?, ~ref=?, component) = 1;
+  let element = (~key=?, ~ref=?, component) => 1;
 };
 
 let divRef = <div />;

--- a/miscTests/reactjs_jsx_ppx_tests/test3.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test3.re
@@ -4,23 +4,23 @@
 /* test setup dummy modules. These are here to make the transform pass the type checker. Also helps validating our transforms thanks to types */
 
 module ReactDOMRe = {
-  let createElement (tag, ~props=?, children) = 1;
-  let props (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) = 1;
+  let createElement = (tag, ~props=?, children) => 1;
+  let props = (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) => 1;
 };
 module Foo = {
-  let make (~className=?, ~width=?, ~comp=?, ~bar=?, children) = 1;
-  let createElement (~className=?, ~ref=?, ~key=?, ~width=?, ~comp=?, ~bar=?, ~children, ()) = 1;
+  let make = (~className=?, ~width=?, ~comp=?, ~bar=?, children) => 1;
+  let createElement = (~className=?, ~ref=?, ~key=?, ~width=?, ~comp=?, ~bar=?, ~children, ()) => 1;
   module Bar = {
-    let make (~className=?, children) = 1;
-    let createElement (~className=?, ~ref=?, ~key=?, ~children, ()) = 1;
+    let make = (~className=?, children) => 1;
+    let createElement = (~className=?, ~ref=?, ~key=?, ~children, ()) => 1;
   };
 };
 module Bar = {
-  let make (~bar=?, children) = 1;
-  let createElement (~bar=?, ~children, ()) = 1;
+  let make = (~bar=?, children) => 1;
+  let createElement = (~bar=?, ~children, ()) => 1;
 };
 module ReasonReact = {
-  let element (~key=?, ~ref=?, component) = 1;
+  let element = (~key=?, ~ref=?, component) => 1;
 };
 
 let divRef = <div />;

--- a/src/reason-parser/reason_lexer.mll
+++ b/src/reason-parser/reason_lexer.mll
@@ -153,6 +153,8 @@ let keyword_table =
     "asr", INFIXOP4("asr")
 ]
 
+let is_keyword str = Hashtbl.mem keyword_table str
+
 (* To buffer string literals *)
 
 let string_buffer = Buffer.create 256

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -1493,7 +1493,7 @@ structure_item:
        to the "_" (any) pattern.  */
     ( item_attributes unattributed_expr
       { mkstrexp $2 $1 }
-    | item_extension_sugar structure_item
+    | item_extension_sweet structure_item
       { struct_item_extension $1 $2 }
     | item_attributes
       EXTERNAL as_loc(val_ident) COLON only_core_type(core_type) EQUAL primitive_declaration
@@ -1535,7 +1535,7 @@ structure_item:
         mkstr(Pstr_include (Incl.mk $3 ~attrs:$1 ~loc))
       }
     | item_attributes item_extension
-      (* No sense in having item_extension_sugar for something that's already an
+      (* No sense in having item_extension_sweet for something that's already an
        * item_extension *)
       { mkstr(Pstr_extension ($2, $1)) }
     | let_bindings
@@ -2216,7 +2216,7 @@ class_type_declaration_details:
  *
  * For each valid sequence item, we must list three forms:
  *
- *   [item_extension_sugar] [nonempty_item_attributes] ITEM
+ *   [item_extension_sweet] [nonempty_item_attributes] ITEM
  *   [nonempty_item_attributes] ITEM
  *   ITEM
  */
@@ -2271,11 +2271,11 @@ seq_expr:
 mark_position_exp
   ( seq_expr_no_seq
     { $1 }
-  | item_extension_sugar mark_position_exp(seq_expr_no_seq)
+  | item_extension_sweet mark_position_exp(seq_expr_no_seq)
     { expression_extension $1 $2 }
   | expr SEMI seq_expr
     { mkexp (Pexp_sequence($1, $3)) }
-  | item_extension_sugar expr SEMI seq_expr
+  | item_extension_sweet expr SEMI seq_expr
     { mkexp (Pexp_sequence(expression_extension $1 $2, $4)) }
   ) { $1 }
 ;
@@ -2514,8 +2514,8 @@ jsx_without_leading_less:
 ;
 
 optional_expr_extension:
-  | (* empty *) { fun exp -> exp }
-  | item_extension_sugar { fun exp -> expression_extension $1 exp  }
+  | (* empty *)  { fun exp -> exp }
+  | item_extension_sweeter { fun exp -> expression_extension $1 exp  }
 ;
 
 /*
@@ -2923,7 +2923,7 @@ let_bindings: let_binding and_let_binding* { addlbs $1 $2 };
 
 let_binding:
   /* Form with item extension sugar */
-  item_attributes LET item_extension_sugar? rec_flag let_binding_body
+  item_attributes LET ioption(item_extension_sweeter) rec_flag let_binding_body
   { let loc = mklocation $symbolstartpos $endpos in
     mklbs $3 $4 (mklb $5 $1 loc) loc }
 ;
@@ -4164,7 +4164,7 @@ opt_LET_MODULE: MODULE { () } | LET MODULE { () };
 
 %inline label: LIDENT { $1 };
 
-rec_flag:
+%inline rec_flag:
   | /* empty */   { Nonrecursive }
   | REC           { Recursive }
 ;
@@ -4288,8 +4288,13 @@ attribute:
   | located_attributes { List.map (fun x -> x.txt) $1 }
 ;
 
-item_extension_sugar:
+item_extension_sweet:
   PERCENT attr_id { ([], $2) }
+;
+
+%inline item_extension_sweeter:
+  | item_extension_sweet { $1 }
+  | as_loc(LIDENT)       { ([], $1) }
 ;
 
 extension:

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -2932,8 +2932,6 @@ let_binding_body:
   | with_patvar(val_ident) type_constraint EQUAL expr
     { let loc = mklocation $symbolstartpos $endpos in
       ($1, ghexp_constraint loc $4 $2) }
-  | with_patvar(val_ident) fun_def(EQUAL,core_type)
-    { ($1, $2) }
   | with_patvar(val_ident) COLON preceded(QUOTE,ident)+ DOT only_core_type(core_type)
       EQUAL mark_position_exp(expr)
     { let typ = mktyp ~ghost:true (Ptyp_poly($3, $5)) in

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -264,9 +264,30 @@ let expression_not_immediate_extension_sugar x =
   | (Some _, _) -> None
   | (None, _) -> expression_extension_sugar x
 
-let add_extension_sugar keyword = function
+let add_sweet_extension keyword = function
   | None -> keyword
   | Some str -> keyword ^ "%" ^ str.txt
+
+let is_lident str =
+  let len = String.length str in
+  not (Reason_lexer.is_keyword str) && len > 0 &&
+  ((str.[0] >= 'a' && str.[0] <= 'z') || str.[0] = '_') && (
+    try
+      for i = 1 to len - 1 do
+        let c = str.[i] in
+        if not ((c >= 'a' && c <= 'z') ||
+                (c >= 'A' && c <= 'Z') ||
+                (c >= '0' && c <= '9') ||
+                (c = '\'') || (c = '_'))
+        then raise Exit
+      done;
+      true
+    with Exit -> false
+  )
+
+let add_sweeter_extension keyword = function
+  | Some str when is_lident str.txt -> keyword ^ " " ^ str.txt
+  | ext -> add_sweet_extension keyword ext
 
 let print_comment_type = function
   | Regular -> "Regular"
@@ -4668,7 +4689,7 @@ class printer  ()= object(self:'self)
       | [] -> raise (NotPossible "no bindings supplied")
       | x :: xs -> x, xs
     in
-    let label = add_extension_sugar "let" extension in
+    let label = add_sweeter_extension "let" extension in
     let label = match rf with
       | Nonrecursive -> label
       | Recursive -> label ^ " rec"
@@ -4895,7 +4916,7 @@ class printer  ()= object(self:'self)
       ~break:IfNeed
       ~inline:(true, true)
       ~pad:(false, false)
-      ((atom ~loc:estimatedFunLocation (add_extension_sugar "fun" extension)) :: (self#case_list l))
+      ((atom ~loc:estimatedFunLocation (add_sweet_extension "fun" extension)) :: (self#case_list l))
 
   method parenthesized_expr ?break expr =
     let result = self#unparseExpr expr in
@@ -4949,7 +4970,7 @@ class printer  ()= object(self:'self)
                 let retValUnparsed = self#unparseExprApplicationItems ret in
                 Some (self#wrapCurriedFunctionBinding
                         ~sweet:(extension = None)
-                        (add_extension_sugar "fun" extension)
+                        (add_sweet_extension "fun" extension)
                         ~arrow:"=>" firstArg tl retValUnparsed)
             )
           | Pexp_try (e, l) ->
@@ -4961,7 +4982,7 @@ class printer  ()= object(self:'self)
             in
             let cases = (self#case_list ~allowUnguardedSequenceBodies:true l) in
             let switchWith = label ~space:true
-                (atom (add_extension_sugar "try" extension))
+                (atom (add_sweeter_extension "try" extension))
                 (self#parenthesized_expr ~break:IfNeed e)
             in
             Some (
@@ -4983,7 +5004,7 @@ class printer  ()= object(self:'self)
              in
              let cases = (self#case_list ~allowUnguardedSequenceBodies:true l) in
              let switchWith =
-               label ~space:true (atom (add_extension_sugar "switch" extension))
+               label ~space:true (atom (add_sweeter_extension "switch" extension))
                  (self#parenthesized_expr ~break:IfNeed e)
              in
              let lbl =
@@ -5038,7 +5059,7 @@ class printer  ()= object(self:'self)
                   sequence nextSoFar tl
             ) in
             let init =
-              let if_ = atom (add_extension_sugar "if" extension) in
+              let if_ = atom (add_sweeter_extension "if" extension) in
               let cond = self#parenthesized_expr e1 in
               label ~space:true
                 (SourceMap (e1.pexp_loc, (label ~space:true if_ cond)))
@@ -5047,7 +5068,7 @@ class printer  ()= object(self:'self)
             Some (sequence init blocks)
           | Pexp_while (e1, e2) ->
             let lbl =
-              let while_ = atom (add_extension_sugar "while" extension) in
+              let while_ = atom (add_sweeter_extension "while" extension) in
               let cond = self#parenthesized_expr e1 in
               label ~space:true
                 (label ~space:true while_ cond)
@@ -5075,7 +5096,7 @@ class printer  ()= object(self:'self)
                 ]
             in
             let upToBody = makeList ~inline:(true, true) ~postSpace:true
-                [atom (add_extension_sugar "for" extension); dockedToFor]
+                [atom (add_sweeter_extension "for" extension); dockedToFor]
             in
             Some (label ~space:true upToBody (makeLetSequence (self#letList e3)))
           | Pexp_new (li) ->


### PR DESCRIPTION
Allow extension sugar without having to put `%`:

```reason
let async f = ...
/* as well as */
switch async / try async / for async / if async / ...
```

The sugar applies for any lowercase identifier that is not a keyword.

The `let f() = ...` / `let f() { ... }` syntax had to be removed (functions are now always bound like any other expressions, `let f = () => ...`).