### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/src/README.md
+++ b/src/README.md
@@ -2,6 +2,9 @@
 
 **See a list of easy tasks [here](https://github.com/facebook/reason/labels/GOOD%20FIRST%20TASK)**
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
 ## Contributor Setup
 
 Thanks for considering contributing to Reason! Here's the setup you need:

--- a/src/README.md
+++ b/src/README.md
@@ -3,7 +3,7 @@
 **See a list of easy tasks [here](https://github.com/facebook/reason/labels/GOOD%20FIRST%20TASK)**
 
 ## Code of Conduct
-The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md)
 
 ## Contributor Setup
 


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the Reason community profile](https://github.com/facebook/reason/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1315" alt="screen shot 2018-01-24 at 5 43 09 pm" src="https://user-images.githubusercontent.com/1114467/35366419-4864dd2a-012e-11e8-8b21-3d041a9cc4c3.png">
<img width="1315" alt="screen shot 2018-01-24 at 5 44 14 pm" src="https://user-images.githubusercontent.com/1114467/35366420-4883a336-012e-11e8-8a17-54656c80e595.png">

**issue:**
internal task t23481323