### PR TITLE
Intelligent whitespace interleaving (WIP)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test-ci: install test
 
 test: build clean-tests
 	node ./formatTest/testOprint.js
-	./miscTests/rtopIntegrationTest.sh
+	# ./miscTests/rtopIntegrationTest.sh
 	./miscTests/jsxPpxTest.sh
 	cd formatTest; ./test.sh
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test-ci: install test
 
 test: build clean-tests
 	node ./formatTest/testOprint.js
-	# ./miscTests/rtopIntegrationTest.sh
+	./miscTests/rtopIntegrationTest.sh
 	./miscTests/jsxPpxTest.sh
 	cd formatTest; ./test.sh
 

--- a/esy.json
+++ b/esy.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@opam/merlin": "*",
-    "ocaml": "~4.2.3"
+    "ocaml": "~4.6.0"
   },
   "notes-ctd": [
     "This is how you make an esy monorepo for development, but then release the monorepo as many individual packages:",
@@ -32,12 +32,10 @@
   ],
   "esy": {
     "build": [
-      [ "jbuilder", "build", "-p", "rebuild,reason,rtop"]
+      [ "jbuilder", "build", "-p", "reason"]
     ],
     "install": [
-      ["esy-installer", "rebuild.install"],
-      ["esy-installer", "reason.install"],
-      ["esy-installer", "rtop.install"]
+      ["esy-installer", "reason.install"]
     ],
     "buildsInSource": "_build"
   }

--- a/esy.json
+++ b/esy.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@opam/merlin": "*",
-    "ocaml": "~4.6.0"
+    "ocaml": "~4.2.3"
   },
   "notes-ctd": [
     "This is how you make an esy monorepo for development, but then release the monorepo as many individual packages:",

--- a/esy.json
+++ b/esy.json
@@ -32,10 +32,12 @@
   ],
   "esy": {
     "build": [
-      [ "jbuilder", "build", "-p", "reason"]
+      [ "jbuilder", "build", "-p", "rebuild,reason,rtop"]
     ],
     "install": [
-      ["esy-installer", "reason.install"]
+      ["esy-installer", "rebuild.install"],
+      ["esy-installer", "reason.install"],
+      ["esy-installer", "rtop.install"]
     ],
     "buildsInSource": "_build"
   }

--- a/esy.lock
+++ b/esy.lock
@@ -55,16 +55,15 @@
     ocaml " >= 4.2.3000"
 
 "@opam/camlp4@*":
-  version "4.2.0-7"
-  uid "762738a7ad145d0581fffe04e4052e34"
-  resolved "@opam/camlp4@4.2.0-7-762738a7ad145d0581fffe04e4052e34.tgz"
+  version "4.6.0-1"
+  uid ec9e71b1e73d101ab8ef9a66cc9035e7
+  resolved "@opam/camlp4@4.6.0-1-ec9e71b1e73d101ab8ef9a66cc9035e7.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
-    "@opam/conf-which" "*"
     "@opam/ocamlbuild" "*"
   peerDependencies:
-    ocaml " >= 4.2.0  < 4.3.0"
+    ocaml " >= 4.6.0  < 4.7.0"
 
 "@opam/camomile@ >= 0.8.0", "@opam/camomile@ >= 0.8.6", "@opam/camomile@*":
   version "0.8.7"
@@ -126,7 +125,7 @@
 
 "@opam/jbuilder@ >= 1.0.0-beta10", "@opam/jbuilder@ >= 1.0.0-beta7", "@opam/jbuilder@ >= 1.0.0-beta9", "@opam/jbuilder@*":
   version "1.0.0-beta16"
-  uid "851f0253157da21f055187b3f296fdae"
+  uid e492fc5752787b8d16b0f1254e096bb0
   resolved "@opam/jbuilder@1.0.0-beta16-c22568b45c8fe3f13c71a9a303e68b66.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -137,7 +136,7 @@
 
 "@opam/jbuilder@ >= 1.0.0-beta181":
   version "1.0.0-beta181"
-  uid "22dede5ab6a27a5646b81c3d05446ec3"
+  uid "18dcffe1ecd49ab48bc9010d386bebb4"
   resolved "@opam/jbuilder@1.0.0-beta181-22dede5ab6a27a5646b81c3d05446ec3.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -148,14 +147,14 @@
 
 "@opam/lambda-term@ >= 1.2.0":
   version "1.12.0"
-  uid "6248a15eadfbd00833f61fc74ebe172b"
+  uid "318456db287041f877e89e7098a12312"
   resolved "@opam/lambda-term@1.12.0-b1b97a4a29e48a80737103642ef60ba2.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
     "@opam/camomile" " >= 0.8.6"
     "@opam/jbuilder" " >= 1.0.0-beta9"
-    "@opam/lwt" " >= 2.7.0"
+    "@opam/lwt" " >= 2.7.0  < 4.0.0"
     "@opam/lwt_react" "*"
     "@opam/react" "*"
     "@opam/zed" " >= 1.2.0"
@@ -229,7 +228,7 @@
 
 "@opam/ocaml-migrate-parsetree@ >= 0.4.0":
   version "1.0.8"
-  uid "250794b1cf9cfc6a635e0d7bf29e1bc9"
+  uid "3e8d3c7d8231ca351dcec68f12f15f25"
   resolved "@opam/ocaml-migrate-parsetree@1.0.8-250794b1cf9cfc6a635e0d7bf29e1bc9.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -238,11 +237,11 @@
     "@opam/ocamlfind" "*"
     "@opam/result" "*"
   peerDependencies:
-    ocaml " >= 4.2.0"
+    ocaml " >= 4.2.0  < 4.8.0"
 
 "@opam/ocaml-migrate-parsetree@*":
   version "1.0.7"
-  uid "8dd63da93ee2ed29313f5b50471c94ae"
+  uid "10c9d8b7b7061b8eedbf55d109bae83e"
   resolved "@opam/ocaml-migrate-parsetree@1.0.7-d5147a474a5eacd4741d9d6cfb40cedc.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -251,37 +250,37 @@
     "@opam/ocamlfind" "*"
     "@opam/result" "*"
   peerDependencies:
-    ocaml " >= 4.2.0"
+    ocaml " >= 4.2.0  < 4.7.0"
 
 "@opam/ocamlbuild@*":
-  version "0.11.0"
-  uid abecf9ccce04123ca6924849ce36399c
-  resolved "@opam/ocamlbuild@0.11.0-abecf9ccce04123ca6924849ce36399c.tgz"
+  version "0.12.0"
+  uid "4d2353d6f9d4e9f658ffea64707c152a"
+  resolved "@opam/ocamlbuild@0.12.0-4d2353d6f9d4e9f658ffea64707c152a.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
   peerDependencies:
-    ocaml "<4.3.0"
+    ocaml " >= 4.3.0"
 
 "@opam/ocamlfind@", "@opam/ocamlfind@ >= 1.5.0", "@opam/ocamlfind@ >= 1.5.2", "@opam/ocamlfind@ >= 1.5.3", "@opam/ocamlfind@ >= 1.6.1", "@opam/ocamlfind@ >= 1.7.2", "@opam/ocamlfind@*":
   version "1.7.3"
-  uid "51d979ffc365a9fcd0859eaba4d4bac8"
+  uid "532b93a80d05ef1ba4e11b20e16962d4"
   resolved "@opam/ocamlfind@1.7.3-51d979ffc365a9fcd0859eaba4d4bac8.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
     "@opam/conf-m4" "*"
   peerDependencies:
-    ocaml " >= 3.12.0"
+    ocaml " >= 3.12.0  < 4.7.0"
 
 "@opam/ppx_tools_versioned@ >= 5.0.1":
   version "5.1.0"
-  uid "8c474fc8622c3cdf7683533fae007ea5"
+  uid "563cec821710613b61de9bf99ebebe65"
   resolved "@opam/ppx_tools_versioned@5.1.0-8c474fc8622c3cdf7683533fae007ea5.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
-    "@opam/ocaml-migrate-parsetree" " >= 0.4.0"
+    "@opam/ocaml-migrate-parsetree" " >= 1.0.7"
     "@opam/ocamlfind" " >= 1.5.0"
   peerDependencies:
     ocaml " >= 4.2.0"
@@ -370,6 +369,6 @@
   peerDependencies:
     ocaml " >= 4.2.3000"
 
-ocaml@~4.2.3:
-  version "4.2.3004"
-  resolved "https://registry.yarnpkg.com/ocaml/-/ocaml-4.2.3004.tgz#4142d03d6c012949c2974c40db3a92edc7981db0"
+ocaml@~4.6.0:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/ocaml/-/ocaml-4.6.1.tgz#8babea2c41a9f734313b4fc1841ec0963c9d7a07"

--- a/esy.lock
+++ b/esy.lock
@@ -43,16 +43,16 @@
 
 "@opam/biniou@ >= 1.2.0":
   version "1.2.0"
-  uid af4880e80be63bbb3043fb7184882eb8
+  uid "3c35c175821fe4c19961842d3bceb95d"
   resolved "@opam/biniou@1.2.0-3c35c175821fe4c19961842d3bceb95d.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
     "@opam/conf-which" "*"
     "@opam/easy-format" "*"
-    "@opam/jbuilder" " >= 1.0.0-beta7"
+    "@opam/jbuilder" "*"
   peerDependencies:
-    ocaml " >= 4.2.3000"
+    ocaml " >= 4.2.3"
 
 "@opam/camlp4@*":
   version "4.6.0-1"
@@ -65,9 +65,9 @@
   peerDependencies:
     ocaml " >= 4.6.0  < 4.7.0"
 
-"@opam/camomile@ >= 0.8.0", "@opam/camomile@ >= 0.8.6", "@opam/camomile@*":
+"@opam/camomile@ >= 0.8.0", "@opam/camomile@*":
   version "0.8.7"
-  uid c128e86f078793c4ef45907002f0cb86
+  uid dee5adee8b39485e2c4e56546c56f2c2
   resolved "@opam/camomile@0.8.7-dee5adee8b39485e2c4e56546c56f2c2.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -77,7 +77,7 @@
     "@opam/cppo" "*"
     "@opam/jbuilder" " >= 1.0.0-beta7"
   peerDependencies:
-    ocaml " >= 4.2.3000"
+    ocaml " >= 4.2.3"
 
 "@opam/conf-m4@*":
   version "1.0.0"
@@ -101,7 +101,7 @@
 
 "@opam/cppo@ >= 1.1.0", "@opam/cppo@ >= 1.1.2", "@opam/cppo@*":
   version "1.6.0"
-  uid "349808856d0a52266567126c6e1a482c"
+  uid e7f9ad67562d5952779e822a0a37d129
   resolved "@opam/cppo@1.6.0-e7f9ad67562d5952779e822a0a37d129.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -110,56 +110,45 @@
     "@opam/base-unix" "*"
     "@opam/jbuilder" " >= 1.0.0-beta10"
   peerDependencies:
-    ocaml " < 4.7.0"
+    ocaml "*"
 
 "@opam/easy-format@*":
   version "1.3.0"
-  uid f5b814cc29a75774dbb5c990c4d16072
+  uid "1aa6bc19799f6e31bccf8c2b171d24de"
   resolved "@opam/easy-format@1.3.0-1aa6bc19799f6e31bccf8c2b171d24de.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
     "@opam/jbuilder" "*"
   peerDependencies:
-    ocaml " >= 4.2.3000"
+    ocaml " >= 4.2.3"
 
 "@opam/jbuilder@ >= 1.0.0-beta10", "@opam/jbuilder@ >= 1.0.0-beta7", "@opam/jbuilder@ >= 1.0.0-beta9", "@opam/jbuilder@*":
   version "1.0.0-beta16"
-  uid e492fc5752787b8d16b0f1254e096bb0
+  uid c22568b45c8fe3f13c71a9a303e68b66
   resolved "@opam/jbuilder@1.0.0-beta16-c22568b45c8fe3f13c71a9a303e68b66.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
     "@opam/ocamlfind" "*"
   peerDependencies:
-    ocaml " >= 4.2.3000"
-
-"@opam/jbuilder@ >= 1.0.0-beta181":
-  version "1.0.0-beta181"
-  uid "18dcffe1ecd49ab48bc9010d386bebb4"
-  resolved "@opam/jbuilder@1.0.0-beta181-22dede5ab6a27a5646b81c3d05446ec3.tgz"
-  dependencies:
-    "@esy-ocaml/esy-installer" "^0.0.0"
-    "@esy-ocaml/substs" "^0.0.1"
-    "@opam/ocamlfind" "*"
-  peerDependencies:
-    ocaml " >= 4.2.3000"
+    ocaml " >= 4.2.3"
 
 "@opam/lambda-term@ >= 1.2.0":
   version "1.12.0"
-  uid "318456db287041f877e89e7098a12312"
+  uid b1b97a4a29e48a80737103642ef60ba2
   resolved "@opam/lambda-term@1.12.0-b1b97a4a29e48a80737103642ef60ba2.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
-    "@opam/camomile" " >= 0.8.6"
+    "@opam/camomile" "*"
     "@opam/jbuilder" " >= 1.0.0-beta9"
-    "@opam/lwt" " >= 2.7.0  < 4.0.0"
+    "@opam/lwt" " >= 2.7.0"
     "@opam/lwt_react" "*"
     "@opam/react" "*"
     "@opam/zed" " >= 1.2.0"
   peerDependencies:
-    ocaml " >= 4.2.3000"
+    ocaml " >= 4.2.3"
 
 "@opam/lwt@ >= 2.7.0", "@opam/lwt@ >= 3.0.0", "@opam/lwt@*":
   version "3.1.0"
@@ -179,7 +168,7 @@
 
 "@opam/lwt_react@*":
   version "1.1.0"
-  uid "20a2a8d3c6e4d1038ae9d01666a15320"
+  uid "9eebd3db713981a8ba2b462b1b2d6071"
   resolved "@opam/lwt_react@1.1.0-9eebd3db713981a8ba2b462b1b2d6071.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -204,7 +193,7 @@
 
 "@opam/merlin-extend@ >= 0.3.0":
   version "0.3.0"
-  uid d688ddc39d2c47f4c3083de2fa51bf7e
+  uid ea08b87b0e52737ef0a98472b0738409
   resolved "@opam/merlin-extend@0.3.0-ea08b87b0e52737ef0a98472b0738409.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -212,11 +201,11 @@
     "@opam/cppo" "*"
     "@opam/ocamlfind" "*"
   peerDependencies:
-    ocaml " >= 4.2.3000"
+    ocaml " >= 4.2.3"
 
 "@opam/merlin@*":
   version "3.0.5"
-  uid "43a4ee2722d4484e3b65826d613451a7"
+  uid "8ae0471d01a563b5552199bffb5b1da5"
   resolved "@opam/merlin@3.0.5-8ae0471d01a563b5552199bffb5b1da5.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -224,24 +213,11 @@
     "@opam/ocamlfind" " >= 1.5.2"
     "@opam/yojson" "*"
   peerDependencies:
-    ocaml " >= 4.2.1000  < 4.7.0"
+    ocaml " >= 4.2.1  < 4.7.0"
 
-"@opam/ocaml-migrate-parsetree@ >= 0.4.0":
-  version "1.0.8"
-  uid "3e8d3c7d8231ca351dcec68f12f15f25"
-  resolved "@opam/ocaml-migrate-parsetree@1.0.8-250794b1cf9cfc6a635e0d7bf29e1bc9.tgz"
-  dependencies:
-    "@esy-ocaml/esy-installer" "^0.0.0"
-    "@esy-ocaml/substs" "^0.0.1"
-    "@opam/jbuilder" " >= 1.0.0-beta181"
-    "@opam/ocamlfind" "*"
-    "@opam/result" "*"
-  peerDependencies:
-    ocaml " >= 4.2.0  < 4.8.0"
-
-"@opam/ocaml-migrate-parsetree@*":
+"@opam/ocaml-migrate-parsetree@ >= 0.7.0", "@opam/ocaml-migrate-parsetree@*":
   version "1.0.7"
-  uid "10c9d8b7b7061b8eedbf55d109bae83e"
+  uid d5147a474a5eacd4741d9d6cfb40cedc
   resolved "@opam/ocaml-migrate-parsetree@1.0.7-d5147a474a5eacd4741d9d6cfb40cedc.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -250,7 +226,7 @@
     "@opam/ocamlfind" "*"
     "@opam/result" "*"
   peerDependencies:
-    ocaml " >= 4.2.0  < 4.7.0"
+    ocaml " >= 4.2.0"
 
 "@opam/ocamlbuild@*":
   version "0.12.0"
@@ -264,30 +240,30 @@
 
 "@opam/ocamlfind@", "@opam/ocamlfind@ >= 1.5.0", "@opam/ocamlfind@ >= 1.5.2", "@opam/ocamlfind@ >= 1.5.3", "@opam/ocamlfind@ >= 1.6.1", "@opam/ocamlfind@ >= 1.7.2", "@opam/ocamlfind@*":
   version "1.7.3"
-  uid "532b93a80d05ef1ba4e11b20e16962d4"
+  uid "51d979ffc365a9fcd0859eaba4d4bac8"
   resolved "@opam/ocamlfind@1.7.3-51d979ffc365a9fcd0859eaba4d4bac8.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
     "@opam/conf-m4" "*"
   peerDependencies:
-    ocaml " >= 3.12.0  < 4.7.0"
+    ocaml " >= 3.12.0"
 
-"@opam/ppx_tools_versioned@ >= 5.0.1":
-  version "5.1.0"
-  uid "563cec821710613b61de9bf99ebebe65"
-  resolved "@opam/ppx_tools_versioned@5.1.0-8c474fc8622c3cdf7683533fae007ea5.tgz"
+"@opam/ppx_tools_versioned@*":
+  version "5.0.1"
+  uid "82925c89f0171955579eb5ed35ac3cc0"
+  resolved "@opam/ppx_tools_versioned@5.0.1-82925c89f0171955579eb5ed35ac3cc0.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
-    "@opam/ocaml-migrate-parsetree" " >= 1.0.7"
+    "@opam/ocaml-migrate-parsetree" " >= 0.7.0"
     "@opam/ocamlfind" " >= 1.5.0"
   peerDependencies:
     ocaml " >= 4.2.0"
 
 "@opam/react@ >= 1.0.0", "@opam/react@*":
   version "1.2.1"
-  uid "719921829ec3b46cecefeeaefcb6cb61"
+  uid e0ffc834c71929b9405f5f0b17f31b4e
   resolved "@opam/react@1.2.1-e0ffc834c71929b9405f5f0b17f31b4e.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -300,7 +276,7 @@
 
 "@opam/result@*":
   version "1.2.0"
-  uid "5c62071e67f4a84e28ceeaac2969d1ae"
+  uid "7ae1525f89c2304e7289f67e37e8409c"
   resolved "@opam/result@1.2.0-7ae1525f89c2304e7289f67e37e8409c.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -310,7 +286,7 @@
 
 "@opam/topkg@ >= 0.9.0":
   version "0.9.1"
-  uid "516192416bf683eb7edf2dbd649d014d"
+  uid "1904471239c5b276018a07645c7397e8"
   resolved "@opam/topkg@0.9.1-1904471239c5b276018a07645c7397e8.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -323,7 +299,7 @@
 
 "@opam/utop@ >= 1.17.0":
   version "2.0.2"
-  uid a769ef27599e130f0d356979ed5e07af
+  uid "0fe7f102082fb483899426ce2fd51a43"
   resolved "@opam/utop@2.0.2-0fe7f102082fb483899426ce2fd51a43.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -339,11 +315,11 @@
     "@opam/ocamlfind" " >= 1.7.2"
     "@opam/react" " >= 1.0.0"
   peerDependencies:
-    ocaml " >= 4.2.3000"
+    ocaml " >= 4.2.3"
 
 "@opam/yojson@*":
   version "1.4.0"
-  uid "139a44cad85290f31b72aecca4e60c65"
+  uid "289a3103a174aaa23411c434cff4406a"
   resolved "@opam/yojson@1.4.0-289a3103a174aaa23411c434cff4406a.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -353,11 +329,11 @@
     "@opam/easy-format" "*"
     "@opam/jbuilder" "*"
   peerDependencies:
-    ocaml " >= 4.2.3000"
+    ocaml " >= 4.2.3"
 
 "@opam/zed@ >= 1.2.0":
   version "1.6.0"
-  uid "9a4c3157c2db719927f9648234487c6d"
+  uid ec11155dad95c6adf214207ca6667363
   resolved "@opam/zed@1.6.0-ec11155dad95c6adf214207ca6667363.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -367,7 +343,7 @@
     "@opam/jbuilder" " >= 1.0.0-beta9"
     "@opam/react" "*"
   peerDependencies:
-    ocaml " >= 4.2.3000"
+    ocaml " >= 4.2.3"
 
 ocaml@~4.6.0:
   version "4.6.1"

--- a/esy.lock
+++ b/esy.lock
@@ -43,16 +43,16 @@
 
 "@opam/biniou@ >= 1.2.0":
   version "1.2.0"
-  uid "3c35c175821fe4c19961842d3bceb95d"
+  uid af4880e80be63bbb3043fb7184882eb8
   resolved "@opam/biniou@1.2.0-3c35c175821fe4c19961842d3bceb95d.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
     "@opam/conf-which" "*"
     "@opam/easy-format" "*"
-    "@opam/jbuilder" "*"
+    "@opam/jbuilder" " >= 1.0.0-beta7"
   peerDependencies:
-    ocaml " >= 4.2.3"
+    ocaml " >= 4.2.3000"
 
 "@opam/camlp4@*":
   version "4.6.0-1"
@@ -65,9 +65,9 @@
   peerDependencies:
     ocaml " >= 4.6.0  < 4.7.0"
 
-"@opam/camomile@ >= 0.8.0", "@opam/camomile@*":
+"@opam/camomile@ >= 0.8.0", "@opam/camomile@ >= 0.8.6", "@opam/camomile@*":
   version "0.8.7"
-  uid dee5adee8b39485e2c4e56546c56f2c2
+  uid c128e86f078793c4ef45907002f0cb86
   resolved "@opam/camomile@0.8.7-dee5adee8b39485e2c4e56546c56f2c2.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -77,7 +77,7 @@
     "@opam/cppo" "*"
     "@opam/jbuilder" " >= 1.0.0-beta7"
   peerDependencies:
-    ocaml " >= 4.2.3"
+    ocaml " >= 4.2.3000"
 
 "@opam/conf-m4@*":
   version "1.0.0"
@@ -101,7 +101,7 @@
 
 "@opam/cppo@ >= 1.1.0", "@opam/cppo@ >= 1.1.2", "@opam/cppo@*":
   version "1.6.0"
-  uid e7f9ad67562d5952779e822a0a37d129
+  uid "349808856d0a52266567126c6e1a482c"
   resolved "@opam/cppo@1.6.0-e7f9ad67562d5952779e822a0a37d129.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -110,45 +110,56 @@
     "@opam/base-unix" "*"
     "@opam/jbuilder" " >= 1.0.0-beta10"
   peerDependencies:
-    ocaml "*"
+    ocaml " < 4.7.0"
 
 "@opam/easy-format@*":
   version "1.3.0"
-  uid "1aa6bc19799f6e31bccf8c2b171d24de"
+  uid f5b814cc29a75774dbb5c990c4d16072
   resolved "@opam/easy-format@1.3.0-1aa6bc19799f6e31bccf8c2b171d24de.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
     "@opam/jbuilder" "*"
   peerDependencies:
-    ocaml " >= 4.2.3"
+    ocaml " >= 4.2.3000"
 
 "@opam/jbuilder@ >= 1.0.0-beta10", "@opam/jbuilder@ >= 1.0.0-beta7", "@opam/jbuilder@ >= 1.0.0-beta9", "@opam/jbuilder@*":
   version "1.0.0-beta16"
-  uid c22568b45c8fe3f13c71a9a303e68b66
+  uid "851f0253157da21f055187b3f296fdae"
   resolved "@opam/jbuilder@1.0.0-beta16-c22568b45c8fe3f13c71a9a303e68b66.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
     "@opam/ocamlfind" "*"
   peerDependencies:
-    ocaml " >= 4.2.3"
+    ocaml " >= 4.2.3000"
+
+"@opam/jbuilder@ >= 1.0.0-beta181":
+  version "1.0.0-beta181"
+  uid "22dede5ab6a27a5646b81c3d05446ec3"
+  resolved "@opam/jbuilder@1.0.0-beta181-22dede5ab6a27a5646b81c3d05446ec3.tgz"
+  dependencies:
+    "@esy-ocaml/esy-installer" "^0.0.0"
+    "@esy-ocaml/substs" "^0.0.1"
+    "@opam/ocamlfind" "*"
+  peerDependencies:
+    ocaml " >= 4.2.3000"
 
 "@opam/lambda-term@ >= 1.2.0":
   version "1.12.0"
-  uid b1b97a4a29e48a80737103642ef60ba2
+  uid "6248a15eadfbd00833f61fc74ebe172b"
   resolved "@opam/lambda-term@1.12.0-b1b97a4a29e48a80737103642ef60ba2.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
-    "@opam/camomile" "*"
+    "@opam/camomile" " >= 0.8.6"
     "@opam/jbuilder" " >= 1.0.0-beta9"
     "@opam/lwt" " >= 2.7.0"
     "@opam/lwt_react" "*"
     "@opam/react" "*"
     "@opam/zed" " >= 1.2.0"
   peerDependencies:
-    ocaml " >= 4.2.3"
+    ocaml " >= 4.2.3000"
 
 "@opam/lwt@ >= 2.7.0", "@opam/lwt@ >= 3.0.0", "@opam/lwt@*":
   version "3.1.0"
@@ -168,7 +179,7 @@
 
 "@opam/lwt_react@*":
   version "1.1.0"
-  uid "9eebd3db713981a8ba2b462b1b2d6071"
+  uid "20a2a8d3c6e4d1038ae9d01666a15320"
   resolved "@opam/lwt_react@1.1.0-9eebd3db713981a8ba2b462b1b2d6071.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -193,7 +204,7 @@
 
 "@opam/merlin-extend@ >= 0.3.0":
   version "0.3.0"
-  uid ea08b87b0e52737ef0a98472b0738409
+  uid d688ddc39d2c47f4c3083de2fa51bf7e
   resolved "@opam/merlin-extend@0.3.0-ea08b87b0e52737ef0a98472b0738409.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -201,11 +212,11 @@
     "@opam/cppo" "*"
     "@opam/ocamlfind" "*"
   peerDependencies:
-    ocaml " >= 4.2.3"
+    ocaml " >= 4.2.3000"
 
 "@opam/merlin@*":
   version "3.0.5"
-  uid "8ae0471d01a563b5552199bffb5b1da5"
+  uid "43a4ee2722d4484e3b65826d613451a7"
   resolved "@opam/merlin@3.0.5-8ae0471d01a563b5552199bffb5b1da5.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -213,11 +224,24 @@
     "@opam/ocamlfind" " >= 1.5.2"
     "@opam/yojson" "*"
   peerDependencies:
-    ocaml " >= 4.2.1  < 4.7.0"
+    ocaml " >= 4.2.1000  < 4.7.0"
 
-"@opam/ocaml-migrate-parsetree@ >= 0.7.0", "@opam/ocaml-migrate-parsetree@*":
+"@opam/ocaml-migrate-parsetree@ >= 0.4.0":
+  version "1.0.8"
+  uid "250794b1cf9cfc6a635e0d7bf29e1bc9"
+  resolved "@opam/ocaml-migrate-parsetree@1.0.8-250794b1cf9cfc6a635e0d7bf29e1bc9.tgz"
+  dependencies:
+    "@esy-ocaml/esy-installer" "^0.0.0"
+    "@esy-ocaml/substs" "^0.0.1"
+    "@opam/jbuilder" " >= 1.0.0-beta181"
+    "@opam/ocamlfind" "*"
+    "@opam/result" "*"
+  peerDependencies:
+    ocaml " >= 4.2.0"
+
+"@opam/ocaml-migrate-parsetree@*":
   version "1.0.7"
-  uid d5147a474a5eacd4741d9d6cfb40cedc
+  uid "8dd63da93ee2ed29313f5b50471c94ae"
   resolved "@opam/ocaml-migrate-parsetree@1.0.7-d5147a474a5eacd4741d9d6cfb40cedc.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -249,21 +273,21 @@
   peerDependencies:
     ocaml " >= 3.12.0"
 
-"@opam/ppx_tools_versioned@*":
-  version "5.0.1"
-  uid "82925c89f0171955579eb5ed35ac3cc0"
-  resolved "@opam/ppx_tools_versioned@5.0.1-82925c89f0171955579eb5ed35ac3cc0.tgz"
+"@opam/ppx_tools_versioned@ >= 5.0.1":
+  version "5.1.0"
+  uid "8c474fc8622c3cdf7683533fae007ea5"
+  resolved "@opam/ppx_tools_versioned@5.1.0-8c474fc8622c3cdf7683533fae007ea5.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
-    "@opam/ocaml-migrate-parsetree" " >= 0.7.0"
+    "@opam/ocaml-migrate-parsetree" " >= 0.4.0"
     "@opam/ocamlfind" " >= 1.5.0"
   peerDependencies:
     ocaml " >= 4.2.0"
 
 "@opam/react@ >= 1.0.0", "@opam/react@*":
   version "1.2.1"
-  uid e0ffc834c71929b9405f5f0b17f31b4e
+  uid "719921829ec3b46cecefeeaefcb6cb61"
   resolved "@opam/react@1.2.1-e0ffc834c71929b9405f5f0b17f31b4e.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -276,7 +300,7 @@
 
 "@opam/result@*":
   version "1.2.0"
-  uid "7ae1525f89c2304e7289f67e37e8409c"
+  uid "5c62071e67f4a84e28ceeaac2969d1ae"
   resolved "@opam/result@1.2.0-7ae1525f89c2304e7289f67e37e8409c.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -286,7 +310,7 @@
 
 "@opam/topkg@ >= 0.9.0":
   version "0.9.1"
-  uid "1904471239c5b276018a07645c7397e8"
+  uid "516192416bf683eb7edf2dbd649d014d"
   resolved "@opam/topkg@0.9.1-1904471239c5b276018a07645c7397e8.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -299,7 +323,7 @@
 
 "@opam/utop@ >= 1.17.0":
   version "2.0.2"
-  uid "0fe7f102082fb483899426ce2fd51a43"
+  uid a769ef27599e130f0d356979ed5e07af
   resolved "@opam/utop@2.0.2-0fe7f102082fb483899426ce2fd51a43.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -315,11 +339,11 @@
     "@opam/ocamlfind" " >= 1.7.2"
     "@opam/react" " >= 1.0.0"
   peerDependencies:
-    ocaml " >= 4.2.3"
+    ocaml " >= 4.2.3000"
 
 "@opam/yojson@*":
   version "1.4.0"
-  uid "289a3103a174aaa23411c434cff4406a"
+  uid "139a44cad85290f31b72aecca4e60c65"
   resolved "@opam/yojson@1.4.0-289a3103a174aaa23411c434cff4406a.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -329,11 +353,11 @@
     "@opam/easy-format" "*"
     "@opam/jbuilder" "*"
   peerDependencies:
-    ocaml " >= 4.2.3"
+    ocaml " >= 4.2.3000"
 
 "@opam/zed@ >= 1.2.0":
   version "1.6.0"
-  uid ec11155dad95c6adf214207ca6667363
+  uid "9a4c3157c2db719927f9648234487c6d"
   resolved "@opam/zed@1.6.0-ec11155dad95c6adf214207ca6667363.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -343,7 +367,7 @@
     "@opam/jbuilder" " >= 1.0.0-beta9"
     "@opam/react" "*"
   peerDependencies:
-    ocaml " >= 4.2.3"
+    ocaml " >= 4.2.3000"
 
 ocaml@~4.6.0:
   version "4.6.1"

--- a/esy.lock
+++ b/esy.lock
@@ -55,15 +55,16 @@
     ocaml " >= 4.2.3000"
 
 "@opam/camlp4@*":
-  version "4.6.0-1"
-  uid ec9e71b1e73d101ab8ef9a66cc9035e7
-  resolved "@opam/camlp4@4.6.0-1-ec9e71b1e73d101ab8ef9a66cc9035e7.tgz"
+  version "4.2.0-7"
+  uid "762738a7ad145d0581fffe04e4052e34"
+  resolved "@opam/camlp4@4.2.0-7-762738a7ad145d0581fffe04e4052e34.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
+    "@opam/conf-which" "*"
     "@opam/ocamlbuild" "*"
   peerDependencies:
-    ocaml " >= 4.6.0  < 4.7.0"
+    ocaml " >= 4.2.0  < 4.3.0"
 
 "@opam/camomile@ >= 0.8.0", "@opam/camomile@ >= 0.8.6", "@opam/camomile@*":
   version "0.8.7"
@@ -253,14 +254,14 @@
     ocaml " >= 4.2.0"
 
 "@opam/ocamlbuild@*":
-  version "0.12.0"
-  uid "4d2353d6f9d4e9f658ffea64707c152a"
-  resolved "@opam/ocamlbuild@0.12.0-4d2353d6f9d4e9f658ffea64707c152a.tgz"
+  version "0.11.0"
+  uid abecf9ccce04123ca6924849ce36399c
+  resolved "@opam/ocamlbuild@0.11.0-abecf9ccce04123ca6924849ce36399c.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
   peerDependencies:
-    ocaml " >= 4.3.0"
+    ocaml "<4.3.0"
 
 "@opam/ocamlfind@", "@opam/ocamlfind@ >= 1.5.0", "@opam/ocamlfind@ >= 1.5.2", "@opam/ocamlfind@ >= 1.5.3", "@opam/ocamlfind@ >= 1.6.1", "@opam/ocamlfind@ >= 1.7.2", "@opam/ocamlfind@*":
   version "1.7.3"
@@ -369,6 +370,6 @@
   peerDependencies:
     ocaml " >= 4.2.3000"
 
-ocaml@~4.6.0:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/ocaml/-/ocaml-4.6.1.tgz#8babea2c41a9f734313b4fc1841ec0963c9d7a07"
+ocaml@~4.2.3:
+  version "4.2.3004"
+  resolved "https://registry.yarnpkg.com/ocaml/-/ocaml-4.2.3004.tgz#4142d03d6c012949c2974c40db3a92edc7981db0"

--- a/formatTest/typeCheckedTests/expected_output/arityConversion.re
+++ b/formatTest/typeCheckedTests/expected_output/arityConversion.re
@@ -31,10 +31,8 @@ Some(1);
 module M = {
   type t =
     | TupleConstructorInModule((int, int));
-
   type t2 =
     | TupleConstructor2((int, int));
-
   type t3 =
     | TupleConstructor3((int, int));
 };

--- a/formatTest/typeCheckedTests/expected_output/arityConversion.re
+++ b/formatTest/typeCheckedTests/expected_output/arityConversion.re
@@ -5,7 +5,6 @@ type bcd =
   | MultiArgumentsConstructor(int, int);
 
 let a = TupleConstructor((1, 2));
-
 let b =
   [@implicit_arity]
   MultiArgumentsConstructor(1, 2);
@@ -17,15 +16,11 @@ module Test = {
 };
 
 let _ = Test.And((1, 2));
-
 let _ = Test.Or((1, 2));
-
 let _ = Some(1);
 
 Test.And((1, 2));
-
 Test.Or((1, 2));
-
 Some(1);
 
 module M = {
@@ -39,26 +34,21 @@ module M = {
 
 type t2 =
   | TupleConstructor2((int, int));
-
 type t3 =
   | TupleConstructor3((int, int));
 
 let _ = M.TupleConstructorInModule((1, 2));
 
 let _ = M.TupleConstructor2((1, 2));
-
 let _ = TupleConstructor2((1, 2));
 
 let _ = M.TupleConstructor3((1, 2));
-
 let _ = TupleConstructor3((1, 2));
 
 M.TupleConstructorInModule((1, 2));
 
 M.TupleConstructor2((1, 2));
-
 TupleConstructor2((1, 2));
 
 M.TupleConstructor3((1, 2));
-
 TupleConstructor3((1, 2));

--- a/formatTest/typeCheckedTests/expected_output/arityConversion.re.4.02.3
+++ b/formatTest/typeCheckedTests/expected_output/arityConversion.re.4.02.3
@@ -5,7 +5,6 @@ type bcd =
   | MultiArgumentsConstructor(int, int);
 
 let a = TupleConstructor((1, 2));
-
 let b =
   [@implicit_arity]
   MultiArgumentsConstructor(1, 2);
@@ -17,15 +16,11 @@ module Test = {
 };
 
 Test.And((1, 2));
-
 Test.Or((1, 2));
-
 Some(1);
 
 Test.And((1, 2));
-
 Test.Or((1, 2));
-
 Some(1);
 
 module M = {
@@ -39,26 +34,21 @@ module M = {
 
 type t2 =
   | TupleConstructor2((int, int));
-
 type t3 =
   | TupleConstructor3((int, int));
 
 M.TupleConstructorInModule((1, 2));
 
 M.TupleConstructor2((1, 2));
-
 TupleConstructor2((1, 2));
 
 M.TupleConstructor3((1, 2));
-
 TupleConstructor3((1, 2));
 
 M.TupleConstructorInModule((1, 2));
 
 M.TupleConstructor2((1, 2));
-
 TupleConstructor2((1, 2));
 
 M.TupleConstructor3((1, 2));
-
 TupleConstructor3((1, 2));

--- a/formatTest/typeCheckedTests/expected_output/arityConversion.re.4.02.3
+++ b/formatTest/typeCheckedTests/expected_output/arityConversion.re.4.02.3
@@ -31,10 +31,8 @@ Some(1);
 module M = {
   type t =
     | TupleConstructorInModule((int, int));
-
   type t2 =
     | TupleConstructor2((int, int));
-
   type t3 =
     | TupleConstructor3((int, int));
 };

--- a/formatTest/typeCheckedTests/expected_output/attributes.4.04.0.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.4.04.0.re
@@ -6,6 +6,7 @@ let () = {
 };
 
 /** Different payloads **/
+
 [@haha:]
 /* Empty signature */
 let x = 5;

--- a/formatTest/typeCheckedTests/expected_output/attributes.4.04.0.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.4.04.0.re
@@ -7,8 +7,9 @@ let () = {
 
 /** Different payloads **/
 
-[@haha:]
 /* Empty signature */
+
+[@haha:]
 let x = 5;
 
 /* signature_item */

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -501,8 +501,8 @@ type value =
 
 /** Different payloads **/
 
-[@haha]
 /* Empty structure */
+[@haha]
 let x = 5;
 
 /* Expression structure */

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -20,9 +20,7 @@
 [@itemAttributeOnTypeDef]
 /**removed text on type def*/
 type itemText = int;
-
 type nodeText = /**removed text on item*/ int;
-
 [@itemAttributeOnTypeDef]
 /**removed text on type def*/
 type nodeAndItemText =
@@ -31,10 +29,8 @@ type nodeAndItemText =
 [@itemAttributeOnTypeDef]
 /**removed doc on type def*/
 type itemDoc = int;
-
 [@itemAttributeOnTypeDef]
 type nodeDoc = /**removed text on item*/ int;
-
 [@itemAttributeOnTypeDef]
 /**removed doc on type def*/
 type nodeAndItemDoc =
@@ -42,7 +38,6 @@ type nodeAndItemDoc =
 
 [@itemAttributeOnTypeDef]
 type x = int;
-
 type attributedInt = [@onTopLevelTypeDef] int;
 
 [@itemAttributeOnTypeDef]
@@ -73,105 +68,75 @@ let thisInst: myType =
   );
 
 let x = [@onHello] "hello";
-
 let x = [@onHello] "hello";
 
 let x = "hello" ++ [@onGoodbye] "goodbye";
-
 let x = [@onHello] "hello" ++ "goodbye";
-
 let x = [@onHello] "hello" ++ "goodbye";
-
 let x = "hello" ++ [@onGoodbye] "goodbye";
-
 let x = [@onEverything] ("hello" ++ "goodbye");
 
 let x = 10 + [@on20] 20;
-
 let x = 10 + [@on20] 20;
-
 let x = [@on10] 10 + 20;
-
 let x = [@on10] 10 + 20;
-
 let x = [@attrEverything] (10 + 20);
 
 let x = 10 - [@on20] 20;
-
 let x = 10 - [@on20] 20;
-
 let x = [@on10] 10 - 20;
-
 let x = [@on10] 10 - 20;
-
 let x = [@attrEntireEverything] (10 - 20);
 
 let x = true && [@onFalse] false;
-
 let x = true && [@onFalse] false;
-
 let x = [@onTrue] true && false;
-
 let x = [@onTrue] true && false;
-
 let x = [@attrEverything] (true && false);
 
 /* now make sure to try with variants (tagged and `) */
+
 /**
  * How attribute parsings respond to other syntactic constructs.
  */
 let add = a => [@onRet] a;
-
 let add = a => [@onRet] a;
-
 let add = [@onEntireFunction] (a => a);
 
 let res =
   if (true) {false} else {[@onFalse] false};
-
 let res =
   [@onEntireIf] (if (true) {false} else {false});
 
 let add = (a, b) =>
   [@onEverything] ([@onA] a + b);
-
 let add = (a, b) =>
   [@onEverything] ([@onA] a + [@onB] b);
-
 let add = (a, b) => a + [@onB] b;
 
 let both = [@onEntireFunction] (a => a);
-
 let both = (a, b) =>
   [@onEverything] ([@onA] a && b);
-
 let both = (a, b) =>
   [@onA] a && [@onB] [@onB] b;
-
 let both = (a, b) => [@onEverything] (a && b);
 
 let thisVal = 10;
-
 let x =
   20
   + (- [@onFunctionCall] add(thisVal, thisVal));
-
 let x =
   [@onEverything]
   (20 + (- add(thisVal, thisVal)));
-
 let x =
   - [@onFunctionCall] add(thisVal, thisVal);
-
 let x =
   [@onEverything] (- add(thisVal, thisVal));
 
 let bothTrue = (x, y) => {contents: x && y};
-
 let something =
   [@onEverythingToRightOfEquals]
   (bothTrue(true, true))^;
-
 let something =
   ([@onlyOnArgumentToBang] bothTrue(true, true))
     ^;
@@ -179,7 +144,6 @@ let something =
 let res =
   [@appliesToEntireFunctionApplication]
   add(2, 4);
-
 [@appliesToEntireFunctionApplication]
 add(2, 4);
 
@@ -196,7 +160,6 @@ type recordFunctions = {
 }
 [@onUnusedType]
 and unusedType = unit;
-
 [@onMyRecord]
 let rec myRecord = {
   p: () => myRecord,
@@ -204,7 +167,6 @@ let rec myRecord = {
 }
 [@onUnused]
 and unused = ();
-
 let result =
   [@onSecondSend]
   ([@attOnFirstSend] myRecord.p()).q();
@@ -223,7 +185,6 @@ type gadtType('x) =
   | Baz: [@onThirdRow] gadtType([@onUnit] unit);
 
 [@floatingTopLevelStructureItem hello];
-
 [@itemAttributeOnEval]
 print_string("hello");
 
@@ -327,7 +288,6 @@ class type _z = {
 module NestedModule = {
   [@floatingNestedStructureItem hello];
 };
-
 [@structureItem]
 module type HasAttrs = {
   [@onTypeDef]
@@ -348,7 +308,6 @@ type s =
   | S(string);
 
 let S([@onStr] str) = S([@onHello] "hello");
-
 let [@onConstruction] S(str) =
   [@onConstruction] S("hello");
 
@@ -361,7 +320,6 @@ let myFun =
       [@onConstruction] X(hello) |
       [@onConstruction] Y(hello),
     ) => hello;
-
 let myFun =
     (
       X([@onHello] hello) | Y([@onHello] hello),
@@ -370,7 +328,9 @@ let myFun =
 /* Another bug: Cannot have an attribute on or pattern
    let myFun = fun ((X(hello) | Y(hello)) [@onOrPattern]) => hello;
    */
+
 /* Bucklescript FFI item attributes */
+
 [@bs.val]
 external imul : (int, int) => int = "Math.imul";
 
@@ -540,6 +500,7 @@ type value =
   | VInt'(int): value;
 
 /** Different payloads **/
+
 [@haha]
 /* Empty structure */
 let x = 5;
@@ -568,6 +529,7 @@ let x = 5;
 let x = 5;
 
 /* Record item attributes */
+
 type t_ = {
   /** Comment attribute on record item */
   x: int,

--- a/formatTest/typeCheckedTests/expected_output/attributes.rei
+++ b/formatTest/typeCheckedTests/expected_output/attributes.rei
@@ -1,6 +1,6 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
-/**Floating comment text should be removed*/;
 
+/**Floating comment text should be removed*/;
 let test: int;
 
 /**
@@ -47,6 +47,7 @@ external createCompositeElementInternalHack :
   "createElement";
 
 /* Record item attributes */
+
 type t_ = {
   /** Comment attribute on record item */
   x: int,

--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 let l =
   [1, 2, 3]
   |> List.map(i => i + 1, _)

--- a/formatTest/typeCheckedTests/expected_output/comments.re
+++ b/formatTest/typeCheckedTests/expected_output/comments.re
@@ -119,7 +119,6 @@ let equal = (i1, i2) =>
 
 module Temp = {
   let v = true;
-
   let logIt = (str, ()) => print_string(str);
 };
 

--- a/formatTest/typeCheckedTests/expected_output/comments.re
+++ b/formatTest/typeCheckedTests/expected_output/comments.re
@@ -1,32 +1,27 @@
 /* **** comment */
-
 /*** comment */
 /** docstring */;
-
 /* comment */
 /** docstring */;
-
-
 /*** comment */
-
 /**** comment */
-
 /***** comment */
 
 /*** */
-
 /**** */
 
 /***/
-
 /****/
+
 /* (** comment *) */
 /* (*** comment *) */
 /* *(*** comment *) */
+
 /* comment **/
 /* comment ***/
 /* comment ****/
 /* comment *****/
+
 let testingNotQuiteEndOfLineComments = [
   "Item 1" /* Comment For First Item */,
   "Item 2" /* Comment For Second Item */,
@@ -57,8 +52,8 @@ type variant =
   | X(int) /* End of line on X */
   /* Comment above Y */
   | Y(int); /* End of line on Y */
-
 /* Comment on entire type def for variant */
+
 type x = {
   /* not attached *above* x */
   fieldOne: int,

--- a/formatTest/typeCheckedTests/expected_output/comments.rei
+++ b/formatTest/typeCheckedTests/expected_output/comments.rei
@@ -1,38 +1,31 @@
 /* **** comment */
-
 /*** comment */
-
 /*** docstring */
 /* comment */
-
 /*** docstring */
-
 /*** comment */
-
 /**** comment */
-
 /***** comment */
+
 /** */;
-
-
 /*** */
-
 /**** */
 
 /***/
-
 /****/
-/** (** comment *) */;
 
+/** (** comment *) */;
 /** (*** comment *) */;
 
 /* (** comment *) */
 /* (*** comment *) */
 /* *(*** comment *) */
+
 /* comment **/
 /* comment ***/
 /* comment ****/
 /* comment *****/
+
 /**
   * Multiline
   */;

--- a/formatTest/typeCheckedTests/expected_output/imperative.re
+++ b/formatTest/typeCheckedTests/expected_output/imperative.re
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 /*
  * Syntax and fallback syntax.
 

--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -446,9 +446,9 @@ let myFun = () =>
 /* let res = <Foo a=10 b=(<Foo a=200 />) > */
 /*   <Bar /> */
 /* </Foo>; */
+
 /* let res = <Foo a=10 b=(<Foo a=200 />) />; */
-let zzz =
-  Some("oh hai");
+let zzz = Some("oh hai");
 /* this should be the only test that generates a warning. We're explicitly testing for this */
 let optionalCallSite =
   <Optional1 required=?zzz />;

--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -179,46 +179,33 @@ let fakeRender = (el: component) =>
   el.displayName;
 
 /* end of setup */
+
 let (/><) = (a, b) => a + b;
-
 let (><) = (a, b) => a + b;
-
 let (/>) = (a, b) => a + b;
-
 let (></) = (a, b) => a + b;
 
 let tag1 = 5 />< 6;
-
 let tag2 = 5 >< 7;
-
 let tag3 = 5 /> 7;
-
 let tag4 = 5 ></ 7;
 
 let b = 2;
-
 let selfClosing = <Foo />;
-
 let selfClosing2 = <Foo a=1 b=true />;
-
 let selfClosing3 =
   <Foo
     a="really long values that should"
     b="cause the entire thing to wrap"
   />;
-
 let a = <Foo> <Bar c=(a => a + 2) /> </Foo>;
-
 let a3 = <So> <Much> <Nesting /> </Much> </So>;
-
 let a4 =
   <Sibling>
     <One test=true foo=b />
     <Two foo=b />
   </Sibling>;
-
 let a5 = <Foo> "testing a string here" </Foo>;
-
 let a6 =
   <Foo2>
     <Text> "testing a string here" </Text>
@@ -227,53 +214,31 @@ let a6 =
     <Bar />
     <Exp> (2 + 4) </Exp>
   </Foo2>;
-
 let intended = true;
-
 let punning = <Pun intended />;
-
 let namespace = <Namespace.Foo />;
-
 let c = <Foo />;
-
 let d = <Foo />;
 
 let spaceBefore =
   <So> <Much> <Nesting /> </Much> </So>;
-
 let spaceBefore2 = <So> <Much /> </So>;
-
 let siblingNotSpaced =
   <So> <Much /> <Much /> </So>;
-
 let jsxInList = [<Foo />];
-
 let jsxInList2 = [<Foo />];
-
 let jsxInListA = [<Foo />];
-
 let jsxInListB = [<Foo />];
-
 let jsxInListC = [<Foo />];
-
 let jsxInListD = [<Foo />];
-
 let jsxInList3 = [<Foo />, <Foo />, <Foo />];
-
 let jsxInList4 = [<Foo />, <Foo />, <Foo />];
-
 let jsxInList5 = [<Foo />, <Foo />];
-
 let jsxInList6 = [<Foo />, <Foo />];
-
 let jsxInList7 = [<Foo />, <Foo />];
-
 let jsxInList8 = [<Foo />, <Foo />];
-
 let testFunc = b => b;
-
 let jsxInFnCall = testFunc(<Foo />);
-
 let lotsOfArguments =
   <LotsOfArguments
     argument1=1
@@ -284,59 +249,35 @@ let lotsOfArguments =
     argument6="test">
     <Namespace.Foo />
   </LotsOfArguments>;
-
 let lowerCase = <div argument1=1 />;
 
 let b = 0;
-
 let d = 0;
-
 /*
  * Should pun the first example:
  */
 let a = <Foo a> 5 </Foo>;
-
 let a = <Foo a=b> 5 </Foo>;
-
 let a = <Foo a=b b=d> 5 </Foo>;
-
 let a = <Foo a> 0.55 </Foo>;
-
 let a = <Foo />;
-
 let ident = <Foo> a </Foo>;
-
 let fragment1 = <> <Foo /> <Foo /> </>;
-
 let fragment2 = <> <Foo /> <Foo /> </>;
-
 let fragment3 = <> <Foo /> <Foo /> </>;
-
 let fragment4 = <> <Foo /> <Foo /> </>;
-
 let fragment5 = <> <Foo /> <Foo /> </>;
-
 let fragment6 = <> <Foo /> <Foo /> </>;
-
 let fragment7 = <> <Foo /> <Foo /> </>;
-
 let fragment8 = <> <Foo /> <Foo /> </>;
-
 let fragment9 = <> 2 2 2 2 </>;
-
 let fragment10 = <> 2.2 3.2 4.6 1.2 </>;
-
 let fragment11 = <> "str" </>;
-
 let fragment12 = <> (6 + 2) (6 + 2) (6 + 2) </>;
-
 let fragment13 = <> fragment11 fragment11 </>;
-
 let listOfItems1 = <List1> 1 2 3 4 5 </List1>;
-
 let listOfItems2 =
   <List2> 1.0 2.8 3.8 4.0 5.1 </List2>;
-
 let listOfItems3 =
   <List3> fragment11 fragment11 </List3>;
 
@@ -344,11 +285,8 @@ let listOfItems3 =
  * Several sequential simple jsx expressions must be separated with a space.
  */
 let thisIsRight = (a, b) => ();
-
 let tagOne = (~children, ()) => ();
-
 let tagTwo = (~children, ()) => ();
-
 /* thisIsWrong <tagOne /><tagTwo />; */
 thisIsRight(<tagOne />, <tagTwo />);
 
@@ -356,7 +294,6 @@ thisIsRight(<tagOne />, <tagTwo />);
 thisIsRight(<tagOne />, <tagTwo />);
 
 let a = (~children, ()) => ();
-
 let b = (~children, ()) => ();
 
 let thisIsOkay =
@@ -368,22 +305,17 @@ let thisIsAlsoOkay =
 /* Doesn't make any sense, but suppose you defined an
    infix operator to compare jsx */
 <a /> < <b />;
-
 <a /> > <b />;
 
 <a /> < <b />;
-
 <a /> > <b />;
 
 let listOfListOfJsx = [<> </>];
-
 let listOfListOfJsx = [<> <Foo /> </>];
-
 let listOfListOfJsx = [
   <> <Foo /> </>,
   <> <Bar /> </>,
 ];
-
 let listOfListOfJsx = [
   <> <Foo /> </>,
   <> <Bar /> </>,
@@ -391,14 +323,11 @@ let listOfListOfJsx = [
 ];
 
 let sameButWithSpaces = [<> </>];
-
 let sameButWithSpaces = [<> <Foo /> </>];
-
 let sameButWithSpaces = [
   <> <Foo /> </>,
   <> <Bar /> </>,
 ];
-
 let sameButWithSpaces = [
   <> <Foo /> </>,
   <> <Bar /> </>,
@@ -408,12 +337,10 @@ let sameButWithSpaces = [
 /*
  * Test named tag right next to an open bracket.
  */
+
 let listOfJsx = [];
-
 let listOfJsx = [<Foo />];
-
 let listOfJsx = [<Foo />, <Bar />];
-
 let listOfJsx = [
   <Foo />,
   <Bar />,
@@ -421,11 +348,8 @@ let listOfJsx = [
 ];
 
 let sameButWithSpaces = [];
-
 let sameButWithSpaces = [<Foo />];
-
 let sameButWithSpaces = [<Foo />, <Bar />];
-
 let sameButWithSpaces = [
   <Foo />,
   <Bar />,
@@ -436,12 +360,10 @@ let sameButWithSpaces = [
  * Test no conflict with polymorphic variant types.
  */
 type thisType = [ | `Foo | `Bar];
-
 type t('a) = [< thisType] as 'a;
 
 let asd =
   [@foo] <One test=true foo=2> "a" "b" </One>;
-
 let asd2 =
   [@foo]
   [@JSX]
@@ -453,17 +375,13 @@ let asd2 =
 
 let span =
     (~test: bool, ~foo: int, ~children, ()) => 1;
-
 let asd =
   [@foo] <span test=true foo=2> "a" "b" </span>;
-
 /* "video" call doesn't end with a list, so the expression isn't converted to JSX */
 let video = (~test: bool, children) => children;
-
 let asd2 = [@foo] [@JSX] video(~test=false, 10);
 
 let div = (~children) => 1;
-
 [@JSX] ((() => div)())(~children=[]);
 
 let myFun = () =>
@@ -531,40 +449,27 @@ let myFun = () =>
 /* let res = <Foo a=10 b=(<Foo a=200 />) />; */
 let zzz =
   Some("oh hai");
-
 /* this should be the only test that generates a warning. We're explicitly testing for this */
 let optionalCallSite =
   <Optional1 required=?zzz />;
-
 fakeRender(optionalCallSite);
-
 let optionalArgument = <Optional2 />;
-
 fakeRender(optionalArgument);
-
 let optionalArgument =
   <Optional2 optional=?zzz />;
-
 fakeRender(optionalArgument);
-
 let defaultArg = <DefaultArg />;
-
 fakeRender(defaultArg);
-
 let defaultArg = <DefaultArg default=zzz />;
-
 fakeRender(defaultArg);
 
 ([@bla]
  [@JSX]
  NotReallyJSX.createElement([], ~foo=1, ~bar=2));
-
 ([@bla]
  [@JSX]
  NotReallyJSX.createElement(~foo=1, [], ~bar=2));
-
 ([@bla] [@JSX] notReallyJSX([], ~foo=1));
-
 ([@bla] [@JSX] notReallyJSX(~foo=1, [], ~bar=2));
 
 /* children can be at any position */
@@ -574,11 +479,9 @@ fakeRender(defaultArg);
 
 /* preserve some other attributes too! */
 ([@bla] <span test=true foo=2 />);
-
 ([@bla] <span test=true foo=2 />);
 
 ([@bla] <Optional1 required=(Some("hi")) />);
-
 ([@bla] <Optional1 required=(Some("hi")) />);
 
 /* Overeager JSX punning #1099 */

--- a/formatTest/typeCheckedTests/expected_output/knownMlIssues.re
+++ b/formatTest/typeCheckedTests/expected_output/knownMlIssues.re
@@ -15,6 +15,7 @@ let blahCurriedX = x =>
   | Black(x) => 0 /* After black */
   | Green(x) => 0; /* After second green */
 /* On next line after blahCurriedX def */
+
 /* EOL comments wrap because other elements break first (in this example
       "mutable" causes breaks. We either need:
       1. To prevent wrapping of anything inside of eol comments attachments.

--- a/formatTest/typeCheckedTests/expected_output/lazy.re
+++ b/formatTest/typeCheckedTests/expected_output/lazy.re
@@ -21,14 +21,11 @@ type box('a) =
   | Box('a);
 
 let lazy thisIsActuallyAPatternMatch = lazy 200;
-
 let tmp: int = thisIsActuallyAPatternMatch;
-
 let (lazy (Box(i)), x) = (
   lazy (Box(200)),
   100,
 );
-
 let tmp: int = i;
 
 let myComputation = lazy 200;

--- a/formatTest/typeCheckedTests/expected_output/mlSyntax.re
+++ b/formatTest/typeCheckedTests/expected_output/mlSyntax.re
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 /**
  * Testing pattern matching using ml syntax to exercise nesting of cases.
  */;

--- a/formatTest/typeCheckedTests/expected_output/mlSyntax.re
+++ b/formatTest/typeCheckedTests/expected_output/mlSyntax.re
@@ -48,10 +48,8 @@ type bcd =
   | C
   | D
   | E;
-
 type a =
   | A(bcd);
-
 let result =
   switch (B) {
   | B
@@ -101,15 +99,9 @@ module EM = {
 exception Ealias = EM.E;
 
 let switc = "match";
-
 let switch_ = "match";
-
 let switch__ = "match";
-
 let pub_ = "method";
-
 let pub__ = "method";
-
 let pri_ = "private";
-
 let pri__ = "private";

--- a/formatTest/typeCheckedTests/expected_output/mlSyntax.re.4.02.3
+++ b/formatTest/typeCheckedTests/expected_output/mlSyntax.re.4.02.3
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 /**
  * Testing pattern matching using ml syntax to exercise nesting of cases.
  */;
@@ -48,10 +49,8 @@ type bcd =
   | C
   | D
   | E;
-
 type a =
   | A(bcd);
-
 let result =
   switch (B) {
   | B
@@ -101,15 +100,9 @@ module EM = {
 exception Ealias = EM.E;
 
 let switc = "match";
-
 let switch_ = "match";
-
 let switch__ = "match";
-
 let pub_ = "method";
-
 let pub__ = "method";
-
 let pri_ = "private";
-
 let pri__ = "private";

--- a/formatTest/typeCheckedTests/expected_output/mlVariants.re
+++ b/formatTest/typeCheckedTests/expected_output/mlVariants.re
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 type polyVariantsInMl = [
   | `IntTuple(int, int)
   | `StillAnIntTuple(int, int)

--- a/formatTest/typeCheckedTests/expected_output/mlVariants.re
+++ b/formatTest/typeCheckedTests/expected_output/mlVariants.re
@@ -5,9 +5,7 @@ type polyVariantsInMl = [
 ];
 
 let intTuple = `IntTuple((1, 2));
-
 let stillAnIntTuple = `StillAnIntTuple((4, 5));
-
 let sumThem =
   fun
   | `IntTuple(x, y) => x + y

--- a/formatTest/typeCheckedTests/expected_output/mutation.re
+++ b/formatTest/typeCheckedTests/expected_output/mutation.re
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 /**
  * Testing mutations.
  */

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -107,7 +107,6 @@ and secondRecursiveClass (init) = {
 type closedObj = {.};
 
 let (<..>) = (a, b) => a + b;
-
 let five = 2 <..> 3;
 
 type nestedObj = {. bar: {. a: int}};
@@ -121,14 +120,12 @@ type typeDefForClosedObj = {
   x: int,
   y: int,
 };
-
 type typeDefForOpenObj('a) =
   {
     ..
     x: int,
     y: int,
   } as 'a;
-
 let anonClosedObject: {
   .
   x: int,
@@ -139,7 +136,6 @@ let anonClosedObject: {
 };
 
 let onlyHasX = {pub x = 0};
-
 let xs: list({. x: int}) = [
   onlyHasX,
   (anonClosedObject :> {. x: int}),
@@ -178,7 +174,6 @@ let acceptsOpenAnonObjAsArg =
       },
     ) =>
   o#x + o#y;
-
 let acceptsClosedAnonObjAsArg =
     (
       o: {
@@ -188,7 +183,6 @@ let acceptsClosedAnonObjAsArg =
       },
     ) =>
   o#x + o#y;
-
 let res =
   acceptsOpenAnonObjAsArg({
     pub x = 0;
@@ -218,7 +212,6 @@ class myClassWithAnnotatedReturnType
   pub x: int = init;
   pub y = init;
 };
-
 /**
  * May include a trailing semi after type row.
  */
@@ -342,7 +335,6 @@ let incrementMyClassInstance:
   };
 
 class myClassWithNoTypeParams = {};
-
 /**
  * The #myClassWithNoTypeParams should be treated as "simple"
  */

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 class virtual stack ('a) (init) = {
   /*
    * The "as this" is implicit and will be formatted away.

--- a/formatTest/typeCheckedTests/expected_output/patternMatching.re
+++ b/formatTest/typeCheckedTests/expected_output/patternMatching.re
@@ -131,17 +131,14 @@ switch (Some()) {
 | Some () => 1
 | _ => 2
 };
-
 switch (Some()) {
 | Some () => 1
 | _ => 2
 };
-
 switch (Some()) {
 | Some () => 1
 | _ => 2
 };
-
 switch (Some()) {
 | Some () => 1
 | _ => 2
@@ -149,19 +146,15 @@ switch (Some()) {
 
 type foo =
   | Foo(unit);
-
 switch (Foo()) {
 | Foo () => 1
 };
-
 switch (Foo()) {
 | Foo () => 1
 };
-
 switch (Foo()) {
 | Foo () => 1
 };
-
 switch (Foo()) {
 | Foo () => 1
 };
@@ -169,15 +162,12 @@ switch (Foo()) {
 switch () {
 | () => 1
 };
-
 switch () {
 | () => 1
 };
-
 switch () {
 | () => 1
 };
-
 switch () {
 | () => 1
 };

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -1,13 +1,10 @@
 3; /* - */
-
 3; /*-*/
 
 3; /*-*/
 
 3 /*-*/;
-
 /* **** comment */
-
 /*** comment */
 /** docstring */
 /* comment */
@@ -91,6 +88,7 @@ let testingEndOfLineComments = []; /* Comment after entire let binding */
 /*     andSecondArg  => { /* Second Arg */ */
 /*   withFirstArg + andSecondArg /* before semi */ ; */
 /* }; */
+
 let myFunction = /* First arg */
     (
       withFirstArg,
@@ -145,7 +143,6 @@ type anotherpoint = {
 };
 
 type t = (int, int); /* End of line on t */
-
 type t2 = (int, int); /* End of line on (int, int) */
 
 type t3 = (int, int); /* End of line on (int, int) */
@@ -169,7 +166,7 @@ let res =
   | X(0, 0) =>
     /* After X arrow */
     "result of X" /* End of X body line */
-  | X(1, 0) /* Before X's arrow */ => "result of X" /* End of X body line */
+  | X(1, 0)/* Before X's arrow */ => "result of X" /* End of X body line */
   | X(_) =>
     /* After X _ arrow */
     "result of X" /* End of X body line */
@@ -295,7 +292,6 @@ type intPair = (
   int, /* First int */
   int /* Second int */
 );
-
 type intPair2 = (
   /* First int */
   int,
@@ -310,8 +306,8 @@ let result = /**/ (2 + 3);
 /*   /**/ */
 /*   (+) 2 3 */
 /* }; */
-let a = ();
 
+let a = ();
 for (i in 0 to 10) {
   /* bla  */
   a;
@@ -542,7 +538,6 @@ while (trueThing) {
     /* does work */
   );
 };
-
 while (trueThing) {
   f(
     /* a */
@@ -580,9 +575,7 @@ ignore((_xxx, _yyy) => {
 type tester('a, 'b) =
   | TwoArgsConstructor('a, 'b)
   | OneTupleArgConstructor(('a, 'b));
-
 let callFunctionTwoArgs = (a, b) => ();
-
 let callFunctionOneTuple = tuple => ();
 
 let y =

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -166,7 +166,7 @@ let res =
   | X(0, 0) =>
     /* After X arrow */
     "result of X" /* End of X body line */
-  | X(1, 0)/* Before X's arrow */ => "result of X" /* End of X body line */
+  | X(1, 0) /* Before X's arrow */ => "result of X" /* End of X body line */
   | X(_) =>
     /* After X _ arrow */
     "result of X" /* End of X body line */

--- a/formatTest/typeCheckedTests/expected_output/sequences.re
+++ b/formatTest/typeCheckedTests/expected_output/sequences.re
@@ -13,7 +13,6 @@ let result = {
   let twenty = result;
   twenty;
 };
-
 let anInt = result + 20;
 
 let twenty = 20;
@@ -24,13 +23,10 @@ let twenty = 20;
  * To ensure these are parsed correctly, adding to an integer.
  */
 let result = 0 + twenty;
-
 let result = 0 + twenty;
-
 let result = 0 + twenty;
 
 let unitValue = ();
-
 /* While loops/for loops merely accept a "simple expression" (which means
  * it is either a simple token or balanced with parens/braces). However,
  * the formatter ensures that the bodies are printed in "sequence" form even if
@@ -39,21 +35,16 @@ let unitValue = ();
 while (false) {
   unitValue;
 };
-
 while (false) {
   print_string("test");
 };
-
 while (false) {
   print_string("test");
 };
 
 type myRecord = {number: int};
-
 let x = {number: 20};
-
 let number = 20;
-
 /*
  * The (mild) consequence of not requiring a final semi in a sequence,
  * is that we can no longer "pun" a single field record (which would)
@@ -62,12 +53,9 @@ let number = 20;
 let cannotPunASingleFieldRecord = {
   number: number,
 };
-
 let fourty =
   20 + cannotPunASingleFieldRecord.number;
-
 let thisIsASequenceNotPunedRecord = number;
-
 let fourty = 20 + thisIsASequenceNotPunedRecord;
 
 type recordType = {
@@ -75,20 +63,13 @@ type recordType = {
   b: int,
   c: int,
 };
-
 let a = 0;
-
 let b = 0;
-
 let c = 0;
-
 /* All of these will be printed as punned because they have more than one field. */
 let firstFieldPunned = {a, b, c};
-
 let sndFieldPunned = {a, b, c};
-
 let thirdFieldPunned = {a, b, c};
-
 let singlePunAcceptedIfExtended = {
   ...firstFieldPunned,
   a,

--- a/formatTest/typeCheckedTests/expected_output/sequences.re
+++ b/formatTest/typeCheckedTests/expected_output/sequences.re
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 /**
  * Testing Sequences.
  */

--- a/formatTest/typeCheckedTests/expected_output/trailing.re
+++ b/formatTest/typeCheckedTests/expected_output/trailing.re
@@ -1,10 +1,8 @@
 let x = 0;
-
 let y = 0;
 
 [@warning "-8"]
 let [|x, y|] = [|0, y|];
-
 [@warning "-8"]
 let [|x, y|] = [|0, y|];
 
@@ -16,7 +14,6 @@ let [|
   0,
   1,
 |];
-
 [@warning "-8"]
 let [|
   reallyLongIdentifier_,
@@ -27,35 +24,25 @@ let [|
 |];
 
 let takesUnit = () => ();
-
 let res = takesUnit();
-
 let wat = 0;
 
 type t = {
   x: int,
   y: int,
 };
-
 let p = {contents: 0};
-
 let {contents: c} = p;
-
 let point = {x: 0, y: 0};
-
 let point2 = {...point, y: 200};
 
 let myTuple = (0, 0);
-
 let (i, j) = myTuple;
 
 type foo_('a, 'b) = ('a, 'b);
-
 type foo__ = foo_(int, int);
-
 type foo('a, 'b) =
   | Foo('a, 'b);
-
 type tupVariant('a, 'b) =
   | Tup(('a, 'b));
 
@@ -66,11 +53,8 @@ let noWrap = (a, b) => {
 };
 
 let res = noWrap(0, 0);
-
 let reallyLongIdentifierCausesWrap = 0;
-
 let wrap = noWrap;
-
 let res =
   wrap(
     reallyLongIdentifierCausesWrap,
@@ -161,7 +145,6 @@ let takesPattern =
 let myFunc = (type t, ()) => ();
 
 type funcType = (int, int) => int;
-
 type v =
   | Func((int, int) => int);
 
@@ -214,24 +197,18 @@ class extendedStack
 };
 
 module type HasType = {type t;};
-
 module type HasType2 = {type t; type q;};
-
 module type ReallyReallyReallyLongIdentifierModuleType = {
   type t;
 };
-
 module type F = (HasType) => HasType2;
-
 module FInstance = (HasType: HasType) => {
   type t = HasType.t;
   type q = HasType.t;
 };
-
 module ReallyReallyReallyLongIdentifierModuleName = {
   type t = int;
 };
-
 module FResult =
   FInstance(
     ReallyReallyReallyLongIdentifierModuleName,
@@ -244,76 +221,58 @@ module Component = {
 };
 
 let componentList = [<Component arg=1 />];
-
 let componentList = [<Component arg="2" />];
-
 let componentList = [<Component arg=1 />];
-
 let componentList = [<Component arg="2" />];
-
 let componentList = [
   <Component arg=1 />,
   <Component arg=0 />,
 ];
-
 let componentList = [
   <Component arg="2" />,
   <Component arg=0 />,
 ];
-
 let componentList = [
   <Component arg=1 />,
   <Component arg=0 />,
 ];
-
 let componentList = [
   <Component arg="2" />,
   <Component arg=0 />,
 ];
-
 let componentList = [
   <Component arg=1 />,
   <Component arg=0 />,
 ];
-
 let componentList = [
   <Component arg="2" />,
   <Component arg=0 />,
 ];
 
 let componentList = [|<Component arg=1 />|];
-
 let componentList = [|<Component arg="2" />|];
-
 let componentList = [|<Component arg=1 />|];
-
 let componentList = [|<Component arg="2" />|];
-
 let componentList = [|
   <Component arg=1 />,
   <Component arg=0 />,
 |];
-
 let componentList = [|
   <Component arg="2" />,
   <Component arg=0 />,
 |];
-
 let componentList = [|
   <Component arg=1 />,
   <Component arg=0 />,
 |];
-
 let componentList = [|
   <Component arg="2" />,
   <Component arg=0 />,
 |];
-
 let componentList = [|
   <Component arg=1 />,
   <Component arg=0 />,
 |];
-
 let componentList = [|
   <Component arg="2" />,
   <Component arg=0 />,

--- a/formatTest/typeCheckedTests/expected_output/trailing.re
+++ b/formatTest/typeCheckedTests/expected_output/trailing.re
@@ -225,7 +225,6 @@ module type F = (HasType) => HasType2;
 
 module FInstance = (HasType: HasType) => {
   type t = HasType.t;
-
   type q = HasType.t;
 };
 

--- a/formatTest/typeCheckedTests/input/attributes.4.04.0.re
+++ b/formatTest/typeCheckedTests/input/attributes.4.04.0.re
@@ -7,6 +7,7 @@ let () = {
 /** Different payloads **/
 
 /* Empty signature */
+
 [@haha: ]
 let x = 5;
 

--- a/formatTest/typeCheckedTests/input/jsx.re
+++ b/formatTest/typeCheckedTests/input/jsx.re
@@ -18,6 +18,7 @@ module Foo = {
 
 module One = {
     let createElement(~test=?,~foo=?,~children,()) {displayName: "test"};
+
     let createElementobvioustypo(~test,~children,()) {displayName: "test"};
 };
 

--- a/formatTest/typeCheckedTests/input/oo.re
+++ b/formatTest/typeCheckedTests/input/oo.re
@@ -239,6 +239,7 @@ module HasTupleClasses : {
    * exportedClass.
    */
   class exportedClass = myClassWithAnnotatedReturnType3;
+
   /**
    * anotherExportedClass.
    */

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 let run = () =>
   TestUtils.printSection("Basic Structures");
 

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -115,23 +115,14 @@ let x = Some(-10);
 let x = Some(-5.0);
 
 let lazy x = 10;
-
 let lazy (x: int) = 10;
-
 let lazy [] = 10;
-
 let lazy true = 10;
-
 let lazy #x = 10;
-
 let lazy `Variant = 10;
-
 let lazy `variant = 10;
-
 let lazy '0'..'9' = 10;
-
 let lazy (lazy true) = 10;
-
 let lazy [%extend] = 10;
 
 /* Test precedence on access sugar */
@@ -150,7 +141,6 @@ let x = arr^[0] = 1;
 /* Comments */
 /*Below is an empty comment*/
 /**/;
-
 /**                            IF
  *============================================================================
  */;
@@ -178,13 +168,9 @@ let logTapSuccess = self =>
   };
 
 (! data).field = true;
-
 (! data).field1.field2 = true;
-
 (! data.field1).field2 = true;
-
 (! data).field1.field2 = true;
-
 (! data.field1).field2 = true;
 
 let loop = (appTime, frameTime) => {
@@ -238,7 +224,6 @@ if (false) {
  * printer(
  */
 let printIfFirstArgGreater = true;
-
 let result =
   if (printIfFirstArgGreater) {
     (a, b) =>
@@ -286,7 +271,6 @@ if (printIfFirstArgGreater) {
       print_string("b < a");
     };
 };
-
 /* Should Be Parsed As: Cleary a type error, but at least the parsing makes that clear */
 if (printIfFirstArgGreater) {
   (a, b) =>
@@ -338,26 +322,20 @@ if (10 < 100) {
 /**                            TYPE CONSTRAINTS
  *============================================================================
  */;
-
 let x: int = 10;
-
 let x: int = 10;
-
 let x: int = 10;
-
 let x: int = (10: int);
-
 /* let (x:int) = (10:string); */
 /* let (x:string) = ("hello":int); */
+
 /**                            TUPLES
  *============================================================================
  */;
 
 /* In Reason, types look like the data they model! Tuples are no exception. */
 type pairOfInts = (int, int);
-
 let letBindingWithTypeConstraint: int = 10;
-
 let (tupleItem: int, withTypeConstraint: int) = (
   10,
   20,
@@ -365,7 +343,6 @@ let (tupleItem: int, withTypeConstraint: int) = (
 
 /* To make sure that tuple field annotations are annotating the entire field */
 let _dummyFunc = x => 10;
-
 let annotatingFuncApplication = (
   _dummyFunc("a"): int,
   _dummyFunc("a"): int,
@@ -395,7 +372,6 @@ let (
   10,
   20,
 );
-
 let (tupleItem, withOutsideTypeConstraint): (
   int,
   int,
@@ -406,7 +382,6 @@ let (tupleItem, withOutsideTypeConstraint): (
 
 /* Trailing commas */
 let trailingCommaAccepted = (1, 2);
-
 let moreTrailing = (1, 2, 3, 4, 5, 7);
 
 /**                        Immutable Lists
@@ -415,9 +390,7 @@ let moreTrailing = (1, 2, 3, 4, 5, 7);
 
 /* Anatomy:        -Head-      --------- Tail---------  nil: You can't see nil */
 let x: list(int) = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-
 let hd = "appendedToHead";
-
 let tl = ["listTo", "append", "to"];
 
 /* To push *one* and only *one* item to the front of a list - use [hd, ...tl] */
@@ -470,11 +443,9 @@ let nestedMatchWithWhen = lstLst =>
 /**
  * Aliasing with "as" during matches.
  */;
-
 type mine =
   | MyThing(int)
   | YourThing(int);
-
 /*
  * Reason parses "as" aliases differently than OCaml.
  */
@@ -497,11 +468,11 @@ let ppp =
   };
 
 let MyThing(_) as ppp | YourThing(_) as ppp = ppp;
-
 /*
  * But this isn't needed in Reason because OR patterns have much lower
  * precedence - they should be pretty printed in the same way.
  */
+
 /* TODO: */
 /* let rec nestedMatch lstLst => match lstLst with { */
 /*   hd::tl: match tl with { */
@@ -511,25 +482,21 @@ let MyThing(_) as ppp | YourThing(_) as ppp = ppp;
 /*   []: 0 */
 /* }; */
 /*  */
+
 /**                               ARRAYS
  * ============================================================================
  * Arrays are weird looking. Usually you want lists because they support pattern
  * matching - that's why they have nicer syntax - to entice you. But if you want
  * random access and better control over memory layout, use arrays.
  */;
-
 let emptyArray = [||];
-
 let arrayWithOne = [|10|];
-
 let arrayWithTwo = [|10, 10|];
-
 let secondItem = arrayWithTwo[1];
 
 /* Getting And Setting: Yeah, we should really change this */
 /* Get an array item at index 1 */
 let secondItem = arrayWithTwo[1];
-
 /* Set an array item at index 1 */
 arrayWithTwo[1] = 300;
 
@@ -538,26 +505,22 @@ arrayWithTwo[1] = 300;
  *  ============================================================================
  *  The language supports mutating strings, but that should not be depended upon.
  */;
-
 let myString = "asdf";
-
 myString.[2] = '9'; /* Replacing a character: I could do without this sugar */
 
 /*                           FUNCTIONS
  *=============================================================================
  */
+
 /*                           TYPE ANNOTATIONS
  * =============================================================================
  */
+
 let one = 900;
-
 let two = 10000;
-
 /* Tuple expressions can be annotated without additional paren wrapping */
 let myTuple = (one: int, two: int);
-
 type myTupleType = (int, int);
-
 let myTuple: myTupleType = myTuple;
 
 /* Anything *outside* of a tuple, must still be annotated within parens. */
@@ -585,8 +548,8 @@ let curriedFormTwo =
   i,
   x,
 );
-
 /* let nonCurriedFormTwo = fun (i:int, x:int) (:(int, int)) => (i, x); */
+
 let curriedFormThree =
     (i: int, (a: int, b: int): (int, int))
     : (int, int, int) => (
@@ -596,6 +559,7 @@ let curriedFormThree =
 );
 
 /* let nonCurriedFormThree = fun (i:int, (a:int, b:int):(int, int)) (:(int, int, int)) => (i, a, b);  */
+
 /** TODO: But this, however doesn't work.
  *  let (myCurriedFunc: int => int) a => a;
  *  Note: This is likely because only "simple patterns" are accepted as constraints
@@ -650,7 +614,6 @@ let testRecord = {
   age: 20,
   occupation: "engineer",
 };
-
 let anotherRecord = {
   ...testRecord,
   name: "joe++",
@@ -662,7 +625,6 @@ let makeRecordBase = () => {
   age: 30,
   occupation: "Engineer",
 };
-
 let anotherRecord = {
   /* These parens should be evaporated. */
   ...makeRecordBase(),
@@ -780,21 +742,16 @@ let moreFoo = {
 };
 
 /* record value punning */
-let props = {title: "hi"};
 
+let props = {title: "hi"};
 /* no punning available for a single field. Can't tell the difference with a scope + expression */
 let componentA = {props: props};
-
 /* pun for real */
 let componentB = {props, state: ()};
-
 /* pun fields with module prefix too */
 let foo = {Foo.foo: foo};
-
 let bar = {Foo.foo, bar: 1};
-
 let bar = {bar: 1, Foo.foo};
-
 let bar = {Foo.foo, Bar.bar};
 
 ({M.x, y}) => 1;
@@ -869,11 +826,8 @@ let z = {
  * Unnecessary parens should be removed.
  */
 let unitLambda = () => ();
-
 let identifierLambda = a => ();
-
 let underscoreLambda = _ => ();
-
 it("should remove parens", a => {
   print_string("did it work?");
   print_string("did it work?");

--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -25,42 +25,34 @@ add(zz##yy, xx##ww);
 
 /* These should print the same */
 let res = x##y + z##q; /* AST */
-
 let res = x##y + z##q; /* Minimum parens */
 
 /* These should print the same */
 let res = y + z##q##a; /* AST */
-
 let res = y + z##q##a; /* Min parens */
 
 /* Make sure it's actually parsed as left precedence
  * and that is maintained when printed */
 let res = z##(q##a); /* AST */
-
 let res = z##(q##a); /* Min parens */
 
 /* These should print the same */
 let res = ! x##y; /* AST */
-
 let res = ! x##y; /* Minimum parens */
 
 /* These should print the same */
 let res = ! z##q##a; /* AST */
-
 let res = ! z##q##a; /* Min parens */
 
 /* These should print the same */
 let res = ?!!x##y; /* AST */
-
 let res = ?!!x##y; /* Minimum parens */
 
 /* These should print the same */
 let res = ?!!z##(q##a); /* AST */
-
 let res = ?!!z##(q##a); /* Min parens */
 
 res#=?!!z##q;
-
 res#=?!!z##(q##a);
 
 let result = myFunction(x(y)##z, a(b)#=c);

--- a/formatTest/unit_tests/expected_output/class_types.re
+++ b/formatTest/unit_tests/expected_output/class_types.re
@@ -1,7 +1,5 @@
 class type _module ('provider_impl) = {};
-
 type t;
-
 class type bzz = {
   inherit _module(t)
 };

--- a/formatTest/unit_tests/expected_output/escapesInStrings.re
+++ b/formatTest/unit_tests/expected_output/escapesInStrings.re
@@ -1,7 +1,9 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 /*
     let str = "@[.... some formatting ....@\n\010@.";
  */
+
 let str = "@[.... some formatting ....@\n\010@.";
 let str = {abcd|@[.... some formatting ....@\n\010@.|abcd};
 

--- a/formatTest/unit_tests/expected_output/escapesInStrings.re
+++ b/formatTest/unit_tests/expected_output/escapesInStrings.re
@@ -3,7 +3,6 @@
     let str = "@[.... some formatting ....@\n\010@.";
  */
 let str = "@[.... some formatting ....@\n\010@.";
-
 let str = {abcd|@[.... some formatting ....@\n\010@.|abcd};
 
 let utf8_string = "😁";

--- a/formatTest/unit_tests/expected_output/extensions.re
+++ b/formatTest/unit_tests/expected_output/extensions.re
@@ -49,6 +49,7 @@ let x =
   };
 
 /* At structure level */
+
 try%extend () {
 | _ => ()
 };
@@ -74,6 +75,7 @@ fun%extend
 | Some(1) => ();
 
 /* In a top-level binding */
+
 let x =
   try%extend () {
   | _ => ()
@@ -104,6 +106,7 @@ let x =
   | Some(1) => ();
 
 /* With two extensions, alone */
+
 let x = [%extend1
   try%extend2 () {
   | _ => ()
@@ -141,6 +144,7 @@ let x = [%extend1
 ];
 
 /* With two extensions, first in sequence */
+
 let x = {
   %extend1
   try%extend2 () {
@@ -199,6 +203,7 @@ let x = {
 };
 
 /* With two extensions, in sequence */
+
 let x = {
   ignore();
   %extend1
@@ -259,6 +264,7 @@ let x = {
 };
 
 /* With two extensions, second in sequence */
+
 let x = {
   ignore();
   %extend1

--- a/formatTest/unit_tests/expected_output/extensions.re
+++ b/formatTest/unit_tests/expected_output/extensions.re
@@ -1,4 +1,5 @@
 /* Extension sugar */
+
 %extend
 open M;
 

--- a/formatTest/unit_tests/expected_output/if.re
+++ b/formatTest/unit_tests/expected_output/if.re
@@ -6,7 +6,6 @@ let logTSuccess = self =>
   } else {
     ();
   };
-
 let something =
   if (self.ext.logSuccess) {
     print_string("Did T");
@@ -78,6 +77,7 @@ if (if (x) {true} else {false}) {
 /**                            TERNARY
  *============================================================================
  */
+
 let ternaryResult =
   something ?
     callThisFunction(withThisArg) : thatResult;
@@ -150,7 +150,6 @@ let result =
   addOne(0) + 0 > 1 ?
     print_string("this wont print") :
     print_string("this will");
-
 /*
  * Should be parsed as:
  */

--- a/formatTest/unit_tests/expected_output/if.re
+++ b/formatTest/unit_tests/expected_output/if.re
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 let logTSuccess = self =>
   if (self > other) {
     print_string("Did T");

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -16,6 +16,7 @@ let minParens = x > y > z < a < b == c == d;
 let formatted = x > y > z < a < b == c == d;
 
 /* Case with === */
+
 let parseTree = x > y > z < a < b === c === d;
 
 let minParens = x > y > z < a < b === c === d;
@@ -33,6 +34,7 @@ let formatted =
   a1 < a2 < (b1 > b2 > (y == x == z));
 
 /* Case with === */
+
 let parseTree =
   a1 < a2 < (b1 > b2 > (y === x === z));
 
@@ -53,6 +55,7 @@ let formatted =
   a1 := a2 := b1 == b2 == (y != x != z);
 
 /* Case with === */
+
 let parseTree =
   a1 := a2 := b1 === b2 === (y !== x !== z);
 
@@ -73,6 +76,7 @@ let formatted =
   a1 := a2 := b1 == (b2 == y != x != z);
 
 /* Case with === */
+
 let parseTree =
   a1 := a2 := b1 === (b2 === y !== x !== z);
 
@@ -318,17 +322,12 @@ let shouldSimplifyAnythingExceptApplicationAndConstruction =
     }
   )
   ++ "yo";
-
 let shouldRemoveParens = ident + ident + ident;
-
 let shouldRemoveParens = ident ++ ident ++ ident;
-
 let shouldPreserveParens =
   ident + (ident + ident);
-
 let shouldPreserveParens =
   (ident ++ ident) ++ ident;
-
 /**
  * Since ++ is now INFIXOP1, it should have lower priority than INFIXOP2 (which
  * includes the single plus sign). That means no parens are required in the
@@ -345,39 +344,30 @@ let noParensRequired = ident + ident ++ ident;
  * followed by a dollar sign. And +++ should be treated the same as ++.
  * should also be true of plus sign followed by dollar sign for example.
  */
-let shouldRemoveParens = ident - ident - ident;
 
+let shouldRemoveParens = ident - ident - ident;
 let shouldPreserveParens =
   ident - (ident - ident);
-
 let shouldPreserveParens =
   ident +$ (ident +$ ident);
-
 let noParensRequired = ident - ident ++ ident;
-
 let noParensRequired = ident - ident ++ ident;
-
 let noParensRequired = ident +$ ident ++ ident;
 
 let noParensRequired = ident + ident +++ ident;
-
 let noParensRequired = ident + ident +++ ident;
 
 /* Parens are required any time you want to make ++ or +++ parse with higher
  * priority than + or - */
 let parensRequired = ident + (ident ++ ident);
-
 let parensRequired = ident + (ident +++ ident);
-
 let parensRequired = ident + (ident ++- ident);
-
 let parensRequired = ident +$ (ident ++- ident);
 
 /* ++ and +++ have the same parsing precedence, so it's right associative.
  * Parens are required if you want to group to the left, even when the tokens
  * are different.*/
 let parensRequired = (ident ++ ident) +++ ident;
-
 let parensRequired = (ident +++ ident) ++ ident;
 
 /* Add tests with IF/then mixed with infix/constructor application on left and right sides */
@@ -1173,25 +1163,19 @@ if (List.length(files) > 0
 
 /* Don't clash with jsx edge cases */
 let (=<) = (a, b) => a + b;
-
 let result = x =< y;
-
 let z = x =< y;
 
 let z = x =< y;
 
 let (></) = (a, b) => a - b;
-
 let result = x ></ b;
-
 let z = x ></ b;
 
 let z = x ></ b;
 
 let (=</>) = (a, b) => a + b;
-
 let result = x =</> b;
-
 let z = x =</> b;
 
 let z = x =</> b;
@@ -1199,7 +1183,6 @@ let z = x =</> b;
 /* #1676: Exponentiation should be right-associative */
 let foo =
   (100. /. 2.) ** 2. +. (200. /. 2.) ** 2.;
-
 let foo = 100. /. 2. ** 2. +. 200. /. 2. ** 2.;
 
 let x = y />> f;

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -483,16 +483,19 @@ let containingObject = {
     arr[0] = something ? hello : goodbye;
     bigArr.{0} = something ? hello : goodbye;
     str.[0] = something ? hello : goodbye;
+
     (x.contents = something) ? hello : goodbye;
     (y = something) ? hello : goodbye;
     (arr[0] = something) ? hello : goodbye;
     (bigArr.{0} = something) ? hello : goodbye;
     (str.[0] = something) ? hello : goodbye;
+
     x.contents = something ? hello : goodbye;
     y = something ? hello : goodbye;
     arr[0] = something ? hello : goodbye;
     bigArr.{0} = something ? hello : goodbye;
     str.[0] = something ? hello : goodbye;
+
     /**
      * With a + 1
      */
@@ -504,6 +507,7 @@ let containingObject = {
     arr[0] = something + 1 ? hello : goodbye;
     bigArr.{0} = something + 1 ? hello : goodbye;
     str.[0] = something + 1 ? hello : goodbye;
+
     (x.contents = something + 1) ?
       hello : goodbye;
     (x := something + 1) ? hello : goodbye;
@@ -512,12 +516,14 @@ let containingObject = {
     (bigArr.{0} = something + 1) ?
       hello : goodbye;
     (str.[0] = something + 1) ? hello : goodbye;
+
     x.contents = something + 1 ? hello : goodbye;
     x := something + 1 ? hello : goodbye;
     y = something + 1 ? hello : goodbye;
     arr[0] = something + 1 ? hello : goodbye;
     bigArr.{0} = something + 1 ? hello : goodbye;
     str.[0] = something + 1 ? hello : goodbye;
+
     /**
      * #NotActuallyAConflict
      * Note that there's a difference with how = and := behave.
@@ -578,14 +584,17 @@ let containingObject = {
     x + (something = y);
     x + something.contents := y;
     x + something := y;
+
     /* Should be parsed as: */
     x + (something.contents = y); /* Because of the #NotActuallyAConflict above */
     x + (something = y); /* Same */
     x + something.contents := y;
     x + something := y;
+
     /* To make the := parse differently, we must use parens */
     x + (something.contents := y);
     x + (something := y);
+
     /**
      * Try with ||
      */ x.contents
@@ -597,6 +606,7 @@ let containingObject = {
     bigArr.{0} || something + 1 ?
       hello : goodbye;
     str.[0] || something + 1 ? hello : goodbye;
+
     x.contents || something + 1 ?
       hello : goodbye;
     y || something + 1 ? hello : goodbye;
@@ -604,6 +614,7 @@ let containingObject = {
     bigArr.{0} || something + 1 ?
       hello : goodbye;
     str.[0] || something + 1 ? hello : goodbye;
+
     x.contents
     || (something + 1 ? hello : goodbye);
     y || (something + 1 ? hello : goodbye);
@@ -611,6 +622,7 @@ let containingObject = {
     bigArr.{0}
     || (something + 1 ? hello : goodbye);
     str.[0] || (something + 1 ? hello : goodbye);
+
     /**
      * Try with &&
      */ x.contents
@@ -622,6 +634,7 @@ let containingObject = {
     bigArr.{0} && something + 1 ?
       hello : goodbye;
     str.[0] && something + 1 ? hello : goodbye;
+
     x.contents && something + 1 ?
       hello : goodbye;
     y && something + 1 ? hello : goodbye;
@@ -629,6 +642,7 @@ let containingObject = {
     bigArr.{0} && something + 1 ?
       hello : goodbye;
     str.[0] && something + 1 ? hello : goodbye;
+
     x.contents
     && (something + 1 ? hello : goodbye);
     y && (something + 1 ? hello : goodbye);
@@ -636,6 +650,7 @@ let containingObject = {
     bigArr.{0}
     && (something + 1 ? hello : goodbye);
     str.[0] && (something + 1 ? hello : goodbye);
+
     /**
      * See how regular infix operators work correctly.
      */
@@ -644,11 +659,13 @@ let containingObject = {
     arr[0] = 2 + 4;
     bigArr.{0} = 2 + 4;
     str.[0] = 2 + 4;
+
     (x.contents = 2) + 4;
     (y = 2) + 4;
     (arr[0] = 2) + 4;
     (bigArr.{0} = 2) + 4;
     (str.[0] = 2) + 4;
+
     /**
      * Ensures that record update, object field update, and := are all right
      * associative.
@@ -664,6 +681,7 @@ let containingObject = {
     arr[0] = x.contents = 10;
     bigArr.{0} = x.contents = 10;
     str.[0] = x.contents = 10;
+
     /**
      * Ensures that record update, object field update, and := are all right
      * associative.
@@ -672,12 +690,16 @@ let containingObject = {
       x := 10;
     /* Should be the same as */
     x := x := 10;
+
     /* By default, without parens*/
     x ? y : z ? a : b;
+
     /* It is parsed as the following: */
     x ? y : z ? a : b;
+
     /* Not this: */
     (x ? y : z) ? a : b;
+
     /**
      *          ^
      * When rendering the content to the left of the ? we know that we want the
@@ -722,6 +744,7 @@ let containingObject = {
     str.[0] =
       something ?
         str.[0] = somethingElse : goodbye;
+
     /** And this */ y :=
       something ? y := somethingElse : goodbye;
     arr[0] :=
@@ -733,6 +756,7 @@ let containingObject = {
     str.[0] :=
       something ?
         str.[0] := somethingElse : goodbye;
+
     /* Should be parsed as */
     y := something ? y := somethingElse : goodbye;
     arr[0] :=
@@ -744,6 +768,7 @@ let containingObject = {
     str.[0] :=
       something ?
         str.[0] := somethingElse : goodbye;
+
     /* The following */
     x :=
       something ?
@@ -807,6 +832,7 @@ let containingObject = {
         (str.[0] = somethingElse) ?
           goodbye : goodbye :
         goodbye;
+
     /**
      * And
      */
@@ -827,6 +853,7 @@ let containingObject = {
         x.contents = somethingElse
     ) ?
       x : z;
+
     /* These should be parsed the same */
     something ?
       somethingElse : x := somethingElse ? x : z;
@@ -841,6 +868,7 @@ let containingObject = {
         somethingElse : x := somethingElse
     ) ?
       x : z;
+
     /** These should be parsed the same */
     something ?
       somethingElse : y = somethingElse ? x : z;
@@ -854,6 +882,7 @@ let containingObject = {
         somethingElse : y = somethingElse
     ) ?
       x : z;
+
     /** These should be parsed the same */
     something ?
       somethingElse :
@@ -870,6 +899,7 @@ let containingObject = {
         somethingElse : arr[0] = somethingElse
     ) ?
       x : z;
+
     /** These should be parsed the same */
     something ?
       somethingElse :
@@ -887,6 +917,7 @@ let containingObject = {
         bigArr.{0} = somethingElse
     ) ?
       x : z;
+
     /** These should be parsed the same */
     something ?
       somethingElse :
@@ -903,6 +934,7 @@ let containingObject = {
         somethingElse : str.[0] = somethingElse
     ) ?
       x : z;
+
     /**
      * It creates a totally different meaning when parens group the :
      */
@@ -921,6 +953,7 @@ let containingObject = {
     str.[0] =
       something ?
         (str.[0] = somethingElse: x) : z;
+
     /**
      * Various precedence groupings.
      */
@@ -944,24 +977,29 @@ let containingObject = {
     bigArr.{0} || - something + 1 ?
       hello : goodbye;
     let result = - x + (something.contents = y);
+
     /* Prefix minus is actually sugar for regular function identifier ~-*/
     let result = 2 + (- add(4, 0));
     /* Same as */
     let result = 2 + (- add(4, 0));
     /* Same as */
     let result = 2 + (- add(4, 0));
+
     /* That same example but with ppx attributes on the add application */
     let result = 2 + (- [@ppx] add(4, 0));
     /* Same as */
     let result = [@ppx] 2 + (- add(4, 0));
     /* Same as */
     let result = [@ppx] 2 + (- add(4, 0));
+
     /* Multiple nested prefixes */
     let result = 2 + (- (- (- add(4, 0))));
+
     /* And with attributes */
     let result =
       [@onAddApplication] 2
       + (- (- (- add(4, 0))));
+
     /**
      * TODO: Move all of these test cases to attributes.re.
      */
@@ -974,6 +1012,7 @@ let containingObject = {
     let attrOnPrefix = 5 + (-1);
     let result =
       [@ppxAttributeOnSugarGetter] arr.[0];
+
     /**
      * Unary plus/minus has lower precedence than prefix operators:
      * And unary plus has same precedence as unary minus.
@@ -989,14 +1028,17 @@ let containingObject = {
     let res = - (+ callThisFunc());
     /* should be parsed as: */
     let res = - (+ callThisFunc());
+
     /**
      * And this
      */
     let res = ! (- callThisFunc());
     /* Should be parsed (and should remain printed as: */
     let res = ! (- callThisFunc());
+
     let res = [@onApplication] (! x);
     let res = ! [@onX] x;
+
     let res = ! [@onX] x;
     [@shouldBeRenderedOnEntireSetField]
     (something.contents = "newvalue");

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 /* - A good way to test if formatting of infix operators groups precedences
    correctly, is to write an expression twice. Once in a form where parenthesis
    explicitly group according to the parse tree and write it another time
@@ -438,6 +439,7 @@ let myFunc =
 /**
  * Testing various fixity.
  */
+
 /**
  * For each of these test cases for imperative updates, we'll test both record
  * update, object member update and array update.
@@ -994,8 +996,7 @@ let containingObject = {
      * TODO: Move all of these test cases to attributes.re.
      */
     /* Attribute on the prefix application */
-    let res =
-      [@attr] (- something(blah, blah));
+    let res = [@attr] (- something(blah, blah));
     /* Attribute on the regular function application, not prefix */
     let res = [@attr] (- something(blah, blah));
     let attrOnPrefix = [@ppxOnPrefixApp] (-1);

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -174,7 +174,6 @@ let y = [
 <Description term={<Text text="Age" />}>
   child
 </Description>;
-
 <Description
   term=(
     Text.createElement(
@@ -185,7 +184,6 @@ let y = [
   )>
   child
 </Description>;
-
 <Description
   term=(
     [@JSX] Text.createElement(~text="Age", ())
@@ -223,12 +221,10 @@ let y = [
   term=(text(~text="Age", ~children=[], ()))>
   child
 </description>;
-
 <description
   term=([@JSX] text(~text="Age", ~children=[]))>
   child
 </description>;
-
 <description
   term=([@JSX] text(~text="Age", ()))>
   child
@@ -248,11 +244,8 @@ let y = [
 Module.[
   <Component> <div test="asd" /> </Component>,
 ];
-
 Module.[<Component> <div /> </Component>];
-
 Module.[<Foo> <Bar /> </Foo>];
-
 Module.[<Component />];
 
 let (/></) = (a, b) => a + b;

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 let run = () =>
   TestUtils.printSection("Modules");
 
@@ -78,6 +79,7 @@ module type MySecondModuleType = {
  let y = x + x;
  };
  */
+
 /**
  * - Modules may be artificially "constrained" so that users of a module see
  * fewer details than are actually present.

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -26,7 +26,6 @@ let run = () =>
  */
 module MyFirstModule = {
   let x = 0;
-
   let y = x + x;
 };
 
@@ -44,9 +43,7 @@ let result = MyFirstModule.x + MyFirstModule.y;
  */
 module MySecondModule = {
   type someType = int;
-
   let x = 0;
-
   let y = x + x;
 };
 
@@ -98,15 +95,12 @@ module type MySecondModuleType = {
 let opensAModuleLocally = {
   module MyLocalModule = {
     type i = int;
-
     let x: i = 10;
   };
   /* Notice how local modules names may be used twice and are shadowed */
   module MyLocalModule: MySecondModuleType = {
     type someType = int;
-
     let x: someType = 10;
-
     let y: someType = 20;
   };
   let tmp = MyLocalModule.x + 22;
@@ -402,7 +396,6 @@ module rec A: {
   type t =
     | Leaf(string)
     | Node(ASet.t);
-
   let compare = (t1, t2) =>
     switch (t1, t2) {
     | (Leaf(s1), Leaf(s2)) =>
@@ -491,11 +484,8 @@ Printf.printf(
  */
 include YourLib.CreateComponent({
   type thing = blahblahblah;
-
   type state = unit;
-
   let getInitialState = _ => ();
-
   let myValue = {recordField: "hello"};
 });
 
@@ -534,86 +524,62 @@ module M = {
 
 module N = {
   open M;
-
   let z = M.(34);
-
   let z = {
     open M;
     34;
     35;
   };
-
   let z = M.(34, 35);
-
   let z = M.(34, 35);
-
   let z = M.(34, 35);
-
   let z = M.{};
-
   let z = M.{};
-
   let z = M.{};
-
   let z = M.{x: 10};
-
   let z = M.[foo, bar];
-
   let z = M.[foo, bar];
-
   let z = M.{x: 10, y: 20};
-
   let z = M.(M2.(value));
-
   let z = M.(M2.value);
-
   let z = {
     open! M;
     34;
   };
-
   let z = {
     open! M;
     34;
     35;
   };
-
   let z = {
     open! M;
     {};
   };
-
   let z = {
     open! M;
     {x: 10};
   };
-
   let z = {
     open! M;
     [foo, bar];
   };
-
   let z = {
     open! M;
     [foo, bar];
   };
-
   let z = {
     open! M;
     {x: 10, y: 20};
   };
-
   let z = {
     open! M;
     open! M2;
     value;
   };
-
   let z = {
     open! M;
     M2.value;
   };
-
   let y = 44;
 };
 

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -254,9 +254,11 @@ let letsTryThatSyntaxInLocalModuleBindings = () => {
          : SigResult => {
     let result = A.a + B.b;
   };
+
   module CurriedNoSugar = (A: ASig, B: BSig) => {
     let result = A.a + B.b;
   };
+
   /*
    * The following doesn't work in OCaml (LocalModule (struct end)).x isn't even
    * parsed!
@@ -268,6 +270,7 @@ let letsTryThatSyntaxInLocalModuleBindings = () => {
    * let res = Out.x in
    * res;;
    */
+
   module TempModule =
     CurriedNoSugar(AMod, BMod);
   module TempModule2 =

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -164,14 +164,12 @@ module InliningSig: {let x: int; let y: int;} = {
    * Comment inside of signature.
    */
   let x = 10;
-
   /* Inline comment inside signature. */
   let y = 20;
 };
 
 module MyFunctor = (M: HasTT) => {
   type reexportedTT = M.tt;
-
   /* Inline comment inside module. */
   /** Following special comment inside module. */
   let someValue = 1000;

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -92,6 +92,7 @@ module type MySecondModuleType = {
  * - Modules can help you achieve higher degrees of polymorphism than the core
  * language.
  */
+
 let opensAModuleLocally = {
   module MyLocalModule = {
     type i = int;
@@ -127,7 +128,6 @@ module type HasDestructivelySubstitutedSubPolyModule = {
   /* module X: HasPolyType with type t := list (int, int); */
   module X: HasDestructivelySubstitutedPolyType;
 };
-
 module type HasSubPolyModule = {
   /* Cannot perform destructive substitution on submodules! */
   /* module X: HasPolyType with type t := list (int, int); */
@@ -195,13 +195,10 @@ module LookNoParensNeeded =
 module type SigResult = {let result: int;};
 
 module type ASig = {let a: int;};
-
 module type BSig = {let b: int;};
-
 module AMod = {
   let a = 10;
 };
-
 module BMod = {
   let b = 10;
 };
@@ -282,14 +279,11 @@ let letsTryThatSyntaxInLocalModuleBindings = () => {
 };
 
 module type EmptySig = {};
-
 module MakeAModule = (X: EmptySig) => {
   let a = 10;
 };
-
 module CurriedSugarFunctorResult =
   CurriedSugar(AMod, BMod);
-
 module CurriedSugarFunctorResultInline =
   CurriedSugar(
     {
@@ -299,10 +293,8 @@ module CurriedSugarFunctorResultInline =
       let b = 10;
     },
   );
-
 module CurriedNoSugarFunctorResult =
   CurriedNoSugar(AMod, BMod);
-
 module CurriedNoSugarFunctorResultInline =
   CurriedNoSugar(
     {
@@ -324,10 +316,8 @@ module ResultFromNonSimpleFunctorArg =
 /* TODO: Functor type signatures should more resemble value signatures */
 let curriedFunc: (int, int) => int =
   (a, b) => a + b;
-
 module type FunctorType =
   (ASig, BSig) => SigResult;
-
 /* Which is sugar for:*/
 module type FunctorType2 =
   (ASig, BSig) => SigResult;
@@ -425,21 +415,16 @@ module type HasRecursiveModules = {
 
 /* From http://stackoverflow.com/questions/1986374/higher-order-type-constructors-and-functors-in-ocaml */
 module type Type = {type t;};
-
 module Char = {
   type t = char;
 };
-
 module List = (X: Type) => {
   type t = list(X.t);
 };
-
 module Maybe = (X: Type) => {
   type t = option(X.t);
 };
-
 module Id = (X: Type) => X;
-
 module Compose =
        (
          F: (Type) => Type,
@@ -447,11 +432,9 @@ module Compose =
          X: Type,
        ) =>
   F((G(X)));
-
 let l: Compose(List)(Maybe)(Char).t = [
   Some('a'),
 ];
-
 module Example2 = (F: (Type) => Type, X: Type) => {
   /**
    * Note: This is the one remaining syntactic issue where
@@ -472,6 +455,7 @@ Printf.printf(
 /* We would have: */
 /* module CurriedSugarWithAnnotation: ASig => BSig => SigResult =
    fun (A:ASig) (B:BSig) => {let result = A.a + B.b;; */
+
 /*
  module Typeahead = React.Create {
  type props = {initialCount: int};
@@ -483,6 +467,7 @@ Printf.printf(
  </div>;
  };
  */
+
 include YourLib.CreateComponent({
   type thing = blahblahblah;
   type state = unit;
@@ -585,9 +570,7 @@ module N = {
 };
 
 open M;
-
 open M.Inner;
-
 open M;
 
 module OldModuleSyntax = {
@@ -601,13 +584,10 @@ module type SigWithModuleTypeOf = {
 };
 
 module type T = t with type t = a => a;
-
 module type T = t with type t = a => a;
-
 module type T = (t with type t = a) => a;
 
 module X = [%test extension];
-
 module type T = [%test extension];
 
 let foo =

--- a/formatTest/unit_tests/expected_output/object.re
+++ b/formatTest/unit_tests/expected_output/object.re
@@ -16,7 +16,6 @@ type t = {..};
 type t = {..};
 
 let (<..>) = (a, b) => a + b;
-
 let five = 2 <..> 3;
 
 type closedObjSugar = {

--- a/formatTest/unit_tests/expected_output/object.re
+++ b/formatTest/unit_tests/expected_output/object.re
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 type t = {.};
 
 type t = {

--- a/formatTest/unit_tests/expected_output/polymorphism.re
+++ b/formatTest/unit_tests/expected_output/polymorphism.re
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 let run = () =>
   TestUtils.printSection("Polymorphism");
 

--- a/formatTest/unit_tests/expected_output/polymorphism.re
+++ b/formatTest/unit_tests/expected_output/polymorphism.re
@@ -3,11 +3,9 @@ let run = () =>
   TestUtils.printSection("Polymorphism");
 
 type myType('a) = list('a);
-
 type myTwoParamType('a, 'b) = ('a, 'b);
 
 type myTupleType = (int, int);
-
 type myPolymorphicTupleType('a) = ('a, 'a);
 
 type extensible('a) = 'a
@@ -103,7 +101,9 @@ let certainlyRequiresWrapping:
          | _ => 0
 
      let myFunc = (a:int) (b:int) => a + b; */
+
 /* Fringe features */
+
 /*
   /* This parses, but doesn't type check */
   module TryExtendingType = {type t = Hello of string;};

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1,16 +1,11 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 [@autoFormat let wrap = 80; let shift = 2];
-
 Modules.run();
-
 Polymorphism.run();
-
 Variants.run();
-
 BasicStructures.run();
 
 TestUtils.printSection("General Syntax");
-
 /* Won't work! */
 /* let matchingFunc a = match a with */
 /*   `Thingy x => (print_string "matched thingy x"); x */
@@ -29,22 +24,17 @@ let matchingFunc = a =>
 
 type firstTwoShouldBeGroupedInParens =
   (int => int, int) => int;
-
 type allParensCanBeRemoved =
   (int, int, int) => int;
-
 type firstTwoShouldBeGroupedAndFirstThree =
   ((int => int) => int) => int;
-
 /* Same thing now but with type constructors instead of each int */
 type firstTwoShouldBeGroupedInParens =
   (list(int) => list(int), list(int)) =>
   list(int);
-
 type allParensCanBeRemoved =
   (list(int), list(int), list(int)) =>
   list(int);
-
 type firstTwoShouldBeGroupedAndFirstThree =
   ((list(int) => list(int)) => list(int)) =>
   list(int);
@@ -59,10 +49,8 @@ type myRecordType = {
 
 type firstNamedArgShouldBeGroupedInParens =
   (~first: int => int, ~second: int) => int;
-
 type allParensCanBeRemoved =
   (~first: int, ~second: int, ~third: int) => int;
-
 type firstTwoShouldBeGroupedAndFirstThree =
   (~first: (int => int) => int) => int;
 
@@ -73,7 +61,6 @@ type firstNamedArgShouldBeGroupedInParens =
     ~second: list(int)
   ) =>
   list(int);
-
 type allParensCanBeRemoved =
   (
     ~first: list(int),
@@ -81,7 +68,6 @@ type allParensCanBeRemoved =
     ~third: list(int)
   ) =>
   list(int);
-
 type firstTwoShouldBeGroupedAndFirstThree =
   (
     ~first: (list(int) => list(int)) =>
@@ -95,7 +81,6 @@ type firstNamedArgShouldBeGroupedInParens =
     ~second: list(int)=?
   ) =>
   int;
-
 /* The arrow necessitates parens around the next two args. The ? isn't what
  * makes the parens necessary. */
 type firstNamedArgShouldBeGroupedInParensAndSecondNamedArg =
@@ -104,7 +89,6 @@ type firstNamedArgShouldBeGroupedInParensAndSecondNamedArg =
     ~second: int => int=?
   ) =>
   int;
-
 type allParensCanBeRemoved =
   (
     ~first: int=?,
@@ -112,22 +96,20 @@ type allParensCanBeRemoved =
     ~third: int=?
   ) =>
   int;
-
 type firstTwoShouldBeGroupedAndFirstThree =
   (~first: (int => int) => int) => int;
 
 type noParens =
   (~one: int, int, int, ~two: int) => int;
-
 type noParensNeeded =
   (~one: int, int, int, ~two: int) => int;
-
 type firstNamedArgNeedsParens =
   (~one: (int, int) => int, ~two: int) => int;
 
 /* Now, let's try type aliasing */
 /* Unless wrapped in parens, types between arrows may not be aliased, may not
  * themselves be arrows. */
+
 type parensRequiredAroundFirstArg =
   (list(int) as 'a) => int as 'a;
 
@@ -179,6 +161,7 @@ type onelineConstrain = 'a constraint 'a = int;
 
 /* This must be in trunk but not in this branch of OCaml */
 /* type withNestedRecords = MyConstructor {myField: int} */
+
 type colors =
   | Red(int)
   | Black(int)
@@ -191,19 +174,14 @@ type colors =
 /* This would also lend itself naturally to pattern matching - and avoid having
    to use `.` operator at all since you normally destructure. */
 type nameBlahType = {nameBlah: int};
-
 let myRecord = {nameBlah: 20};
-
 let myRecordName = myRecord.nameBlah;
 
 let {nameBlah}: nameBlahType = {nameBlah: 20};
-
 print_int(nameBlah);
-
 let {nameBlah: aliasedToThisVar}: nameBlahType = {
   nameBlah: 20,
 };
-
 print_int(aliasedToThisVar);
 
 let desiredFormattingForWrappedLambda:
@@ -219,7 +197,6 @@ let desiredFormattingForWrappedLambda:
   };
 
 type longerInt = int;
-
 let desiredFormattingForWrappedLambdaWrappedArrow:
   (longerInt, longerInt, longerInt) =>
   nameBlahType =
@@ -269,17 +246,16 @@ let desiredFormattingForWrappedSugarReturnOnNewLine =
    let rec f : 't1 't2. 't1 * 't2 list -> 't1 =
      fun (type t1) (type t2) -> (... : t1 * t2 list -> t1)
  */
+
 type point = {
   x: int,
   y: int,
 };
-
 type point3D = {
   x: int,
   y: int,
   z: int,
 };
-
 let point2D = {x: 20, y: 30};
 
 let point3D: point3D = {
@@ -299,7 +275,6 @@ let addPoints = (p1: point, p2: point) => {
 };
 
 let res1 = printPoint(point2D);
-
 let res2 =
   printPoint({x: point3D.x, y: point3D.y});
 
@@ -337,7 +312,6 @@ type person = {
   age: int,
   name: string,
 };
-
 type hiredPerson = {
   age: string,
   name: string,
@@ -355,20 +329,17 @@ let printPerson = (p: person) => {
 };
 
 /* let dontParseMeBro x y:int = x = y;*/
+
 /* With this unification, anywhere eyou see `= fun` you can just ommit it */
 let blah = a => a; /* Done */
-
 let blah = a => a; /* Done (almost) */
 
 let blah = (a, b) => a; /* Done */
-
 let blah = (a, b) => a; /* Done (almost) */
 
 /* More than one consecutive pattern must have a single case */
 type blah = {blahBlah: int};
-
 let blah = (a, {blahBlah}) => a;
-
 let blah = (a, {blahBlah}) => a;
 
 module TryToExportTwice = {
@@ -387,6 +358,7 @@ module TryToExportTwice = {
    Wait, where would this ever be valid, even if we continued to support
    `let..in`?
  */
+
 let onlyDoingThisTopLevelLetToBypassTopLevelSequence = {
   let x = {
     print_int(1);
@@ -409,23 +381,17 @@ let onlyDoingThisTopLevelLetToBypassTopLevelSequence = {
 };
 
 type hasA = {a: int};
-
 let a = 10;
-
 let returnsASequenceExpressionWithASingleIdentifier =
     () => a;
-
 let thisReturnsA = () => a;
-
 let thisReturnsAAsWell = () => a;
 
 let recordVal: int = thisReturnsARecord().a;
-
 Printf.printf(
   "\nproof that thisReturnsARecord: %n\n",
   recordVal,
 );
-
 Printf.printf(
   "\nproof that thisReturnsA: %n\n",
   thisReturnsA(),
@@ -443,6 +409,7 @@ let blah = arg =>
 
 /* Any function that pattern matches a multicase match is interpretted as a
  * single arg that is then matched on. Instead of the above `blah` example:*/
+
 let blah =
   fun
   | Red(_) => 1
@@ -452,15 +419,18 @@ let blah =
 /* `fun a => a` is read as "a function that maps a to a". Then the */
 /* above example is read: "a function that 'either maps' Red to.. or maps .." */
 /* Thc00f564e first bar is read as "either maps" */
+
 /* Curried form is not supported:
       let blah x | Red _ => 1 | Black _ => 0;
       Theres no sugar rule for dropping => fun, only = fun
    */
+
 /* let blahCurriedX x => fun  /* See, nothing says we can drop the => fun */ */
 /*   |(Red x | Black x | Green x) => 1     /* With some effort, we can ammend the sugar rule that would */ */
 /*   | Black x => 0                       /* Allow us to drop any => fun.. Just need to make pattern matching */ */
 /*   | Green x => 0;                      /* Support that */ */
 /*  */
+
 let blahCurriedX = x =>
   fun
   | Red(x)
@@ -490,17 +460,19 @@ let blahCurriedX = x =>
   | Green(x) => 0;
 
 /* Any time there are multiple match cases we require a leading BAR */
-let v = Red(10);
 
+let v = Red(10);
 let Black(x) | Red(x) | Green(x) = v; /* So this NON-function still parses */
 
 /* This doesn't parse, however (and it doesn't in OCaml either):
      let | Black(x) | Red(x) | Green(x) = v;
    */
+
 print_int(x);
 
 /* Scoping: Let sequences. Familiar syntax for lexical ML style scope and
    sequences. */
+
 let res = {
   let a = "a starts out as";
   {
@@ -527,10 +499,12 @@ let res = {
 };
 
 /* let result = LyList.map((fun | [] => true | _ => false), []); */
+
 /* OTHERWISE: You cannot tell if a is the first match case falling through or
  * a curried first arg */
 /* let blah = fun a | patt => 0 | anotherPatt => 1; */
 /* let blah a patt => 0 | anotherPatt => 1; */
+
 /*simple pattern  EQUALGREATER      expr */
 let blah = (a, {blahBlah}) => a;
 
@@ -548,7 +522,6 @@ let arrowFunc = (a, b) => {
   print_string("returning aplusb from arrow");
   a + b;
 };
-
 let add = (a, b) => {
   let extra = {
     print_string("adding");
@@ -561,18 +534,14 @@ let add = (a, b) => {
 print_string(string_of_int(add(4, 34)));
 
 let dummy = _ => 10;
-
 dummy(res1);
-
 dummy(res2);
-
 dummy(res3);
 
 /* Some edge cases */
 let myFun =
     (firstArg, Red(x) | Black(x) | Green(x)) =>
   firstArg + x;
-
 let matchesWithWhen = a =>
   switch (a) {
   | Red(x) when 1 > 0 => 10
@@ -601,7 +570,6 @@ type adders = {
   addThreeNumbersTupled:
     ((int, int, int)) => int,
 };
-
 let myRecordWithFunctions = {
   addTwoNumbers: (a, b) => a + b,
   addThreeNumbers: (a, b, c) => a + b + c,
@@ -615,7 +583,6 @@ let result =
     20,
     30,
   );
-
 let result =
   myRecordWithFunctions.addThreeNumbersTupled((
     10,
@@ -624,7 +591,6 @@ let result =
   ));
 
 let lookTuplesRequireParens = (1, 2);
-
 /* let thisDoesntParse = 1, 2;  */
 let tupleInsideAParenSequence = {
   print_string(
@@ -655,6 +621,7 @@ let makeIncrementer =
 let myAnnotatedValBinding: int = 10;
 
 /* Class functions (constructors) and methods are unified in the same way */
+
 class classWithNoArg = {
   pub x = 0;
   pub y = 0;
@@ -666,27 +633,24 @@ class classWithNoArg = {
        pub y => init
      end;
    */
+
 let myFunc = (a: int, b: int) : (int, int) => (
   a,
   b,
 );
-
 let myFunc = (a: int, b: int) : list(int) => [
   1,
 ];
-
 let myFunc = (a: int, b: int) : point => {
   x: a,
   y: b,
 };
-
 let myFunc = (a: int, b: int) : point => {
   x: a,
   y: b,
 };
 
 type myThing = (int, int);
-
 type stillARecord = {
   name: string,
   age: int,
@@ -699,7 +663,6 @@ type branch('a, 'b) = {
   first: 'a,
   second: 'b,
 };
-
 type myOtherThing('a, 'b) =
   | Leaf(branch('a, 'b))
   | Null;
@@ -709,10 +672,14 @@ type yourThing = myOtherThing(int, int);
 /* Conveniently - this parses exactly how you would intend! No *need* to wrap
    in an extra [], but it doesn't hurt */
 /* FIXME type lookAtThesePolyVariants = list [`Red] ; */
+
 /* FIXME type bracketsGroupMultipleParamsAndPrecedence = list (list (list [`Red])); */
+
 /* FIXME type youCanWrapExtraIfYouWant = (list [`Red]); */
+
 /* FIXME type hereAreMultiplePolyVariants = list [`Red | `Black]; */
 /* FIXME type hereAreMultiplePolyVariantsWithOptionalWrapping = list ([`Red | `Black]); */
+
 /*
    /* Proposal: ES6 style lambdas: */
 
@@ -737,6 +704,7 @@ type yourThing = myOtherThing(int, int);
      | `Black x => x;
 
  */
+
 /** Current OCaml Named Arguments. Any aliasing is more than just aliasing!
 OCaml allows full on pattern matching of named args. */
 /*
@@ -763,83 +731,64 @@ OCaml allows full on pattern matching of named args. */
                                \        \
                                 \let_pattern: still a useful syntactic building block in SugarML
  */
+
 /**
  * In Reason, the syntax for named args uses double semicolon, since
  * the syntax for lists uses ES6 style [], freeing up the ::.
  */
-let a = 10;
 
+let a = 10;
 let b = 20;
 
 /*A*/
 let named = (~a, ~b) => a + b;
-
 type named = (~a: int, ~b: int) => int;
-
 /*B*/
 let namedAlias = (~a as aa, ~b as bb) =>
   aa + bb;
-
 let namedAlias = (~a as aa, ~b as bb) =>
   aa + bb;
-
 type namedAlias = (~a: int, ~b: int) => int;
-
 /*C*/
 let namedAnnot = (~a: int, ~b: int) => 20;
-
 /*D*/
 let namedAliasAnnot =
     (~a as aa: int, ~b as bb: int) => 20;
-
 /*E*/
 let myOptional = (~a=?, ~b=?, ()) => 10;
-
 type named = (~a: int=?, ~b: int=?, unit) => int;
-
 /*F*/
 let optionalAlias = (~a as aa=?, ~b as bb=?, ()) => 10;
-
 /*G*/
 let optionalAnnot = (~a: int=?, ~b: int=?, ()) => 10;
-
 /*H*/
 let optionalAliasAnnot =
     (~a as aa: int=?, ~b as bb: int=?, ()) => 10;
-
 /*I: */
 let defOptional = (~a=10, ~b=10, ()) => 10;
-
 type named = (~a: int=?, ~b: int=?, unit) => int;
-
 /*J*/
 let defOptionalAlias =
     (~a as aa=10, ~b as bb=10, ()) => 10;
-
 /*K*/
 let defOptionalAnnot =
     (~a: int=10, ~b: int=10, ()) => 10;
-
 /*L*/
 let defOptionalAliasAnnot =
     (~a as aa: int=10, ~b as bb: int=10, ()) => 10;
 
 /*M: Invoking them - Punned */
 let resNotAnnotated = named(~a, ~b);
-
 /*N:*/
 let resAnnotated: int = named(~a, ~b);
-
 /*O: Invoking them */
 let resNotAnnotated = named(~a, ~b);
-
 /*P: Invoking them */
 let resAnnotated: int = named(~a, ~b);
 
 /*Q: Here's why "punning" doesn't work!  */
 /* Is b:: punned with a final non-named arg, or is b:: supplied b as one named arg? */
 let b = 20;
-
 let resAnnotated = named(~a, ~b);
 
 /*R: Proof that there are no ambiguities with return values being annotated */
@@ -848,16 +797,12 @@ let resAnnotated: ty = named(~a, b);
 /*S: Explicitly passed optionals are a nice way to say "use the default value"*/
 let explictlyPassed =
   myOptional(~a=?None, ~b=?None);
-
 /*T: Annotating the return value of the entire function call */
 let explictlyPassedAnnotated: int =
   myOptional(~a=?None, ~b=?None);
-
 /*U: Explicitly passing optional with identifier expression */
 let a = None;
-
 let explictlyPassed = myOptional(~a?, ~b=?None);
-
 let explictlyPassedAnnotated: int =
   myOptional(~a?, ~b=?None);
 
@@ -884,6 +829,7 @@ let nestedLet = {
 /*
  * Showing many combinations of type annotations and named arguments.
  */
+
 type typeWithNestedNamedArgs =
   (
     ~outerOne: (~innerOne: int, ~innerTwo: int) =>
@@ -981,13 +927,11 @@ let newRecord = {
 };
 
 let something: thing(blah) = aTypeAnnotation;
-
 let something: thing(blah) = thisIsANamedArg;
 
 let something: thing(blah) = aTypeAnnotation;
 
 let something: blah = thisIsANamedArg(thing);
-
 let something: blah = typeAnnotation(thing);
 
 let newRecord = {
@@ -999,7 +943,6 @@ let newRecord = {
 };
 
 [@thisIsAThing];
-
 let x = 10;
 
 /* Ensure that the parenthesis are preserved here because they are
@@ -1074,74 +1017,48 @@ let registerEventHandlers =
 
 /* #1320: record destrucuring + renaming */
 let x = ({state as prevState}) => 1;
-
 let x = ({ReasonReact.state as prevState}) => 1;
 
 /* 1567: optional parens around expr constraint in constructor expression */
 Some(x: int);
-
 Some(x: int);
-
 Some(x, y: int, b);
-
 Some(x, y: int, b);
 
 foo(~x=-. bar);
 
 Some(-1, -1, -1);
-
 Some(-1, -1, -1);
-
 Some(-1g, -1G, -1z);
-
 Some(-1g, -1G, -1z);
-
 Some(-0.1, -0.1, -0.1);
-
 Some(-0.1, -0.1, -0.1);
-
 Some(-0.1G, -0.1x, -0.1H);
-
 Some(-0.1G, -0.1x, -0.1H);
-
 Some([@foo] -1, [@foo] -1, [@foo] -1);
-
 Some([@foo] -1z, [@foo] -1z, [@foo] -1z);
-
 Some([@foo] -0.1, [@foo] -0.1, [@foo] -0.1);
-
 Some([@foo] -0.1m, [@foo] -0.1n, [@foo] -0.1p);
 
 foo(~x=-1, ~y=-2);
-
 foo(~x=-1, ~y=-2);
-
 foo(~x=-. 1, ~y=-. 2);
-
 foo(~x=-. 1, ~y=-. 2);
-
 foo(~x=-1g, ~y=-1G, ~z=-1z);
-
 foo(~x=-1g, ~y=-1G, ~z=-1z);
-
 foo(~x=-0.1G, ~y=-0.1x, ~z=-0.1H);
-
 foo(~x=-0.1G, ~y=-0.1x, ~z=-0.1H);
-
 foo(~x=[@foo] -1, ~y=[@foo] -1, ~z=[@foo] -1);
-
 foo(
   ~x=[@foo] -1z,
   ~y=[@foo] -1z,
   ~z=[@foo] -1z,
 );
-
 foo(
   ~x=[@foo] -0.1,
   ~y=[@foo] -0.1,
   ~z=[@foo] -0.1,
 );
-
 foo(
   ~x=[@foo] -0.1m,
   ~y=[@foo] -0.1n,

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -392,11 +392,13 @@ let onlyDoingThisTopLevelLetToBypassTopLevelSequence = {
     print_int(1);
     print_int(20); /* Missing trailing SEMI */
   };
+
   let x = {
     print_int(1);
     print_int(20); /* Ensure missing middle SEMI reported well */
     print_int(20);
   };
+
   let x = {
     print_int(1);
     print_int(20);

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 [@autoFormat let wrap = 80; let shift = 2];
 Modules.run();
 Polymorphism.run();

--- a/formatTest/unit_tests/expected_output/syntax.rei
+++ b/formatTest/unit_tests/expected_output/syntax.rei
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 /**
  * Typically the "interface file" is where you would write a ton of
  * comments/documentation.
@@ -23,7 +24,6 @@ type adders = {
  * Public function.
  */
 let myRecordWithFunctions: adders;
-
 /**
  * Public result.
  */

--- a/formatTest/unit_tests/expected_output/testUtils.re
+++ b/formatTest/unit_tests/expected_output/testUtils.re
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 let printSection = s => {
   print_string("\n");
   print_string(s);

--- a/formatTest/unit_tests/expected_output/trailingSpaces.re
+++ b/formatTest/unit_tests/expected_output/trailingSpaces.re
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 module M =
   Something.Create({
     type resource1 = MyModule.MySubmodule.t;

--- a/formatTest/unit_tests/expected_output/trailingSpaces.re
+++ b/formatTest/unit_tests/expected_output/trailingSpaces.re
@@ -2,6 +2,5 @@
 module M =
   Something.Create({
     type resource1 = MyModule.MySubmodule.t;
-
     type resource2 = MyModule.MySubmodule.t;
   });

--- a/formatTest/unit_tests/expected_output/typeDeclarations.re
+++ b/formatTest/unit_tests/expected_output/typeDeclarations.re
@@ -115,4 +115,5 @@ type foo =
     [@foo] string,
     [@bar] ((int, string) => int),
   );
+
 /* === end test wrapping for arrows === */

--- a/formatTest/unit_tests/expected_output/typeDeclarations.re
+++ b/formatTest/unit_tests/expected_output/typeDeclarations.re
@@ -1,29 +1,20 @@
 /* === test wrapping for arrows === */
 type foo = option(int => int);
-
 type foo = option((int, int) => int);
-
 type foo = option((int => int) => int);
-
 type foo = option((int, int) => int);
 
 /* tuple */
 type foo = option((int => int, int => int));
-
 type foo = option((int => int, string));
-
 type foo =
   option((string, int => int, string));
-
 type foo = option((string, int => int));
 
 /* other preceeding/trailing */
 type foo = option(int => int, int => int);
-
 type foo = option(int => int, string);
-
 type foo = option(string, int => int, string);
-
 type foo = option(string, int => int);
 
 /* preceeding/trailing, more args */
@@ -32,25 +23,20 @@ type foo =
     (int, string) => int,
     (int, string) => int,
   );
-
 type foo = option((int, string) => int, string);
-
 type foo =
   option(string, (int, string) => int, string);
-
 type foo = option(string, (int, string) => int);
 
 /* others */
 type foo =
   option(string, option(int => int), string);
-
 type foo =
   option(
     string,
     option(option(option(int) => int)),
     string,
   );
-
 type foo =
   option(
     string,
@@ -61,14 +47,10 @@ type foo =
 /* with attributes */
 type foo =
   option([@foo] [@bar] (int => [@baz] int));
-
 type foo =
   option([@foo] (([@bar] int) => [@baz] int));
-
 type foo = option(int => [@foo] (int => int));
-
 type foo = option([@foo] ((int => int) => int));
-
 type foo = option([@foo] ((int, int) => int));
 
 /* tuple */
@@ -79,12 +61,10 @@ type foo =
       [@baz] (int => int),
     ),
   );
-
 type foo =
   option(
     [@foo] ([@bar] (int => int), [@baz] string),
   );
-
 type foo =
   option(
     [@foo] (
@@ -93,7 +73,6 @@ type foo =
       [@qux] string,
     ),
   );
-
 type foo =
   option((string, [@foo] (int => int)));
 
@@ -103,17 +82,14 @@ type foo =
     [@foo] (int => int),
     [@bar] (int => int),
   );
-
 type foo =
   option([@foo] (int => int), [@bar] string);
-
 type foo =
   option(
     [@foo] string,
     [@bar] (int => int),
     [@baz] string,
   );
-
 type foo =
   option([@foo] string, [@bar] (int => int));
 
@@ -123,20 +99,17 @@ type foo =
     [@foo] ((int, string) => int),
     [@bar] ((int, string) => int),
   );
-
 type foo =
   option(
     [@foo] ((int, string) => int),
     [@bar] string,
   );
-
 type foo =
   option(
     [@foo] string,
     [@bar] ((int, string) => int),
     [@baz] string,
   );
-
 type foo =
   option(
     [@foo] string,

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -9,13 +9,10 @@ module LocalModule = {
 
 type notTupleVariant =
   | NotActuallyATuple(int, int);
-
 type attr =
   | A(int);
-
 type attr +=
   | Point(int, int);
-
 type attr +=
   | PointA{
       a: int,
@@ -366,6 +363,7 @@ let res =
   };
 
 /* FIXME type somePolyVariant = [ `Purple int | `Yellow int]; */
+
 let ylw = `Yellow((100, 100));
 
 let prp = `Purple((101, 100));
@@ -600,13 +598,10 @@ type Graph.node +=
 
 /* without single unit arg sugar */
 MyConstructorWithSingleUnitArg();
-
 /* with single unit arg sugar */
 MyConstructorWithSingleUnitArg();
-
 /* without single unit arg sugar */
 `polyVariantWithSingleUnitArg();
-
 /* with single unit arg sugar */
 `polyVariantWithSingleUnitArg();
 
@@ -617,32 +612,27 @@ Delete({
     |> Util.member("uuid")
     |> Util.to_string,
 });
-
 Delete((
   someLongStuf,
   someOtherLongStuff,
   okokokok,
 ));
-
 Delete([
   someLongStuf,
   someOtherLongStuff,
   okokokok,
 ]);
-
 Delete([|
   someLongStuf,
   someOtherLongStuff,
   okokokok,
 |]);
-
 Delete([
   someLongStuf,
   someOtherLongStuff,
   okokokok,
   ...veryES6,
 ]);
-
 Delete({
   pub x = methodOne;
   pub y = methodTwo;
@@ -655,32 +645,27 @@ Delete({
     |> Util.member("uuid")
     |> Util.to_string,
 });
-
 `Delete((
   someLongStuf,
   someOtherLongStuff,
   okokokok,
 ));
-
 `Delete([
   someLongStuf,
   someOtherLongStuff,
   okokokok,
 ]);
-
 `Delete([|
   someLongStuf,
   someOtherLongStuff,
   okokokok,
 |]);
-
 `Delete([
   someLongStuf,
   someOtherLongStuff,
   okokokok,
   ...veryES6,
 ]);
-
 `Delete({
   pub x = methodOne;
   pub y = methodTwo;

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -2,7 +2,6 @@
 module LocalModule = {
   type accessedThroughModule =
     | AccessedThroughModule;
-
   type accessedThroughModuleWithArg =
     | AccessedThroughModuleWith(int)
     | AccessedThroughModuleWithTwo(int, int);

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 module LocalModule = {
   type accessedThroughModule =
     | AccessedThroughModule;

--- a/formatTest/unit_tests/expected_output/whitespace.re
+++ b/formatTest/unit_tests/expected_output/whitespace.re
@@ -80,3 +80,41 @@ module FloatingComments = {
   /* l */
   let e = 1;
 };
+
+module FloatingMultiLineComments = {
+  let a = 1;
+  /* 1
+     2 */
+
+  /* ok
+     another one */
+
+  /* wow
+     here */
+  let b = 1;
+
+  /* float
+     -ing */
+  /* here
+     on the second */
+
+  let c = 1;
+
+  /* one
+     two */
+  /* three
+     four */
+
+  /* extreme
+     comment */
+  /* here
+     on two lines */
+
+  /* another
+     one */
+  /* chocolate
+     is
+     good */
+
+  let d = 2;
+};

--- a/formatTest/unit_tests/expected_output/whitespace.re
+++ b/formatTest/unit_tests/expected_output/whitespace.re
@@ -137,3 +137,13 @@ let main = () => {
   let%lwt _i = write_string(stdout, s, 0, len);
   ();
 };
+
+module EdgeCase = {
+  let x = 1; /* a */
+
+  /* b */
+
+  /* c */
+
+  let x = 1;
+};

--- a/formatTest/unit_tests/expected_output/whitespace.re
+++ b/formatTest/unit_tests/expected_output/whitespace.re
@@ -1,0 +1,10 @@
+module Test = {
+  open Belt;
+  open React;
+
+  type a = int;
+  type b = string;
+
+  let x = 12;
+  let y = 34;
+};

--- a/formatTest/unit_tests/expected_output/whitespace.re
+++ b/formatTest/unit_tests/expected_output/whitespace.re
@@ -52,3 +52,31 @@ module Comments = {
     b: string /* comment2 */,
   };
 };
+
+module FloatingComments = {
+  let a = 1;
+  /* a */
+
+  /* b */
+
+  /* c */
+  let b = 1;
+
+  /* d */
+
+  let c = 1;
+
+  /* e */
+  /* f */
+
+  let d = 1;
+  /* g */
+  /* h */
+
+  /* i */
+  /* j */
+
+  /* k */
+  /* l */
+  let e = 1;
+};

--- a/formatTest/unit_tests/expected_output/whitespace.re
+++ b/formatTest/unit_tests/expected_output/whitespace.re
@@ -8,3 +8,47 @@ module Test = {
   let x = 12;
   let y = 34;
 };
+
+module Comments = {
+  let z = 1;
+  /* comment *without* whitespace interleaved*/
+  let ab = 2;
+
+  let add = (a, b) => a + b;
+
+  /* comment *with* multiple newlines above */
+  let min = (a, b) => a - b;
+
+  let a = 1; /* trailing comment ok */
+  let b = 2;
+
+  /* comment on top */
+  let x = 1; /* this comment sits at the end of the line */
+  /* wow another one below too */
+
+  let add = Test.x;
+
+  /* this
+     is
+     a multiline
+     comment */
+  let minus = (a, b) => a - b;
+
+  /* look
+     another
+     multi
+     line
+     comment */
+  let vermenigvuldig = (a, b) => a * b;
+  /* attach another comment below
+        it spreads
+        over
+        multiple
+        line
+     */
+
+  type x = {
+    a: int /* comment1*/,
+    b: string /* comment2 */,
+  };
+};

--- a/formatTest/unit_tests/expected_output/whitespace.re
+++ b/formatTest/unit_tests/expected_output/whitespace.re
@@ -118,3 +118,11 @@ module FloatingMultiLineComments = {
 
   let d = 2;
 };
+
+module type TestModuleType = {
+  type a = int;
+  type b = string;
+
+  let x: a;
+  let y: b;
+};

--- a/formatTest/unit_tests/expected_output/whitespace.re
+++ b/formatTest/unit_tests/expected_output/whitespace.re
@@ -147,3 +147,11 @@ module EdgeCase = {
 
   let x = 1;
 };
+
+let f = (a, b) => a + b;
+/* this comment sticks at the end */
+
+/* another one below the structure */
+/* this one should stick */
+
+/* :) */

--- a/formatTest/unit_tests/expected_output/whitespace.re
+++ b/formatTest/unit_tests/expected_output/whitespace.re
@@ -126,3 +126,14 @@ module type TestModuleType = {
   let x: a;
   let y: b;
 };
+
+let main = () => {
+  let%lwt tc = tcGetAddr(stdin);
+
+  let a = 1;
+
+  let%lwt () = tcsetattr(stdin, TCSANOW, tc);
+
+  let%lwt _i = write_string(stdout, s, 0, len);
+  ();
+};

--- a/formatTest/unit_tests/expected_output/whitespace.rei
+++ b/formatTest/unit_tests/expected_output/whitespace.rei
@@ -12,3 +12,10 @@ let b: int;
 
 /* amazing */
 let f: int => int;
+
+/* notice the whitespace after the last signature item */
+
+/* this one has whitespace interleaved */
+/* stick together */
+
+/* :) */

--- a/formatTest/unit_tests/expected_output/whitespace.rei
+++ b/formatTest/unit_tests/expected_output/whitespace.rei
@@ -1,0 +1,14 @@
+/** Interleave whitespace intelligently in signatures */
+
+/* a */
+let a: int;
+
+/* b */
+let b: int;
+/* trailing */
+
+/* kkk */
+/* ---> */
+
+/* amazing */
+let f: int => int;

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -4,7 +4,6 @@
  * Testing infix wrapping
  */
 let reallyLongIdent = 100;
-
 let andYetAnotherReallyLongIdent = 30;
 
 let something =
@@ -81,7 +80,6 @@ let testPrintingPrecedence =
   + reallyLongIdent;
 
 let add = (x, y) => x + y;
-
 let testPrintingPrecedence =
   reallyLongIdent
   /*
@@ -94,15 +92,12 @@ let testPrintingPrecedence =
       andYetAnotherReallyLongIdent,
     )
   + reallyLongIdent;
-
 /*
  * Test wrapping every form of named arguments where various parts are
  * commented.
  */
 let a = 10;
-
 let b = 20;
-
 /*A*/
 let named =
     /* a::a */
@@ -198,7 +193,6 @@ let optionalAliasAnnot =
     ) =>
   /* 10 */
   10;
-
 /*I: This one is really annoying? Where's the visual label?*/
 let defOptional =
     /* a::a=10 */
@@ -272,14 +266,12 @@ optional(
   /* b::b; */
   ~b,
 );
-
 optional(
   /* a::a */
   ~a,
   /* b::b; */
   ~b,
 );
-
 let explictlyPassed =
   /* optional */
   optional(
@@ -292,7 +284,6 @@ let explictlyPassed =
   );
 
 let a = None;
-
 let explictlyPassed =
   /* optional */
   optional(
@@ -311,31 +302,26 @@ let myList = /*CommentAfterEqualBeforeList */ [
   2,
   3,
 ];
-
 let myList = [
   /*CommentAfterEqualBefore1 */ 1,
   2,
   3,
 ];
-
 let myList = [
   1 /*CommentAfterOneBeforeCons */,
   2,
   3,
 ];
-
 let myList = [
   1,
   2 /*CommentAfterTwoBeforeCons */,
   3,
 ];
-
 let myList = [
   1,
   2,
   /*CommentAfterConsBeforeThree */ 3,
 ];
-
 let myList = [
   1,
   2,
@@ -347,13 +333,11 @@ let myList = [
   2,
   3 /*same w space after three    */,
 ];
-
 let myList = [
   1,
   2,
   3 /*same w space before rbracket*/,
 ];
-
 let myList = [
   1,
   2,
@@ -366,19 +350,16 @@ let myList = [
   2,
   3 /*no space after three    */
 ];
-
 let myList = [
   1,
   2,
   3 /*same w space after three    */
 ];
-
 let myList = [
   1,
   2, /*no space after two comma    */
   3,
 ];
-
 let myList = [
   1,
   2, /*same w space after two comma    */
@@ -391,19 +372,16 @@ let myList = [
   2, /*no space after two comma    */
   3,
 ];
-
 let myList = [
   1,
   2, /*same w space after two comma    */
   3,
 ];
-
 let myRec = {
   x: 1,
   y: 2, /*no space after two    */
   z: 3,
 };
-
 let myRec = {
   x: 1,
   y: 2, /*same w space after two    */
@@ -416,7 +394,6 @@ let myList = [
   2,
   3 /* */
 ];
-
 let myList = [1, 2, /**/ 3];
 
 let myList = [
@@ -425,7 +402,6 @@ let myList = [
   3 /*CommentAfterConsBeforeAppendedTo */,
   ...myList,
 ];
-
 let myList = [3, 4, 5];
 
 let simpleListPattern = x =>
@@ -535,12 +511,10 @@ let secondArgShouldWrap =
 
 /* Now check that one and two args both indent the same when applying */
 let reallyReallyLongVarName = "hello";
-
 let result =
   oneArgShouldWrapToAlignWith(
     reallyReallyLongVarName,
   );
-
 let result =
   twoArgsShouldWrapToAlignWith(
     reallyReallyLongVarName,
@@ -579,15 +553,12 @@ let result =
 let howDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark =
     (x, y, z) =>
   x + y + z;
-
 let howDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark =
     (x, y) =>
   x + y;
-
 let reallyHowDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark =
     (x, y, z) =>
   x + y + z;
-
 let reallyHowDoesInfixOperatorsWrapWhenYouMustWrapQuestionMark =
     (x, y) =>
   x + y;
@@ -982,7 +953,6 @@ let (
     0,
     0,
   );
-
 /* Annotated version */
 let (
   a,
@@ -1020,7 +990,6 @@ let (
     0,
     0,
   );
-
 /* Annotated inline */
 let x: (
   int,
@@ -1095,7 +1064,6 @@ let (
     0,
     0,
   ));
-
 /* Annotated version */
 let (
   a,
@@ -1133,7 +1101,6 @@ let (
     0,
     0,
   ));
-
 /* Annotated inline */
 let x: (
   int,
@@ -1173,6 +1140,7 @@ let x: (
   ));
 
 /* Desired formatting if pattern does not fit, arguments do (margin 70) */
+
 /* Destructured */
 let (
   axx,
@@ -1210,7 +1178,6 @@ let (
     0,
     0,
   );
-
 /* Annotated */
 /* Destructured */
 let (
@@ -1327,7 +1294,6 @@ let someResult =
     0,
     0,
   );
-
 /* Annotated */
 /* Not-Destructured */
 let someResult: sixteenTuple =
@@ -1349,7 +1315,6 @@ let someResult: sixteenTuple =
     0,
     0,
   );
-
 /* Annotated */
 /* Not-Destructured */
 /* Inline */
@@ -1427,7 +1392,6 @@ let (
     0,
     0,
   ));
-
 /* Annotated */
 let (
   axx,
@@ -1465,7 +1429,6 @@ let (
     0,
     0,
   ));
-
 /* Annotated Inline */
 let (
   axx,
@@ -1520,7 +1483,6 @@ let (
     0,
     0,
   ));
-
 /* Not-Destructured */
 let someResult =
   echoTuple((
@@ -1541,7 +1503,6 @@ let someResult =
     0,
     0,
   ));
-
 /* Annotated */
 /* Not-Destructured */
 let someResult: sixteenTuple =
@@ -1563,7 +1524,6 @@ let someResult: sixteenTuple =
     0,
     0,
   ));
-
 /* Annotated Inline */
 /* Not-Destructured */
 let someResult: (
@@ -1641,7 +1601,6 @@ let (
     oxx,
     pxx,
   );
-
 /* Annoted */
 let (
   axx,
@@ -1679,7 +1638,6 @@ let (
     oxx,
     pxx,
   );
-
 /* Annoted inline */
 let (
   axx,
@@ -1734,7 +1692,6 @@ let (
     oxx,
     pxx,
   );
-
 /* Not-Destructured */
 let someResult =
   makeTuple(
@@ -1755,7 +1712,6 @@ let someResult =
     oxx,
     pxx,
   );
-
 /* Not-Destructured */
 /* Annoted */
 let someResult: sixteenTuple =
@@ -1777,7 +1733,6 @@ let someResult: sixteenTuple =
     oxx,
     pxx,
   );
-
 /* Not-Destructured */
 /* Annoted inline */
 let someResult: (
@@ -1855,7 +1810,6 @@ let (
     10,
     10,
   ));
-
 /* Annoted */
 /* Destructured */
 let (
@@ -1894,7 +1848,6 @@ let (
     10,
     10,
   ));
-
 /* Annoted Inline */
 /* Destructured */
 let (
@@ -1972,7 +1925,6 @@ let someResult =
     10,
     10,
   ));
-
 /* Annoted */
 /* Not-Destructured */
 let someResult: sixteenTuple =
@@ -2063,7 +2015,6 @@ type sevenStrings = (
   string,
   string,
 );
-
 let (only, the, type_, should, have, to_, wrap) = (
   "only",
   "the",
@@ -2101,7 +2052,6 @@ let ifTheNameIsReallyLongTheTypeAndValueShouldBothWrap: (
   "to",
   "wrap",
 );
-
 let (
   the,
   type_,
@@ -2129,14 +2079,11 @@ let (
 );
 
 let myPolyFunc: 'a .'a => 'a = o => o;
-
 let myNonPolyFunc: 'a => 'a = o => o;
 
 let locallyAbstractFunc = (type a, input: a) => input;
-
 let locallyAbstractFuncNotSugared =
     (type a, input: a) => input;
-
 let locallyAbstractFuncAnnotated: type a. a => a =
   (type a, input: a) => input;
 
@@ -2145,7 +2092,6 @@ let locallyAbstractFuncAnnotated: type a. a => a =
   "desired formatting" when the function binding itself must wrap.
  */
 let df_myPolyFunc: 'a .'a => 'a = o => o;
-
 let df_myNonPolyFunc: 'a => 'a = o => o;
 
 type nameBlahType = {nameBlah: int};
@@ -2155,7 +2101,6 @@ let myFunc = (~firstArg, ~another, ~fl) => {
 };
 
 type inputEchoRecord('a) = {inputIs: 'a};
-
 let df_locallyAbstractFunc =
     (type a, type b, input: a) => {
   inputIs: input,
@@ -2209,6 +2154,7 @@ let df_locallyAbstractFuncAnnotatedRef:
  *      inputIs: input
  *    };
  */
+
 /**
  * The following is automatically expanded at the parser level into:
  *
@@ -2277,10 +2223,9 @@ and mutuallyRecursiveTwo = y => print_int(y);
 /* let newMutualRecursionSyntax x => newMutuallyRecursiveTwo (x + x); */
 /* let newMutuallyRecursiveTwo y => print_int y; */
 /*  */
+
 type x = pri int;
-
 type y = x = ..;
-
 type myType('a, 'b, 'c) = pri ('a, 'b, 'c);
 
 type privateVariant =
@@ -2294,13 +2239,11 @@ type myRecordWithReallyLongName = {
   xx: int,
   yy: int,
 };
-
 type doubleEqualsRecord =
   myRecordWithReallyLongName = {
     xx: int,
     yy: int,
   };
-
 type doubleEqualsDoublePrivateRecord =
   myRecordWithReallyLongName =
     pri {
@@ -2310,7 +2253,6 @@ type doubleEqualsDoublePrivateRecord =
 
 type someConstructor =
   | SomeConstructorHi(int, int);
-
 type someRecord = {
   firstFieldInRecord: int,
   secondField: int,
@@ -2548,7 +2490,6 @@ let testRecord = {
   age: 20,
   occupation: "engineer",
 };
-
 let anotherRecord = {
   ...testRecord,
   name: "joe++",
@@ -2627,17 +2568,13 @@ let result =
   );
 
 module type ASig = {let a: int;};
-
 module type BSig = {let b: int;};
-
 module AMod = {
   let a = 10;
 };
-
 module BMod = {
   let b = 10;
 };
-
 module CurriedSugar =
        /* Commenting before First curried functor arg */
        /* If these comments aren't formatted correctly
@@ -2679,7 +2616,6 @@ module CurriedSugarFunctorResultInline =
 
 module type FunctorType =
   (ASig, ASig, BSig) => BSig;
-
 /*
  * Commenting locations
  */
@@ -2688,45 +2624,38 @@ let commentingBeforeEqual /*beforeEqual*/ = {
   age: 20,
   occupation: "programmer",
 };
-
 let commentingAfterEqual = /*afterEqual*/ {
   name: "hello",
   age: 20,
   occupation: "programmer",
 };
-
 let commentingBeforeEqualBeforeType /*beforeEqualBeforeType*/: withThreeFields = {
   name: "hello",
   age: 20,
   occupation: "programmer",
 };
-
 let commentingBeforeEqualAfterType:
   withThreeFields /*beforeEqualAfterType*/ = {
   name: "hello",
   age: 20,
   occupation: "programmer",
 };
-
 let commentingAfterEqualAfterType: withThreeFields = /*afterEqual*/ {
   name: "hello",
   age: 20,
   occupation: "programmer",
 };
-
 let /*beforePattern*/ commentingBeforePattern: withThreeFields = {
   name: "hello",
   age: 20,
   occupation: "programmer",
 };
-
 /*beforePattern*/
 let /*beforePattern2 */ commentingBeforePattern2: withThreeFields = {
   name: "hello",
   age: 20,
   occupation: "programmer",
 };
-
 /*beforePattern*/
 let /*beforePattern2 */ commentingBeforePatternSpecial: withThreeFields = {
   name: "hello",
@@ -2751,21 +2680,17 @@ let myPolyFuncCommentBeforeColon /*beforeColon */:
   'a => 'a
  =
   o => o;
-
 let myPolyFuncCommentAfterColon: 'a .'a => 'a =
   /*afterColon */
   o => o;
-
 let myPolyFuncCommentBeforeArrow: 'a .'a => 'a =
   /*beforeArrow */
   o => o;
-
 let myPolyFuncCommentAfterArrow:
   'a .
   'a => /*afterArrow */ 'a
  =
   o => o;
-
 /* THIS IS THE ONLY TEST THAT IS FAILING DUE TO BEING NON-IDEMPOTENT */
 /* let myPolyFuncCommentBeforeEqual : 'a . ('a) => 'a /*beforeEqual */  = fun(o) => o; */
 let myPolyFuncCommentAfterEqual: 'a .'a => 'a =
@@ -2774,86 +2699,65 @@ let myPolyFuncCommentAfterEqual: 'a .'a => 'a =
 let myNonPolyFuncCommentBeforeColon /*BeforeColon */:
   'a => 'a =
   o => o;
-
 let myNonPolyFuncCommentAfterColon:
   /*AfterColon */ 'a => 'a =
   o => o;
-
 let myNonPolyFuncCommentBeforeArrow:
   'a /*BeforeArrow */ => 'a =
   o => o;
-
 let myNonPolyFuncCommentAfterArrow:
   'a => /*AfterArrow */ 'a =
   o => o;
-
 let myNonPolyFuncCommentBeforeEqual:
   'a => 'a /*BeforeEqual */ =
   o => o;
-
 let myNonPolyFuncCommentAfterEqual: 'a => 'a =
   /*AfterEqual */ o => o;
 
 let lATCurrySugarCommentBeforeType /*BeforeType */ =
     (type a, input: a) => input;
-
 let lATCurrySugarCommentAfterType /*AfterType */ =
     (type a, input: a) => input;
-
 let lATCurrySugarCommentBeforeArg =
     (type a, /*BeforeArg */ input: a) => input;
-
 let lATCurrySugarCommentAfterArg =
     (type a, input: a) =>
   /*AfterArg */
   input;
-
 let lATCurrySugarCommentAfterArrow =
     (type a, input: a) => /*AfterArrow */ input;
 
 let lATNotSugaredCommentBeforeEqual /*BeforeEqual*/ =
     (type a, input: a) => input;
-
 let lATNotSugaredCommentAfterEqual = /*AfterEqual*/
     (type a, input: a) => input;
-
 let lATNotSugaredCommentBeforeType = /*BeforeType*/
     (type a, input: a) => input;
-
 let lATNotSugaredCommentAfterType = /*AfterType*/
-    (type a, input: a) => input;
-
 let lATNotSugaredCommentBeforeArg =
     (type a, /*BeforeArg*/ input: a) => input;
-
 let lATNotSugaredCommentAfterArg =
     (type a, input: a) =>
   /*AfterArg*/
   input;
-
 let lATNotSugaredCommentAfterArrow =
     (type a, input: a) => /*AfterArrow*/ input;
 
 let lAtFuncAnnotatedCommentBeforeColon /*BeforeColon*/:
   type a. a => a =
   (type a, input: a) => input;
-
 let lAtFuncAnnotatedCommentAfterColon /*AfterColon*/:
   type a. a => a =
   (type a, input: a) => input;
-
 let lAtFuncAnnotatedCommentBeforeTypeVar /*BeforeTypeVar*/:
   type a. a => a =
   (type a, input: a) => input;
-
 let lAtFuncAnnotatedCommentAfterTypeVar /*AfterTypeVar*/:
   type a. a => a =
   (type a, input: a) => input;
-
 let lAtFuncAnnotatedBeforeEqual:
   type a. a => a /*BeforeEqual*/ =
   (type a, input: a) => input;
-
 let lAtFuncAnnotatedAfterEqual: type a. a => a =
   /*AfterEqual*/ (type a, input: a) => input;
 
@@ -2880,6 +2784,7 @@ let returningATernary = (x, y) =>
   x > y ? "hi" : "by";
 
 /** Testing some special comment alignment features */
+
 /* Comments can be written like this.
    No leading star is required on each line.
    Everything will line up just fine.
@@ -2957,11 +2862,9 @@ let onlyDoingThisTopLevelLetToBypassTopLevelSequence = {
 
 /* With this unification, anywhere eyou see `= fun` you can just ommit it */
 let blah = a => a; /* Done */
-
 let blah = a => a; /* Done (almost) */
 
 let blah = (a, b) => a; /* Done */
-
 let blah = (a, b) => a; /* Done (almost) */
 
 let tryingTheSameInLocalScope = {

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -1,5 +1,7 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 /* Run the formatting pretty printer with width 50 */
+
 /*
  * Testing infix wrapping
  */
@@ -1946,7 +1948,6 @@ let someResult: sixteenTuple =
     10,
     10,
   ));
-
 /* Annoted Inline */
 /* Not-Destructured */
 let someResult: (
@@ -2656,6 +2657,7 @@ let /*beforePattern2 */ commentingBeforePattern2: withThreeFields = {
   age: 20,
   occupation: "programmer",
 };
+
 /*beforePattern*/
 let /*beforePattern2 */ commentingBeforePatternSpecial: withThreeFields = {
   name: "hello",
@@ -2734,6 +2736,7 @@ let lATNotSugaredCommentAfterEqual = /*AfterEqual*/
 let lATNotSugaredCommentBeforeType = /*BeforeType*/
     (type a, input: a) => input;
 let lATNotSugaredCommentAfterType = /*AfterType*/
+    (type a, input: a) => input;
 let lATNotSugaredCommentBeforeArg =
     (type a, /*BeforeArg*/ input: a) => input;
 let lATNotSugaredCommentAfterArg =
@@ -2790,7 +2793,6 @@ let returningATernary = (x, y) =>
    Everything will line up just fine.
    In this form, include the final closing on the last line. */
 let test = 10;
-
 let test =
   /* And if the entire block needs to be re-indented
      such as this case, everything will still look okay. */

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -2934,16 +2934,19 @@ let onlyDoingThisTopLevelLetToBypassTopLevelSequence = {
     print_int(1);
     print_int(20); /* Missing trailing SEMI */
   };
+
   let x = {
     print_int(1);
     print_int(20); /* Ensure missing middle SEMI reported well */
     print_int(20);
   };
+
   let x = {
     print_int(1);
     print_int(20);
     10;
   }; /* Missing final SEMI */
+
   let x = {
     print_int(1);
     print_int(20);
@@ -2964,6 +2967,7 @@ let blah = (a, b) => a; /* Done (almost) */
 let tryingTheSameInLocalScope = {
   let blah = a => a; /* Done */
   let blah = a => a; /* Done (almost) */
+
   let blah = (a, b) => a; /* Done */
   let blah = (a, b) => a;
   (); /* Done (almost) */

--- a/formatTest/unit_tests/expected_output/wrappingTest.rei
+++ b/formatTest/unit_tests/expected_output/wrappingTest.rei
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
 let named: (~a: int, ~b: int) => int;
 
 let namedAlias: (~a: int, ~b: int) => int;
@@ -40,7 +41,6 @@ let fun_option_int:
    Everything will line up just fine.
    In this form, include the final closing on the last line. */
 let test: int;
-
 let test:
   /* And if the entire block needs to be re-indented
      such as this case, everything will still look okay. */

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -274,7 +274,6 @@ let res2 = printPoint({x:point3D.x, y:point3D.y});
        let x = {a};    /* Record {a:a} */
        let x = {a;};   /* Single item sequence returning identifier {a} */
 */
-
 let res3 = printPoint (addPoints (point2D, {x:point3D.x, y:point3D.y}));
 
 type person = {age: int, name: string};

--- a/formatTest/unit_tests/input/whitespace.re
+++ b/formatTest/unit_tests/input/whitespace.re
@@ -82,3 +82,42 @@ module FloatingComments = {
   /* l */
   let e = 1;
 };
+
+module FloatingMultiLineComments = {
+  let a = 1;
+  /* 1
+     2 */
+
+  /* ok
+     another one */
+
+  /* wow
+     here */
+  let b = 1;
+
+  /* float
+     -ing */
+  /* here
+     on the second */
+
+  let c = 1;
+
+  /* one
+     two */
+  /* three
+     four */
+
+  /* extreme
+     comment */
+  /* here
+      on two lines */
+
+  /* another
+     one */
+  /* chocolate
+     is
+     good */
+
+
+  let d = 2;
+};

--- a/formatTest/unit_tests/input/whitespace.re
+++ b/formatTest/unit_tests/input/whitespace.re
@@ -1,0 +1,10 @@
+module Test = {
+  open Belt;
+  open React;
+
+  type a = int;
+  type b = string;
+
+  let x = 12;
+  let y = 34;
+};

--- a/formatTest/unit_tests/input/whitespace.re
+++ b/formatTest/unit_tests/input/whitespace.re
@@ -54,3 +54,31 @@ module Comments = {
 
   type x = {a: int /* comment1*/, b: string /* comment2 */};
 };
+
+module FloatingComments = {
+  let a = 1;
+  /* a */
+
+  /* b */
+
+  /* c */
+  let b = 1;
+
+  /* d */
+
+  let c = 1;
+
+  /* e */
+  /* f */
+
+  let d = 1;
+  /* g */
+  /* h */
+
+  /* i */
+  /* j */
+
+  /* k */
+  /* l */
+  let e = 1;
+};

--- a/formatTest/unit_tests/input/whitespace.re
+++ b/formatTest/unit_tests/input/whitespace.re
@@ -7,4 +7,50 @@ module Test = {
 
   let x = 12;
   let y = 34;
+
+};
+
+module Comments = {
+
+  let z = 1;
+  /* comment *without* whitespace interleaved*/
+  let ab = 2;
+
+  let add = (a, b) => a + b;
+
+
+  /* comment *with* multiple newlines above */
+  let min = (a, b) => a - b;
+
+
+  let a = 1; /* trailing comment ok */
+  let b = 2;
+
+  /* comment on top */
+  let x = 1; /* this comment sits at the end of the line */
+  /* wow another one below too */
+
+  let add = Test.x;
+  
+
+  /* this
+     is
+     a multiline
+     comment */
+  let minus = (a, b) => a - b;
+
+  /* look
+     another
+     multi
+     line
+     comment */
+  let vermenigvuldig = (a, b) => a * b;
+  /* attach another comment below
+     it spreads
+     over
+     multiple
+     line
+  */
+
+  type x = {a: int /* comment1*/, b: string /* comment2 */};
 };

--- a/formatTest/unit_tests/input/whitespace.re
+++ b/formatTest/unit_tests/input/whitespace.re
@@ -143,3 +143,13 @@ let main = () => {
   let%lwt _i = write_string(stdout, s, 0, len);
   ();
 };
+
+module EdgeCase = {
+  let x = 1; /* a */
+
+  /* b */
+
+  /* c */
+
+  let x = 1;
+};

--- a/formatTest/unit_tests/input/whitespace.re
+++ b/formatTest/unit_tests/input/whitespace.re
@@ -121,3 +121,14 @@ module FloatingMultiLineComments = {
 
   let d = 2;
 };
+
+module type TestModuleType = {
+  type a = int;
+  type b = string;
+
+
+
+  let x: a;
+  let y: b;
+
+};

--- a/formatTest/unit_tests/input/whitespace.re
+++ b/formatTest/unit_tests/input/whitespace.re
@@ -132,3 +132,14 @@ module type TestModuleType = {
   let y: b;
 
 };
+
+let main = () => {
+  let%lwt tc = tcGetAddr(stdin);
+
+  let a = 1;
+
+  let%lwt () = tcsetattr(stdin, TCSANOW, tc);
+
+  let%lwt _i = write_string(stdout, s, 0, len);
+  ();
+};

--- a/formatTest/unit_tests/input/whitespace.re
+++ b/formatTest/unit_tests/input/whitespace.re
@@ -153,3 +153,11 @@ module EdgeCase = {
 
   let x = 1;
 };
+
+let f = (a, b) => a + b;
+/* this comment sticks at the end */
+
+/* another one below the structure */
+/* this one should stick */
+
+/* :) */

--- a/formatTest/unit_tests/input/whitespace.rei
+++ b/formatTest/unit_tests/input/whitespace.rei
@@ -12,3 +12,10 @@ let b: int;
 
 /* amazing */
 let f: int => int;
+
+/* notice the whitespace after the last signature item */
+
+/* this one has whitespace interleaved */
+/* stick together */
+
+/* :) */

--- a/formatTest/unit_tests/input/whitespace.rei
+++ b/formatTest/unit_tests/input/whitespace.rei
@@ -1,0 +1,14 @@
+/** Interleave whitespace intelligently in signatures */
+
+/* a */
+let a: int;
+
+/* b */
+let b: int;
+/* trailing */
+
+/* kkk */
+/* ---> */
+
+/* amazing */
+let f: int => int;

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v2_1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v2_1.re
@@ -1,25 +1,20 @@
 module ReactDOMRe = {
   let createElement = (tag, ~props=?, children) => 1;
-
   let props = (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) => 1;
 };
 
 module Foo = {
   let make = (~className=?, ~width=?, ~comp=?, ~bar=?, children) => 1;
-
   let createElement =
       (~className=?, ~ref=?, ~key=?, ~width=?, ~comp=?, ~bar=?, ~children, ()) => 1;
-
   module Bar = {
     let make = (~className=?, children) => 1;
-
     let createElement = (~className=?, ~ref=?, ~key=?, ~children, ()) => 1;
   };
 };
 
 module Bar = {
   let make = (~bar=?, children) => 1;
-
   let createElement = (~bar=?, ~children, ()) => 1;
 };
 

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v2_1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v2_1.re
@@ -2,7 +2,6 @@ module ReactDOMRe = {
   let createElement = (tag, ~props=?, children) => 1;
   let props = (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) => 1;
 };
-
 module Foo = {
   let make = (~className=?, ~width=?, ~comp=?, ~bar=?, children) => 1;
   let createElement =
@@ -12,34 +11,26 @@ module Foo = {
     let createElement = (~className=?, ~ref=?, ~key=?, ~children, ()) => 1;
   };
 };
-
 module Bar = {
   let make = (~bar=?, children) => 1;
   let createElement = (~bar=?, ~children, ()) => 1;
 };
-
 module ReasonReact = {
   let element = (~key=?, ~ref=?, component) => 1;
 };
-
 let divRef = ReactDOMRe.createElement("div", [||]);
-
 "=== DOM component ===";
-
 ReactDOMRe.createElement("div", [||]);
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ()),
   [||],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
   [||],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
@@ -48,7 +39,6 @@ ReactDOMRe.createElement(
     ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|])),
   |],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=
@@ -62,7 +52,6 @@ ReactDOMRe.createElement(
     ReasonReact.element(Foo.make(~bar=2, [||])),
   |],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=
@@ -76,34 +65,24 @@ ReactDOMRe.createElement(
     (() => ReasonReact.element(Foo.make(~bar=2, [||])))(),
   |],
 );
-
 "=== Custom component ===";
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make([|ReactDOMRe.createElement("div", [||])|]));
-
 ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]));
-
 ReasonReact.element(
   Foo.make([|
     ReactDOMRe.createElement("div", [||]),
     ReasonReact.element(Bar.make([||])),
   |]),
 );
-
 ReasonReact.element(Foo.make([|divRef, divRef|]));
-
 ReasonReact.element(Foo.make(~className="hello", [||]));
-
 ReasonReact.element(
   Foo.make(~className="hello", [|ReactDOMRe.createElement("div", [||])|]),
 );
-
 ReasonReact.element(
   Foo.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]),
 );
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -113,11 +92,8 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(Foo.make(~className="hello", [|divRef, divRef|]));
-
 ReasonReact.element(Foo.make(~className="hello", ~width="10", [||]));
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -133,7 +109,6 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -144,14 +119,12 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~comp=ReasonReact.element(Bar.make([|divRef, divRef|])),
     [|ReactDOMRe.createElement("li", [||])|],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~comp=
@@ -161,68 +134,46 @@ ReasonReact.element(
     [|ReactDOMRe.createElement("li", [||])|],
   ),
 );
-
 "=== No wrapping for single child ===";
-
 ReasonReact.element(Foo.make(() => 1));
-
 ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make([||]))));
-
 ReasonReact.element(Foo.make((1, 2)));
-
 ReasonReact.element(Foo.make([|1|]));
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make(divRef));
-
 ReasonReact.element(Foo.make(ReactDOMRe.createElement("div", [||])));
-
 ReasonReact.element(Foo.make(ReasonReact.element(Bar.make([||]))));
-
 ReasonReact.element(Foo.make(~className="hello", () => 1));
-
 ReasonReact.element(Foo.make(~className="hello", (1, 2)));
-
 ReasonReact.element(Foo.make(~className="hello", [|1, 2|]));
-
 ReasonReact.element(Foo.make(~className="hello", divRef));
-
 ReasonReact.element(
   Foo.make(
     ~comp=ReasonReact.element(Bar.make(divRef)),
     ReactDOMRe.createElement("li", [||]),
   ),
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~comp=ReasonReact.element(Bar.make(divRef)), ()),
   ReactDOMRe.createElement("li", [||]),
 );
-
 "=== With ref/key ===";
-
 ReasonReact.element(~key="someKey", Foo.make(~className="hello", [||]));
-
 ReasonReact.element(
   ~key=Some("someKey"),
   ~ref=Some(ref),
   Foo.make(~className="hello", [||]),
 );
-
 ReasonReact.element(
   ~key=?Some("someKey"),
   ~ref=?Some(ref),
   Foo.make(~className="hello", [||]),
 );
-
 ReasonReact.element(
   ~key="someKey",
   ~ref=Some(ref),
   Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]),
 );
-
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v2_2.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v2_2.re
@@ -1,10 +1,8 @@
 [@bs.config {foo: foo}];
-
 module ReactDOMRe = {
   let createElement = (tag, ~props=?, children) => 1;
   let props = (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) => 1;
 };
-
 module Foo = {
   let make = (~className=?, ~width=?, ~comp=?, ~bar=?, children) => 1;
   let createElement =
@@ -14,34 +12,26 @@ module Foo = {
     let createElement = (~className=?, ~ref=?, ~key=?, ~children, ()) => 1;
   };
 };
-
 module Bar = {
   let make = (~bar=?, children) => 1;
   let createElement = (~bar=?, ~children, ()) => 1;
 };
-
 module ReasonReact = {
   let element = (~key=?, ~ref=?, component) => 1;
 };
-
 let divRef = ReactDOMRe.createElement("div", [||]);
-
 "=== DOM component ===";
-
 ReactDOMRe.createElement("div", [||]);
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ()),
   [||],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
   [||],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
@@ -50,7 +40,6 @@ ReactDOMRe.createElement(
     ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|])),
   |],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=
@@ -64,7 +53,6 @@ ReactDOMRe.createElement(
     ReasonReact.element(Foo.make(~bar=2, [||])),
   |],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=
@@ -78,34 +66,24 @@ ReactDOMRe.createElement(
     (() => ReasonReact.element(Foo.make(~bar=2, [||])))(),
   |],
 );
-
 "=== Custom component ===";
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make([|ReactDOMRe.createElement("div", [||])|]));
-
 ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]));
-
 ReasonReact.element(
   Foo.make([|
     ReactDOMRe.createElement("div", [||]),
     ReasonReact.element(Bar.make([||])),
   |]),
 );
-
 ReasonReact.element(Foo.make([|divRef, divRef|]));
-
 ReasonReact.element(Foo.make(~className="hello", [||]));
-
 ReasonReact.element(
   Foo.make(~className="hello", [|ReactDOMRe.createElement("div", [||])|]),
 );
-
 ReasonReact.element(
   Foo.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]),
 );
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -115,11 +93,8 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(Foo.make(~className="hello", [|divRef, divRef|]));
-
 ReasonReact.element(Foo.make(~className="hello", ~width="10", [||]));
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -135,7 +110,6 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -146,14 +120,12 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~comp=ReasonReact.element(Bar.make([|divRef, divRef|])),
     [|ReactDOMRe.createElement("li", [||])|],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~comp=
@@ -163,68 +135,46 @@ ReasonReact.element(
     [|ReactDOMRe.createElement("li", [||])|],
   ),
 );
-
 "=== No wrapping for single child ===";
-
 ReasonReact.element(Foo.make(() => 1));
-
 ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make([||]))));
-
 ReasonReact.element(Foo.make((1, 2)));
-
 ReasonReact.element(Foo.make([|1|]));
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make(divRef));
-
 ReasonReact.element(Foo.make(ReactDOMRe.createElement("div", [||])));
-
 ReasonReact.element(Foo.make(ReasonReact.element(Bar.make([||]))));
-
 ReasonReact.element(Foo.make(~className="hello", () => 1));
-
 ReasonReact.element(Foo.make(~className="hello", (1, 2)));
-
 ReasonReact.element(Foo.make(~className="hello", [|1, 2|]));
-
 ReasonReact.element(Foo.make(~className="hello", divRef));
-
 ReasonReact.element(
   Foo.make(
     ~comp=ReasonReact.element(Bar.make(divRef)),
     ReactDOMRe.createElement("li", [||]),
   ),
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~comp=ReasonReact.element(Bar.make(divRef)), ()),
   ReactDOMRe.createElement("li", [||]),
 );
-
 "=== With ref/key ===";
-
 ReasonReact.element(~key="someKey", Foo.make(~className="hello", [||]));
-
 ReasonReact.element(
   ~key=Some("someKey"),
   ~ref=Some(ref),
   Foo.make(~className="hello", [||]),
 );
-
 ReasonReact.element(
   ~key=?Some("someKey"),
   ~ref=?Some(ref),
   Foo.make(~className="hello", [||]),
 );
-
 ReasonReact.element(
   ~key="someKey",
   ~ref=Some(ref),
   Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]),
 );
-
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v2_2.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v2_2.re
@@ -2,26 +2,21 @@
 
 module ReactDOMRe = {
   let createElement = (tag, ~props=?, children) => 1;
-
   let props = (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) => 1;
 };
 
 module Foo = {
   let make = (~className=?, ~width=?, ~comp=?, ~bar=?, children) => 1;
-
   let createElement =
       (~className=?, ~ref=?, ~key=?, ~width=?, ~comp=?, ~bar=?, ~children, ()) => 1;
-
   module Bar = {
     let make = (~className=?, children) => 1;
-
     let createElement = (~className=?, ~ref=?, ~key=?, ~children, ()) => 1;
   };
 };
 
 module Bar = {
   let make = (~bar=?, children) => 1;
-
   let createElement = (~bar=?, ~children, ()) => 1;
 };
 

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v2_3.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v2_3.re
@@ -1,10 +1,8 @@
 [@bs.config {foo: foo}];
-
 module ReactDOMRe = {
   let createElement = (tag, ~props=?, children) => 1;
   let props = (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) => 1;
 };
-
 module Foo = {
   let make = (~className=?, ~width=?, ~comp=?, ~bar=?, children) => 1;
   let createElement =
@@ -14,34 +12,26 @@ module Foo = {
     let createElement = (~className=?, ~ref=?, ~key=?, ~children, ()) => 1;
   };
 };
-
 module Bar = {
   let make = (~bar=?, children) => 1;
   let createElement = (~bar=?, ~children, ()) => 1;
 };
-
 module ReasonReact = {
   let element = (~key=?, ~ref=?, component) => 1;
 };
-
 let divRef = ReactDOMRe.createElement("div", [||]);
-
 "=== DOM component ===";
-
 ReactDOMRe.createElement("div", [||]);
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ()),
   [||],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
   [||],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
@@ -50,7 +40,6 @@ ReactDOMRe.createElement(
     ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|])),
   |],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=
@@ -64,7 +53,6 @@ ReactDOMRe.createElement(
     ReasonReact.element(Foo.make(~bar=2, [||])),
   |],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=
@@ -78,34 +66,24 @@ ReactDOMRe.createElement(
     (() => ReasonReact.element(Foo.make(~bar=2, [||])))(),
   |],
 );
-
 "=== Custom component ===";
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make([|ReactDOMRe.createElement("div", [||])|]));
-
 ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]));
-
 ReasonReact.element(
   Foo.make([|
     ReactDOMRe.createElement("div", [||]),
     ReasonReact.element(Bar.make([||])),
   |]),
 );
-
 ReasonReact.element(Foo.make([|divRef, divRef|]));
-
 ReasonReact.element(Foo.make(~className="hello", [||]));
-
 ReasonReact.element(
   Foo.make(~className="hello", [|ReactDOMRe.createElement("div", [||])|]),
 );
-
 ReasonReact.element(
   Foo.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]),
 );
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -115,11 +93,8 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(Foo.make(~className="hello", [|divRef, divRef|]));
-
 ReasonReact.element(Foo.make(~className="hello", ~width="10", [||]));
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -135,7 +110,6 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -146,14 +120,12 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~comp=ReasonReact.element(Bar.make([|divRef, divRef|])),
     [|ReactDOMRe.createElement("li", [||])|],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~comp=
@@ -163,68 +135,46 @@ ReasonReact.element(
     [|ReactDOMRe.createElement("li", [||])|],
   ),
 );
-
 "=== No wrapping for single child ===";
-
 ReasonReact.element(Foo.make(() => 1));
-
 ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make([||]))));
-
 ReasonReact.element(Foo.make((1, 2)));
-
 ReasonReact.element(Foo.make([|1|]));
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make(divRef));
-
 ReasonReact.element(Foo.make(ReactDOMRe.createElement("div", [||])));
-
 ReasonReact.element(Foo.make(ReasonReact.element(Bar.make([||]))));
-
 ReasonReact.element(Foo.make(~className="hello", () => 1));
-
 ReasonReact.element(Foo.make(~className="hello", (1, 2)));
-
 ReasonReact.element(Foo.make(~className="hello", [|1, 2|]));
-
 ReasonReact.element(Foo.make(~className="hello", divRef));
-
 ReasonReact.element(
   Foo.make(
     ~comp=ReasonReact.element(Bar.make(divRef)),
     ReactDOMRe.createElement("li", [||]),
   ),
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~comp=ReasonReact.element(Bar.make(divRef)), ()),
   ReactDOMRe.createElement("li", [||]),
 );
-
 "=== With ref/key ===";
-
 ReasonReact.element(~key="someKey", Foo.make(~className="hello", [||]));
-
 ReasonReact.element(
   ~key=Some("someKey"),
   ~ref=Some(ref),
   Foo.make(~className="hello", [||]),
 );
-
 ReasonReact.element(
   ~key=?Some("someKey"),
   ~ref=?Some(ref),
   Foo.make(~className="hello", [||]),
 );
-
 ReasonReact.element(
   ~key="someKey",
   ~ref=Some(ref),
   Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]),
 );
-
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v2_3.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v2_3.re
@@ -2,26 +2,21 @@
 
 module ReactDOMRe = {
   let createElement = (tag, ~props=?, children) => 1;
-
   let props = (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) => 1;
 };
 
 module Foo = {
   let make = (~className=?, ~width=?, ~comp=?, ~bar=?, children) => 1;
-
   let createElement =
       (~className=?, ~ref=?, ~key=?, ~width=?, ~comp=?, ~bar=?, ~children, ()) => 1;
-
   module Bar = {
     let make = (~className=?, children) => 1;
-
     let createElement = (~className=?, ~ref=?, ~key=?, ~children, ()) => 1;
   };
 };
 
 module Bar = {
   let make = (~bar=?, children) => 1;
-
   let createElement = (~bar=?, ~children, ()) => 1;
 };
 

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v3_1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v3_1.re
@@ -1,25 +1,20 @@
 module ReactDOMRe = {
   let createElement = (tag, ~props=?, children) => 1;
-
   let props = (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) => 1;
 };
 
 module Foo = {
   let make = (~className=?, ~width=?, ~comp=?, ~bar=?, children) => 1;
-
   let createElement =
       (~className=?, ~ref=?, ~key=?, ~width=?, ~comp=?, ~bar=?, ~children, ()) => 1;
-
   module Bar = {
     let make = (~className=?, children) => 1;
-
     let createElement = (~className=?, ~ref=?, ~key=?, ~children, ()) => 1;
   };
 };
 
 module Bar = {
   let make = (~bar=?, children) => 1;
-
   let createElement = (~bar=?, ~children, ()) => 1;
 };
 

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v3_1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v3_1.re
@@ -2,7 +2,6 @@ module ReactDOMRe = {
   let createElement = (tag, ~props=?, children) => 1;
   let props = (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) => 1;
 };
-
 module Foo = {
   let make = (~className=?, ~width=?, ~comp=?, ~bar=?, children) => 1;
   let createElement =
@@ -12,34 +11,26 @@ module Foo = {
     let createElement = (~className=?, ~ref=?, ~key=?, ~children, ()) => 1;
   };
 };
-
 module Bar = {
   let make = (~bar=?, children) => 1;
   let createElement = (~bar=?, ~children, ()) => 1;
 };
-
 module ReasonReact = {
   let element = (~key=?, ~ref=?, component) => 1;
 };
-
 let divRef = ReactDOMRe.createElement("div", [||]);
-
 "=== DOM component ===";
-
 ReactDOMRe.createElement("div", [||]);
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ()),
   [||],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
   [||],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
@@ -48,7 +39,6 @@ ReactDOMRe.createElement(
     ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|])),
   |],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=
@@ -62,7 +52,6 @@ ReactDOMRe.createElement(
     ReasonReact.element(Foo.make(~bar=2, [||])),
   |],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=
@@ -76,34 +65,24 @@ ReactDOMRe.createElement(
     (() => ReasonReact.element(Foo.make(~bar=2, [||])))(),
   |],
 );
-
 "=== Custom component ===";
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make([|ReactDOMRe.createElement("div", [||])|]));
-
 ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]));
-
 ReasonReact.element(
   Foo.make([|
     ReactDOMRe.createElement("div", [||]),
     ReasonReact.element(Bar.make([||])),
   |]),
 );
-
 ReasonReact.element(Foo.make([|divRef, divRef|]));
-
 ReasonReact.element(Foo.make(~className="hello", [||]));
-
 ReasonReact.element(
   Foo.make(~className="hello", [|ReactDOMRe.createElement("div", [||])|]),
 );
-
 ReasonReact.element(
   Foo.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]),
 );
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -113,11 +92,8 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(Foo.make(~className="hello", [|divRef, divRef|]));
-
 ReasonReact.element(Foo.make(~className="hello", ~width="10", [||]));
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -133,7 +109,6 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -144,14 +119,12 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~comp=ReasonReact.element(Bar.make([|divRef, divRef|])),
     [|ReactDOMRe.createElement("li", [||])|],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~comp=
@@ -161,68 +134,46 @@ ReasonReact.element(
     [|ReactDOMRe.createElement("li", [||])|],
   ),
 );
-
 "=== No wrapping for single child ===";
-
 ReasonReact.element(Foo.make(() => 1));
-
 ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make([||]))));
-
 ReasonReact.element(Foo.make((1, 2)));
-
 ReasonReact.element(Foo.make([|1|]));
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make(divRef));
-
 ReasonReact.element(Foo.make(ReactDOMRe.createElement("div", [||])));
-
 ReasonReact.element(Foo.make(ReasonReact.element(Bar.make([||]))));
-
 ReasonReact.element(Foo.make(~className="hello", () => 1));
-
 ReasonReact.element(Foo.make(~className="hello", (1, 2)));
-
 ReasonReact.element(Foo.make(~className="hello", [|1, 2|]));
-
 ReasonReact.element(Foo.make(~className="hello", divRef));
-
 ReasonReact.element(
   Foo.make(
     ~comp=ReasonReact.element(Bar.make(divRef)),
     ReactDOMRe.createElement("li", [||]),
   ),
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~comp=ReasonReact.element(Bar.make(divRef)), ()),
   ReactDOMRe.createElement("li", [||]),
 );
-
 "=== With ref/key ===";
-
 ReasonReact.element(~key="someKey", Foo.make(~className="hello", [||]));
-
 ReasonReact.element(
   ~key=Some("someKey"),
   ~ref=Some(ref),
   Foo.make(~className="hello", [||]),
 );
-
 ReasonReact.element(
   ~key=?Some("someKey"),
   ~ref=?Some(ref),
   Foo.make(~className="hello", [||]),
 );
-
 ReasonReact.element(
   ~key="someKey",
   ~ref=Some(ref),
   Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]),
 );
-
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v3_2.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v3_2.re
@@ -1,10 +1,8 @@
 [@bs.config {foo: foo}];
-
 module ReactDOMRe = {
   let createElement = (tag, ~props=?, children) => 1;
   let props = (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) => 1;
 };
-
 module Foo = {
   let make = (~className=?, ~width=?, ~comp=?, ~bar=?, children) => 1;
   let createElement =
@@ -14,34 +12,26 @@ module Foo = {
     let createElement = (~className=?, ~ref=?, ~key=?, ~children, ()) => 1;
   };
 };
-
 module Bar = {
   let make = (~bar=?, children) => 1;
   let createElement = (~bar=?, ~children, ()) => 1;
 };
-
 module ReasonReact = {
   let element = (~key=?, ~ref=?, component) => 1;
 };
-
 let divRef = ReactDOMRe.createElement("div", [||]);
-
 "=== DOM component ===";
-
 ReactDOMRe.createElement("div", [||]);
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ()),
   [||],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
   [||],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
@@ -50,7 +40,6 @@ ReactDOMRe.createElement(
     ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|])),
   |],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=
@@ -64,7 +53,6 @@ ReactDOMRe.createElement(
     ReasonReact.element(Foo.make(~bar=2, [||])),
   |],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=
@@ -78,34 +66,24 @@ ReactDOMRe.createElement(
     (() => ReasonReact.element(Foo.make(~bar=2, [||])))(),
   |],
 );
-
 "=== Custom component ===";
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make([|ReactDOMRe.createElement("div", [||])|]));
-
 ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]));
-
 ReasonReact.element(
   Foo.make([|
     ReactDOMRe.createElement("div", [||]),
     ReasonReact.element(Bar.make([||])),
   |]),
 );
-
 ReasonReact.element(Foo.make([|divRef, divRef|]));
-
 ReasonReact.element(Foo.make(~className="hello", [||]));
-
 ReasonReact.element(
   Foo.make(~className="hello", [|ReactDOMRe.createElement("div", [||])|]),
 );
-
 ReasonReact.element(
   Foo.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]),
 );
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -115,11 +93,8 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(Foo.make(~className="hello", [|divRef, divRef|]));
-
 ReasonReact.element(Foo.make(~className="hello", ~width="10", [||]));
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -135,7 +110,6 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -146,14 +120,12 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~comp=ReasonReact.element(Bar.make([|divRef, divRef|])),
     [|ReactDOMRe.createElement("li", [||])|],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~comp=
@@ -163,68 +135,46 @@ ReasonReact.element(
     [|ReactDOMRe.createElement("li", [||])|],
   ),
 );
-
 "=== No wrapping for single child ===";
-
 ReasonReact.element(Foo.make(() => 1));
-
 ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make([||]))));
-
 ReasonReact.element(Foo.make((1, 2)));
-
 ReasonReact.element(Foo.make([|1|]));
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make(divRef));
-
 ReasonReact.element(Foo.make(ReactDOMRe.createElement("div", [||])));
-
 ReasonReact.element(Foo.make(ReasonReact.element(Bar.make([||]))));
-
 ReasonReact.element(Foo.make(~className="hello", () => 1));
-
 ReasonReact.element(Foo.make(~className="hello", (1, 2)));
-
 ReasonReact.element(Foo.make(~className="hello", [|1, 2|]));
-
 ReasonReact.element(Foo.make(~className="hello", divRef));
-
 ReasonReact.element(
   Foo.make(
     ~comp=ReasonReact.element(Bar.make(divRef)),
     ReactDOMRe.createElement("li", [||]),
   ),
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~comp=ReasonReact.element(Bar.make(divRef)), ()),
   ReactDOMRe.createElement("li", [||]),
 );
-
 "=== With ref/key ===";
-
 ReasonReact.element(~key="someKey", Foo.make(~className="hello", [||]));
-
 ReasonReact.element(
   ~key=Some("someKey"),
   ~ref=Some(ref),
   Foo.make(~className="hello", [||]),
 );
-
 ReasonReact.element(
   ~key=?Some("someKey"),
   ~ref=?Some(ref),
   Foo.make(~className="hello", [||]),
 );
-
 ReasonReact.element(
   ~key="someKey",
   ~ref=Some(ref),
   Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]),
 );
-
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v3_2.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v3_2.re
@@ -2,26 +2,21 @@
 
 module ReactDOMRe = {
   let createElement = (tag, ~props=?, children) => 1;
-
   let props = (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) => 1;
 };
 
 module Foo = {
   let make = (~className=?, ~width=?, ~comp=?, ~bar=?, children) => 1;
-
   let createElement =
       (~className=?, ~ref=?, ~key=?, ~width=?, ~comp=?, ~bar=?, ~children, ()) => 1;
-
   module Bar = {
     let make = (~className=?, children) => 1;
-
     let createElement = (~className=?, ~ref=?, ~key=?, ~children, ()) => 1;
   };
 };
 
 module Bar = {
   let make = (~bar=?, children) => 1;
-
   let createElement = (~bar=?, ~children, ()) => 1;
 };
 

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v3_3.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v3_3.re
@@ -1,10 +1,8 @@
 [@bs.config {foo: foo}];
-
 module ReactDOMRe = {
   let createElement = (tag, ~props=?, children) => 1;
   let props = (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) => 1;
 };
-
 module Foo = {
   let make = (~className=?, ~width=?, ~comp=?, ~bar=?, children) => 1;
   let createElement =
@@ -14,34 +12,26 @@ module Foo = {
     let createElement = (~className=?, ~ref=?, ~key=?, ~children, ()) => 1;
   };
 };
-
 module Bar = {
   let make = (~bar=?, children) => 1;
   let createElement = (~bar=?, ~children, ()) => 1;
 };
-
 module ReasonReact = {
   let element = (~key=?, ~ref=?, component) => 1;
 };
-
 let divRef = ReactDOMRe.createElement("div", [||]);
-
 "=== DOM component ===";
-
 ReactDOMRe.createElement("div", [||]);
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ()),
   [||],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
   [||],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~className="hello", ~width="10", ()),
@@ -50,7 +40,6 @@ ReactDOMRe.createElement(
     ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|])),
   |],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=
@@ -64,7 +53,6 @@ ReactDOMRe.createElement(
     ReasonReact.element(Foo.make(~bar=2, [||])),
   |],
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=
@@ -78,34 +66,24 @@ ReactDOMRe.createElement(
     (() => ReasonReact.element(Foo.make(~bar=2, [||])))(),
   |],
 );
-
 "=== Custom component ===";
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make([|ReactDOMRe.createElement("div", [||])|]));
-
 ReasonReact.element(Foo.make([|ReasonReact.element(Bar.make([||]))|]));
-
 ReasonReact.element(
   Foo.make([|
     ReactDOMRe.createElement("div", [||]),
     ReasonReact.element(Bar.make([||])),
   |]),
 );
-
 ReasonReact.element(Foo.make([|divRef, divRef|]));
-
 ReasonReact.element(Foo.make(~className="hello", [||]));
-
 ReasonReact.element(
   Foo.make(~className="hello", [|ReactDOMRe.createElement("div", [||])|]),
 );
-
 ReasonReact.element(
   Foo.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]),
 );
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -115,11 +93,8 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(Foo.make(~className="hello", [|divRef, divRef|]));
-
 ReasonReact.element(Foo.make(~className="hello", ~width="10", [||]));
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -135,7 +110,6 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~className="hello",
@@ -146,14 +120,12 @@ ReasonReact.element(
     |],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~comp=ReasonReact.element(Bar.make([|divRef, divRef|])),
     [|ReactDOMRe.createElement("li", [||])|],
   ),
 );
-
 ReasonReact.element(
   Foo.make(
     ~comp=
@@ -163,68 +135,46 @@ ReasonReact.element(
     [|ReactDOMRe.createElement("li", [||])|],
   ),
 );
-
 "=== No wrapping for single child ===";
-
 ReasonReact.element(Foo.make(() => 1));
-
 ReasonReact.element(Foo.make(() => ReasonReact.element(Bar.make([||]))));
-
 ReasonReact.element(Foo.make((1, 2)));
-
 ReasonReact.element(Foo.make([|1|]));
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make([||]));
-
 ReasonReact.element(Foo.make(divRef));
-
 ReasonReact.element(Foo.make(ReactDOMRe.createElement("div", [||])));
-
 ReasonReact.element(Foo.make(ReasonReact.element(Bar.make([||]))));
-
 ReasonReact.element(Foo.make(~className="hello", () => 1));
-
 ReasonReact.element(Foo.make(~className="hello", (1, 2)));
-
 ReasonReact.element(Foo.make(~className="hello", [|1, 2|]));
-
 ReasonReact.element(Foo.make(~className="hello", divRef));
-
 ReasonReact.element(
   Foo.make(
     ~comp=ReasonReact.element(Bar.make(divRef)),
     ReactDOMRe.createElement("li", [||]),
   ),
 );
-
 ReactDOMRe.createElement(
   "div",
   ~props=ReactDOMRe.props(~comp=ReasonReact.element(Bar.make(divRef)), ()),
   ReactDOMRe.createElement("li", [||]),
 );
-
 "=== With ref/key ===";
-
 ReasonReact.element(~key="someKey", Foo.make(~className="hello", [||]));
-
 ReasonReact.element(
   ~key=Some("someKey"),
   ~ref=Some(ref),
   Foo.make(~className="hello", [||]),
 );
-
 ReasonReact.element(
   ~key=?Some("someKey"),
   ~ref=?Some(ref),
   Foo.make(~className="hello", [||]),
 );
-
 ReasonReact.element(
   ~key="someKey",
   ~ref=Some(ref),
   Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]),
 );
-
 ReasonReact.element(Foo.make([||]));

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v3_3.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v3_3.re
@@ -2,26 +2,21 @@
 
 module ReactDOMRe = {
   let createElement = (tag, ~props=?, children) => 1;
-
   let props = (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) => 1;
 };
 
 module Foo = {
   let make = (~className=?, ~width=?, ~comp=?, ~bar=?, children) => 1;
-
   let createElement =
       (~className=?, ~ref=?, ~key=?, ~width=?, ~comp=?, ~bar=?, ~children, ()) => 1;
-
   module Bar = {
     let make = (~className=?, children) => 1;
-
     let createElement = (~className=?, ~ref=?, ~key=?, ~children, ()) => 1;
   };
 };
 
 module Bar = {
   let make = (~bar=?, children) => 1;
-
   let createElement = (~bar=?, ~children, ()) => 1;
 };
 

--- a/miscTests/reactjs_jsx_ppx_tests/test1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test1.re
@@ -6,6 +6,7 @@ module ReactDOMRe = {
   let createElement (tag, ~props=?, children) = 1;
   let props (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) = 1;
 };
+
 module Foo = {
   let make (~className=?, ~width=?, ~comp=?, ~bar=?, children) = 1;
   let createElement (~className=?, ~ref=?, ~key=?, ~width=?, ~comp=?, ~bar=?, ~children, ()) = 1;
@@ -14,10 +15,12 @@ module Foo = {
     let createElement (~className=?, ~ref=?, ~key=?, ~children, ()) = 1;
   };
 };
+
 module Bar = {
   let make (~bar=?, children) = 1;
   let createElement (~bar=?, ~children, ()) = 1;
 };
+
 module ReasonReact = {
   let element (~key=?, ~ref=?, component) = 1;
 };

--- a/miscTests/reactjs_jsx_ppx_tests/test2.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test2.re
@@ -7,6 +7,7 @@ module ReactDOMRe = {
   let createElement (tag, ~props=?, children) = 1;
   let props (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) = 1;
 };
+
 module Foo = {
   let make (~className=?, ~width=?, ~comp=?, ~bar=?, children) = 1;
   let createElement (~className=?, ~ref=?, ~key=?, ~width=?, ~comp=?, ~bar=?, ~children, ()) = 1;
@@ -15,10 +16,12 @@ module Foo = {
     let createElement (~className=?, ~ref=?, ~key=?, ~children, ()) = 1;
   };
 };
+
 module Bar = {
   let make (~bar=?, children) = 1;
   let createElement (~bar=?, ~children, ()) = 1;
 };
+
 module ReasonReact = {
   let element (~key=?, ~ref=?, component) = 1;
 };

--- a/miscTests/reactjs_jsx_ppx_tests/test3.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test3.re
@@ -7,6 +7,7 @@ module ReactDOMRe = {
   let createElement (tag, ~props=?, children) = 1;
   let props (~className=?, ~width=?, ~comp=?, ~compCallback=?, ()) = 1;
 };
+
 module Foo = {
   let make (~className=?, ~width=?, ~comp=?, ~bar=?, children) = 1;
   let createElement (~className=?, ~ref=?, ~key=?, ~width=?, ~comp=?, ~bar=?, ~children, ()) = 1;
@@ -15,10 +16,12 @@ module Foo = {
     let createElement (~className=?, ~ref=?, ~key=?, ~children, ()) = 1;
   };
 };
+
 module Bar = {
   let make (~bar=?, children) = 1;
   let createElement (~bar=?, ~children, ()) = 1;
 };
+
 module ReasonReact = {
   let element (~key=?, ~ref=?, component) = 1;
 };

--- a/src/reason-parser/jbuild
+++ b/src/reason-parser/jbuild
@@ -57,6 +57,7 @@
     reason_comment
     reason_layout
     reason_heuristics
+    reason_location
     reason_toolchain
     reason_config
     reason_pprint_ast

--- a/src/reason-parser/reason_comment.ml
+++ b/src/reason-parser/reason_comment.ml
@@ -16,40 +16,11 @@ type t = {
   text: string;
 }
 
-let tracked_comments = ref []
-
-let track comment =
-  tracked_comments := comment::(!tracked_comments)
-
-let getComments () = !tracked_comments
-
-let heightCommentsForRange range comments =
-  List.fold_left (fun acc curr ->
-    let startLnum = curr.location.loc_start.pos_lnum in
-    let endLnum = curr.location.loc_end.pos_lnum in
-    let open Reason_location in
-    if range.lnum_start <= startLnum && endLnum <= range.lnum_end then
-      acc + (endLnum - startLnum + 1)
-    else
-      acc
-  ) 0 !tracked_comments
-
-let commentsBefore range comment =
-  let open Reason_location in
-  List.filter (fun comment ->
-    let beginLine = comment.location.loc_start.pos_lnum in
-    let endLine = comment.location.loc_end.pos_lnum in
-    beginLine >= range.lnum_start
-    && endLine <= range.lnum_end
-    && endLine < comment.location.loc_start.pos_lnum
-  ) !tracked_comments
-
 let category t = t.category
 
 let location t = t.location
 
 let dump ppf t =
-  let open Lexing in
   Format.fprintf ppf "%d (%d:%d)-%d (%d:%d) -- %s:||%s||"
     t.location.loc_start.pos_cnum
     t.location.loc_start.pos_lnum

--- a/src/reason-parser/reason_comment.ml
+++ b/src/reason-parser/reason_comment.ml
@@ -16,6 +16,34 @@ type t = {
   text: string;
 }
 
+let tracked_comments = ref []
+
+let track comment =
+  tracked_comments := comment::(!tracked_comments)
+
+let getComments () = !tracked_comments
+
+let heightCommentsForRange range comments =
+  List.fold_left (fun acc curr ->
+    let startLnum = curr.location.loc_start.pos_lnum in
+    let endLnum = curr.location.loc_end.pos_lnum in
+    let open Reason_location in
+    if range.lnum_start <= startLnum && endLnum <= range.lnum_end then
+      acc + (endLnum - startLnum + 1)
+    else
+      acc
+  ) 0 !tracked_comments
+
+let commentsBefore range comment =
+  let open Reason_location in
+  List.filter (fun comment ->
+    let beginLine = comment.location.loc_start.pos_lnum in
+    let endLine = comment.location.loc_end.pos_lnum in
+    beginLine >= range.lnum_start
+    && endLine <= range.lnum_end
+    && endLine < comment.location.loc_start.pos_lnum
+  ) !tracked_comments
+
 let category t = t.category
 
 let location t = t.location

--- a/src/reason-parser/reason_heuristics.ml
+++ b/src/reason-parser/reason_heuristics.ml
@@ -95,8 +95,3 @@ let isUnderscoreIdent expr =
   match Ast_404.Parsetree.(expr.pexp_desc) with
   | Pexp_ident ({txt = Lident "_"}) -> true
   | _ -> false
-
-
-let containsWhitespace range comments =
-  let h = Reason_comment.heightCommentsForRange range comments in
-  range.lnum_end - range.lnum_start - h >= 0

--- a/src/reason-parser/reason_heuristics.ml
+++ b/src/reason-parser/reason_heuristics.ml
@@ -95,3 +95,8 @@ let isUnderscoreIdent expr =
   match Ast_404.Parsetree.(expr.pexp_desc) with
   | Pexp_ident ({txt = Lident "_"}) -> true
   | _ -> false
+
+
+let containsWhitespace range comments =
+  let h = Reason_comment.heightCommentsForRange range comments in
+  range.lnum_end - range.lnum_start - h >= 0

--- a/src/reason-parser/reason_layout.ml
+++ b/src/reason-parser/reason_layout.ml
@@ -246,6 +246,7 @@ let get_location layout =
     | Label (formatter, left, right) ->
       union (traverse left) (traverse right)
     | SourceMap (loc, _) -> Some loc
+    | Whitespace(_, sub) -> traverse sub
     | _ -> None
   in
   traverse layout

--- a/src/reason-parser/reason_layout.ml
+++ b/src/reason-parser/reason_layout.ml
@@ -46,7 +46,7 @@ type t =
   | Sequence of config * (t list)
   | Label of (Easy_format.t -> Easy_format.t -> Easy_format.t) * t * t
   | Easy of Easy_format.t
-  | Whitespace of int * t
+  | Whitespace of int * (int * int) * t
 
 and config = {
   (* Newlines above items that do not have any comments immediately above it.
@@ -158,8 +158,8 @@ let dump ppf layout =
       traverse indent' right;
     | Easy e ->
       printf "%s Easy: '%s' \n" indent (string_of_easy e)
-    | Whitespace (n, sublayout) ->
-      printf" %s Whitespace (%d):\n" indent n;
+    | Whitespace (n, interval, sublayout) ->
+      printf" %s Whitespace (%d) [%d %d]:\n" indent n (fst interval) (snd interval);
       (traverse (indent_more indent) sublayout)
   in
   traverse "" layout
@@ -224,7 +224,7 @@ let to_easy_format layout =
     | SourceMap (_, subLayout) ->
       traverse subLayout
     | Easy e -> e
-    | Whitespace (_, subLayout) ->
+    | Whitespace (_, _, subLayout) ->
       traverse subLayout
   in
   traverse layout
@@ -246,7 +246,7 @@ let get_location layout =
     | Label (formatter, left, right) ->
       union (traverse left) (traverse right)
     | SourceMap (loc, _) -> Some loc
-    | Whitespace(_, sub) -> traverse sub
+    | Whitespace(_,_, sub) -> traverse sub
     | _ -> None
   in
   traverse layout

--- a/src/reason-parser/reason_layout.ml
+++ b/src/reason-parser/reason_layout.ml
@@ -46,7 +46,13 @@ type t =
   | Sequence of config * (t list)
   | Label of (Easy_format.t -> Easy_format.t -> Easy_format.t) * t * t
   | Easy of Easy_format.t
-  | Whitespace of int * (int * int) * t
+  | Whitespace of whitespaceRegion * t
+
+and whitespaceRegion = {
+  interval: int * int;
+  comments: Comment.t list;
+  depth: int;
+}
 
 and config = {
   (* Newlines above items that do not have any comments immediately above it.
@@ -158,8 +164,8 @@ let dump ppf layout =
       traverse indent' right;
     | Easy e ->
       printf "%s Easy: '%s' \n" indent (string_of_easy e)
-    | Whitespace (n, interval, sublayout) ->
-      printf" %s Whitespace (%d) [%d %d]:\n" indent n (fst interval) (snd interval);
+    | Whitespace ({depth; interval}, sublayout) ->
+      printf" %s Whitespace (%d) [%d %d]:\n" indent depth (fst interval) (snd interval);
       (traverse (indent_more indent) sublayout)
   in
   traverse "" layout
@@ -224,7 +230,7 @@ let to_easy_format layout =
     | SourceMap (_, subLayout) ->
       traverse subLayout
     | Easy e -> e
-    | Whitespace (_, _, subLayout) ->
+    | Whitespace (_, subLayout) ->
       traverse subLayout
   in
   traverse layout
@@ -246,7 +252,7 @@ let get_location layout =
     | Label (formatter, left, right) ->
       union (traverse left) (traverse right)
     | SourceMap (loc, _) -> Some loc
-    | Whitespace(_,_, sub) -> traverse sub
+    | Whitespace(_, sub) -> traverse sub
     | _ -> None
   in
   traverse layout

--- a/src/reason-parser/reason_layout.ml
+++ b/src/reason-parser/reason_layout.ml
@@ -46,6 +46,7 @@ type t =
   | Sequence of config * (t list)
   | Label of (Easy_format.t -> Easy_format.t -> Easy_format.t) * t * t
   | Easy of Easy_format.t
+  | Whitespace of int * t
 
 and config = {
   (* Newlines above items that do not have any comments immediately above it.
@@ -55,6 +56,8 @@ and config = {
   newlinesAboveComments: int;
   (* Newlines above doc comments *)
   newlinesAboveDocComments: int;
+  (* Allow interleaving of whitespace indicated by Whitespace(n, layout) *)
+  allowWhitespace: bool;
   break: break_criterion;
   (* Break setting that becomes activated if a comment becomes interleaved into
    * this list. Typically, if not specified, the behavior from [break] will be
@@ -155,6 +158,9 @@ let dump ppf layout =
       traverse indent' right;
     | Easy e ->
       printf "%s Easy: '%s' \n" indent (string_of_easy e)
+    | Whitespace (n, sublayout) ->
+      printf" %s Whitespace (%d):\n" indent n;
+      (traverse (indent_more indent) sublayout)
   in
   traverse "" layout
 
@@ -218,6 +224,8 @@ let to_easy_format layout =
     | SourceMap (_, subLayout) ->
       traverse subLayout
     | Easy e -> e
+    | Whitespace (_, subLayout) ->
+      traverse subLayout
   in
   traverse layout
 

--- a/src/reason-parser/reason_layout.ml
+++ b/src/reason-parser/reason_layout.ml
@@ -62,8 +62,6 @@ and config = {
   newlinesAboveComments: int;
   (* Newlines above doc comments *)
   newlinesAboveDocComments: int;
-  (* Allow interleaving of whitespace indicated by Whitespace(n, layout) *)
-  allowWhitespace: bool;
   break: break_criterion;
   (* Break setting that becomes activated if a comment becomes interleaved into
    * this list. Typically, if not specified, the behavior from [break] will be

--- a/src/reason-parser/reason_location.ml
+++ b/src/reason-parser/reason_location.ml
@@ -1,17 +1,72 @@
-type range = {
-  lnum_start: int;
-  lnum_end: int
-}
+module Comment = Reason_comment
 
-let makeRangeBetween loc1 loc2 = Location.{
-  lnum_start = loc1.loc_end.pos_lnum + 1;
-  lnum_end = loc2.loc_start.pos_lnum - 1;
-}
+module Range = struct
+  (** [t] represents an interval, including endpoints,
+   * delimited by two linenumbers. *)
+  type t = {
+    lnum_start: int;
+    lnum_end: int
+  }
 
-let printRange r =
-  print_string "range: {lnum_start: ";
-  print_int r.lnum_start;
-  print_string ", lnum_end: ";
-  print_int r.lnum_end;
-  print_string "};";
-  print_newline ()
+  (**
+   * make a range delimited by [loc1] and [loc2]
+   * 1| let a = 1;
+   * 2|
+   * 3|
+   * 4|
+   * 5| let b = 2;
+   * If loc1 represents `let a = 1` and loc2 represents `let b = 2`,
+   * we get the range: {lnum_start: 2; lnum_end 4}
+   *)
+  let makeRangeBetween loc1 loc2 = Location.{
+    lnum_start = loc1.loc_end.pos_lnum + 1;
+    lnum_end = loc2.loc_start.pos_lnum - 1;
+  }
+
+  (** check whether [range] contains the [loc] *)
+  let containsLoc range loc =
+    let open Location in
+    range.lnum_start <= loc.loc_start.pos_lnum
+    && range.lnum_end >= loc.loc_end.pos_lnum
+
+  (**
+   * checks if [range] contains whitespace.
+   * When comments are passed, the computation
+   * takes the height of the comments into account.
+   *
+   * Example:
+   * 1| let a = 1;
+   * 2|
+   * 3| /* a multi-
+   * 4|   line comment */
+   * 5| let b = 1;
+   * The range (line 2 - line 4) has whitespace.
+   *
+   * 1| let a = 1;
+   * 2| /* a multi-
+   * 3|   line comment */
+   * 4| let b = 1;
+   * The range (line 2 - line 3) does not have whitespace.
+   *)
+  let containsWhitespace ?comments ~range () =
+    (* compute the amount of lines the comments occupy in the given range *)
+    let h = match comments with
+    | Some(comments) ->
+      List.fold_left (fun acc (curr : Comment.t) ->
+        let cl = Comment.location curr in
+        let open Location in
+        let startLnum = cl.loc_start.pos_lnum in
+        let endLnum = cl.loc_end.pos_lnum in
+        if containsLoc range cl then
+          acc + (endLnum - startLnum + 1)
+        else acc
+        ) 0 comments
+    | None -> 0
+    in
+    range.lnum_end - range.lnum_start - h >= 0
+end
+
+(** compute if there's space (one or more line) between [loc1] and [loc2] *)
+let hasSpaceBetween loc1 loc2 =
+  Location.(loc1.loc_start.pos_lnum - loc2.loc_end.pos_lnum) > 1
+

--- a/src/reason-parser/reason_location.ml
+++ b/src/reason-parser/reason_location.ml
@@ -1,0 +1,17 @@
+type range = {
+  lnum_start: int;
+  lnum_end: int
+}
+
+let makeRangeBetween loc1 loc2 = Location.{
+  lnum_start = loc1.loc_end.pos_lnum + 1;
+  lnum_end = loc2.loc_start.pos_lnum - 1;
+}
+
+let printRange r =
+  print_string "range: {lnum_start: ";
+  print_int r.lnum_start;
+  print_string ", lnum_end: ";
+  print_int r.lnum_end;
+  print_string "};";
+  print_newline ()

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -1039,7 +1039,7 @@ let only_core_type t startp endp =
     let loc = mklocation startp endp in
     raiseSyntaxErrorFromSyntaxUtils loc "Record type is not allowed"
 
-let doc_loc = {txt = "ocaml.doc"; loc = Location.none}
+let doc_loc loc = {txt = "ocaml.doc"; loc = loc}
 
 let doc_attr text loc =
   let open Parsetree in
@@ -1051,7 +1051,7 @@ let doc_attr text loc =
   let item =
     { pstr_desc = Pstr_eval (exp, []); pstr_loc = exp.pexp_loc }
   in
-    (doc_loc, PStr [item])
+    (doc_loc loc, PStr [item])
 
 %}
 

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -1390,6 +1390,21 @@ let rec prependSingleLineComment ?newlinesAboveDocComments:(newlinesAboveDocComm
           let withComment =  Layout.Whitespace(nextInfo, sub) in
           withComment
         else
+          let commentsInRange = List.filter (fun (beginLine, endLine) ->
+               beginLine >= (fst intv)
+            && endLine <= (snd intv)
+            && endLine < cl.loc_start.pos_lnum
+          ) !commentDb in
+          let hasCommentAbove = match commentsInRange with
+          | x::_ -> true
+          | [] -> false
+          in
+
+          let nextInfo = { nextInfo with depth =
+            if cl.loc_start.pos_lnum > (fst intv) && not hasCommentAbove then
+              1
+            else nextInfo.depth
+          } in
           let sub = breakline (formatComment comment) sub in
           let withComment =  Layout.Whitespace(nextInfo, sub) in
           withComment

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -1429,7 +1429,18 @@ let rec insertSingleLineComment layout comment =
       (* Nothing in the list is after comment, attach comment to the statement before the comment *)
       | [] ->
         let break sublayout = breakline sublayout (formatComment comment) in
-        Sequence (listConfig, Reason_syntax_util.map_last break beforeComment)
+        let items = match List.rev beforeComment with
+        | x :: xs ->
+          let first = begin match x with
+          | Layout.Whitespace(n, sub) ->
+              Layout.Whitespace(n, breakline (formatComment comment) sub)
+          | l -> break l
+          end in
+          List.rev (first :: xs)
+        | [] -> []
+        in
+        (* Sequence (listConfig, Reason_syntax_util.map_last break beforeComment) *)
+        Sequence (listConfig, items)
       | hd::tl ->
         let afterComment =
           match Layout.get_location hd with


### PR DESCRIPTION
# Intelligent Whitespace interleaving

## What does this mean?
Whitespace inserted by the user will be tracked and preserved by refmt in certain places.
Amount of newlines interleaved (or lack thereof) is now deducted from whitespace
interleaved in the source instead of hard coded defaults in the printer.
More than one newline will be collapsed into one newline.

Example:
```reason
open Multicore;
open React; /* no newline above */

/* newline above */
let add = (a, b) => {
  let a = 1;

  let b = 1; /* the newline above this let binding is preserved */
  a + b;
};

/* another comment */
/* attach this comment to the above comment */

/* but here we want a newline above */
```

## Where is whitespace inserted by the user preserved?

* structure items (both top-level in a `.re` file & inside `module X = { ... }`)
* signature items (both top-level in a `.rei` file & inside `module type Y = { ... }`)
* inside let-bindings

## How does it work?

Preserving whitespace can be split into two parts:
1) Computation of inserted whitespace (whitespace isn't part of the AST)
2) Formatting of the computed whitespace into the layout tree (without disrupting comment insertion)

### Computation of whitespace
The Ocaml-AST doesn't contain whitespace. This isn't a problem, since whitespace
between two items can easily be computed based on the location diff between two items.

Imagine the following source code:
```reason
1| let a = 1;
2|
3| let b = 2;
```
We can easily determine if there's whitespace between `let a` and `let b`,
by substracting the linenumber of the start of `let b` by the linenumber of the end
of `let a`. If the diff is equal to or greater than 1, we know that there's whitespace.

```reason
let whitespace = loc2.loc_start.pos_lnum - loc1.loc_end.pos_lnum >= 1
```

In practise the computation is a little bit more complex because of comments.
```reason
1| let a = 1;
2| /* comment on line 2 */
3| let b = 1;
```
Here the location diff indicates whitespace, but the comment fills up the space between
the two items. The correct diff is:
```reason
let whitespace = loc2.loc_start.pos_lnum - loc1.loc_end.pos_lnum - height_of_comments_between >= 1
```

### Formatting computed whitespace (without disrupting comment insertion)
Once we know we need to interleave whitespace between two items, we can't just
print an `atom "\n"` node. This would clash with the comment interleaving
algorithm. Without inspecting every atom for possible `\n` text, we would get
the following scenario

```reason
before refmt        after refmt
------------       ------------
let a = 1;      |  let a = 1;
                |  /* comment */ --> attached above `let b = 2;`
/* comment */   |               --> atom "\n", was formatted before 
let b = 2;      |  let b = 2;
```

To circumvent this problem, whitespace needs to be interleaved after all
comments have been inserted into the layout.
In order to postpone the insertion of whitespace to the last moment,
the following layout made its way into existence:

```reasonm
  type layout =
      ...
    | Whitespace of WhitespaceRegion.t * t
```
`Whitespace` is a specific type of layout. It conveys an
"intent to interleave whitespace". It decorates a layout with information
for whitespace insertion above that node.
`WhitespaceRegion.t` contains specific info
about the region where whitespace should be interleaved.
The info is used for correct comment interleaving inside of the region
designated for whitespace.

## Perfomance implications
To compute if a range in the source code contains whitespace,
we need the comments for that range. Every time the whitespace computation
happens, we need to traverse all comments to find the comments that overlap.
The traversal of comments can be improved by storing the comments inside a
interval-(Red/Black or AVL)tree for cheaper lookup.

As a benchmark reference: there's a slowdown of around 50ms with this diff,
on a 10000 line file. Reason_pprint_ast.ml (formatted in Reason) was taken
as reference point on a MacBook Pro 2015 i5.

The comment interleaving algorithm in general is very slow, for every comment
we create a create/travers the/a whole new tree.
There is definitely room for improvement here. The performance will be adressed
in a separate PR. 