### PR TITLE
Fix underscore sugar printing bug with string/array/bigarray access sugar.

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/basics.re
+++ b/formatTest/typeCheckedTests/expected_output/basics.re
@@ -22,6 +22,10 @@ let l2 =
   |> List.map(incr(~v=_))
   |> List.length;
 
+let a1 = [|1, 2, 3|] |> Array.get(_, 1);
+
+let s1 = "roses are red" |> String.get(_, 4);
+
 let optParam = (~v=?, ()) => v == None ? 0 : 1;
 
 let l1 =

--- a/formatTest/typeCheckedTests/input/basics.re
+++ b/formatTest/typeCheckedTests/input/basics.re
@@ -14,6 +14,10 @@ let l1 = [1,2,3] |> List.map(incr(~v=_)) |> List.length;
 
 let l2 = [1,2,3] |> List.map(incr(~v =_)) |> List.length;
 
+let a1 = [|1, 2, 3|] |> Array.get(_, 1);
+
+let s1 = "roses are red" |> String.get(_, 4);
+
 let optParam = (~v=?, ()) => v == None ? 0 : 1;
 
 let l1 =

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1395,3 +1395,12 @@ let result =
   });
 
 let result = F.call(x => doStuff(x));
+
+let () =
+  x |> Bigarray.Genarray.get(_, [|1, 2, 3, 4|]);
+
+let () = x |> Bigarray.Array1.get(_, 1);
+
+let () = x |> Bigarray.Array2.get(_, 1, 2);
+
+let () = x |> Bigarray.Array3.get(_, 1, 2, 3);

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -1141,3 +1141,11 @@ let result =
   });
 
 let result = F.call(x => doStuff(x));
+
+let () = x |> Bigarray.Genarray.get(_, [|1, 2, 3, 4|]);
+
+let () = x |> Bigarray.Array1.get(_, 1);
+
+let () = x |> Bigarray.Array2.get(_, 1, 2);
+
+let () = x |> Bigarray.Array3.get(_, 1, 2, 3);

--- a/src/reason-parser/reason_heuristics.ml
+++ b/src/reason-parser/reason_heuristics.ml
@@ -90,3 +90,8 @@ let bsExprCanBeUncurried expr =
   | Pexp_fun _
   | Pexp_apply _ -> true
   | _ -> false
+
+let isUnderscoreIdent expr =
+  match Ast_404.Parsetree.(expr.pexp_desc) with
+  | Pexp_ident ({txt = Lident "_"}) -> true
+  | _ -> false


### PR DESCRIPTION
fixes https://github.com/facebook/reason/issues/1889
```reason
let () = x |> Array.get(_, 0);
// should not reformat to
let () = x |> _.[0]
```
cc @chenglou @cristianoc 