### PR TITLE
More familiar assert

### DIFF
--- a/formatTest/unit_tests/expected_output/assert.re
+++ b/formatTest/unit_tests/expected_output/assert.re
@@ -1,0 +1,23 @@
+switch (true) {
+| true => ()
+| false => assert(false)
+| _ => assert(false)
+};
+
+let root = {
+  let root = Doc.rootNode(doc);
+  assert(root.type_ == "expression");
+  assert(Node.namedChildCount(root) == 1);
+  assert(Node.childCount(root) == 1);
+  assert(
+    Point.toString(root.startPoint)
+    == "(Point.t {:row 0 :column 0})",
+  );
+  assert(
+    Point.toString(root.endPoint)
+    == "(Point.t {:row 0 :column 9})",
+  );
+  root;
+};
+
+assert(theTruth());

--- a/formatTest/unit_tests/expected_output/extensions.re
+++ b/formatTest/unit_tests/expected_output/extensions.re
@@ -25,7 +25,7 @@ let x = {
 let x = {
   if%extend (true) {1} else {2};
   switch%extend (None) {
-  | Some(x) => assert false
+  | Some(x) => assert(false)
   | None => ()
   };
   try%extend (raise(Not_found)) {
@@ -38,7 +38,7 @@ let x = if%extend (true) {1} else {2};
 
 let x =
   switch%extend (None) {
-  | Some(x) => assert false
+  | Some(x) => assert(false)
   | None => ()
   };
 

--- a/formatTest/unit_tests/input/assert.re
+++ b/formatTest/unit_tests/input/assert.re
@@ -1,0 +1,17 @@
+switch(true) {
+  | true => ()
+  | false => assert(false)
+  | _ => assert false
+};
+
+let root = {
+  let root = Doc.rootNode(doc);
+  assert (root.type_ == "expression");
+  assert (Node.namedChildCount(root) == 1);
+  assert (Node.childCount(root) == 1);
+  assert (Point.toString(root.startPoint) == "(Point.t {:row 0 :column 0})");
+  assert (Point.toString(root.endPoint) == "(Point.t {:row 0 :column 9})");
+  root;
+};
+
+assert(theTruth());

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4672,9 +4672,9 @@ let printer = object(self:'self)
             Some (label ~space:true (atom "new") (self#longident_class_or_type_loc li))
           | Pexp_assert e ->
             Some (
-              label ~space:true
+              label
                 (atom "assert")
-                (self#reset#simplifyUnparseExpr e);
+                (makeTup [(self#unparseExpr e)]);
             )
           | Pexp_lazy e ->
               Some (label ~space:true (atom "lazy") (self#simplifyUnparseExpr e))


### PR DESCRIPTION
Although `assert` is a specific expression (Pexp_assert), we can make it more familiar for newcomers.
We could print it as a classic function application to reduce cognitive overhead.
I.e. you just apply `assert` as a function. I don't see any advantages too printing it as a special language construct.


```reason
/* Before */
assert (Node.namedChildCount(root) == 1);
assert false;

/* After */
assert(Node.namedChildCount(root) == 1);
assert(false);
```