### PR TITLE
Allow whitespace interleaving between cases in pattern matching.

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -266,6 +266,7 @@ let res =
       _, /* retain this */
       _ /* retain this */
     ) => "result of X"
+
   /* Above Y line */
   | Y(_) => "result of Y" /* End of arrow and Y line */
   };

--- a/formatTest/unit_tests/expected_output/whitespace.re
+++ b/formatTest/unit_tests/expected_output/whitespace.re
@@ -138,6 +138,40 @@ let main = () => {
   ();
 };
 
+module PatternMatching = {
+  let x =
+    switch (color) {
+    | Black => ()
+
+    | Red => ()
+
+    | White => ()
+    };
+
+  /* with comments */
+  let color =
+    switch (color) {
+    /* c1 */
+
+    /* c2 */
+    | Black => "black"
+
+    /* c3 */
+
+    /* c4 */
+    /* c5 */
+
+    /* c6 */
+    | Green => "green"
+
+    /* multi
+       line
+       comment */
+
+    | Blue => "blue"
+    };
+};
+
 module EdgeCase = {
   let x = 1; /* a */
 

--- a/formatTest/unit_tests/input/whitespace.re
+++ b/formatTest/unit_tests/input/whitespace.re
@@ -144,6 +144,39 @@ let main = () => {
   ();
 };
 
+module PatternMatching = {
+  let x = switch(color) {
+  | Black => ()
+
+  | Red => ()
+
+  | White => ()
+  };
+
+  /* with comments */
+  let color = switch (color) {
+  /* c1 */
+
+  /* c2 */
+  | Black =>
+      "black"
+
+  /* c3 */
+
+  /* c4 */
+  /* c5 */
+
+  /* c6 */
+  | Green => "green"
+
+  /* multi
+     line
+     comment */
+
+  | Blue => "blue"
+  };
+};
+
 module EdgeCase = {
   let x = 1; /* a */
 

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -3247,8 +3247,13 @@ let_binding_body:
 %inline match_cases(EXPR): lnonempty_list(match_case(EXPR)) { $1 };
 
 match_case(EXPR):
-  BAR pattern preceded(WHEN,expr)? EQUALGREATER EXPR
-  { Exp.case $2 ?guard:$3 $5 }
+  as_loc(BAR) pattern preceded(WHEN,expr)? EQUALGREATER EXPR
+  { let pat = {$2 with ppat_loc =
+      { $2.ppat_loc with
+        loc_start = $1.loc.loc_start
+      }
+    } in
+    Exp.case pat ?guard:$3 $5 }
 ;
 
 fun_def(DELIM, typ):

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -6698,7 +6698,11 @@ let printer = object(self:'self)
         (makeList ~break:Always_rec ~inline:(true, true)
            (List.map bar (appendLabelToLast orsWithWhereAndArrowOnLast rhs)))
     in
-    List.map case_row l
+    groupAndPrint
+      ~xf:case_row
+      ~getLoc:(fun {pc_lhs; pc_rhs} -> {pc_lhs.ppat_loc with loc_end = pc_rhs.pexp_loc.loc_end})
+      ~comments:self#comments
+      l
 
   (* Formats a list of a single expr param in such a way that the parens of the function or
    * (poly)-variant application and the wrapping of the param stick together when the layout breaks.


### PR DESCRIPTION
Collapse/preserve n >= 1 whitespaces between cases in pattern matching into one newline between the cases. This allows better grouping of cases when desired. Pattern matching suffers from less claustrofobia if the user wants to preserve the whitespace. If there isn't whitespace inserted between the cases, there won't be any extra newlines. This behaviour is also the default in tools like Prettier and Golang.