### PR TITLE
POC/WIP: Attempt at prettier printing of UTF-8 strings

### DIFF
--- a/src/reason-parser/jbuild
+++ b/src/reason-parser/jbuild
@@ -64,4 +64,5 @@
   (libraries
    (ocaml-migrate-parsetree
     menhirLib
-    reason.easy_format))))
+    reason.easy_format
+    uutf))))

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -2368,13 +2368,29 @@ let constant_string f s = pp f "%S" s
 
 let tyvar f str = pp f "'%s" str
 
+let pp_string_literal f s =
+  let buf = Buffer.create 4 in
+  Uutf.String.fold_utf_8 (
+    fun () _i uc ->
+      match uc with
+      | `Malformed s -> failwith (Format.asprintf "Invalid UTF-8 string literal: %s" s)
+      | `Uchar c ->
+        if Uchar.to_int c <= 255 then
+          pp f "%s" (Char.escaped (Uchar.to_char c))
+        else (
+          Uutf.Buffer.add_utf_8 buf c;
+          pp f "%s" (Buffer.contents buf);
+          Buffer.clear buf
+        )
+  ) () s
+
 (* In some places parens shouldn't be printed for readability:
  * e.g. Some((-1)) should be printed as Some(-1)
  * In `1 + (-1)` -1 should be wrapped in parens for readability
  *)
 let constant ?(parens=true) f = function
   | Pconst_char i -> pp f "%C"  i
-  | Pconst_string (i, None) -> pp f "%S" i
+  | Pconst_string (i, None) -> pp f "%a" pp_string_literal i
   | Pconst_string (i, Some delim) -> pp f "{%s|%s|%s}" delim i delim
   | Pconst_integer (i, None) ->
       paren (parens && i.[0] = '-') (fun f -> pp f "%s") f i

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -2390,7 +2390,7 @@ let pp_string_literal f s =
  *)
 let constant ?(parens=true) f = function
   | Pconst_char i -> pp f "%C"  i
-  | Pconst_string (i, None) -> pp f "%a" pp_string_literal i
+  | Pconst_string (i, None) -> pp f "\"%a\"" pp_string_literal i
   | Pconst_string (i, Some delim) -> pp f "{%s|%s|%s}" delim i delim
   | Pconst_integer (i, None) ->
       paren (parens && i.[0] = '-') (fun f -> pp f "%s") f i


### PR DESCRIPTION
Basic, simple-minded use of `Uutf` for slightly safer printing of string literals.

Guaranteed to have bugs in its current state.