### PR TITLE
Add more source maps

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -268,8 +268,8 @@ let result =
  */
 let res =
   switch (
-    X
-      (2, 3) /* Retain this */
+    /* Retain this */
+    X(2, 3)
   ) {
   /* Above X line */
   | X(

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -252,62 +252,56 @@ let defOptionalAliasAnnot =
   10;
 
 /* Invoking them */
-named
+named(
   /* a::a */
-  (
-    ~a,
-    /* b::b; */
-    ~b
-  );
+  ~a,
+  /* b::b; */
+  ~b
+);
 
-named
+named(
   /* a::a */
-  (
-    ~a,
-    /* b::b; */
-    ~b
-  );
+  ~a,
+  /* b::b; */
+  ~b
+);
 
-optional
+optional(
   /* a::a */
-  (
-    ~a,
-    /* b::b; */
-    ~b
-  );
+  ~a,
+  /* b::b; */
+  ~b
+);
 
-optional
+optional(
   /* a::a */
-  (
-    ~a,
-    /* b::b; */
-    ~b
-  );
+  ~a,
+  /* b::b; */
+  ~b
+);
 
 let explictlyPassed =
   /* optional */
-  optional
+  optional(
     /* a::? */
     /* None */
-    (
-      ~a=?None,
-      /* b::? */
-      /* None; */
-      ~b=?None
-    );
+    ~a=?None,
+    /* b::? */
+    /* None; */
+    ~b=?None
+  );
 
 let a = None;
 
 let explictlyPassed =
   /* optional */
-  optional
+  optional(
     /* a::? */
-    (
-      ~a?,
-      /* b::? */
-      /* None; */
-      ~b=?None
-    );
+    ~a?,
+    /* b::? */
+    /* None; */
+    ~b=?None
+  );
 
 let complex_default = (~callback=(k, d) => 4, x) => 3;
 
@@ -2588,13 +2582,12 @@ let callMeWithComments =
 
 let result =
   /* Comment before function to invoke */
-  callMeWithComments
+  callMeWithComments(
     /* Comment before first argument expression */
-    (
-      1 + 2 + 3 + 3,
-      /* Comment before second argument expression */
-      1 + 2 + 3 + 3
-    );
+    1 + 2 + 3 + 3,
+    /* Comment before second argument expression */
+    1 + 2 + 3 + 3
+  );
 
 module type ASig = {let a: int;};
 

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4837,7 +4837,7 @@ class printer  ()= object(self:'self)
     let space, arguments = match arguments with
       | [x] when is_direct_pattern x -> (true, self#simple_pattern x)
       | xs when isSingleArgParenPattern xs -> (false, self#singleArgParenPattern xs)
-      | xs -> (false, makeTup (List.map self#pattern xs))
+      | xs -> (false, SourceMap(po.ppat_loc, makeTup (List.map self#pattern xs)))
     in
     let construction = label ~space ctor arguments in
     if implicit_arity && (not polyVariant) then
@@ -4863,14 +4863,14 @@ class printer  ()= object(self:'self)
    *  Also see `isSingleArgParenPattern` to determine if this kind of wrapping applies.
    *)
   method singleArgParenPattern = function
-    | [{ppat_desc = Ppat_record (l, closed)}] ->
-        self#patternRecord ~wrap:("(", ")") l closed
-    | [{ppat_desc = Ppat_array l}] ->
-        self#patternArray ~wrap:("(", ")") l
-    | [{ppat_desc = Ppat_tuple l}] ->
-        self#patternTuple ~wrap:("(", ")") l
-    | [{ppat_desc = Ppat_construct (({txt=Lident "::"}), po)} as listPattern]  ->
-        self#patternList ~wrap:("(", ")")  listPattern
+    | [{ppat_desc = Ppat_record (l, closed); ppat_loc}] ->
+        SourceMap (ppat_loc, self#patternRecord ~wrap:("(", ")") l closed)
+    | [{ppat_desc = Ppat_array l; ppat_loc}] ->
+        SourceMap (ppat_loc, self#patternArray ~wrap:("(", ")") l)
+    | [{ppat_desc = Ppat_tuple l; ppat_loc}] ->
+        SourceMap (ppat_loc, self#patternTuple ~wrap:("(", ")") l)
+    | [{ppat_desc = Ppat_construct (({txt=Lident "::"}), po); ppat_loc} as listPattern]  ->
+        SourceMap (ppat_loc, self#patternList ~wrap:("(", ")")  listPattern)
     | _ -> assert false
 
   method patternArray ?(wrap=("","")) l =


### PR DESCRIPTION
Summary: This is required in order to enable intelligent printing of trailing commas, but probably improves some other printings too. The SourceMap was just lost at some point on these AST structures.