### PR TITLE
class_instance_type call ordering.

### DIFF
--- a/formatTest/unit_tests/expected_output/class_types.re
+++ b/formatTest/unit_tests/expected_output/class_types.re
@@ -1,0 +1,7 @@
+class type _module ('provider_impl) = {};
+
+type t;
+
+class type bzz = {
+  inherit _module(t)
+};

--- a/formatTest/unit_tests/input/class_types.re
+++ b/formatTest/unit_tests/input/class_types.re
@@ -1,0 +1,7 @@
+class type _module ('provider_impl) = {
+  
+};
+type t;
+class type bzz = {
+  inherit _module(t)
+};

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -5787,9 +5787,8 @@ class printer  ()= object(self:'self)
         | [] -> self#longident_loc li
         | _::_ ->
           label
-            ~space:true
-            (makeList ~wrap:("(", ")") ~sep:"," (List.map self#core_type l))
             (self#longident_loc li)
+            (makeList ~wrap:("(", ")") ~sep:"," (List.map self#core_type l))
       )
     | Pcty_extension e ->
       self#attach_std_item_attrs x.pcty_attributes (self#extension e)


### PR DESCRIPTION
Pretty printer had the arguments before the class_instance_type identifier.
https://github.com/facebook/reason/blob/dbadff3312be4c1f26c3f8dadd2db37ff2f0b10a/src/reason-parser/reason_pprint_ast.ml#L5789

The parser had the arguments after the class_instance_type identifier
https://github.com/facebook/reason/blob/dbadff3312be4c1f26c3f8dadd2db37ff2f0b10a/src/reason-parser/reason_parser.mly#L2080

Fixes #1746