### PR TITLE
Nested uncurrying + paren hugging

### DIFF
--- a/formatTest/unit_tests/expected_output/uncurried.re
+++ b/formatTest/unit_tests/expected_output/uncurried.re
@@ -113,3 +113,24 @@ Thing.map(
 type f = int => (. int) => unit;
 
 type f = int => (. int) => unit;
+
+add(. 2);
+
+add(. 2);
+
+add(. 2, . 3);
+
+add(. 2, . 3);
+
+type timerId;
+
+[@bs.val]
+external setTimeout :
+  ((. unit) => unit, int) => timerId =
+  "setTimeout";
+
+let id =
+  setTimeout((.) => Js.log("hello"), 1000);
+
+let id =
+  setTimeout(1000, (.) => Js.log("hello"));

--- a/formatTest/unit_tests/expected_output/uncurried.re
+++ b/formatTest/unit_tests/expected_output/uncurried.re
@@ -10,6 +10,21 @@ f(. a, b, c);
 [@attr]
 f(. a, b, c);
 
+f(. a);
+
+f(. (1, 2));
+
+f(. (1, 2), (3, 4));
+
+f(. "string");
+
+f(. 1);
+
+f(. {
+  a: "supersupersupersupersupersuperlong",
+  b: "supersupersupersupersupersuperlong",
+});
+
 let f = (. a, b) => a + b;
 
 let f = [@attr] ((. a, b) => a + b);

--- a/formatTest/unit_tests/input/uncurried.re
+++ b/formatTest/unit_tests/input/uncurried.re
@@ -8,6 +8,18 @@ f(. a, b, c);
 
 [@attr] f(. a, b, c);
 
+f(. a);
+
+f(. (1, 2));
+
+f(. (1, 2), (3, 4));
+
+f(. "string");
+
+f(. 1);
+
+f(. {a: "supersupersupersupersupersuperlong", b: "supersupersupersupersupersuperlong"});
+
 let f = (. a, b) => a + b;
 
 let f = [@attr] (. a, b) => a + b;

--- a/formatTest/unit_tests/input/uncurried.re
+++ b/formatTest/unit_tests/input/uncurried.re
@@ -105,3 +105,19 @@ Thing.map(
 type f = int => (. int) => unit;
 
 type f = (int, . int) => unit;
+
+add(. 2);
+
+([@bs] add(. 2));
+
+add(. 2, . 3);
+
+([@bs] add(2, [@bs] 3));
+
+type timerId;
+
+[@bs.val] external setTimeout : ([@bs] (unit => unit), int) => timerId = "setTimeout";
+
+let id = setTimeout([@bs] (() => Js.log("hello")), 1000);
+
+let id = setTimeout(1000, [@bs] (() => Js.log("hello")));

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -6186,23 +6186,25 @@ let printer = object(self:'self)
    *  when the line length dictates breaking. Notice how `({` and `})` 'hug'.
    *  Also see "isSingleArgParenApplication" which determines if
    *  this kind of formatting should happen. *)
-  method singleArgParenApplication = function
+  method singleArgParenApplication ?(uncurried=false) es =
+    let lparen = if uncurried then "(. " else "(" in
+    match es with
     | [{pexp_attributes = []; pexp_desc = Pexp_record (l, eo)}] ->
-      self#unparseRecord ~wrap:("(", ")") l eo
+      self#unparseRecord ~wrap:(lparen, ")") l eo
     | [{pexp_attributes = []; pexp_desc = Pexp_tuple l}] ->
-      self#unparseSequence ~wrap:("(", ")") ~construct:`Tuple l
+      self#unparseSequence ~wrap:(lparen, ")") ~construct:`Tuple l
     | [{pexp_attributes = []; pexp_desc = Pexp_array l}] ->
-      self#unparseSequence ~wrap:("(", ")") ~construct:`Array l
+      self#unparseSequence ~wrap:(lparen, ")") ~construct:`Array l
     | [{pexp_attributes = []; pexp_desc = Pexp_object cs}] ->
-      self#classStructure ~wrap:("(", ")") cs
+      self#classStructure ~wrap:(lparen, ")") cs
     | [{pexp_attributes = []; pexp_desc = Pexp_extension (s, p)}] when s.txt = "bs.obj" ->
-      self#formatBsObjExtensionSugar ~wrap:("(", ")") p
+      self#formatBsObjExtensionSugar ~wrap:(lparen, ")") p
     | [({pexp_attributes = []; pexp_desc} as exp)] when (is_simple_list_expr exp) ->
           (match view_expr exp with
           | `list xs ->
-              self#unparseSequence ~construct:`List ~wrap:("(", ")") xs
+              self#unparseSequence ~construct:`List ~wrap:(lparen, ")") xs
           | `cons xs ->
-              self#unparseSequence ~construct:`ES6List ~wrap:("(", ")") xs
+              self#unparseSequence ~construct:`ES6List ~wrap:(lparen, ")") xs
           | _ -> assert false)
     | _ -> assert false
 
@@ -6239,7 +6241,7 @@ let printer = object(self:'self)
        *  when the line-length indicates breaking.
        *)
       | [(Nolabel, exp)] when isSingleArgParenApplication [exp] ->
-          self#singleArgParenApplication [exp]
+          self#singleArgParenApplication ~uncurried [exp]
       | params ->
           makeTup ~uncurried (List.map self#label_x_expression_param params)
 


### PR DESCRIPTION
As @cristianoc pointed out, nested uncurrying should be possible:
```
add(. 2)(. 3);
```
now formats as
```
add(. 2, . 3);
```

Also adds test cases/support for uncurried syntax with "paren hugging":
```
f(. (1, 2));
f(. {
  a: "supersupersupersupersupersuperlong",
  b: "supersupersupersupersupersuperlong",
});
```