### PR TITLE
Rename syntax_util to reason_syntax_util

### DIFF
--- a/bspacks/refmtJsApi.ml
+++ b/bspacks/refmtJsApi.ml
@@ -61,7 +61,7 @@ let parseWith f code =
     in
     Js.Unsafe.fun_call throwAnything [|Js.Unsafe.inject jsError|]
   (* from reason *)
-  | Refmt_api.Syntax_util.Error (location, Syntax_error err) ->
+  | Refmt_api.Reason_syntax_util.Error (location, Syntax_error err) ->
     let jsLocation = locationToJsObj location in
     let jsError =
       Js.Unsafe.obj [|

--- a/src/README.md
+++ b/src/README.md
@@ -124,7 +124,7 @@ Our lexer & parser use [Menhir](http://gallium.inria.fr/~fpottier/menhir/), a li
 
 - `*.sh`: some of our binaries' entries.
 
-- `src/rtop/reason_util.ml`, `syntax_util.ml`: utils.
+- `src/rtop/reason_util.ml`, `reason_syntax_util.ml`: utils.
 
 - `src/reason-parser/reactjs_jsx_ppx_v2.ml/v3.ml`: our ReactJS interop that translates [Reason JSX](https://reasonml.github.io/docs/en/jsx.html) into something that ReactJS understands. See the comments in the file and the description in [ReasonReact](https://reasonml.github.io/reason-react/#reason-react-jsx).
 

--- a/src/reason-parser/jbuild
+++ b/src/reason-parser/jbuild
@@ -53,7 +53,7 @@
   (wrapped false)
   (modules
    (lexer_warning
-    syntax_util
+    reason_syntax_util
     reason_comment
     reason_layout
     reason_heuristics

--- a/src/reason-parser/reason_layout.ml
+++ b/src/reason-parser/reason_layout.ml
@@ -245,9 +245,9 @@ let get_location layout =
 let is_before ~location layout =
   match get_location layout with
   | None -> true
-  | Some loc -> Syntax_util.location_is_before loc location
+  | Some loc -> Reason_syntax_util.location_is_before loc location
 
 let contains_location layout ~location =
   match get_location layout with
   | None -> false
-  | Some layout_loc -> Syntax_util.location_contains layout_loc location
+  | Some layout_loc -> Reason_syntax_util.location_contains layout_loc location

--- a/src/reason-parser/reason_oprint.ml
+++ b/src/reason-parser/reason_oprint.ml
@@ -124,7 +124,7 @@ let parenthesized_ident name =
     | _ -> true)
 
 (* #if defined BS_NO_COMPILER_PATCH then *)
-let ml_to_reason_swap = Syntax_util.ml_to_reason_swap
+let ml_to_reason_swap = Reason_syntax_util.ml_to_reason_swap
 (* #else *)
 
 (* please keep this section in sync with Reason repo's Syntax_util file's
@@ -252,7 +252,7 @@ let print_out_value ppf tree =
     | Oval_float f -> pp_print_string ppf (float_repres f)
     | Oval_char c -> fprintf ppf "%C" c
     | Oval_string s ->
-        begin try fprintf ppf "\"%s\"" (Syntax_util.escape_string s) with
+        begin try fprintf ppf "\"%s\"" (Reason_syntax_util.escape_string s) with
           Invalid_argument "String.create" -> fprintf ppf "<huge string>"
         end
     | Oval_list tl ->

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -49,7 +49,7 @@
 
 %{
 open Migrate_parsetree.OCaml_404.Ast
-open Syntax_util
+open Reason_syntax_util
 open Location
 open Asttypes
 open Longident
@@ -465,7 +465,7 @@ let array_function ?(loc=dummy_loc()) str name =
 
 let syntax_error_str loc msg =
   if !Reason_config.recoverable then
-    Str.mk ~loc:loc (Pstr_extension (Syntax_util.syntax_error_extension_node loc msg, []))
+    Str.mk ~loc:loc (Pstr_extension (Reason_syntax_util.syntax_error_extension_node loc msg, []))
   else
     raise(Syntaxerr.Error(Syntaxerr.Other loc))
 
@@ -474,25 +474,25 @@ let syntax_error () =
 
 let syntax_error_exp loc msg =
   if !Reason_config.recoverable then
-    Exp.mk ~loc (Pexp_extension (Syntax_util.syntax_error_extension_node loc msg))
+    Exp.mk ~loc (Pexp_extension (Reason_syntax_util.syntax_error_extension_node loc msg))
   else
     syntax_error ()
 
 let syntax_error_pat loc msg =
   if !Reason_config.recoverable then
-    Pat.extension ~loc (Syntax_util.syntax_error_extension_node loc msg)
+    Pat.extension ~loc (Reason_syntax_util.syntax_error_extension_node loc msg)
   else
     syntax_error ()
 
 let syntax_error_typ loc msg =
   if !Reason_config.recoverable then
-    Typ.extension ~loc (Syntax_util.syntax_error_extension_node loc msg)
+    Typ.extension ~loc (Reason_syntax_util.syntax_error_extension_node loc msg)
   else
     raise (Syntaxerr.Error(Syntaxerr.Not_expecting (loc, msg)))
 
 let syntax_error_mod loc msg =
   if !Reason_config.recoverable then
-    Mty.extension ~loc (Syntax_util.syntax_error_extension_node loc msg)
+    Mty.extension ~loc (Reason_syntax_util.syntax_error_extension_node loc msg)
   else
     syntax_error ()
 
@@ -501,7 +501,7 @@ let unclosed opening closing =
                                            closing.loc, closing.txt)))
 
 let unclosed_extension closing =
-  Syntax_util.syntax_error_extension_node closing.loc ("Expecting \"" ^ closing.txt ^ "\"")
+  Reason_syntax_util.syntax_error_extension_node closing.loc ("Expecting \"" ^ closing.txt ^ "\"")
 
 let unclosed_mod opening closing =
   if !Reason_config.recoverable then
@@ -544,7 +544,7 @@ let expecting nonterm =
 
 let expecting_pat nonterm =
   if !Reason_config.recoverable then
-    mkpat(Ppat_extension (Syntax_util.syntax_error_extension_node nonterm.loc ("Expecting " ^ nonterm.txt)))
+    mkpat(Ppat_extension (Reason_syntax_util.syntax_error_extension_node nonterm.loc ("Expecting " ^ nonterm.txt)))
   else
     expecting nonterm
 
@@ -1002,10 +1002,10 @@ let jsx_component module_name attrs children loc =
   { body with pexp_attributes = attribute :: body.pexp_attributes }
 
 (* We might raise some custom error messages in this file.
-  Do _not_ directly raise a Location.Error. Our public interface guarantees that we only throw Syntaxerr or Syntax_util.Error *)
+  Do _not_ directly raise a Location.Error. Our public interface guarantees that we only throw Syntaxerr or Reason_syntax_util.Error *)
 let raiseSyntaxErrorFromSyntaxUtils loc fmt =
   Printf.ksprintf
-    (fun msg -> raise Syntax_util.(Error(loc, (Syntax_error msg))))
+    (fun msg -> raise Reason_syntax_util.(Error(loc, (Syntax_error msg))))
     fmt
 
 let ensureTagsAreEqual startTag endTag loc =
@@ -1599,20 +1599,20 @@ mark_position_mod
 structure:
   | /* Empty */ { [] }
   | as_loc(error) structure
-    { let menhirError = Syntax_util.findMenhirErrorMessage $1.loc in
+    { let menhirError = Reason_syntax_util.findMenhirErrorMessage $1.loc in
       match menhirError with
       | MenhirMessagesError errMessage -> (syntax_error_str errMessage.loc errMessage.msg) :: $2
       | _ -> (syntax_error_str $1.loc "Invalid statement") :: $2
     }
   | as_loc(error) SEMI structure
-    { let menhirError = Syntax_util.findMenhirErrorMessage $1.loc in
+    { let menhirError = Reason_syntax_util.findMenhirErrorMessage $1.loc in
       match menhirError with
       | MenhirMessagesError errMessage -> (syntax_error_str errMessage.loc errMessage.msg) :: $3
       | _ -> (syntax_error_str $1.loc "Invalid statement") :: $3
     }
   | structure_item { $1 }
   | as_loc(structure_item) error structure
-    { let menhirError = Syntax_util.findMenhirErrorMessage $1.loc in
+    { let menhirError = Reason_syntax_util.findMenhirErrorMessage $1.loc in
       match menhirError with
       | MenhirMessagesError errMessage -> (syntax_error_str errMessage.loc errMessage.msg) :: $3
       | _ -> (syntax_error_str $1.loc "Statement has to end with a semicolon") :: $3
@@ -2559,7 +2559,7 @@ as_loc
         match p.txt with
         | Term (Labelled _, _, _)
         | Term (Optional _, _, _)  ->
-            raise Syntax_util.(Error(p.loc, (Syntax_error "Uncurried function definition with labelled arguments is not supported at the moment.")));
+            raise Reason_syntax_util.(Error(p.loc, (Syntax_error "Uncurried function definition with labelled arguments is not supported at the moment.")));
             ()
         | _ -> ()
       ) $3 in
@@ -2604,19 +2604,19 @@ jsx_arguments:
   {
     match $1.txt with
     | "/>>" ->
-     let err = Syntax_util.Syntax_error {|JSX in a JSX-argument needs to be wrapped in braces.
+     let err = Reason_syntax_util.Syntax_error {|JSX in a JSX-argument needs to be wrapped in braces.
     If you wrote:
       <Description term=<Text text="Age" />> child </Description>
     Try wrapping <Text /> in braces.
       <Description term={<Text text="Age" />}> child </Description>|} in
-      raise (Syntax_util.Error($1.loc, err))
+      raise (Reason_syntax_util.Error($1.loc, err))
     | "/>/>" ->
-     let err = Syntax_util.Syntax_error {|JSX in a JSX-argument needs to be wrapped in braces.
+     let err = Reason_syntax_util.Syntax_error {|JSX in a JSX-argument needs to be wrapped in braces.
     If you wrote:
       <Description term=<Text text="Age" />/>
     Try wrapping <Text /> in braces.
       <Description term={<Text text="Age" />} />|} in
-      raise (Syntax_util.Error($1.loc, err))
+      raise (Reason_syntax_util.Error($1.loc, err))
     | _ -> syntax_error ()
   }
 ;
@@ -4171,7 +4171,7 @@ arrow_type_parameter:
   { let uncurried = match $1 with | Some _ -> true | None -> false in
     match $2.txt with
     | (Labelled _, _) when uncurried ->
-        raise Syntax_util.(Error($2.loc, (Syntax_error "An uncurried function type with labelled arguments is not supported at the moment.")))
+        raise Reason_syntax_util.(Error($2.loc, (Syntax_error "An uncurried function type with labelled arguments is not supported at the moment.")))
     | _ -> ($2, uncurried)
   }
 

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -52,7 +52,7 @@ open Location
 open Longident
 open Parsetree
 open Easy_format
-open Syntax_util
+open Reason_syntax_util
 
 module Comment = Reason_comment
 module Layout = Reason_layout
@@ -61,7 +61,7 @@ let source_map = Layout.source_map
 
 exception NotPossible of string
 
-let commaTrail = Layout.SepFinal (",", Syntax_util.TrailingCommaMarker.string)
+let commaTrail = Layout.SepFinal (",", Reason_syntax_util.TrailingCommaMarker.string)
 let commaSep = Layout.Sep (",")
 
 type ruleInfoData = {
@@ -1178,7 +1178,7 @@ let lineZeroMeaningfulContent line =
 
 let formatComment_ txt =
   let commLines =
-    Syntax_util.split_by ~keep_empty:true (fun x -> x = '\n')
+    Reason_syntax_util.split_by ~keep_empty:true (fun x -> x = '\n')
       (Comment.wrap txt)
   in
   match commLines with
@@ -1353,10 +1353,10 @@ let rec looselyAttachComment ~breakAncestors layout comment =
     Sequence (listConfig, [formatComment comment])
   | Sequence (listConfig, subLayouts) ->
     let (beforeComment, afterComment) =
-      Syntax_util.pick_while (Layout.is_before ~location) subLayouts in
+      Reason_syntax_util.pick_while (Layout.is_before ~location) subLayouts in
     let newSubLayout = match List.rev beforeComment with
       | [] ->
-        Syntax_util.map_first (prependSingleLineComment comment) afterComment
+        Reason_syntax_util.map_first (prependSingleLineComment comment) afterComment
       | hd :: tl ->
         List.rev_append
           (appendComment ~breakAncestors hd comment :: tl) afterComment
@@ -1396,12 +1396,12 @@ let rec insertSingleLineComment layout comment =
   | Sequence (listConfig, subLayouts) ->
     let newlinesAboveDocComments = listConfig.newlinesAboveDocComments in
     let (beforeComment, afterComment) =
-      Syntax_util.pick_while (Layout.is_before ~location) subLayouts in
+      Reason_syntax_util.pick_while (Layout.is_before ~location) subLayouts in
     begin match afterComment with
       (* Nothing in the list is after comment, attach comment to the statement before the comment *)
       | [] ->
         let break sublayout = breakline sublayout (formatComment comment) in
-        Sequence (listConfig, Syntax_util.map_last break beforeComment)
+        Sequence (listConfig, Reason_syntax_util.map_last break beforeComment)
       | hd::tl ->
         let afterComment =
           match Layout.get_location hd with
@@ -1568,7 +1568,7 @@ let format_layout ?comments ppf layout =
   if debugWithHtml.contents then
     Easy_format.Pretty.define_styles fauxmatter html_escape html_style;
   let _ = Easy_format.Pretty.to_formatter fauxmatter easy in
-  let trimmed = Syntax_util.processLineEndingsAndStarts (Buffer.contents buf) in
+  let trimmed = Reason_syntax_util.processLineEndingsAndStarts (Buffer.contents buf) in
   Format.fprintf ppf "%s\n" trimmed;
   Format.pp_print_flush ppf ()
 
@@ -1776,7 +1776,7 @@ let constant ?raw_literal ?(parens=true) ppf = function
       | Some text ->
         Format.fprintf ppf "\"%s\"" text
       | None ->
-        Format.fprintf ppf "\"%s\"" (Syntax_util.escape_string i)
+        Format.fprintf ppf "\"%s\"" (Reason_syntax_util.escape_string i)
     end
   | Pconst_string (i, Some delim) ->
     Format.fprintf ppf "{%s|%s|%s}" delim i delim

--- a/src/reason-parser/reason_syntax_util.ml
+++ b/src/reason-parser/reason_syntax_util.ml
@@ -440,12 +440,12 @@ let () =
      )
 
 let map_first f = function
-  | [] -> invalid_arg "Syntax_util.map_first: empty list"
+  | [] -> invalid_arg "Reason_syntax_util.map_first: empty list"
   | x :: xs -> f x :: xs
 
 let map_last f l =
   match List.rev l with
-  | [] -> invalid_arg "Syntax_util.map_last: empty list"
+  | [] -> invalid_arg "Reason_syntax_util.map_last: empty list"
   | x :: xs -> List.rev (f x :: xs)
 
 type menhirMessagesError = {

--- a/src/reason-parser/reason_toolchain.ml
+++ b/src/reason-parser/reason_toolchain.ml
@@ -294,12 +294,12 @@ module Create_parse_entrypoint (Toolchain_impl: Toolchain_spec) :Toolchain = str
         | Location.Error err -> (err.loc, err.msg)
         | _ ->
           let loc = Location.curr lexbuf in
-          match Syntax_util.findMenhirErrorMessage loc with
-          | Syntax_util.MenhirMessagesError errMessage ->
-            (errMessage.Syntax_util.loc, errMessage.Syntax_util.msg)
+          match Reason_syntax_util.findMenhirErrorMessage loc with
+          | Reason_syntax_util.MenhirMessagesError errMessage ->
+            (errMessage.Reason_syntax_util.loc, errMessage.Reason_syntax_util.msg)
           | _ -> (loc, invalidLex)
       in
-      let error = Syntax_util.syntax_error_extension_node loc msg in
+      let error = Reason_syntax_util.syntax_error_extension_node loc msg in
       ([Ast_helper.Str.mk ~loc (Parsetree.Pstr_extension (error, []))], [])
 
   let core_type_with_comments lexbuf =
@@ -309,7 +309,7 @@ module Create_parse_entrypoint (Toolchain_impl: Toolchain_spec) :Toolchain = str
         | Location.Error err -> (err.loc, err.msg)
         | _ -> (Location.curr lexbuf, invalidLex)
       in
-      let error = Syntax_util.syntax_error_extension_node loc msg in
+      let error = Reason_syntax_util.syntax_error_extension_node loc msg in
       (Ast_helper.Typ.mk ~loc (Parsetree.Ptyp_extension error), [])
 
   let interface_with_comments lexbuf =
@@ -319,7 +319,7 @@ module Create_parse_entrypoint (Toolchain_impl: Toolchain_spec) :Toolchain = str
         | Location.Error err -> (err.loc, err.msg)
         | _ -> (Location.curr lexbuf, invalidLex)
       in
-      let error = Syntax_util.syntax_error_extension_node loc msg in
+      let error = Reason_syntax_util.syntax_error_extension_node loc msg in
       ([Ast_helper.Sig.mk ~loc (Parsetree.Psig_extension (error, []))], [])
 
   let toplevel_phrase_with_comments lexbuf =
@@ -441,7 +441,7 @@ module OCaml_syntax = struct
 
   (* Skip tokens to the end of the phrase *)
   (* TODO: consolidate these copy-paste skip/trys into something that works for
-   * every syntax (also see [syntax_util]). *)
+   * every syntax (also see [Reason_syntax_util]). *)
   let rec skip_phrase lexbuf =
     try
       match Lexer.token lexbuf with
@@ -620,15 +620,15 @@ module Reason_syntax = struct
 
     | I.HandlingError env when !Reason_config.recoverable ->
       let loc = last_token_loc supplier in
-      begin match Syntax_util.findMenhirErrorMessage loc with
-        | Syntax_util.MenhirMessagesError err -> ()
-        | Syntax_util.NoMenhirMessagesError ->
+      begin match Reason_syntax_util.findMenhirErrorMessage loc with
+        | Reason_syntax_util.MenhirMessagesError err -> ()
+        | Reason_syntax_util.NoMenhirMessagesError ->
           let token = match supplier.last_token with
             | Some token -> token
             | None -> assert false
           in
           let msg = Reason_parser_explain.message env token in
-          Syntax_util.add_error_message Syntax_util.{loc = loc; msg = msg};
+          Reason_syntax_util.add_error_message Reason_syntax_util.{loc = loc; msg = msg};
       end;
       let checkpoint = I.resume checkpoint in
       (* Enter error recovery state *)
@@ -647,7 +647,7 @@ module Reason_syntax = struct
        * associated with the current parser state *)
       let msg = Reason_parser_explain.message env token in
       let msg_with_state = Printf.sprintf "%d: %s" state msg in
-      raise (Syntax_util.Error (loc, (Syntax_util.Syntax_error msg_with_state)))
+      raise (Reason_syntax_util.Error (loc, (Reason_syntax_util.Syntax_error msg_with_state)))
 
     | I.Rejected ->
       let loc = last_token_loc supplier in

--- a/src/rtop/reason_util.ml
+++ b/src/rtop/reason_util.ml
@@ -54,5 +54,5 @@ let correctly_catch_parse_errors fn lexbuf =
     raise (match exn with
           | Reason_lexer.Error _ -> transmogrify_exn exn exn_Lexer_Error
           | Syntaxerr.Error _ -> transmogrify_exn exn exn_Syntaxerr_Error
-          | Syntax_util.Error (loc, _) -> transmogrify_exn (Syntaxerr.Error(Syntaxerr.Other loc)) exn_Syntaxerr_Error
+          | Reason_syntax_util.Error (loc, _) -> transmogrify_exn (Syntaxerr.Error(Syntaxerr.Other loc)) exn_Syntaxerr_Error
           | _ -> exn)


### PR DESCRIPTION
This file might need to be dragged into BS repo because the outcome
printer relies on it now. No problem with that, but every other file in
the directory start with `reason`, so let's make this one start with
`reason` as well. Easier to copy paste around without name clashes too.