### PR TITLE
Pretty print lowercase jsx as attr of a jsx with braces.

### DIFF
--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -176,6 +176,24 @@ let y = [
 </Description>;
 
 <Description
+  term=(
+    Text.createElement(
+      ~text="Age",
+      ~children=[],
+      (),
+    )
+  )>
+  child
+</Description>;
+
+<Description
+  term=(
+    [@JSX] Text.createElement(~text="Age", ())
+  )>
+  child
+</Description>;
+
+<Description
   term={
     <Text
       superLongPunnedProp
@@ -196,3 +214,33 @@ let y = [
 />;
 
 <div> <span> (str("hello")) </span> </div>;
+
+<description term={<text text="Age" />}>
+  child
+</description>;
+
+<description
+  term=(text(~text="Age", ~children=[], ()))>
+  child
+</description>;
+
+<description
+  term=([@JSX] text(~text="Age", ~children=[]))>
+  child
+</description>;
+
+<description
+  term=([@JSX] text(~text="Age", ()))>
+  child
+</description>;
+
+<description
+  term={
+    <div
+      superLongPunnedProp
+      anotherSuperLongOneCrazyLongThingHere
+      text="Age"
+    />
+  }>
+  child
+</description>;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -127,9 +127,19 @@ let y = [<div />, <div />];
 let y = [<Button onClick=handleStaleClick />, <Button onClick=handleStaleClick />];
 
 <Description term={<Text text="Age" />}> child </Description>;
+<Description term=(Text.createElement(~text="Age", ~children=[], ()))> child </Description>;
+<Description term=([@JSX] Text.createElement(~text="Age", ()))> child </Description>;
 
 <Description term={<Text superLongPunnedProp anotherSuperLongOneCrazyLongThingHere text="Age" />}> child </Description>;
 
 <Foo bar={<Baz superLongPunnedProp anotherSuperLongOneCrazyLongThingHere/>}/>;
 
 <div><span>(str("hello"))</span></div>;
+
+<description term={<text text="Age" />}>child</description>;
+
+<description term=(text(~text="Age",~children=[], ()))>child</description>;
+<description term=([@JSX] text(~text="Age",~children=[]))>child</description>;
+<description term=([@JSX] text(~text="Age", ()))>child</description>;
+
+<description term={<div superLongPunnedProp anotherSuperLongOneCrazyLongThingHere text="Age" />}> child </description>;

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -1836,7 +1836,7 @@ let isJSXComponent expr =
     | (Nolabel, _) :: rest -> false
     | _ :: rest -> hasSingleNonLabelledUnitAndIsAtTheEnd rest
     in
-    if List.length jsxAttrs > 0
+    if jsxAttrs != []
        && hasLabelledChildrenLiteral
        && hasSingleNonLabelledUnitAndIsAtTheEnd args
     then

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -1822,25 +1822,28 @@ let is_direct_pattern x = x.ppat_attributes = [] && match x.ppat_desc with
   | Ppat_construct ( {txt= Lident"()"}, None) -> true
   | _ -> false
 
-let isJSXComponent loc args =
-  let hasLabelledChildrenLiteral = List.exists (function
-    | (Labelled "children", _) -> true
-    | _ -> false
-  ) args in
-  let rec hasSingleNonLabelledUnitAndIsAtTheEnd l = match l with
-  | [] -> false
-  | (Nolabel, {pexp_desc = Pexp_construct ({txt = Lident "()"}, _)}) :: [] -> true
-  | (Nolabel, _) :: rest -> false
-  | _ :: rest -> hasSingleNonLabelledUnitAndIsAtTheEnd rest
-  in
-  if hasLabelledChildrenLiteral && hasSingleNonLabelledUnitAndIsAtTheEnd args then
-    let moduleNameList = List.rev (List.tl (List.rev (Longident.flatten loc.txt))) in
-    if List.length moduleNameList > 0 && Longident.last loc.txt = "createElement" then
-       true
-    else false
-  else
-    false
-
+let isJSXComponent expr =
+  match expr with
+  | ({pexp_desc= Pexp_apply ({pexp_desc=Pexp_ident _}, args); pexp_attributes}) ->
+    let {jsxAttrs} = partitionAttributes pexp_attributes in
+    let hasLabelledChildrenLiteral = List.exists (function
+      | (Labelled "children", _) -> true
+      | _ -> false
+    ) args in
+    let rec hasSingleNonLabelledUnitAndIsAtTheEnd l = match l with
+    | [] -> false
+    | (Nolabel, {pexp_desc = Pexp_construct ({txt = Lident "()"}, _)}) :: [] -> true
+    | (Nolabel, _) :: rest -> false
+    | _ :: rest -> hasSingleNonLabelledUnitAndIsAtTheEnd rest
+    in
+    if List.length jsxAttrs > 0
+       && hasLabelledChildrenLiteral
+       && hasSingleNonLabelledUnitAndIsAtTheEnd args
+    then
+      true
+    else
+      false
+  | _ -> false
 
 (* Some cases require special formatting when there's a function application
  * with a single argument containing some kind of structure with braces/parens/brackets.
@@ -3570,7 +3573,7 @@ let printer = object(self:'self)
          let nextAttr =
            match expression.pexp_desc with
            | Pexp_ident ident when isPunnedJsxArg lbl ident -> atom lbl
-           | Pexp_apply ({pexp_desc=Pexp_ident loc}, l) when isJSXComponent loc l ->
+           | _ when isJSXComponent expression  ->
                label (atom (lbl ^ "="))
                      (makeList ~break:IfNeed ~wrap:("{", "}") [(self#simplifyUnparseExpr expression)])
            | Pexp_record _


### PR DESCRIPTION
Prints braces around jsx attributes containing lowercase jsx:
```
<form label=<div /> />;
/* post-refmt: */
<form label={<div />} />;
```
Makes lowercase jsx as jsx attribute consistent with https://github.com/facebook/reason/pull/1745
