### PR TITLE
[POC][Donotmerge] Support ? syntax sugar in application.

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -8,6 +8,10 @@ let l =
   (i => i + 1)
   |> (__x => List.map(__x, [1, 2, 3]));
 
+let l =
+  (__x => Some(__x))
+  |> (__x => List.map(__x, [1, 2, 3]));
+
 type reasonXyz =
   | X
   | Y(int, int, int)

--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -1,4 +1,13 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+let l =
+  [1, 2, 3]
+  |> (__x => List.map(i => i + 1, __x))
+  |> (__x => List.filter(i => i > 0, __x));
+
+let l =
+  (i => i + 1)
+  |> (__x => List.map(__x, [1, 2, 3]));
+
 type reasonXyz =
   | X
   | Y(int, int, int)

--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -8,9 +8,7 @@ let l =
   (i => i + 1)
   |> (__x => List.map(__x, [1, 2, 3]));
 
-let l =
-  (__x => Some(__x))
-  |> (__x => List.map(__x, [1, 2, 3]));
+let x = __x => List.length(__x);
 
 let incr = (~v) => v + 1;
 

--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -1,25 +1,23 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 let l =
   [1, 2, 3]
-  |> (__x => List.map(i => i + 1, __x))
-  |> (__x => List.filter(i => i > 0, __x));
+  |> List.map(i => i + 1, _)
+  |> List.filter(i => i > 0, _);
 
-let l =
-  (i => i + 1)
-  |> (__x => List.map(__x, [1, 2, 3]));
+let l = (i => i + 1) |> List.map(_, [1, 2, 3]);
 
-let x = __x => List.length(__x);
+let x = List.length(_);
 
 let incr = (~v) => v + 1;
 
 let l1 =
   [1, 2, 3]
-  |> List.map(__x => incr(~v=__x))
+  |> List.map(incr(~v=_))
   |> List.length;
 
 let l2 =
   [1, 2, 3]
-  |> List.map(__x => incr(~v=__x))
+  |> List.map(incr(~v=_))
   |> List.length;
 
 type reasonXyz =

--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -28,7 +28,7 @@ let unSomeFun =
   | None => 0;
 
 let unSome =
-  switch _ {
+  switch (_) {
   | Some(n) => n
   | None => 0
   };

--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -20,6 +20,17 @@ let l2 =
   |> List.map(incr(~v=_))
   |> List.length;
 
+let unSomeFun =
+  fun
+  | Some(n) => n
+  | None => 0;
+
+let unSome =
+  switch _ {
+  | Some(n) => n
+  | None => 0
+  };
+
 type reasonXyz =
   | X
   | Y(int, int, int)

--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -22,6 +22,18 @@ let l2 =
   |> List.map(incr(~v=_))
   |> List.length;
 
+let optParam = (~v=?, ()) => v == None ? 0 : 1;
+
+let l1 =
+  [Some(1), None, Some(2)]
+  |> List.map(optParam(~v=?_, ()))
+  |> List.length;
+
+let l2 =
+  [Some(1), None, Some(2)]
+  |> List.map(optParam(~v=?_, ()))
+  |> List.length;
+
 let unSomeFun =
   fun
   | Some(n) => n

--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -12,6 +12,18 @@ let l =
   (__x => Some(__x))
   |> (__x => List.map(__x, [1, 2, 3]));
 
+let incr = (~v) => v + 1;
+
+let l1 =
+  [1, 2, 3]
+  |> List.map(__x => incr(~v=__x))
+  |> List.length;
+
+let l2 =
+  [1, 2, 3]
+  |> List.map(__x => incr(~v=__x))
+  |> List.length;
+
 type reasonXyz =
   | X
   | Y(int, int, int)

--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -8,6 +8,8 @@ let l = (i => i + 1) |> List.map(_, [1, 2, 3]);
 
 let x = List.length(_);
 
+let nested = x => List.length(_);
+
 let incr = (~v) => v + 1;
 
 let l1 =

--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -34,17 +34,6 @@ let l2 =
   |> List.map(optParam(~v=?_, ()))
   |> List.length;
 
-let unSomeFun =
-  fun
-  | Some(n) => n
-  | None => 0;
-
-let unSome =
-  switch (_) {
-  | Some(n) => n
-  | None => 0
-  };
-
 type reasonXyz =
   | X
   | Y(int, int, int)

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -1,5 +1,9 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
+let l = [1,2,3] |> List.map (i => i+1, ?) |> List.filter (i => i>0, ?);
+
+let l = (i => i+1) |> List.map(?, [1,2,3]);
+
 type reasonXyz =
   | X
   | Y(int,int,int)

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -14,6 +14,14 @@ let l1 = [1,2,3] |> List.map(incr(~v=_)) |> List.length;
 
 let l2 = [1,2,3] |> List.map(incr(~v =_)) |> List.length;
 
+let optParam = (~v=?, ()) => v == None ? 0 : 1;
+
+let l1 =
+  [Some(1), None, Some(2)] |> List.map(optParam(~v=?_, ())) |> List.length;
+
+let l2 =
+  [Some(1), None, Some(2)] |> List.map(optParam(~v =?_, ())) |> List.length;
+
 let unSomeFun = fun | Some(n) => n | None => 0;
 let unSome = switch (_) { | Some(n) => n | None => 0 };
 

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -12,6 +12,9 @@ let l1 = [1,2,3] |> List.map(incr(~v=_)) |> List.length;
 
 let l2 = [1,2,3] |> List.map(incr(~v =_)) |> List.length;
 
+let unSomeFun = fun | Some(n) => n | None => 0;
+let unSome = switch _ { | Some(n) => n | None => 0 };
+
 type reasonXyz =
   | X
   | Y(int,int,int)

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -4,7 +4,7 @@ let l = [1,2,3] |> List.map (i => i+1, ?) |> List.filter (i => i>0, ?);
 
 let l = (i => i+1) |> List.map(?, [1,2,3]);
 
-let l = Some(?) |> List.map(?, [1,2,3]);
+let x = List.length(?);
 
 let incr = (~v) => v+1;
 

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -6,6 +6,8 @@ let l = (i => i+1) |> List.map(_, [1,2,3]);
 
 let x = List.length(_);
 
+let nested = x => List.length(_);
+
 let incr = (~v) => v+1;
 
 let l1 = [1,2,3] |> List.map(incr(~v=_)) |> List.length;

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -15,7 +15,7 @@ let l1 = [1,2,3] |> List.map(incr(~v=_)) |> List.length;
 let l2 = [1,2,3] |> List.map(incr(~v =_)) |> List.length;
 
 let unSomeFun = fun | Some(n) => n | None => 0;
-let unSome = switch _ { | Some(n) => n | None => 0 };
+let unSome = switch (_) { | Some(n) => n | None => 0 };
 
 type reasonXyz =
   | X

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -22,9 +22,6 @@ let l1 =
 let l2 =
   [Some(1), None, Some(2)] |> List.map(optParam(~v =?_, ())) |> List.length;
 
-let unSomeFun = fun | Some(n) => n | None => 0;
-let unSome = switch (_) { | Some(n) => n | None => 0 };
-
 type reasonXyz =
   | X
   | Y(int,int,int)

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -4,6 +4,8 @@ let l = [1,2,3] |> List.map (i => i+1, ?) |> List.filter (i => i>0, ?);
 
 let l = (i => i+1) |> List.map(?, [1,2,3]);
 
+let l = Some(?) |> List.map(?, [1,2,3]);
+
 type reasonXyz =
   | X
   | Y(int,int,int)

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -6,6 +6,12 @@ let l = (i => i+1) |> List.map(?, [1,2,3]);
 
 let l = Some(?) |> List.map(?, [1,2,3]);
 
+let incr = (~v) => v+1;
+
+let l1 = [1,2,3] |> List.map(incr(~v=?)) |> List.length;
+
+let l2 = [1,2,3] |> List.map(incr(~v =?)) |> List.length;
+
 type reasonXyz =
   | X
   | Y(int,int,int)

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -1,16 +1,16 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
-let l = [1,2,3] |> List.map (i => i+1, ?) |> List.filter (i => i>0, ?);
+let l = [1,2,3] |> List.map (i => i+1, _) |> List.filter (i => i>0, _);
 
-let l = (i => i+1) |> List.map(?, [1,2,3]);
+let l = (i => i+1) |> List.map(_, [1,2,3]);
 
-let x = List.length(?);
+let x = List.length(_);
 
 let incr = (~v) => v+1;
 
-let l1 = [1,2,3] |> List.map(incr(~v=?)) |> List.length;
+let l1 = [1,2,3] |> List.map(incr(~v=_)) |> List.length;
 
-let l2 = [1,2,3] |> List.map(incr(~v =?)) |> List.length;
+let l2 = [1,2,3] |> List.map(incr(~v =_)) |> List.length;
 
 type reasonXyz =
   | X

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -3120,17 +3120,17 @@ labeled_expr:
       let loc = (mklocation $symbolstartpos $endpos) in
       ($2 $1.txt, $3 (mkloc (Longident.parse $1.txt) loc))
     }
-  | TILDE as_loc(val_longident) EQUAL as_loc(UNDERSCORE)
+  | TILDE as_loc(val_longident) EQUAL optional as_loc(UNDERSCORE)
     { (* foo(~l =_) *)
-      let loc = $4.loc in
+      let loc = $5.loc in
       let exp = mkexp (Pexp_ident (mkloc (Lident "_") loc)) ~loc in
-      (Labelled (String.concat "" (Longident.flatten $2.txt)), exp)
+      ($4 (String.concat "" (Longident.flatten $2.txt)), exp)
     }
-  | as_loc(LABEL_WITH_EQUAL) as_loc(UNDERSCORE)
+  | as_loc(LABEL_WITH_EQUAL) optional as_loc(UNDERSCORE)
     { (* foo(~l=_) *)
-      let loc = $2.loc in
+      let loc = $3.loc in
       let exp = mkexp (Pexp_ident (mkloc (Lident "_") loc)) ~loc in
-      (Labelled $1.txt, exp)
+      ($2 $1.txt, exp)
     }
   | as_loc(UNDERSCORE)
     { (* foo(_) *)

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -2687,6 +2687,15 @@ mark_position_exp
   | SWITCH optional_expr_extension simple_expr_no_constructor
     LBRACE match_cases(seq_expr) RBRACE
     { $2 (mkexp (Pexp_match ($3, $5))) }
+  | SWITCH as_loc(UNDERSCORE)
+    LBRACE match_cases(seq_expr) RBRACE
+    { (* switch _ { ... } *)
+      let loc = $2.loc in
+      let exp = mkexp (Pexp_ident (mkloc (Lident "__x") loc)) ~loc in 
+      let exp_match = mkexp (Pexp_match (exp, $4)) in
+      let pattern = mkpat (Ppat_var (mkloc "__x" loc)) ~loc in
+      mkexp (Pexp_fun (Nolabel, None, pattern, exp_match)) ~loc
+    }
   | TRY optional_expr_extension simple_expr_no_constructor
     LBRACE match_cases(seq_expr) RBRACE
     { $2 (mkexp (Pexp_try ($3, $5))) }
@@ -3086,19 +3095,19 @@ labeled_expr:
       ($2 $1.txt, $3 (mkloc (Longident.parse $1.txt) loc))
     }
   | TILDE as_loc(val_longident) EQUAL as_loc(UNDERSCORE)
-    { (* foo(~l =?) *)
+    { (* foo(~l =_) *)
       let loc = $4.loc in
       let exp = mkexp (Pexp_ident (mkloc (Lident "_") loc)) ~loc in
       (Labelled (String.concat "" (Longident.flatten $2.txt)), exp)
     }
   | as_loc(LABEL_WITH_EQUAL) as_loc(UNDERSCORE)
-    { (* foo(~l=?) *)
+    { (* foo(~l=_) *)
       let loc = $2.loc in
       let exp = mkexp (Pexp_ident (mkloc (Lident "_") loc)) ~loc in
       (Labelled $1.txt, exp)
     }
   | as_loc(UNDERSCORE)
-    { (* foo(?) *)
+    { (* foo(_) *)
       let loc = $1.loc in
       let exp = mkexp (Pexp_ident (mkloc (Lident "_") loc)) ~loc in
       (Nolabel, exp)

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -3086,12 +3086,11 @@ labeled_arguments:
 
 labeled_expr_constraint:
   | expr_optional_constraint { fun _punned -> $1 }
-  | type_constraint?
+  | type_constraint
     { fun punned ->
       let exp = mkexp (Pexp_ident punned) ~loc:punned.loc in
       match $1 with
-      | None -> exp
-      | Some typ ->
+      | typ ->
         let loc = mklocation punned.loc.loc_start $endpos in
         ghexp_constraint loc exp typ
     }
@@ -3118,8 +3117,20 @@ labeled_expr:
       let loc = (mklocation $symbolstartpos $endpos) in
       ($2 $1.txt, $3 (mkloc (Longident.parse $1.txt) loc))
     }
+  | TILDE as_loc(val_longident) EQUAL as_loc(QUESTION)
+    { (* foo(~l =?) *)
+      let loc = $4.loc in
+      let exp = mkexp (Pexp_ident (mkloc (Lident "?") loc)) ~loc in
+      (Labelled (String.concat "" (Longident.flatten $2.txt)), exp)
+    }
+  | as_loc(LABEL_WITH_EQUAL) as_loc(QUESTION)
+    { (* foo(~l=?) *)
+      let loc = $2.loc in
+      let exp = mkexp (Pexp_ident (mkloc (Lident "?") loc)) ~loc in
+      (Labelled $1.txt, exp)
+    }
   | as_loc(QUESTION)
-    {
+    { (* foo(?) *)
       let loc = $1.loc in
       let exp = mkexp (Pexp_ident (mkloc (Lident "?") loc)) ~loc in
       (Nolabel, exp)

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -2703,17 +2703,7 @@ mark_position_exp
     { $2 (mkexp (Pexp_function $3)) }
   | SWITCH optional_expr_extension simple_expr_no_constructor
     LBRACE match_cases(seq_expr) RBRACE
-    { let exp_match = $2 (mkexp (Pexp_match ($3, $5))) in
-      match $3.pexp_desc with
-      | Pexp_ident {txt = Lident "_"} -> (* switch (_) {...} *)
-        let loc = $3.pexp_loc in
-        let exp = mkexp (Pexp_ident (mkloc (Lident "__x") loc)) ~loc in 
-        let exp_match = $2 (mkexp (Pexp_match (exp, $5))) in
-        let pattern = mkpat (Ppat_var (mkloc "__x" loc)) ~loc in
-        mkexp (Pexp_fun (Nolabel, None, pattern, exp_match)) ~loc
-      | _ ->
-        $2 (mkexp (Pexp_match ($3, $5)))
-    }
+    { $2 (mkexp (Pexp_match ($3, $5))) }
   | TRY optional_expr_extension simple_expr_no_constructor
     LBRACE match_cases(seq_expr) RBRACE
     { $2 (mkexp (Pexp_try ($3, $5))) }
@@ -2858,10 +2848,6 @@ parenthesized_expr:
     { mkexp (Pexp_variant ($1, None)) }
   | LPAREN expr_list RPAREN
     { may_tuple $startpos $endpos $2 }
-  | LPAREN as_loc(UNDERSCORE) RPAREN {
-      let loc = $2.loc in
-      mkexp (Pexp_ident (mkloc (Lident "_") loc)) ~loc
-    }
   | as_loc(LPAREN) expr_list as_loc(error)
     { unclosed_exp (with_txt $1 "(") (with_txt $3 ")") }
   | E as_loc(POSTFIXOP)

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3236,7 +3236,6 @@ let printer = object(self:'self)
 
   (*
    * Replace (__x) => foo(__x) with foo(_)
-   * And (__x) => switch __x { ... } with swich _ { ... } 
    *)
   method process_underscore_application x =
     let process_application expr =
@@ -3256,14 +3255,6 @@ let printer = object(self:'self)
     | Pexp_fun (Nolabel, None, {ppat_desc = Ppat_var {txt="__x"}},
         ({pexp_desc = Pexp_apply _} as e)) ->
       process_application e
-    | Pexp_fun (Nolabel, None, {ppat_desc = Ppat_var {txt="__x"}},
-        ({pexp_desc = Pexp_match
-          ({pexp_desc = Pexp_ident
-            ({txt = Lident "__x"} as id)
-           } as e_x, ls)
-         } as e)) ->
-      let e_ = {e_x with pexp_desc = Pexp_ident {id with txt = Lident "_"}} in
-      {e with pexp_desc = Pexp_match (e_, ls)}
     | Pexp_fun (l, eo, p, e) ->
        let e_processed = self#process_underscore_application e in
        if e == e_processed then

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3264,6 +3264,12 @@ let printer = object(self:'self)
          } as e)) ->
       let e_ = {e_x with pexp_desc = Pexp_ident {id with txt = Lident "_"}} in
       {e with pexp_desc = Pexp_match (e_, ls)}
+    | Pexp_fun (l, eo, p, e) ->
+       let e_processed = self#process_underscore_application e in
+       if e == e_processed then
+         x
+       else
+         {x with pexp_desc = Pexp_fun (l, eo, p, e_processed)}
     | _ ->
       x
 

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4444,7 +4444,7 @@ let printer = object(self:'self)
   method parenthesized_expr ?break expr =
     let result = self#unparseExpr expr in
     match expr.pexp_attributes, expr.pexp_desc with
-    | [], (Pexp_tuple _ | Pexp_construct ({txt=Lident "()"}, None) | Pexp_ident {txt=Lident "_"}) -> result
+    | [], (Pexp_tuple _ | Pexp_construct ({txt=Lident "()"}, None)) -> result
     | _ -> makeList ~wrap:("(",")") ?break [self#unparseExpr expr]
 
   (* Expressions requiring parens, in most contexts such as separated by infix *)

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3234,7 +3234,29 @@ let printer = object(self:'self)
     | Simple itm -> ([itm], Some x.pexp_loc)
 
 
+  (* Replace (__x) => foo(__x) with foo(_) *)
+  method process_underscore_application x =
+    let process_application expr =
+      let process_arg (l,e) = match e.pexp_desc with
+        | Pexp_ident ({ txt = Lident "__x"} as id) ->
+          let pexp_desc = Pexp_ident {id with txt = Lident "_"} in
+          (l, {e with pexp_desc})
+        | _ ->
+          (l,e) in
+      match expr.pexp_desc with
+      | Pexp_apply (e_fun, args) ->
+        let pexp_desc = Pexp_apply (e_fun, List.map process_arg args) in
+        {expr with pexp_desc}
+      | _ ->
+        expr in
+    match x.pexp_desc with
+    | Pexp_fun (Nolabel, None, {ppat_desc = Ppat_var {txt="__x"}}, ({pexp_desc = Pexp_apply _} as e)) ->
+      process_application e
+    | _ ->
+      x
+
   method unparseExprRecurse x =
+    let x = self#process_underscore_application x in
     (* If there are any attributes, render unary like `(~-) x [@ppx]`, and infix like `(+) x y [@attr]` *)
     let {arityAttrs; stdAttrs; jsxAttrs; uncurried} = partitionAttributes x.pexp_attributes in
     let () = if uncurried then Hashtbl.add uncurriedTable x.pexp_loc true in
@@ -3266,6 +3288,7 @@ let printer = object(self:'self)
     | None ->
     match x.pexp_desc with
     | Pexp_apply (e, ls) -> (
+      let ls = List.map (fun (l,expr) -> (l, self#process_underscore_application expr)) ls in
       match (self#sugar_set_expr_parts x) with
       (* Returns None if there's attributes - would render as regular function *)
       (* Format as if it were an infix function application with identifier "=" *)
@@ -3956,6 +3979,7 @@ let printer = object(self:'self)
          }
    *)
   method wrappedBinding prefixText ~arrow pattern patternAux expr =
+    let expr = self#process_underscore_application expr in
     let (argsList, return) = self#curriedPatternsAndReturnVal expr in
     let patternList = match patternAux with
       | [] -> pattern


### PR DESCRIPTION
Proof of concept to support `?` as syntax sugar in function application.
The implementation is crude, just to illustrate the idea, and check that there are no parsing conflicts. (No printer implementation at the moment).

An application
  `f(?, 3);`
is transformed to
  `(__x) => f(__x, 3);`

This enables the use of pipe in arbitrary positions, as in
  `let l = [1,2,3] |> List.map (i => i+1, ?) |> List.filter (i => i>0, ?);`
or in
  `let l = (i => i+1) |> List.map(?, [1,2,3]);`