### PR TITLE
Fix comments erroneously interleaved in presence of switch expr with extension points

### DIFF
--- a/formatTest/unit_tests/expected_output/extensions.re
+++ b/formatTest/unit_tests/expected_output/extensions.re
@@ -310,3 +310,11 @@ let x = {
   | None => ()
   | Some(1) => ();
 };
+
+let _ =
+  switch%ext (expr) {
+  | A =>
+    /* Comment under A */
+    ()
+  | B => ()
+  };

--- a/formatTest/unit_tests/input/extensions.re
+++ b/formatTest/unit_tests/input/extensions.re
@@ -291,3 +291,11 @@ let x = {
     | None => ()
     | Some(1) => ();
 };
+
+let _ =
+  switch%ext (expr) {
+  | A =>
+    /* Comment under A */
+    ()
+  | B => ()
+  };

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4537,6 +4537,11 @@ let printer = object(self:'self)
   method expression_requiring_parens_in_infix x =
     let {stdAttrs} = partitionAttributes x.pexp_attributes in
     assert (stdAttrs == []);
+    (* keep the incoming expression around, an expr with
+     * immediate extension sugar might contain less than perfect location
+     * info in its children (used for comment interleaving), the expression passed to
+     * 'expression_requiring_parens_in_infix' contains the correct location *)
+    let originalExpr = x in
     let extension, x = expression_immediate_extension_sugar x in
     match x.pexp_desc with
       (* The only reason Pexp_fun must also be wrapped in parens when under
@@ -4610,7 +4615,9 @@ let printer = object(self:'self)
           | Pexp_match (e, l) ->
              let estimatedBracePoint = {
                loc_start = e.pexp_loc.loc_end;
-               loc_end = x.pexp_loc.loc_end;
+               (* See originalExpr binding, for more info.
+                * It contains the correct location under immediate extension sugar *)
+               loc_end = originalExpr.pexp_loc.loc_end;
                loc_ghost = false;
              }
              in


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/1906

The location info for the sourcemap around the `switch` (matchexpression) in`switch%ext`, is marked as ghost in the presence of an extension. By using the location info on the extension which contains the matchexpression we get a correct sourcemap: results in correct comment interleaving.

```reason
/* original */
let _ =
  switch%ext (expr) {
  | A =>
    /* Comment under A */
    ()
  | B => ()
  };

/* before this patch */
let _ =
  switch%ext (expr)
    {
    | A => ()
    | B => ()
    };
    /* Comment under A */

/* with this patch */
let _ =
  switch%ext (expr) {
  | A =>
    /* Comment under A */
    ()
  | B => ()
  };

```