### PR TITLE
Consider two adjacent comments at end of line to both be EOL comments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ See Reason license in [LICENSE.txt](LICENSE.txt).
 
 Works that are forked from other projects are under their original licenses.
 
+
 ## Credit
 
 The general structure of `refmt` repo was copied from [whitequark's m17n project](https://github.com/whitequark/ocaml-m17n), including parts of the `README` that instruct how to use this with the OPAM toolchain. Thank you OCaml!


### PR DESCRIPTION
For the sake of formatting logic, they should be treated the same.
This comes in handy when doing trailing commas as well as removing some over-abstractions from the printer. Diffs coming soon.