### PR TITLE
fix-1765: Fix idempotency of polymorphic variant inheritance.

### DIFF
--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -80,6 +80,12 @@ type colorList1 = [
   | `Black
 ];
 
+type colorList2 = [
+  | `Red
+  | `Black
+  | otherThingInheritedFrom
+];
+
 type colorList = [<
   | `Red(int, int) &(int)
   | `Black&(int, int) &(int)

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -86,6 +86,14 @@ type colorList2 = [
   | otherThingInheritedFrom
 ];
 
+type colorList3 = [
+  bar
+  | foo
+  | `Red
+  | `Black
+  | foo
+];
+
 type colorList = [<
   | `Red(int, int) &(int)
   | `Black&(int, int) &(int)

--- a/formatTest/unit_tests/input/variants.re
+++ b/formatTest/unit_tests/input/variants.re
@@ -61,6 +61,8 @@ type colorList1 = [
   | `Black
 ];
 
+type colorList2 = [ | `Red | `Black | otherThingInheritedFrom ];
+
 type colorList = [<
   | `Red (int, int) &(int)
   | `Black &(int, int) &(int)

--- a/formatTest/unit_tests/input/variants.re
+++ b/formatTest/unit_tests/input/variants.re
@@ -63,6 +63,8 @@ type colorList1 = [
 
 type colorList2 = [ | `Red | `Black | otherThingInheritedFrom ];
 
+type colorList3 = [ bar | foo | `Red  | `Black | foo ];
+
 type colorList = [<
   | `Red (int, int) &(int)
   | `Black &(int, int) &(int)

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3243,7 +3243,7 @@ class printer  ()= object(self:'self)
           let pcd_loc = x.ptyp_loc in
           let pcd_attributes = x.ptyp_attributes in
           let pcd_res = None in
-          let variant_helper rf =
+          let variant_helper i rf =
             match rf with
               | Rtag (label, attrs, opt_ampersand, ctl) ->
                 let pcd_name = {
@@ -3253,13 +3253,20 @@ class printer  ()= object(self:'self)
                 let pcd_args = Pcstr_tuple ctl in
                 let all_attrs = List.concat [pcd_attributes; attrs] in
                 self#type_variant_leaf ~opt_ampersand ~polymorphic:true {pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes = all_attrs}
-              | Rinherit ct -> self#core_type ct in
+              | Rinherit ct ->
+                (* '| type' is required if the Rinherit is not the first
+                  row_field in the list
+                 *)
+                if i = 0 then
+                  self#core_type ct
+                else
+                  makeList ~postSpace:true [atom "|"; self#core_type ct] in
           let (designator, tl) =
             match (closed,low) with
               | (Closed,None) -> ("", [])
               | (Closed,Some tl) -> ("<", tl)
               | (Open,_) -> (">", []) in
-          let node_list = List.map variant_helper l in
+          let node_list = List.mapi variant_helper l in
           let ll = (List.map (fun t -> atom ("`" ^ t)) tl) in
           let tag_list = makeList ~postSpace:true ~break:IfNeed ((atom ">")::ll) in
           let type_list = if List.length tl != 0 then node_list@[tag_list] else node_list in


### PR DESCRIPTION
Polymorphic variant inheritance is already tested using the expression:

```reason
type colorList1 = [  otherThingInheritedFrom  | `Red  | `Black ];
```

Issue #1765 is caused by polymorphic variant inheritance appearing at the end (or in the middle) of the list of variants.

```reason
type colorList2 = [ | `Red | `Black | otherThingInheritedFrom ];
```

There is a design decision to make here:
1. all parts of the variant list be prefixed with a `|`
2. all but the first past of the variant list be prefixed with a `|`
3. all parts of the variant list be prefixed with a `|` except if its the first variant and its an inheritance type.
4. a) in multi-line variant lists, all parts of the variant list should be prefixed and b) in single line variant lists, all but the first variant should be prefixed with a `|`.

This patch implements design 3.

I personally think that design 4 would be the most consistent (and seems to be the intention when looking at other examples in the testsuite), but is also most the complicated to implement as it is a similar problem to intelligent comma insertion.