### PR TITLE
Remove hacks from reason_oprint; add commented cppo stuff for reason_syntax_util

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ We're spoiled with more APIs on the native side. To use Reason from OPAM as a na
 - `Reason_toolchain.ML.implementation_with_comments`
 - etc.
 
-The `ML` parsing functions might throw [`Syntaxerr.Error error`](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Syntaxerr.html). The `RE` parsing functions might throw [this](https://github.com/facebook/reason/blob/5a253048e8077c4597a8935adbed7aa22bfff647/src/syntax_util.ml#L301) (docs on `Location.t` [here](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Location.html)) in addition to `Syntaxerr.Error error`.
+The `ML` parsing functions might throw [`Syntaxerr.Error error`](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Syntaxerr.html). The `RE` parsing functions might throw [this](https://github.com/facebook/reason/blob/2ceb9d9c8c95dbc78a5fb98b3798c7c102cd64f5/src/reason-parser/reason_syntax_util.ml#L428) (docs on `Location.t` [here](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Location.html)) in addition to `Syntaxerr.Error error`.
 
 Example usage:
 

--- a/src/reason-parser/reason_oprint.ml
+++ b/src/reason-parser/reason_oprint.ml
@@ -123,64 +123,9 @@ let parenthesized_ident name =
         false
     | _ -> true)
 
-(* #if defined BS_NO_COMPILER_PATCH then *)
-let ml_to_reason_swap = Reason_syntax_util.ml_to_reason_swap
-(* #else *)
-
-(* please keep this section in sync with Reason repo's Syntax_util file's
-  helpers of the same names *)
-
-(* let string_add_suffix x = x ^ "_" *)
-(* let string_drop_suffix x = String.sub x 0 (String.length x - 1) *)
-(** Check to see if the string `s` is made up of `keyword` and zero or more
-    trailing `_` characters. *)
-(* let potentially_conflicts_with ~keyword s = *)
-  (* let s_length = String.length s in *)
-  (* let keyword_length = String.length keyword in *)
-  (* It can't be a match if s is shorter than keyword *)
-  (* s_length >= keyword_length && ( *)
-    (* try *)
-      (* Ensure s starts with keyword... *)
-      (* for i = 0 to keyword_length - 1 do *)
-        (* if keyword.[i] <> s.[i] then raise Exit; *)
-      (* done; *)
-      (* ...and contains nothing else except trailing _ characters *)
-      (* for i = keyword_length to s_length - 1 do *)
-        (* if s.[i] <> '_' then raise Exit; *)
-      (* done; *)
-      (* If we've made it this far there's a potential conflict *)
-      (* true *)
-    (* with *)
-    (* | Exit -> false *)
-  (* ) *)
-(* let ml_to_reason_swap = function *)
-  (* | "not" -> "!" *)
-  (* | "!" -> "^" *)
-  (* | "^" -> "++" *)
-  (* | "==" -> "===" *)
-  (* | "=" -> "==" *)
-  (* ===\/ and !==\/ are not representable in OCaml but
-   * representable in Reason
-   *)
-  (* | "!==" -> "\\!==" *)
-  (* |  "===" -> "\\===" *)
-  (* | "<>" -> "!=" *)
-  (* | "!=" -> "!==" *)
-  (* | x when ( *)
-    (* potentially_conflicts_with ~keyword:"match_" x *)
-    (* || potentially_conflicts_with ~keyword:"method_" x *)
-    (* || potentially_conflicts_with ~keyword:"private_" x) -> string_drop_suffix x *)
-  (* | x when ( *)
-    (* potentially_conflicts_with ~keyword:"switch" x *)
-    (* || potentially_conflicts_with ~keyword:"pub" x *)
-    (* || potentially_conflicts_with ~keyword:"pri" x) -> string_add_suffix x *)
-  (* | everything_else -> everything_else *)
-
-(* #end *)
-
 let value_ident ppf name =
   if parenthesized_ident name then
-    fprintf ppf "( %s )" (ml_to_reason_swap name)
+    fprintf ppf "( %s )" (Reason_syntax_util.ml_to_reason_swap name)
   else
     pp_print_string ppf name
 


### PR DESCRIPTION
This makes syncing reason_syntax_utils into BuckleScript much easier.

No change on Reason's side