### PR TITLE
Specialize syntax error for underscore.

### DIFF
--- a/src/reason-parser/reason_parser_explain.ml
+++ b/src/reason-parser/reason_parser_explain.ml
@@ -49,6 +49,11 @@ let semicolon_might_be_missing state _token =
   else
     raise Not_found
 
+let token_specific_message = function
+  | Parser.UNDERSCORE ->
+    "underscore is not a valid identifier. Use _ only in pattern matching and partial function application"
+  | _ ->
+    raise Not_found
 let message env (token, startp, endp) =
   let state = Interp.current_state_number env in
   (* Is there a message for this specific state ? *)
@@ -61,6 +66,8 @@ let message env (token, startp, endp) =
   try uppercased_instead_of_lowercased state token
   with Not_found ->
   try semicolon_might_be_missing state token
+  with Not_found ->
+  try token_specific_message token
   with Not_found ->
     (* TODO: we don't know what to say *)
     "<UNKNOWN SYNTAX ERROR>"


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/1856.

Try to give a more descriptive error message that “UNKNOWN SYNTAX ERROR” when the error is caused by the presence of an underscore.

This is an attempt to give some hints, though it's not so easy to do in full generality.

E.g.
```
let x = A(1,_);
```
gives
```
File "a.re", line 1, characters 12-13:
Error: 3205: underscore is not a valid identifier. Use _ only in pattern matching and partial function application
```