### PR TITLE
Update --version info before publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 SUBSTS:=$(ROOT_DIR)/pkg/substs
 
 # For publishing esy releases to npm
-esy-prepublish: build clean-tests
+esy-prepublish: build clean-tests pre_release
 	node ./scripts/esy-prepublish.js
 
 # For OPAM


### PR DESCRIPTION
This makes sure that `refmt --version` shows the right info. It's been
stuck at 3.0.0 forever now.

cc @jordwalke. Not sure how you're running this command, but should just
work.