### PR TITLE
Make lexer not crash on `//`.

### DIFF
--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -127,6 +127,8 @@ let x = arr^[0] = 1;
  *============================================================================
  */;
 
+let (/\/) = (+); /* // is not a comment */
+
 let something =
   if (self.ext.logSuccess) {
     print_string("Did tap");

--- a/formatTest/unit_tests/input/basicStructures.re
+++ b/formatTest/unit_tests/input/basicStructures.re
@@ -115,6 +115,7 @@ let x = arr^[0] = 1;
  *============================================================================
  */;
 
+let (//) = (+); /* // is not a comment */
 
 let something = if (self.ext.logSuccess) {
                             print_string("Did tap");

--- a/src/reason-parser/reason_lexer.mll
+++ b/src/reason-parser/reason_lexer.mll
@@ -195,7 +195,7 @@ let set_lexeme_length buf n = (
 )
 
 (* This cut comment characters of the current buffer.
- * Operators (including "/*" and "//") are lexed with the same rule, and this
+ * Operators (including "/*" and "*/") are lexed with the same rule, and this
  * function cuts the lexeme at the beginning of an operator. *)
 let lexeme_without_comment buf = (
   let lexeme = Lexing.lexeme buf in
@@ -203,7 +203,7 @@ let lexeme_without_comment buf = (
   let found = ref (-1) in
   while !i < len && !found = -1 do
     begin match lexeme.[!i], lexeme.[!i+1] with
-      | ('/', '*') | ('/', '/') | ('*', '/') ->
+      | ('/', '*') | ('*', '/') ->
         found := !i;
       | _ -> ()
     end;


### PR DESCRIPTION
Currently the lexer crashes on `//`.
With this, it likely gives a syntax error if used as a comment.