### PR TITLE
Allow underscore as single argument to a function.

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -34,13 +34,13 @@ let l2 =
   |> List.map(optParam(~v=?_, ()))
   |> List.length;
 
-let argIsUnderscore1 = (_) => 34;
+let argIsUnderscore1 = _ => 34;
 
-let argIsUnderscore2 = (_) => 34;
+let argIsUnderscore2 = _ => 34;
 
-let argIsUnderscore3 = (_) : int => 34;
+let argIsUnderscore3 = _ : int => 34;
 
-let argIsUnderscore4 = (_) : int => 34;
+let argIsUnderscore4 = _ : int => 34;
 
 let argIsUnderscore5 = (_: int) => 34;
 

--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -34,6 +34,18 @@ let l2 =
   |> List.map(optParam(~v=?_, ()))
   |> List.length;
 
+let argIsUnderscore1 = (_) => 34;
+
+let argIsUnderscore2 = (_) => 34;
+
+let argIsUnderscore3 = (_) : int => 34;
+
+let argIsUnderscore4 = (_) : int => 34;
+
+let argIsUnderscore5 = (_: int) => 34;
+
+let argIsUnderscore6 = (_: int) => 34;
+
 type reasonXyz =
   | X
   | Y(int, int, int)

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -22,6 +22,18 @@ let l1 =
 let l2 =
   [Some(1), None, Some(2)] |> List.map(optParam(~v =?_, ())) |> List.length;
 
+let argIsUnderscore1 = _ => 34;
+
+let argIsUnderscore2 = (_ => 34);
+  
+let argIsUnderscore3 = _ : int => 34;
+  
+let argIsUnderscore4 = (_ : int => 34);
+
+let argIsUnderscore5 = (_: int) => 34;
+
+let argIsUnderscore6 = ((_: int) => 34);
+
 type reasonXyz =
   | X
   | Y(int,int,int)

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -872,14 +872,9 @@ let unitLambda = () => ();
 
 let identifierLambda = a => ();
 
+let underscoreLambda = _ => ();
+
 it("should remove parens", a => {
   print_string("did it work?");
   print_string("did it work?");
 });
-
-/**
- * Parens around "any" pattern in lambda should be kept.
- * We should also support removing these parens too, but that requires a parser
- * change.
- */
-let keepTheseParens = (_) => ();

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -483,7 +483,7 @@ Printf.printf(
 include YourLib.CreateComponent({
   type thing = blahblahblah;
   type state = unit;
-  let getInitialState = (_) => ();
+  let getInitialState = _ => ();
   let myValue = {recordField: "hello"};
 });
 

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -558,7 +558,7 @@ let add = (a, b) => {
 
 print_string(string_of_int(add(4, 34)));
 
-let dummy = (_) => 10;
+let dummy = _ => 10;
 
 dummy(res1);
 

--- a/formatTest/unit_tests/input/basicStructures.re
+++ b/formatTest/unit_tests/input/basicStructures.re
@@ -676,14 +676,8 @@ let z = {"a": {pub b = c; pub d = e}, "f": g};
  */
 let unitLambda = (()) => ();
 let identifierLambda = (a) => ();
+let underscoreLambda = (_) => ();
 it("should remove parens", (a) => {
   print_string("did it work?");
   print_string("did it work?");
 });
-
-/**
- * Parens around "any" pattern in lambda should be kept.
- * We should also support removing these parens too, but that requires a parser
- * change.
- */
-let keepTheseParens = (_) => ();

--- a/src/reason-parser/reason_lexer.mll
+++ b/src/reason-parser/reason_lexer.mll
@@ -944,7 +944,7 @@ and skip_sharp_bang = parse
         let acc = if is_triggering_token tok' then inject_es6_fun acc else acc in
         lex_balanced_step closing lexbuf (rparen @ acc) tok'
       end
-    | (LIDENT _, _) ->
+    | ((LIDENT _ | UNDERSCORE), _) ->
       begin match token lexbuf with
       | exception exn ->
         raise (Lex_balanced_failed (acc, Some (save_triple lexbuf exn)))
@@ -1004,7 +1004,7 @@ and skip_sharp_bang = parse
       begin match token lexbuf with
       | LPAREN | LBRACE as tok ->
           lookahead_esfun lexbuf (save_triple lexbuf tok)
-      | LIDENT _ as tok ->
+      | (LIDENT _ | UNDERSCORE) as tok ->
           let tok = save_triple lexbuf tok in
           begin match token lexbuf with
           | exception exn ->

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -2571,6 +2571,8 @@ es6_parameters:
   | labeled_pattern_list { $1 }
   | as_loc(val_ident)
     { ([{$1 with txt = Term (Nolabel, None, mkpat ~loc:$1.loc (Ppat_var $1))}], false) }
+  | as_loc(UNDERSCORE)
+    { ([{$1 with txt = Term (Nolabel, None, mkpat ~loc:$1.loc Ppat_any)}], false) }
 ;
 
 // TODO: properly fix JSX labelled/optional stuff


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/1853.
Allow single argument functions where the argument is an underscore without parentheses: ` _ => 34`.
It can be confusing when a single variable argument is formatted without parentheses: from `(x)=>34` to ` x => 34`. And typically renamed with an underscore when not used ` _x => 34`, but using just underscore is a syntax error.

@let-def just checking that the changes are safe.