### PR TITLE
Interleave and attach doc comments correct on signatures

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -17,22 +17,22 @@
 
 /**Floating doc text should be removed*/;
 
-[@itemAttributeOnTypeDef]
 /**removed text on type def*/
+[@itemAttributeOnTypeDef]
 type itemText = int;
 type nodeText = /**removed text on item*/ int;
-[@itemAttributeOnTypeDef]
 /**removed text on type def*/
+[@itemAttributeOnTypeDef]
 type nodeAndItemText =
   /**removed text on item*/ int;
 
-[@itemAttributeOnTypeDef]
 /**removed doc on type def*/
+[@itemAttributeOnTypeDef]
 type itemDoc = int;
 [@itemAttributeOnTypeDef]
 type nodeDoc = /**removed text on item*/ int;
-[@itemAttributeOnTypeDef]
 /**removed doc on type def*/
+[@itemAttributeOnTypeDef]
 type nodeAndItemDoc =
   /**removed text on item*/ int;
 

--- a/formatTest/typeCheckedTests/expected_output/mlSyntax.re
+++ b/formatTest/typeCheckedTests/expected_output/mlSyntax.re
@@ -94,6 +94,7 @@ let nestedSomeSimple = Some(Some((1, 2, 3)));
 
 module EM = {
   /** Exception */
+
   exception E(int, int);
 };
 

--- a/formatTest/typeCheckedTests/expected_output/mlSyntax.re.4.02.3
+++ b/formatTest/typeCheckedTests/expected_output/mlSyntax.re.4.02.3
@@ -94,6 +94,7 @@ let nestedSomeSimple = Some(Some((1, 2, 3)));
 
 module EM = {
   /** Exception */
+
   exception E(int, int);
 };
 

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -105,6 +105,7 @@ and secondRecursiveClass (init) = {
 /**
  * Anonymous objects.
  */
+
 type closedObj = {.};
 
 let (<..>) = (a, b) => a + b;

--- a/formatTest/unit_tests/expected_output/whitespace.rei
+++ b/formatTest/unit_tests/expected_output/whitespace.rei
@@ -3,6 +3,17 @@
 /* a */
 let a: int;
 
+/** Hi I'm a doc comment for some_definition */
+let some_definition:
+  (
+    ~what_a_long_label: M.its_a_type,
+    ~just_need_to_make_this: long_enough_to_wrap
+  ) =>
+  unit;
+
+/** Hi I'm a doc comment for another_definition */
+let another_definition: unit => unit;
+
 /* b */
 let b: int;
 /* trailing */
@@ -12,6 +23,226 @@ let b: int;
 
 /* amazing */
 let f: int => int;
+
+/** stick to x */
+type x = string;
+
+/** one newline below */
+
+type x = string;
+
+/** one newline below with comment */
+
+/* comment */
+type x = string;
+
+/** doc comment attached */
+type payload =
+  | PStr(structure)
+  | PSig(signature)
+  | PTyp(core_type)
+  | PPat(pattern, option(expression));
+
+/** doc comment with whitespace */
+
+type payload =
+  | PStr(structure)
+  | PSig(signature)
+  | PTyp(core_type)
+  | PPat(pattern, option(expression));
+
+/** doc comment with whitespace and comment below */
+
+/* comment here */
+type payload =
+  | PStr(structure)
+  | PSig(signature)
+  | PTyp(core_type)
+  | PPat(pattern, option(expression));
+
+/** doc attached */
+type core_type = {
+  ptyp_desc: core_type_desc,
+  ptyp_loc: Location.t,
+  ptyp_attributes: attributes,
+};
+
+/** doc attached with newline */
+
+type core_type = {
+  ptyp_desc: core_type_desc,
+  ptyp_loc: Location.t,
+  ptyp_attributes: attributes,
+};
+
+/** doc attached with newline and comments */
+
+/* comment1 */
+
+/* comment2 */
+type core_type = {
+  ptyp_desc: core_type_desc,
+  ptyp_loc: Location.t,
+  ptyp_attributes: attributes,
+};
+
+/** doc attached */
+type water +=
+  | H20
+  | Spritzer;
+
+/** doc with newline */
+
+type water +=
+  | H20
+  | Spritzer;
+
+/** doc with newline and comment */
+
+/* test */
+type water +=
+  | H20
+  | Spritzer;
+
+/** doc attached */
+exception Key_not_found(string);
+
+/** doc attached with newline  */
+
+exception Key_not_found(string);
+
+/** doc attached with newline and comment  */
+
+/* comment */
+exception Key_not_found(string);
+
+/** doc on open */
+open Belt;
+
+/** doc on open with whitespace */
+
+open Belt;
+
+/** doc on open with whitespace and comment */
+
+/* test */
+open Belt;
+
+/** doc attached */
+include Shared;
+
+/** doc attached with whitespace */
+include Shared;
+
+/** doc attached with whitespace and comment */
+
+/* test */
+include Shared;
+
+/** doc attached */
+module type X = {let x: int;};
+
+/** doc attached with whitespace */
+
+module type X = {let x: int;};
+
+/** doc attached with whitespace and comment */
+
+/* test */
+module type X = {let x: int;};
+
+/** doc attached */
+module X: MX;
+
+/** doc attached with whitespace */
+
+module X: MX;
+
+/** doc attached with whitespace and comment */
+
+/* test */
+module X: MX;
+
+/** doc attached */
+module X = MX;
+
+/** doc attached with whitespace */
+
+module X = MX;
+
+/** doc attached with whitespace and comment */
+
+/* test */
+module X = MX;
+
+/** doc attr attached */
+class type x = {
+  pub height: int
+};
+
+/** doc attr with newline */
+
+class type x = {
+  pub height: int
+};
+
+/** doc attr with newline and comment */
+
+/* test */
+class type x = {
+  pub height: int
+};
+
+/** doc attr attached */;
+[@id];
+
+/** doc attr with newline */;
+
+[@id];
+
+/** doc attr with newline and comment */;
+
+/* test */
+[@id];
+
+/** doc attr attached */
+[%%obj {a: 1}];
+
+/** doc attr attached with newline */
+
+[%%obj {a: 1}];
+
+/** doc attr attached with newline and comment */
+
+/* test */
+[%%obj {a: 1}];
+
+/** doc attached */
+class reason : ocaml;
+
+/** doc attached with whitespace */
+
+class reason : ocaml;
+
+/** doc attached with whitespace and comment */
+
+/* test */
+class reason : ocaml;
+
+/** doc attached */
+module rec X1: Y1
+and X2: Y2;
+
+/** doc attached with whitespace */
+
+module rec X1: Y1
+and X2: Y2;
+
+/** doc attached with whitespace and comment */
+
+/* comment */
+module rec X1: Y1
+and X2: Y2;
 
 /* notice the whitespace after the last signature item */
 

--- a/formatTest/unit_tests/input/whitespace.rei
+++ b/formatTest/unit_tests/input/whitespace.rei
@@ -3,6 +3,17 @@
 /* a */
 let a: int;
 
+/** Hi I'm a doc comment for some_definition */
+let some_definition:
+  (
+    ~what_a_long_label: M.its_a_type,
+    ~just_need_to_make_this: long_enough_to_wrap
+  ) =>
+  unit;
+
+/** Hi I'm a doc comment for another_definition */
+let another_definition: unit => unit;
+
 /* b */
 let b: int;
 /* trailing */
@@ -12,6 +23,227 @@ let b: int;
 
 /* amazing */
 let f: int => int;
+
+/** stick to x */
+type x = string;
+
+/** one newline below */
+
+type x = string;
+
+
+/** one newline below with comment */
+
+/* comment */
+type x = string;
+
+/** doc comment attached */
+type payload =
+|	PStr(structure)
+|	PSig(signature)
+|	PTyp(core_type)
+|	PPat(pattern, option(expression));
+
+/** doc comment with whitespace */
+
+type payload =
+|	PStr(structure)
+|	PSig(signature)
+|	PTyp(core_type)
+|	PPat(pattern, option(expression));
+
+/** doc comment with whitespace and comment below */
+
+/* comment here */
+type payload =
+|	PStr(structure)
+|	PSig(signature)
+|	PTyp(core_type)
+|	PPat(pattern, option(expression));
+
+/** doc attached */
+type core_type = {
+  ptyp_desc: core_type_desc,
+  ptyp_loc: Location.t,
+  ptyp_attributes: attributes,
+};
+
+/** doc attached with newline */
+
+type core_type = {
+  ptyp_desc: core_type_desc,
+  ptyp_loc: Location.t,
+  ptyp_attributes: attributes,
+};
+
+/** doc attached with newline and comments */
+
+/* comment1 */
+
+/* comment2 */
+type core_type = {
+  ptyp_desc: core_type_desc,
+  ptyp_loc: Location.t,
+  ptyp_attributes: attributes,
+};
+
+/** doc attached */
+type water +=
+  | H20
+  | Spritzer;
+
+/** doc with newline */
+
+type water +=
+  | H20
+  | Spritzer;
+
+/** doc with newline and comment */
+
+/* test */
+type water +=
+  | H20
+  | Spritzer;
+
+/** doc attached */
+exception Key_not_found(string);
+
+/** doc attached with newline  */
+
+exception Key_not_found(string);
+
+/** doc attached with newline and comment  */
+
+/* comment */
+exception Key_not_found(string);
+
+/** doc on open */
+open Belt;
+
+/** doc on open with whitespace */
+
+open Belt;
+
+/** doc on open with whitespace and comment */
+
+/* test */
+open Belt;
+
+/** doc attached */
+include Shared;
+
+/** doc attached with whitespace */
+include Shared;
+
+/** doc attached with whitespace and comment */
+
+/* test */
+include Shared;
+
+/** doc attached */
+module type X = {let x: int};
+
+/** doc attached with whitespace */
+
+module type X = {let x: int};
+
+/** doc attached with whitespace and comment */
+
+/* test */
+module type X = {let x: int};
+
+/** doc attached */
+module X : MX;
+
+/** doc attached with whitespace */
+
+module X : MX;
+
+/** doc attached with whitespace and comment */
+
+/* test */
+module X : MX;
+
+/** doc attached */
+module X = MX;
+
+/** doc attached with whitespace */
+
+module X = MX;
+
+/** doc attached with whitespace and comment */
+
+/* test */
+module X = MX;
+
+/** doc attr attached */
+class type x = {
+  pub height: int
+};
+
+/** doc attr with newline */
+
+class type x = {
+  pub height: int
+};
+
+/** doc attr with newline and comment */
+
+/* test */
+class type x = {
+  pub height: int
+};
+
+/** doc attr attached */
+[@id];
+
+/** doc attr with newline */
+
+[@id];
+
+/** doc attr with newline and comment */
+
+/* test */
+[@id];
+
+/** doc attr attached */
+[%%obj {a: 1}];
+
+/** doc attr attached with newline */
+
+[%%obj {a: 1}];
+
+/** doc attr attached with newline and comment */
+
+/* test */
+[%%obj {a: 1}];
+
+/** doc attached */
+class reason : ocaml;
+
+/** doc attached with whitespace */
+
+class reason : ocaml;
+
+/** doc attached with whitespace and comment */
+
+/* test */
+class reason : ocaml;
+
+/** doc attached */
+module rec X1: Y1
+and X2: Y2;
+
+/** doc attached with whitespace */
+
+module rec X1: Y1
+and X2: Y2;
+
+/** doc attached with whitespace and comment */
+
+/* comment */
+module rec X1: Y1
+and X2: Y2;
 
 /* notice the whitespace after the last signature item */
 

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -1770,7 +1770,7 @@ signature:
 signature_item:
   | item_attributes
     LET as_loc(val_ident) COLON core_type
-    { let loc = mklocation $symbolstartpos $endpos in
+    { let loc = mklocation $startpos($2) $endpos in
       Psig_value (Val.mk $3 $5 ~attrs:$1 ~loc)
     }
   | item_attributes
@@ -3667,7 +3667,7 @@ primitive_declaration: nonempty_list(STRING { let (s, _, _) = $1 in s }) {$1};
 type_declarations:
   item_attributes TYPE nonrec_flag type_declaration_details
   { let (ident, params, constraints, kind, priv, manifest), endpos, and_types = $4 in
-    let loc = mklocation $symbolstartpos endpos in
+    let loc = mklocation $startpos($2) endpos in
     let ty = Type.mk ident ~params:params ~cstrs:constraints
              ~kind ~priv ?manifest ~attrs:$1 ~loc in
     ($3, ty :: and_types)


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/1929

Gives correct attachment of doc comments on signatures, interleaves whitespace where appropiate. 