### PR TITLE
Fix the format idempotency of open type declarations

### DIFF
--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -2279,6 +2279,8 @@ and mutuallyRecursiveTwo = y => print_int(y);
 /*  */
 type x = pri int;
 
+type y = x = ..;
+
 type myType('a, 'b, 'c) = pri ('a, 'b, 'c);
 
 type privateVariant =

--- a/formatTest/unit_tests/input/wrappingTest.re
+++ b/formatTest/unit_tests/input/wrappingTest.re
@@ -1424,7 +1424,7 @@ and mutuallyRecursiveTwo(y) = print_int(y);
 
 
 type x = pri int;
-
+type y = x = ..;
 type myType('a,'b,'c) = pri ('a, 'b, 'c);
 
 type privateVariant = pri

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3097,8 +3097,8 @@ class printer  ()= object(self:'self)
 
       (* EQUAL core_type EQUAL DOTDOT {(Ptype_open, Public, Some $2)} *)
       | (Ptype_open, Public, Some mani) -> [
-          [atom ".."];
           [self#core_type mani];
+          [atom ".."];
         ]
       (* EQUAL core_type EQUAL private_flag LBRACE label_declarations opt_comma RBRACE
            {(Ptype_record _, $4, Some $2)} *)


### PR DESCRIPTION
e.g.

```reason
  type a = b = ..;
```
was being formatted as
```reason
  type a = .. = b;
```