### PR TITLE
Print newline after doc comments before attributes

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -738,3 +738,12 @@ external url : t => string = "";
 
 /* normal comment */
 [@bs.send] external url : t => string = "";
+
+/** doc type */
+type q = {
+  a: int,
+  b: string,
+};
+
+/** doc let */
+let letter: q = {a: 42, b: "answer"};

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -721,3 +721,20 @@ let r = {
   fieldOne: (identifier: string), /*eol1*/
   fieldTwo: (identifier: string) /* eol2 with trailing comma */
 };
+
+/** doc comment */
+[@bs.send]
+external url : t => string = "";
+
+/**
+ * Short multiline doc comment
+ */
+[@bs.send]
+external url : t => string = "";
+
+/** Longer doc comment before an attribute on an external. */
+[@bs.send]
+external url : t => string = "";
+
+/* normal comment */
+[@bs.send] external url : t => string = "";

--- a/formatTest/typeCheckedTests/input/reasonComments.re
+++ b/formatTest/typeCheckedTests/input/reasonComments.re
@@ -728,3 +728,9 @@ external url : t => string = "";
 
 /* normal comment */
 [@bs.send] external url : t => string = "";
+
+/** doc type */
+type q = {a: int, b: string};
+
+/** doc let */
+let letter : q = {a: 42, b: "answer"};

--- a/formatTest/typeCheckedTests/input/reasonComments.re
+++ b/formatTest/typeCheckedTests/input/reasonComments.re
@@ -711,3 +711,20 @@ let r = {
   fieldOne: (identifier : string), /*eol1*/
   fieldTwo: (identifier : string), /* eol2 with trailing comma */
 };
+
+/** doc comment */
+[@bs.send]
+external url : t => string = "";
+
+/**
+ * Short multiline doc comment
+ */
+[@bs.send]
+external url : t => string = "";
+
+/** Longer doc comment before an attribute on an external. */
+[@bs.send]
+external url : t => string = "";
+
+/* normal comment */
+[@bs.send] external url : t => string = "";

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -340,23 +340,6 @@ let rec partitionAttributes ?(partDoc=false) ?(allowUncurry=true) attrs : attrib
         let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
         {partition with stdAttrs=atHd::partition.stdAttrs}
 
-type docAttributesPartition = {
-  docAttrs : attributes;
-  otherAttrs : attributes
-}
-
-let rec partitionDocAttributes attrs : docAttributesPartition =
-  match attrs with
-    | [] ->
-      {docAttrs=[]; otherAttrs=[]}
-    | (({txt="ocaml.text"; loc}, _) as doc)::atTl
-    | (({txt="ocaml.doc"; loc}, _) as doc)::atTl ->
-        let partition = partitionDocAttributes atTl in
-        {partition with docAttrs=doc::partition.docAttrs}
-    | atHd :: atTl ->
-        let partition = partitionDocAttributes atTl in
-        {partition with otherAttrs=atHd::partition.otherAttrs}
-
 let extractStdAttrs attrs =
   (partitionAttributes attrs).stdAttrs
 
@@ -5824,12 +5807,12 @@ let printer = object(self:'self)
     match vd.pval_attributes with
     | [] -> primDecl
     | attrs ->
-        let {docAttrs; otherAttrs} = partitionDocAttributes attrs in
+        let {stdAttrs; docAttrs} = partitionAttributes ~partDoc:true attrs in
         let docs = List.map self#item_attribute docAttrs in
         let formattedDocs = makeList ~postSpace:true docs in
-        let attrs = List.map self#item_attribute otherAttrs in
+        let attrs = List.map self#item_attribute stdAttrs in
         let formattedAttrs = makeSpacedBreakableInlineList attrs in
-        let layouts = match (docAttrs, otherAttrs) with
+        let layouts = match (docAttrs, stdAttrs) with
         | ([], _) -> [formattedAttrs; primDecl]
         | (_, []) -> [formattedDocs; primDecl]
         | _ -> [formattedDocs; formattedAttrs; primDecl] in


### PR DESCRIPTION
Forces a line break following doc comments before the first non-comment attribute on a BuckleScript external.

**Before:**

```reason
/** doc comment */ [@bs.send] external url : t => string = "";

/**
 * Short multiline doc comment
 */ [@bs.send]
external url : t => string = "";

/** Longer doc comment before an attribute on an external. */ [@bs.send]
external url : t => string = "";

/* normal comment */
[@bs.send] external url : t => string = "";
```

**After:**

```reason
/** doc comment */
[@bs.send]
external url : t => string = "";

/**
 * Short multiline doc comment
 */
[@bs.send]
external url : t => string = "";

/** Longer doc comment before an attribute on an external. */
[@bs.send]
external url : t => string = "";

/* normal comment */
[@bs.send] external url : t => string = "";
```

Fixes #1857.