### PR TITLE
Preserve function body braces and distinguish open vs. X.()

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -120,7 +120,11 @@ let x = [@attrEverything] (true && false);
 /**
  * How attribute parsings respond to other syntactic constructs.
  */
-let add = a => [@onRet] a;
+let add = a =>
+  [@onRet]
+  {
+    a;
+  };
 
 let add = a => [@onRet] a;
 
@@ -382,8 +386,18 @@ type classAttributesOnKeys = {
   .
   [@bs.set] key1: string,
   /* The follow two are the same */
-  [@bs.get null] key2: [@onType2] Js.t(int),
-  [@bs.get null] key3: [@onType2] Js.t(int),
+  [@bs.get
+    {
+      null;
+    }
+  ]
+  key2: [@onType2] Js.t(int),
+  [@bs.get
+    {
+      null;
+    }
+  ]
+  key3: [@onType2] Js.t(int),
   key4: Js.t([@justOnInt] int),
 };
 
@@ -533,7 +547,13 @@ let res =
 
 let res =
   switch (x) {
-  | _ => [@attr] String.(Array.(concat))
+  | _ =>
+    [@attr]
+    {
+      open String;
+      open Array;
+      concat;
+    }
   };
 
 /* GADT */
@@ -601,10 +621,6 @@ type tttttt = {
   [@attr "testing with mutable field"]
   mutable x: int,
 };
-
-let tmp =
-  /** On if statement */
-  (if (true) {true} else {false});
 
 type foo =
   option(

--- a/formatTest/typeCheckedTests/expected_output/braces.re
+++ b/formatTest/typeCheckedTests/expected_output/braces.re
@@ -1,0 +1,181 @@
+let preserveThis = "preserveThis";
+
+let x = a => {
+  preserveThis;
+};
+
+let x = a => {
+  /* Even with comment */
+  preserveThis;
+};
+
+let res = {
+  /**
+   * doc comment.
+   */
+  (if (true) {()} else {()});
+  ();
+};
+
+let x = a => {
+  /* It would be okay for this comment to get formatted into
+   * the braces but ideally it wouldn't. */
+  preserveThis;
+};
+
+type recordType = {
+  recordTypeFieldOne: int,
+  recordTypeFieldTwo: string,
+};
+
+let x =
+  {
+    recordTypeFieldOne: 0,
+    recordTypeFieldTwo: "two",
+  }.recordTypeFieldOne;
+
+/**
+ * Use a pointless wrapping.
+ */
+let x =
+  {
+    {
+      recordTypeFieldOne: 0,
+      recordTypeFieldTwo: "two",
+    };
+  }.recordTypeFieldOne;
+
+let createRecord = () => {
+  recordTypeFieldOne: 0,
+  recordTypeFieldTwo: "two",
+};
+
+let x =
+  {
+    createRecord();
+  }.recordTypeFieldOne;
+
+let y = [@attr] 3;
+
+/* The attribute on the explicit braces should also be preserved */
+let y =
+  [@attr]
+  {
+    3;
+  };
+
+let myFun = (. a, b, c) => a + b + c;
+
+let result = {
+  myFun(. 0, 1, 2);
+};
+
+let result =
+  [@attr]
+  {
+    myFun(. 0, 1, 2);
+  };
+
+let tmp =
+  /** On if statement */
+  {
+    if (true) {true} else {false};
+  };
+
+let tmp = {
+  let tmp = false;
+  /** On if statement */
+  (if (tmp) {true} else {false});
+};
+
+let tmp = {
+  let tmp = false;
+  /** On if statement */
+  (if (tmp) {"true"} else {"false"});
+  "but the if statement wasn't the last";
+};
+
+module Callbacks = {
+  let runThisCallback = (s, next) => {
+    s ++ next("!");
+    ();
+  };
+};
+
+let result =
+  Callbacks.runThisCallback("hi", s =>
+    s ++ "concatThis!"
+  );
+
+let result =
+  Callbacks.runThisCallback("hi", s => {
+    s ++ "!";
+  });
+
+Callbacks.runThisCallback("hi", s =>
+  s ++ "concatThis!"
+);
+
+Callbacks.runThisCallback("hi", s => {
+  s ++ "concatThis!";
+});
+
+Callbacks.runThisCallback("hi", s => {
+  let s = s ++ s;
+  s ++ "concatThis!";
+});
+
+let test = {
+  open Callbacks;
+  ();
+  34;
+};
+
+/* Even though these braces aren't needed we will preserve them because they
+ * were requested */
+let test = {
+  open Callbacks;
+  open String;
+  34;
+};
+
+/* You can have unecessary braces around inline opens even */
+let test = {
+  Callbacks.(String.(34));
+};
+
+/* Even though these braces aren't needed we will preserve them because they
+ * were requested */
+let test = {
+  open Callbacks;
+  String.("hello" ++ "!");
+};
+
+let test = {
+  open Callbacks;
+  [@attr] String.("hello" ++ "!");
+};
+
+/* Doesn't currently parse.
+     let test = {
+       [@attr1]
+       open Callbacks;
+       String.("hello" ++ "!");
+     };
+   */
+let test = {
+  Callbacks.(
+    {
+      let f = 0;
+      f;
+    }
+  );
+};
+
+let test =
+  Callbacks.(
+    {
+      let f = 0;
+      f;
+    }
+  );

--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -101,29 +101,32 @@ module Namespace = {
 };
 
 module Optional1 = {
-  let createElement = (~required, ~children, ()) =>
+  let createElement = (~required, ~children, ()) => {
     switch (required) {
     | Some(a) => {displayName: a}
     | None => {displayName: "nope"}
     };
+  };
 };
 
 module Optional2 = {
   let createElement =
-      (~optional=?, ~children, ()) =>
+      (~optional=?, ~children, ()) => {
     switch (optional) {
     | Some(a) => {displayName: a}
     | None => {displayName: "nope"}
     };
+  };
 };
 
 module DefaultArg = {
   let createElement =
-      (~default=Some("foo"), ~children, ()) =>
+      (~default=Some("foo"), ~children, ()) => {
     switch (default) {
     | Some(a) => {displayName: a}
     | None => {displayName: "nope"}
     };
+  };
 };
 
 module LotsOfArguments = {
@@ -174,8 +177,9 @@ let notReallyJSX = (~foo, ~bar, children) => {
   displayName: "test",
 };
 
-let fakeRender = (el: component) =>
+let fakeRender = (el: component) => {
   el.displayName;
+};
 
 /* end of setup */
 let (/><) = (a, b) => a + b;
@@ -465,7 +469,7 @@ let div = (~children) => 1;
 
 [@JSX] ((() => div)())(~children=[]);
 
-let myFun = () =>
+let myFun = () => {
   <>
     <Namespace.Foo
       intended=true
@@ -486,10 +490,13 @@ let myFun = () =>
       <Foo />
     </Namespace.Foo>
   </>;
+};
 
-let myFun = () => <> </>;
+let myFun = () => {
+  <> </>;
+};
 
-let myFun = () =>
+let myFun = () => {
   <>
     <Namespace.Foo
       intended=true
@@ -510,6 +517,7 @@ let myFun = () =>
       <Foo />
     </Namespace.Foo>
   </>;
+};
 
 /**
  * Children should wrap without forcing attributes to.

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -13,12 +13,18 @@ class virtual stack ('a) (init) = {
       Some(hd);
     | [] => None
     };
-  pub push = hd => v = [hd, ...v];
-  initializer (
-    print_string("initializing object")
-  );
-  pub explicitOverrideTest = a => a + 1;
-  pri explicitOverrideTest2 = a => a + 1;
+  pub push = hd => {
+    v = [hd, ...v];
+  };
+  initializer {
+    print_string("initializing object");
+  };
+  pub explicitOverrideTest = a => {
+    a + 1;
+  };
+  pri explicitOverrideTest2 = a => {
+    a + 1;
+  };
 };
 
 let tmp = {
@@ -49,10 +55,12 @@ class virtual stackWithAttributes ('a) (init) = {
       Some(hd);
     | [] => None
     };
-  pub push = hd => v = [hd, ...v];
-  initializer (
-    print_string("initializing object")
-  );
+  pub push = hd => {
+    v = [hd, ...v];
+  };
+  initializer {
+    print_string("initializing object");
+  };
 };
 
 class extendedStack ('a) (init) = {
@@ -66,9 +74,15 @@ class extendedStackAcknowledgeOverride
       (init) = {
   inherit (class stack('a))(init);
   val dummy = ();
-  pub implementMe = i => i + 1;
-  pub! explicitOverrideTest = a => a + 2;
-  pri! explicitOverrideTest2 = a => a + 2;
+  pub implementMe = i => {
+    i + 1;
+  };
+  pub! explicitOverrideTest = a => {
+    a + 2;
+  };
+  pri! explicitOverrideTest2 = a => {
+    a + 2;
+  };
 };
 
 let inst = (new extendedStack)([1, 2]);
@@ -134,8 +148,12 @@ let anonClosedObject: {
   x: int,
   y: int,
 } = {
-  pub x = 0;
-  pub y = 0
+  pub x = {
+    0;
+  };
+  pub y = {
+    0;
+  }
 };
 
 let onlyHasX = {pub x = 0};

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -96,8 +96,9 @@ let myFunction = /* First arg */
       withFirstArg,
       /* Second Arg */
       andSecondArg,
-    ) =>
-  withFirstArg + andSecondArg; /* After Semi */
+    ) => {
+  withFirstArg + andSecondArg;
+}; /* After Semi */
 
 type point = {
   x: string, /* x field */
@@ -303,7 +304,11 @@ type intPair2 = (
   int,
 );
 
-let result = /**/ (2 + 3);
+let result =
+  /**/
+  {
+    2 + 3;
+  };
 
 /* This is not yet idempotent */
 /* { */
@@ -336,7 +341,9 @@ let blahCurriedX = x =>
   | Black(x) => 0 /* After black */
   | Green(x) => 0; /* After second green */ /* On next line after blahCurriedX def */
 
-let name_equal = (x, y) => x == y;
+let name_equal = (x, y) => {
+  x == y;
+};
 
 let equal = (i1, i2) =>
   i1.contents === i2.contents && true; /* most unlikely first */

--- a/formatTest/typeCheckedTests/expected_output/sequences.re
+++ b/formatTest/typeCheckedTests/expected_output/sequences.re
@@ -23,9 +23,17 @@ let twenty = 20;
  * printed in reduced form because sequences are a *parse* time construct.
  * To ensure these are parsed correctly, adding to an integer.
  */
-let result = 0 + twenty;
+let result =
+  0
+  + {
+    twenty;
+  };
 
-let result = 0 + twenty;
+let result =
+  0
+  + {
+    twenty;
+  };
 
 let result = 0 + twenty;
 
@@ -66,7 +74,9 @@ let cannotPunASingleFieldRecord = {
 let fourty =
   20 + cannotPunASingleFieldRecord.number;
 
-let thisIsASequenceNotPunedRecord = number;
+let thisIsASequenceNotPunedRecord = {
+  number;
+};
 
 let fourty = 20 + thisIsASequenceNotPunedRecord;
 

--- a/formatTest/typeCheckedTests/expected_output/trailing.re
+++ b/formatTest/typeCheckedTests/expected_output/trailing.re
@@ -189,9 +189,9 @@ class virtual
   ];
   pub virtual implementMe:
     (int, int) => (int, int);
-  initializer (
-    print_string("initializing object")
-  );
+  initializer {
+    print_string("initializing object");
+  };
 };
 
 class extendedStack

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -459,16 +459,6 @@ type tttttt = {
   mutable x: int
 };
 
-
-let tmp = {
-  /** On if statement */
-  if (true) {
-    true
-  } else {
-    false
-  };
-};
-
 type foo =
    option(
     [@foo ["how does this break", "when long enough"]] (

--- a/formatTest/typeCheckedTests/input/braces.re
+++ b/formatTest/typeCheckedTests/input/braces.re
@@ -1,0 +1,181 @@
+
+
+let preserveThis = "preserveThis";
+
+let x = (a) => {
+  preserveThis;
+};
+
+let x = (a) => {
+  /* Even with comment */
+  preserveThis;
+};
+
+let res = {
+  /**
+   * doc comment.
+   */
+  if (true) {
+    ()
+  } else {
+    ()
+  };
+  ();
+};
+
+let x = (a) =>
+/* It would be okay for this comment to get formatted into
+ * the braces but ideally it wouldn't. */
+{
+  preserveThis;
+};
+
+type recordType = {
+  recordTypeFieldOne: int,
+  recordTypeFieldTwo: string
+};
+let x = {
+  recordTypeFieldOne: 0,
+  recordTypeFieldTwo: "two",
+}.recordTypeFieldOne;
+
+/**
+ * Use a pointless wrapping.
+ */
+let x = {
+  {
+    recordTypeFieldOne: 0,
+    recordTypeFieldTwo: "two",
+  }
+}.recordTypeFieldOne;
+
+let createRecord = () => {
+  recordTypeFieldOne: 0,
+  recordTypeFieldTwo: "two",
+};
+
+let x = {
+  createRecord();
+}.recordTypeFieldOne;
+
+
+let y = [@attr] 3;
+
+/* The attribute on the explicit braces should also be preserved */
+let y = [@attr] {
+  3;
+};
+
+let myFun = (.a, b, c) => a + b + c;
+
+let result = {
+  myFun(. 0, 1, 2);
+};
+
+let result = [@attr] {
+  myFun(. 0, 1, 2);
+};
+
+let tmp = {
+  /** On if statement */
+  if (true) {
+    true
+  } else {
+    false
+  };
+};
+
+let tmp = {
+  let tmp = false;
+  /** On if statement */
+  if (tmp) {
+    true
+  } else {
+    false
+  };
+};
+
+let tmp = {
+  let tmp = false;
+  /** On if statement */
+  if (tmp) {
+    "true"
+  } else {
+    "false"
+  };
+  "but the if statement wasn't the last";
+};
+
+
+module Callbacks = {
+  let runThisCallback = (s, next) => {s ++ next("!"); ()};
+};
+
+let result = Callbacks.runThisCallback("hi", (s) => s ++ "concatThis!");
+let result = Callbacks.runThisCallback("hi", (s) => {
+  s ++ "!"
+});
+
+Callbacks.runThisCallback("hi", (s) => s ++ "concatThis!");
+Callbacks.runThisCallback("hi", (s) => {
+  s ++ "concatThis!"
+});
+
+Callbacks.runThisCallback("hi", (s) => {
+  let s = s ++ s;
+  s ++ "concatThis!"
+});
+
+
+let test = {
+  open Callbacks;
+  ();
+  34;
+};
+
+/* Even though these braces aren't needed we will preserve them because they
+ * were requested */
+let test = {
+  open Callbacks;
+  open String;
+  34;
+};
+
+/* You can have unecessary braces around inline opens even */
+let test = {
+  Callbacks.(String.(34));
+};
+
+/* Even though these braces aren't needed we will preserve them because they
+ * were requested */
+let test = {
+  open Callbacks;
+  String.("hello" ++ "!");
+};
+
+let test = {
+  open Callbacks;
+  [@attr]
+  String.("hello" ++ "!");
+};
+
+/* Doesn't currently parse.
+  let test = {
+    [@attr1]
+    open Callbacks;
+    String.("hello" ++ "!");
+  };
+*/
+
+let test = {
+  Callbacks.({
+    let f = 0;
+    f;
+  });
+};
+
+let test =
+  Callbacks.({
+    let f = 0;
+    f;
+  });

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -1,6 +1,7 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
-let run = () =>
+let run = () => {
   TestUtils.printSection("Basic Structures");
+};
 
 while (something) {
   print_string("You're in a while loop");
@@ -247,12 +248,14 @@ let result =
       } else {
         print_string("b >= a");
       };
-  } else if ((a, b) =>
-               if (a > b) {
-                 print_string("b < a");
-               } else {
-                 print_string("a <= b");
-               }) {
+  } else if ({
+               (a, b) =>
+                 if (a > b) {
+                   print_string("b < a");
+                 } else {
+                   print_string("a <= b");
+                 };
+             }) {
     print_string(
       "That could never possibly type check",
     );
@@ -564,9 +567,13 @@ let myTuple: myTupleType = myTuple;
 let myTuple: myTupleType = (one: int, two: int);
 
 /* Now functions that accept a single argument being a tuple look familiar */
-let addValues = (a: int, b: int) => a + b;
+let addValues = (a: int, b: int) => {
+  a + b;
+};
 
-let addValues = (a: int, b: int) => a + b;
+let addValues = (a: int, b: int) => {
+  a + b;
+};
 
 let myFunction = (a: int, b: int) : int =>
   a + b;

--- a/formatTest/unit_tests/expected_output/extensions.re
+++ b/formatTest/unit_tests/expected_output/extensions.re
@@ -28,25 +28,37 @@ let x = {
   | Some(x) => assert false
   | None => ()
   };
-  try%extend (raise(Not_found)) {
+  try%extend (
+    {
+      raise(Not_found);
+    }
+  ) {
   | Not_found => ()
   | Invalid_argument(msg) => prerr_endline(msg)
   };
 };
 
-let x = if%extend (true) {1} else {2};
+let x = {
+  if%extend (true) {1} else {2};
+};
 
-let x =
+let x = {
   switch%extend (None) {
   | Some(x) => assert false
   | None => ()
   };
+};
 
-let x =
-  try%extend (raise(Not_found)) {
+let x = {
+  try%extend (
+    {
+      raise(Not_found);
+    }
+  ) {
   | Not_found => ()
   | Invalid_argument(msg) => prerr_endline(msg)
   };
+};
 
 /* At structure level */
 try%extend () {
@@ -104,41 +116,50 @@ let x =
   | Some(1) => ();
 
 /* With two extensions, alone */
-let x = [%extend1
+let x = {
+  %extend1
   try%extend2 () {
   | _ => ()
-  }
-];
+  };
+};
 
-let x = [%extend1
+let x = {
+  %extend1
   switch%extend2 () {
   | _ => ()
-  }
-];
+  };
+};
 
-let x = [%extend1
-  if%extend2 (true) {1} else {2}
-];
+let x = {
+  %extend1
+  if%extend2 (true) {1} else {2};
+};
 
-let x = [%extend1
+let x = {
+  %extend1
   for%extend2 (i in 1 to 10) {
     ();
-  }
-];
+  };
+};
 
-let x = [%extend1
+let x = {
+  %extend1
   while%extend2 (false) {
     ();
-  }
-];
+  };
+};
 
-let x = [%extend1 fun%extend2 () => ()];
+let x = {
+  %extend1
+  fun%extend2 () => ();
+};
 
-let x = [%extend1
+let x = {
+  %extend1
   fun%extend2
   | None => ()
-  | Some(1) => ()
-];
+  | Some(1) => ();
+};
 
 /* With two extensions, first in sequence */
 let x = {

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -1075,14 +1075,15 @@ let server = {
     body
     |> Cohttp_lwt_body.to_string
     >|= (
-      body =>
+      body => {
         Printf.sprintf(
           "okokok",
           uri,
           meth,
           headers,
           body,
-        )
+        );
+      }
     )
     >>= (
       body =>

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -1,6 +1,7 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
-let run = () =>
+let run = () => {
   TestUtils.printSection("Modules");
+};
 
 /**
  * Modules:
@@ -531,24 +532,52 @@ module M = {
 
 module N = {
   open M;
-  let z = M.(34);
+  let z = {
+    open M;
+    34;
+  };
   let z = {
     open M;
     34;
     35;
   };
+  let z = {
+    open M;
+    (34, 35);
+  };
   let z = M.(34, 35);
   let z = M.(34, 35);
-  let z = M.(34, 35);
+  let z = {
+    open M;
+    {};
+  };
   let z = M.{};
   let z = M.{};
-  let z = M.{};
-  let z = M.{x: 10};
-  let z = M.[foo, bar];
-  let z = M.[foo, bar];
-  let z = M.{x: 10, y: 20};
-  let z = M.(M2.(value));
-  let z = M.(M2.value);
+  let z = {
+    open M;
+    {x: 10};
+  };
+  let z = {
+    open M;
+    [foo, bar];
+  };
+  let z = {
+    open M;
+    [foo, bar];
+  };
+  let z = {
+    open M;
+    {x: 10, y: 20};
+  };
+  let z = {
+    open M;
+    open M2;
+    value;
+  };
+  let z = {
+    open M;
+    M2.value;
+  };
   let z = {
     open! M;
     34;

--- a/formatTest/unit_tests/expected_output/polymorphism.re
+++ b/formatTest/unit_tests/expected_output/polymorphism.re
@@ -1,6 +1,7 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
-let run = () =>
+let run = () => {
   TestUtils.printSection("Polymorphism");
+};
 
 type myType('a) = list('a);
 

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -411,9 +411,13 @@ type hasA = {a: int};
 let a = 10;
 
 let returnsASequenceExpressionWithASingleIdentifier =
-    () => a;
+    () => {
+  a;
+};
 
-let thisReturnsA = () => a;
+let thisReturnsA = () => {
+  a;
+};
 
 let thisReturnsAAsWell = () => a;
 
@@ -1048,8 +1052,9 @@ let match = "match";
 let method = "method";
 
 let foo =
-    (x, ~x as bar, ~z, ~foo as bar, ~foo as z) =>
+    (x, ~x as bar, ~z, ~foo as bar, ~foo as z) => {
   bar + 2;
+};
 
 let zzz = myFunc(1, 2, [||]);
 
@@ -1201,17 +1206,17 @@ test(~desc=?[@attr] "my test", ~f=?[@attr] () => {
   x + y;
 });
 
-describe("App", () =>
-  test("math", () =>
-    Expect.expect(1 + 2) |> toBe(3)
-  )
-);
+describe("App", () => {
+  test("math", () => {
+    Expect.expect(1 + 2) |> toBe(3);
+  });
+});
 
-describe([@attr] "App", [@attr] () =>
-  test([@attr] "math", [@attr] () =>
-    Expect.expect(1 + 2) |> toBe(3)
-  )
-);
+describe([@attr] "App", [@attr] () => {
+  test([@attr] "math", [@attr] () => {
+    Expect.expect(1 + 2) |> toBe(3);
+  });
+});
 
 describe(~text="App", ~f=() =>
   test(~text="math", ~f=() =>

--- a/src/reason-parser/jbuild
+++ b/src/reason-parser/jbuild
@@ -56,6 +56,7 @@
     syntax_util
     reason_comment
     reason_layout
+    reason_attrs
     reason_heuristics
     reason_toolchain
     reason_config

--- a/src/reason-parser/reason_attrs.ml
+++ b/src/reason-parser/reason_attrs.ml
@@ -1,0 +1,93 @@
+(**
+  * Kinds of attributes.
+  * TODO: Deprecate this in favor of `partition`.
+  *)
+open Ast_404.Parsetree
+open Ast_404.Asttypes
+type attributesPartition = {
+  arityAttrs : attributes;
+  docAttrs : attributes;
+  stdAttrs : attributes;
+  jsxAttrs : attributes;
+  refmtAttrs : attributes;
+  (* Sometimes these are printed, and sometimes not! *)
+  uncurriedAttrs : attributes;
+}
+
+
+let isArity = function
+  | ({txt="explicit_arity"; loc}, _)
+  | ({txt="implicit_arity"; loc}, _) -> true
+  | _ -> false
+
+let isJsx = function
+  | ({txt="JSX"; loc}, _) -> true
+  | _ -> false
+
+let isUncurried ?(bsIsUncurried=true) = function
+  | ({txt = "bs"}, PStr []) -> bsIsUncurried
+  | _ -> false
+
+let isRefmt ~filter attr =
+  match attr with
+  | (
+      {txt="refmt"; loc},
+      PStr [{pstr_desc=Pstr_eval({pexp_desc=Pexp_constant(Pconst_string(tag, None))}, _)}]
+    ) -> (
+      match filter with
+      | None -> true
+      | Some style -> String.compare tag style == 0
+    )
+  | _ -> false
+
+let isRefmtExplicitBraces = isRefmt ~filter:(Some "explicitBraces")
+
+let isRefmtInlineOpen = isRefmt ~filter:(Some "inlineOpen")
+
+let isStandard ?(bsIsUncurried=true) attr = not (
+  isArity attr ||
+  isJsx attr ||
+  isRefmt ~filter:None attr ||
+  isUncurried ~bsIsUncurried attr
+)
+
+(** Partition attributes into kinds:
+    NOTE: Use the better `partition` version which helps preserve
+    ordering by only pulling off the attributes you need.
+    bsIsUncurried: Whether or not uncurried attribute should be treated as a
+    special non "standard" attribute. Another valid name would have been
+    "considerUncurriedArgumentsSpecial" *)
+let rec partitionAttributes ?(bsIsUncurried=true) attrs : attributesPartition =
+  match attrs with
+  | [] ->
+    {arityAttrs=[]; docAttrs=[]; stdAttrs=[]; jsxAttrs=[]; refmtAttrs=[]; uncurriedAttrs=[]}
+  | attr::atTl when isUncurried ~bsIsUncurried attr ->
+    let partition = partitionAttributes atTl in
+    {partition with uncurriedAttrs=attr::partition.uncurriedAttrs}
+  | attr::atTl when isJsx attr ->
+    let partition = partitionAttributes atTl in
+    {partition with jsxAttrs=attr::partition.jsxAttrs}
+  | attr::atTl when (isRefmt ~filter:None) attr ->
+    let partition = partitionAttributes atTl in
+    {partition with refmtAttrs=attr::partition.refmtAttrs}
+  | attr::atTl when isArity attr ->
+    let partition = partitionAttributes atTl in
+    {partition with arityAttrs=attr::partition.arityAttrs}
+  (*| (({txt="ocaml.text"; loc}, _) as doc)::atTl
+  | (({txt="ocaml.doc"; loc}, _) as doc)::atTl ->
+      let partition = partitionAttributes atTl in
+      {partition with docAttrs=doc::partition.docAttrs}*)
+  | atHd::atTl ->
+      let partition = partitionAttributes atTl in
+      {partition with stdAttrs=atHd::partition.stdAttrs}
+
+(* Returns (selected, remaining) *)
+let rec partition fn attrs : attribute list * attribute list =
+  match attrs with
+  | [] -> ([], [])
+  | attr::atTl when fn attr ->
+    let (selectedRec, remainingRec) = partition fn atTl in
+    (attr::selectedRec, remainingRec)
+  | attr::atTl ->
+    let (selectedRec, remainingRec) = partition fn atTl in
+    (selectedRec, attr::remainingRec)

--- a/src/reason-parser/reason_heuristics.ml
+++ b/src/reason-parser/reason_heuristics.ml
@@ -1,3 +1,4 @@
+
 let is_punned_labelled_expression e lbl =
   let open Ast_404.Parsetree in
   match e.pexp_desc with
@@ -75,3 +76,25 @@ let funAppCallbackExceedsWidth ~printWidth ~args ~funExpr () =
  * | X(y) =>
  *)
 let singleTokenPatternOmmitTrail txt = String.length txt < 4
+
+(* There may be other reasons why braces are rendered even if they weren't
+ * required. The user might have requested them! *)
+let rec astRequiresSequenceBraces expr =
+  let open Ast_404.Parsetree in
+  let open Ast_404.Asttypes in
+  match expr.pexp_desc with
+  | Pexp_let (rf, l, e) -> true
+  | Pexp_sequence _ -> true
+  | Pexp_letmodule (s, me, e) -> true
+  | Pexp_open (Fresh, lid, e) -> not (List.exists Reason_attrs.isRefmtInlineOpen expr.pexp_attributes)
+  | Pexp_open (Override, lid, e) -> true
+  | Pexp_letexception _ -> true
+  | _ -> false
+
+(* In the event they weren't required - did the user request braces *)
+let rec userRequestedSequenceBraces expr =
+  let open Ast_404.Parsetree in
+  let open Ast_404.Asttypes in
+  List.exists Reason_attrs.isRefmtExplicitBraces expr.pexp_attributes
+
+let requiresSequenceBracesBecauseUserRequested x = false

--- a/src/reason-parser/syntax_util.ml
+++ b/src/reason-parser/syntax_util.ml
@@ -5,6 +5,18 @@ open Ast_mapper
 open Parsetree
 open Longident
 
+(*
+    UTF-8 characters are encoded like this (most editors are UTF-8)
+    0xxxxxxx (length 1)
+    110xxxxx 10xxxxxx (length 2)
+    1110xxxx 10xxxxxx 10xxxxxx (length 3)
+    11110xxx 10xxxxxx 10xxxxxx 10xxxxxx (length 4)
+
+  Numbers over 127 cannot be encoded in UTF in a single byte, so they use two
+  bytes. That means we can use any characters between 128-255 to encode special
+  characters that would never be written by the user and thus never be confused
+  for our special formatting characters.
+*)
 (* Logic for handling special behavior that only happens if things break. We
   use characters that will never appear in the printed output if actually
   written in source code. The OCaml formatter will replace them with the escaped
@@ -20,6 +32,7 @@ module TrailingCommaMarker = struct
   let char = Char.chr 249 (* ˘ *)
   let string = String.make 1 char
 end
+
 module OpenBraceMarker = struct
   (* An open brace marker will only be rendered if it is immediately
    * followed by a newline. This should NOT BE USED WITH


### PR DESCRIPTION
Summary:Created a new place to store some stylistic information in the
AST. `[@refmt "foo"]` attributes used at parse time, never printed.

Test Plan:

Reviewers:

CC: