### PR TITLE
Better alignment of closing ">" when jsx breaks.

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -280,7 +280,8 @@ let lotsOfArguments =
     argument3=3
     argument4=4
     argument5=5
-    argument6="test">
+    argument6="test"
+  >
     <Namespace.Foo />
   </LotsOfArguments>;
 
@@ -476,7 +477,8 @@ let myFun = () =>
       anotherOptional=200
     />
     <Namespace.Foo
-      intended=true anotherOptional=200>
+      intended=true anotherOptional=200
+    >
       <Foo />
       <Foo />
       <Foo />
@@ -500,7 +502,8 @@ let myFun = () =>
       anotherOptional=200
     />
     <Namespace.Foo
-      intended=true anotherOptional=200>
+      intended=true anotherOptional=200
+    >
       <Foo />
       <Foo />
       <Foo />

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -182,7 +182,8 @@ let y = [
       anotherSuperLongOneCrazyLongThingHere
       text="Age"
     />
-  }>
+  }
+>
   child
 </Description>;
 

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3601,13 +3601,14 @@ let printer = object(self:'self)
       let openTagAndAttrs =
         match reversedAttributes with
         | [] -> (atom ("<" ^ componentName ^ ">"))
-        | revAttrHd::revAttrTl ->
-          let finalAttrList = (List.rev (makeList ~break:Layout.Never [revAttrHd; atom ">"] :: revAttrTl)) in
-          let renderedAttrList = (makeList ~inline:(true, true) ~break:IfNeed ~pad:(false, false) ~preSpace:true finalAttrList) in
-          label
-            ~space:true
-            (atom ("<" ^ componentName))
-            renderedAttrList
+        | revAttrs ->
+          let renderedAttrList =
+            makeList ~inline:(true, true) ~break:IfNeed ~pad:(false, false) ~preSpace:true (List.rev revAttrs)
+          in
+          makeList ~inline:(true, true) ~break:IfNeed [
+            label ~space:true (atom ("<" ^ componentName)) renderedAttrList;
+            atom ">"
+          ]
       in
       label
         openTagAndAttrs


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/1835
Small change which makes jsx a pleasure to read in reason (and more consistent with Prettier...)

```
// Before
<Namespace.Foo
  intended=true
  anotherOptional=200>
  child
</Namespace.Foo>

// After
<Namespace.Foo
  intended=true
  anotherOptional=200
>
  child
</Namespace.Foo>
```