### PR TITLE
Break up into multiple packages

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -17,22 +17,17 @@
   "peerDependencies": {
     "ocaml": " >= 4.2.0  < 4.7.0"
   },
-  "HOW-TO-TEST-OCAML-4.04": [
-    "To test with OCaml 4.04:",
-    "1. Change the OCaml devDependency to: ~4.4.2 instead of ~4.2.3000",
-    "2. Rerun esy install",
-    "3. Rerun esy build"
-  ],
   "devDependencies": {
-    "@opam/merlin": "2.5.4",
-    "ocaml": "~4.2.3004"
+    "@opam/merlin": "*",
+    "ocaml": "~4.6.0"
   },
   "esy": {
     "build": [
-      [ "jbuilder", "build", "--root", "." ]
+      [ "jbuilder", "build", "-p", "rebuild,reason"]
     ],
     "install": [
-      ["esy-installer"]
+      ["esy-installer", "rebuild.install"],
+      ["esy-installer", "reason.install"]
     ],
     "buildsInSource": "_build"
   }

--- a/esy.lock
+++ b/esy.lock
@@ -55,16 +55,15 @@
     ocaml " >= 4.2.3"
 
 "@opam/camlp4@*":
-  version "4.2.0-7"
-  uid "526b13aa19ac9daa90d43fa628ad8544"
-  resolved "@opam/camlp4@4.2.0-7-526b13aa19ac9daa90d43fa628ad8544.tgz"
+  version "4.6.0-1"
+  uid ec9e71b1e73d101ab8ef9a66cc9035e7
+  resolved "@opam/camlp4@4.6.0-1-ec9e71b1e73d101ab8ef9a66cc9035e7.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
-    "@opam/conf-which" "*"
     "@opam/ocamlbuild" "*"
   peerDependencies:
-    ocaml " >= 4.2.0  < 4.3.0"
+    ocaml " >= 4.6.0  < 4.7.0"
 
 "@opam/camomile@ >= 0.8.0", "@opam/camomile@*":
   version "0.8.7"
@@ -204,17 +203,17 @@
   peerDependencies:
     ocaml " >= 4.2.3"
 
-"@opam/merlin@2.5.4":
-  version "2.5.4"
-  uid "63ed7b40952fbd1aeb288734cf2af222"
-  resolved "@opam/merlin@2.5.4-63ed7b40952fbd1aeb288734cf2af222.tgz"
+"@opam/merlin@*":
+  version "3.0.5"
+  uid "8ae0471d01a563b5552199bffb5b1da5"
+  resolved "@opam/merlin@3.0.5-8ae0471d01a563b5552199bffb5b1da5.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
     "@opam/ocamlfind" " >= 1.5.2"
     "@opam/yojson" "*"
   peerDependencies:
-    ocaml " >= 4.2.1  < 4.5.0"
+    ocaml " >= 4.2.1  < 4.7.0"
 
 "@opam/ocaml-migrate-parsetree@ >= 0.7.0", "@opam/ocaml-migrate-parsetree@*":
   version "1.0.7"
@@ -230,14 +229,14 @@
     ocaml " >= 4.2.0"
 
 "@opam/ocamlbuild@*":
-  version "0.11.0"
-  uid abecf9ccce04123ca6924849ce36399c
-  resolved "@opam/ocamlbuild@0.11.0-abecf9ccce04123ca6924849ce36399c.tgz"
+  version "0.12.0"
+  uid "4d2353d6f9d4e9f658ffea64707c152a"
+  resolved "@opam/ocamlbuild@0.12.0-4d2353d6f9d4e9f658ffea64707c152a.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
   peerDependencies:
-    ocaml "<4.3.0"
+    ocaml " >= 4.3.0"
 
 "@opam/ocamlfind@", "@opam/ocamlfind@ >= 1.5.0", "@opam/ocamlfind@ >= 1.5.2", "@opam/ocamlfind@ >= 1.5.3", "@opam/ocamlfind@ >= 1.6.1", "@opam/ocamlfind@ >= 1.7.2", "@opam/ocamlfind@*":
   version "1.7.3"
@@ -346,6 +345,6 @@
   peerDependencies:
     ocaml " >= 4.2.3"
 
-ocaml@~4.2.3004:
-  version "4.2.3004"
-  resolved "https://registry.yarnpkg.com/ocaml/-/ocaml-4.2.3004.tgz#4142d03d6c012949c2974c40db3a92edc7981db0"
+ocaml@~4.6.0:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/ocaml/-/ocaml-4.6.1.tgz#8babea2c41a9f734313b4fc1841ec0963c9d7a07"


### PR DESCRIPTION
Make 'rebuild' package testable w esy workflow

Now, rebuild is in its own opam package, and more of the internals of the reason repo are being broken into their own packages (rtop is next).
That means that to build them with `esy` (such that the tests succeed)  we need to tell each package to be built and installed.

This also restores the ability to depend on master branch of Reason from another esy project.