### PR TITLE
Fix parsing/lexing of jsx inside a list under open sugar.

### DIFF
--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -244,3 +244,17 @@ let y = [
   }>
   child
 </description>;
+
+Module.[
+  <Component> <div test="asd" /> </Component>,
+];
+
+Module.[<Component> <div /> </Component>];
+
+Module.[<Foo> <Bar /> </Foo>];
+
+Module.[<Component />];
+
+let (/></) = (a, b) => a + b;
+
+let x = foo /></ bar;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -143,3 +143,12 @@ let y = [<Button onClick=handleStaleClick />, <Button onClick=handleStaleClick /
 <description term=([@JSX] text(~text="Age", ()))>child</description>;
 
 <description term={<div superLongPunnedProp anotherSuperLongOneCrazyLongThingHere text="Age" />}> child </description>;
+
+Module.[<Component><div test="asd" /></Component>];
+Module.[<Component><div/></Component>];
+Module.[<Foo><Bar/></Foo>];
+Module.[<Component />];
+
+let (/></) = (a, b) => a + b;
+
+let x = foo /></ bar;

--- a/src/reason-parser/reason_lexer.mll
+++ b/src/reason-parser/reason_lexer.mll
@@ -573,6 +573,12 @@ rule token = parse
     set_lexeme_length lexbuf 2;
     LBRACKETBAR
   }
+    (* allow parsing of <div /></Component> *)
+  | "/></" uppercase_or_lowercase+ {
+    (* allow parsing of <div asd=1></div> *)
+    set_lexeme_length lexbuf 2;
+    SLASHGREATER
+  }
   | "></" uppercase_or_lowercase+ {
     (* allow parsing of <div asd=1></div> *)
     set_lexeme_length lexbuf 1;

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -2959,6 +2959,14 @@ parenthesized_expr:
     }
   | mod_longident DOT as_loc(LBRACKETBAR) expr_list as_loc(error)
     { unclosed_exp (with_txt $3 "[|") (with_txt $5 "|]") }
+  (* Parse Module.[<Component> <div/> </Component>] *)
+  | as_loc(mod_longident) DOT LBRACKETLESS jsx_without_leading_less RBRACKET
+    { let seq, ext_opt = [$4], None in
+      let loc = mklocation $startpos($4) $endpos($4) in
+      let list_exp = make_real_exp (mktailexp_extension loc seq ext_opt) in
+      let list_exp = { list_exp with pexp_loc = loc } in
+      mkexp (Pexp_open (Fresh, $1, list_exp))
+    }
   | as_loc(mod_longident) DOT LBRACKET expr_comma_seq_extension RBRACKET
     { let seq, ext_opt = $4 in
       let loc = mklocation $startpos($4) $endpos($4) in


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/1893

Allow:
```
  Module.[<Component />];
```