### PR TITLE
Wrap vendored easy_format in a new name

### DIFF
--- a/src/reason-parser/reason_layout.ml
+++ b/src/reason-parser/reason_layout.ml
@@ -1,4 +1,5 @@
 module Comment = Reason_comment
+module Easy_format = Reason_easy_format.Easy_format
 
 type break_criterion =
   | Never

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -46,6 +46,7 @@
 
 (* TODO more fine-grained precedence pretty-printing *)
 
+module Easy_format = Reason_easy_format.Easy_format
 open Ast_404
 open Asttypes
 open Location

--- a/src/reason-parser/vendor/easy_format/jbuild
+++ b/src/reason-parser/vendor/easy_format/jbuild
@@ -1,6 +1,5 @@
 (jbuild_version 1)
 
 (library
- ((name reason.easy_format)
-  (public_name reason.easy_format)
-  (wrapped false)))
+ ((name reason_easy_format)
+  (public_name reason.easy_format)))


### PR DESCRIPTION
This helps avoid conflicts with yojson in rtop, for example.

I've only tested with native as I don't have an npm/bucklescript on my system.

Fixes #1740 