### PR TITLE
ocamlmerlin-reason: implement for_completion command

### DIFF
--- a/src/reason-merlin/ocamlmerlin_reason.ml
+++ b/src/reason-merlin/ocamlmerlin_reason.ml
@@ -25,8 +25,12 @@ module Reason_reader = struct
     else
       structure (Reason_toolchain.RE.implementation buf)
 
-  let for_completion t _ =
-    ({complete_labels = true}, parse t)
+  let for_completion t pos =
+    let pos' = !Reason_toolchain.insert_completion_ident in
+    Reason_toolchain.insert_completion_ident := Some pos;
+    Misc.try_finally
+      (fun () -> ({complete_labels = true}, parse t))
+      (fun () -> Reason_toolchain.insert_completion_ident := pos')
 
   let parse_line t pos line =
     let buf = Lexing.from_string line in

--- a/src/reason-parser/reason_toolchain.ml
+++ b/src/reason-parser/reason_toolchain.ml
@@ -490,9 +490,14 @@ module OCaml_syntax = struct
       (To_current.copy_structure structure)
 end
 
+let insert_completion_ident : Lexing.position option ref = ref None
+
 module Reason_syntax = struct
   module I = Reason_parser.MenhirInterpreter
-  module Lexer_impl = Reason_lexer
+  module Lexer_impl = struct
+    include Reason_lexer
+    let init () = init ?insert_completion_ident:!insert_completion_ident ()
+  end
   type token = Reason_parser.token
 
   (* [tracking_supplier] is a supplier that tracks the last token read *)


### PR DESCRIPTION
This PR refines merlin integration by implementing the `for-completion` stub: this inserts a fake identifier in the token stream when completion is triggered.

This enables slightly more cases to typecheck and adjusts the shape of an AST in the middle of an expression to take into account the identifier to be inserted.

See this example, where the most likely completion should be `list_to_string`:

Before, the type can't be inferred:
![before](https://user-images.githubusercontent.com/1048096/36748439-24bca42c-1bf8-11e8-8014-60b6e2786fa7.png)

After, merlin can first compute the type and then sorts the completion results:
![after](https://user-images.githubusercontent.com/1048096/36748444-2714dd84-1bf8-11e8-984f-0bb1755de477.png)

Note: the completion position has to be passed to the lexer, the patch introduces a reference in `Reason_toolchain` to pass this side information. This seems to be the easiest way to pass extra information. Any suggestion?