### PR TITLE
Trailing commas in reason objects

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -384,7 +384,7 @@ type classAttributesOnKeys = {
   /* The follow two are the same */
   [@bs.get null] key2: [@onType2] Js.t(int),
   [@bs.get null] key3: [@onType2] Js.t(int),
-  key4: Js.t([@justOnInt] int)
+  key4: Js.t([@justOnInt] int),
 };
 
 /* extensible variants */

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -119,20 +119,20 @@ let bigger = 3 >> 2;
 type typeDefForClosedObj = {
   .
   x: int,
-  y: int
+  y: int,
 };
 
 type typeDefForOpenObj('a) =
   {
     ..
     x: int,
-    y: int
+    y: int,
   } as 'a;
 
 let anonClosedObject: {
   .
   x: int,
-  y: int
+  y: int,
 } = {
   pub x = 0;
   pub y = 0
@@ -150,7 +150,7 @@ let constrainedAndCoerced = (
     list({
       .
       x: int,
-      y: int
+      y: int,
     }) :>
     list({. x: int})
 );
@@ -174,7 +174,7 @@ let acceptsOpenAnonObjAsArg =
       o: {
         ..
         x: int,
-        y: int
+        y: int,
       },
     ) =>
   o#x + o#y;
@@ -184,7 +184,7 @@ let acceptsClosedAnonObjAsArg =
       o: {
         .
         x: int,
-        y: int
+        y: int,
       },
     ) =>
   o#x + o#y;
@@ -416,5 +416,5 @@ module Js = {
 /* supports trailing comma */
 type stream('a) = {
   .
-  "observer": ('a => unit) => unit
+  "observer": ('a => unit) => unit,
 };

--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -106,7 +106,7 @@ this#arrayInObject[count] = 1;
 type y = {
   .
   [@bs.set no_get] "height": int,
-  [@bs.set no_get] "width": int
+  [@bs.set no_get] "width": int,
 };
 
 type y = {
@@ -116,7 +116,7 @@ type y = {
     int => unit,
   [@foo barbaz]
   "widthThatIsASuperLongStringForceBreak":
-    int => unit
+    int => unit,
 };
 
 type y = {
@@ -126,5 +126,5 @@ type y = {
     (int, int, int, float, float, float) => unit,
   [@foo barbaz]
   "height":
-    (int, int, int, float, float, float) => unit
+    (int, int, int, float, float, float) => unit,
 };

--- a/formatTest/unit_tests/expected_output/object.re
+++ b/formatTest/unit_tests/expected_output/object.re
@@ -4,7 +4,7 @@ type t = {.};
 type t = {
   .
   u: int,
-  v: int
+  v: int,
 };
 
 type t = {.. u: int};
@@ -22,13 +22,13 @@ let five = 2 <..> 3;
 type closedObjSugar = {
   .
   "foo": bar,
-  "baz": int
+  "baz": int,
 };
 
 type openObjSugar = {
   ..
   "x": int,
-  "y": int
+  "y": int,
 };
 
 type x = Js.t({.});
@@ -39,11 +39,11 @@ type y = Js.t({..});
 type o = {
   .
   a: int,
-  b: int
+  b: int,
 };
 
 type o2 = {
   ..
   a: int,
-  b: int
+  b: int,
 };

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4831,7 +4831,7 @@ let printer = object(self:'self)
     in
     (* if an object has more than 2 rows, always break for readability *)
     let rows_layout = makeList
-        ~inline:(true, true) ~postSpace:true ~sep:(Sep ",") rows
+        ~inline:(true, true) ~postSpace:true ~sep:commaTrail rows
         ~break:(if List.length rows >= 2
                 then Layout.Always_rec
                 else Layout.IfNeed)


### PR DESCRIPTION
Enforce printing of trailing commas in reason objects that contain multiple rows.

Fixes #1820.