### PR TITLE
Don't include semicolon in structure item loc. Makes it consistent wi…

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -40,7 +40,8 @@
  **
  */
 module JustString = {
-  include Map.Make(Int32); /* Comment eol include */
+  include
+    Map.Make(Int32); /* Comment eol include */
 };
 
 let testingEndOfLineComments = [
@@ -83,7 +84,8 @@ let testPlacementOfTrailingComment = [
   /* Comment after last item in list. */
 ]; /* Comment after semi */
 
-let testingEndOfLineComments = []; /* Comment after entire let binding */
+let testingEndOfLineComments =
+  []; /* Comment after entire let binding */
 
 /* The following is not yet idempotent */
 /* let myFunction */

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -1478,7 +1478,7 @@ structure:
     { let rec prepend = function
         | [] -> assert false
         | [x] ->
-           let effective_loc = mklocation x.pstr_loc.loc_start $endpos($2) in
+           let effective_loc = mklocation x.pstr_loc.loc_start $endpos($1) in
            let x = set_structure_item_location x effective_loc in
            x :: $3
         | x :: xs -> x :: prepend xs


### PR DESCRIPTION
Don't include semicolon in structure item loc. Makes it consistent with other separators like tuples.
