### PR TITLE
Update README.md

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -27,6 +27,7 @@ eval $(opam config env)
 git clone https://github.com/facebook/reason.git
 cd reason
 opam pin add -y reason .
+opam pin add -y rtop .
 ```
 
 ### With esy


### PR DESCRIPTION
Add `opam pin add -y rtop .` to the building instructions to make `./miscTests/rtopIntegrationTest.sh` pass.