### PR TITLE
Print non-ascii characters (for utf8) & keep raw string literals

### DIFF
--- a/formatTest/unit_tests/expected_output/escapesInStrings.re
+++ b/formatTest/unit_tests/expected_output/escapesInStrings.re
@@ -2,8 +2,13 @@
 /*
     let str = "@[.... some formatting ....@\n\010@.";
  */
-let str = "@[.... some formatting ....@\n\n@.";
+let str = "@[.... some formatting ....@\n\010@.";
 
 let str = {abcd|@[.... some formatting ....@\n\010@.|abcd};
 
 let utf8_string = "😁";
+
+let keep_representation = "\n
+\t . this should be on a new line\
+   ^ this should be aligned with the .
+";

--- a/formatTest/unit_tests/expected_output/escapesInStrings.re
+++ b/formatTest/unit_tests/expected_output/escapesInStrings.re
@@ -5,3 +5,5 @@
 let str = "@[.... some formatting ....@\n\n@.";
 
 let str = {abcd|@[.... some formatting ....@\n\010@.|abcd};
+
+let utf8_string = "😁";

--- a/formatTest/unit_tests/input/escapesInStrings.re
+++ b/formatTest/unit_tests/input/escapesInStrings.re
@@ -8,3 +8,8 @@ let str = "@[.... some formatting ....@\n\010@.";
 let str = {abcd|@[.... some formatting ....@\n\010@.|abcd};
 
 let utf8_string = "😁";
+
+let keep_representation = "\n
+\t . this should be on a new line\
+   ^ this should be aligned with the .
+";

--- a/formatTest/unit_tests/input/escapesInStrings.re
+++ b/formatTest/unit_tests/input/escapesInStrings.re
@@ -6,3 +6,5 @@
 
 let str = "@[.... some formatting ....@\n\010@.";
 let str = {abcd|@[.... some formatting ....@\n\010@.|abcd};
+
+let utf8_string = "😁";

--- a/src/reason-parser/reason_oprint.ml
+++ b/src/reason-parser/reason_oprint.ml
@@ -252,7 +252,7 @@ let print_out_value ppf tree =
     | Oval_float f -> pp_print_string ppf (float_repres f)
     | Oval_char c -> fprintf ppf "%C" c
     | Oval_string s ->
-        begin try fprintf ppf "%S" s with
+        begin try fprintf ppf "\"%s\"" (Syntax_util.escape_string s) with
           Invalid_argument "String.create" -> fprintf ppf "<huge string>"
         end
     | Oval_list tl ->

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -1757,7 +1757,7 @@ let constant ?(parens=true) ppf = function
   | Pconst_char i ->
     Format.fprintf ppf "%C"  i
   | Pconst_string (i, None) ->
-    Format.fprintf ppf "%S" i
+    Format.fprintf ppf "\"%s\"" (Syntax_util.escape_string i)
   | Pconst_string (i, Some delim) ->
     Format.fprintf ppf "{%s|%s|%s}" delim i delim
   | Pconst_integer (i, None) ->

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -285,6 +285,7 @@ type attributesPartition = {
   docAttrs : attributes;
   stdAttrs : attributes;
   jsxAttrs : attributes;
+  literalAttrs : attributes;
   uncurried : bool
 }
 
@@ -292,7 +293,7 @@ type attributesPartition = {
 let rec partitionAttributes ?(allowUncurry=true) attrs : attributesPartition =
   match attrs with
     | [] ->
-        {arityAttrs=[]; docAttrs=[]; stdAttrs=[]; jsxAttrs=[]; uncurried = false}
+      {arityAttrs=[]; docAttrs=[]; stdAttrs=[]; jsxAttrs=[]; literalAttrs=[]; uncurried = false}
     | (({txt = "bs"}, PStr []) as attr)::atTl ->
         let partition = partitionAttributes ~allowUncurry atTl in
         if allowUncurry then
@@ -309,12 +310,26 @@ let rec partitionAttributes ?(allowUncurry=true) attrs : attributesPartition =
     | (({txt="ocaml.doc"; loc}, _) as doc)::atTl ->
         let partition = partitionAttributes atTl in
         {partition with docAttrs=doc::partition.docAttrs}*)
-    | atHd::atTl ->
+    | (({txt="reason.raw_literal"; _}, _) as attr) :: atTl ->
+        let partition = partitionAttributes ~allowUncurry atTl in
+        {partition with literalAttrs=attr::partition.literalAttrs}
+    | atHd :: atTl ->
         let partition = partitionAttributes ~allowUncurry atTl in
         {partition with stdAttrs=atHd::partition.stdAttrs}
 
 let extractStdAttrs attrs =
   (partitionAttributes attrs).stdAttrs
+
+let extract_raw_literal attrs =
+  let rec loop acc = function
+    | ({txt="reason.raw_literal"; loc},
+       PStr [{pstr_desc = Pstr_eval({pexp_desc = Pexp_constant(Pconst_string(text, None)); _}, _); _}])
+      :: rest ->
+      (Some text, List.rev_append acc rest)
+    | [] -> (None, List.rev acc)
+    | attr :: rest -> loop (attr :: acc) rest
+  in
+  loop [] attrs
 
 let rec sequentialIfBlocks x =
   match x with
@@ -1753,11 +1768,16 @@ let tyvar ppf str =
  * e.g. Some((-1)) should be printed as Some(-1)
  * In `1 + (-1)` -1 should be wrapped in parens for readability
  *)
-let constant ?(parens=true) ppf = function
+let constant ?raw_literal ?(parens=true) ppf = function
   | Pconst_char i ->
     Format.fprintf ppf "%C"  i
   | Pconst_string (i, None) ->
-    Format.fprintf ppf "\"%s\"" (Syntax_util.escape_string i)
+    begin match raw_literal with
+      | Some text ->
+        Format.fprintf ppf "\"%s\"" text
+      | None ->
+        Format.fprintf ppf "\"%s\"" (Syntax_util.escape_string i)
+    end
   | Pconst_string (i, Some delim) ->
     Format.fprintf ppf "{%s|%s|%s}" delim i delim
   | Pconst_integer (i, None) ->
@@ -2019,7 +2039,9 @@ let printer = object(self:'self)
   (* TODO: Fail if observing applicative functors for this form. *)
   method longident_loc (x:Longident.t Location.loc) =
     source_map ~loc:x.loc (self#longident x.txt)
-  method constant ?(parens=true) = wrap (constant ~parens)
+
+  method constant ?raw_literal ?(parens=true) =
+    wrap (constant ?raw_literal ~parens)
 
   method constant_string = wrap constant_string
   method tyvar = wrap tyvar
@@ -2864,8 +2886,11 @@ let printer = object(self:'self)
              self#patternRecord l closed
           | Ppat_tuple l ->
              self#patternTuple l
-          | Ppat_constant c -> (self#constant c)
-          | Ppat_interval (c1, c2) -> makeList [self#constant c1; atom ".."; self#constant c2]
+          | Ppat_constant c ->
+            let raw_literal, _ = extract_raw_literal x.ppat_attributes in
+            (self#constant ?raw_literal c)
+          | Ppat_interval (c1, c2) ->
+            makeList [self#constant c1; atom ".."; self#constant c2]
           | Ppat_variant (l, None) -> makeList[atom "`"; atom l]
           | Ppat_constraint (p, ct) ->
               formatPrecedence (formatTypeConstraint (self#pattern p) (self#core_type ct))
@@ -3174,7 +3199,10 @@ let printer = object(self:'self)
          * pass through this case. In this context they don't need to be wrapped in extra parens
          * Some((-1)) should be printed as Some(-1). This is in contrast with
          * 1 + (-1) where we print the parens for readability. *)
-          let constant = self#constant ~parens:ensureExpr c in
+          let raw_literal, pexp_attributes =
+            extract_raw_literal pexp_attributes
+          in
+          let constant = self#constant ?raw_literal ~parens:ensureExpr c in
           begin match pexp_attributes with
           | [] -> constant
           | attrs ->
@@ -3247,11 +3275,11 @@ let printer = object(self:'self)
     let x = self#process_underscore_application x in
     (* If there are any attributes, render unary like `(~-) x [@ppx]`, and infix like `(+) x y [@attr]` *)
 
-    let {arityAttrs; stdAttrs; jsxAttrs; uncurried} =
+    let {arityAttrs; stdAttrs; jsxAttrs; literalAttrs; uncurried} =
       partitionAttributes ~allowUncurry:(Reason_heuristics.bsExprCanBeUncurried x) x.pexp_attributes
     in
     let () = if uncurried then Hashtbl.add uncurriedTable x.pexp_loc true in
-    let x = {x with pexp_attributes = (arityAttrs @ stdAttrs @ jsxAttrs) } in
+    let x = {x with pexp_attributes = (literalAttrs @ arityAttrs @ stdAttrs @ jsxAttrs) } in
     (* If there's any attributes, recurse without them, then apply them to
        the ends of functions, or simplify infix printings then append. *)
     if stdAttrs <> [] then
@@ -4949,7 +4977,9 @@ let printer = object(self:'self)
             Some (ensureSingleTokenSticksToLabel (self#longident_loc li))
         | Pexp_constant c ->
             (* Constants shouldn't break when to the right of a label *)
-            Some (ensureSingleTokenSticksToLabel (self#constant c))
+          let raw_literal, _ = extract_raw_literal x.pexp_attributes in
+            Some (ensureSingleTokenSticksToLabel
+                    (self#constant ?raw_literal c))
         | Pexp_pack me ->
           Some (
             makeList
@@ -5049,8 +5079,9 @@ let printer = object(self:'self)
 
   method formatChildren children processedRev =
     match children with
-    | {pexp_desc = Pexp_constant constant} :: remaining ->
-      self#formatChildren remaining (self#constant constant :: processedRev)
+    | {pexp_desc = Pexp_constant constant} as x :: remaining ->
+      let raw_literal, _ = extract_raw_literal x.pexp_attributes in
+      self#formatChildren remaining (self#constant ?raw_literal constant :: processedRev)
     | {pexp_desc = Pexp_construct ({txt = Lident "::"}, Some {pexp_desc = Pexp_tuple children} )} :: remaining ->
       self#formatChildren (remaining @ children) processedRev
     | {pexp_desc = Pexp_apply(expr, l); pexp_attributes} :: remaining ->

--- a/src/reason-parser/syntax_util.ml
+++ b/src/reason-parser/syntax_util.ml
@@ -485,3 +485,16 @@ let location_contains loc1 loc2 =
   loc1.loc_start.Lexing.pos_cnum <= loc2.loc_start.Lexing.pos_cnum &&
   loc1.loc_end.Lexing.pos_cnum >= loc2.loc_end.Lexing.pos_cnum
 
+let escape_string str =
+  let buf = Buffer.create (String.length str) in
+  String.iter (fun c ->
+      match c with
+      | '\t' -> Buffer.add_string buf "\\t"
+      | '\r' -> Buffer.add_string buf "\\r"
+      | '\n' -> Buffer.add_string buf "\\n"
+      | '\\' -> Buffer.add_string buf "\\\\"
+      | '"'  -> Buffer.add_string buf "\\\""
+      | c when c < ' ' -> Buffer.add_string buf (Char.escaped c)
+      | c -> Buffer.add_char buf c
+    ) str;
+  Buffer.contents buf


### PR DESCRIPTION
This PR implements two changes to the parser:

1) Don't escape non-ascii characters.
This allow printing of utf-8 strings without plenty of escapings. Only control characters, as well as `"` and `\`, are escaped with this patch.
The printing behavior is now comparable with OCaml one.

2) Keep literal string representation.
This preserve the exact representation of strings, when possible. The representation is stored in an attribute `reason.raw_literal`.

Patch 2) improves behavior of refmt from reason to reason. Patch 1) improves behavior of toplevel, as well as refmt, for any source (ast, ml, ...) that doesn't contain the `raw_literal` attribute.
