### PR TITLE
Outcome printer: remove function type single-arg parens

### DIFF
--- a/formatTest/testOprint.js
+++ b/formatTest/testOprint.js
@@ -65,9 +65,9 @@ const files = fs.readdirSync(base)
 const main = async () => {
   const inputFiles = files.filter(name => name.endsWith('.re'))
   const results = await Promise.all(inputFiles.map(async name => {
-    const full = path.join(base, name)
+    const fullPath = path.join(base, name)
 
-    const {result, error} = await outcomePrint(full)
+    const {result, error} = await outcomePrint(fullPath)
 
     if (error) {
       return `Printing failure ${name}:\n\n${error}`
@@ -76,7 +76,7 @@ const main = async () => {
     const {stdout, stderr, code} = await checkResult(result)
 
     if (code !== 0) {
-      let {stdout: refmtOut, stderr: refmtErr} = await refmtInterface(full)
+      let {stdout: refmtOut, stderr: refmtErr} = await refmtInterface(fullPath)
       return `Output printed for the signature of "${name}" not parseable:
 
 ## Refmt's error:

--- a/miscTests/rtopIntegrationTest.sh
+++ b/miscTests/rtopIntegrationTest.sh
@@ -16,11 +16,11 @@ export TERM=
 # Given the above, we're gonna test that utop integration works by piping code
 # into it and asserting the existence of some output.
 echo "Testing rtop..."
-echo "let f = (a) => a;" \
+echo "let f = a => a;" \
 | utop-full -init ./_build/install/default/bin/rtop_init.ml -I $HOME \
-| grep "let f: ('a) => 'a = <fun>" > /dev/null
+| grep "let f: 'a => 'a = <fun>" > /dev/null
 if [ $? -ne 0 ]; then
-  echo "rtop is failing! Failed to evaluate \`let f = (a) => a;\`"
+  echo "rtop is failing! Failed to evaluate \`let f = a => a;\`"
   exit 1
 fi
 

--- a/src/reason-parser/reason_oprint.ml
+++ b/src/reason-parser/reason_oprint.ml
@@ -302,10 +302,22 @@ and print_out_type_1 ppf =
         | _ -> (args, typ)
       in
       pp_open_box ppf 0;
-      pp_print_string ppf "(";
-      let (args, result) = collect_args [(lab, ty1)] ty2 in
-      print_list print_arg (fun ppf -> fprintf ppf ",@ ") ppf args;
-      pp_print_string ppf ")";
+      let (args, result) = collect_args [(lab, ty1)] ty2 in begin
+        match args with
+        (* single argument should not be wrapped... *)
+        | [(_, Otyp_tuple _) as arg] ->
+          (* ...unless it's for tuple. ((int, int)) => string *)
+          pp_print_string ppf "(";
+          print_arg ppf arg;
+          pp_print_string ppf ")"
+        | [("", typ) as arg] ->
+          (* see above. Though we only unwrap when there's no label *)
+          print_arg ppf arg
+        | args ->
+          pp_print_string ppf "(";
+          print_list print_arg (fun ppf -> fprintf ppf ",@ ") ppf args;
+          pp_print_string ppf ")"
+      end;
       pp_print_string ppf " =>";
       pp_print_space ppf ();
       print_out_type_1 ppf result;


### PR DESCRIPTION
`(int) => int` now becomes `int => int`.
Still doubly wraps for tuple. Wraps for labeled args too, etc.