### PR TITLE
Update link in getting started section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple, fast & type safe code that leverages the JavaScript & OCaml ecosystems.
 
 [![Build Status](https://travis-ci.org/facebook/reason.svg?branch=master)](https://travis-ci.org/facebook/reason) [![CircleCI](https://circleci.com/gh/facebook/reason/tree/master.svg?style=svg)](https://circleci.com/gh/facebook/reason/tree/master)
 
-## [Getting Started](https://reasonml.github.io/guide/javascript/quickstart)
+## [Getting Started](https://reasonml.github.io/docs/en/quickstart-javascript.html)
 
 ## [Community](https://reasonml.github.io/community/)
 


### PR DESCRIPTION
The old link (https://reasonml.github.io/guide/javascript/quickstart/) seem to be deprecated, and asks for pointers to that site to be updated to the new one.