### PR TITLE
Fix parsing & printing of es6 function syntax inside attribrutes

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -590,3 +590,6 @@ let test = {
   let s = "hello" ++ "!";
   [@attr2] Callbacks.("hello" ++ "!");
 };
+
+[@test.call string => string]
+let processCommandItem = 12;

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -488,3 +488,6 @@ let test = {
   let s = "hello" ++ "!";
   [@attr2] Callbacks.("hello" ++ "!");
 };
+
+[@test.call string => string]
+let processCommandItem = 12;

--- a/formatTest/unit_tests/expected_output/extensions.re
+++ b/formatTest/unit_tests/expected_output/extensions.re
@@ -347,3 +347,5 @@ let () = {
   /* 3. comment attached to next expr */
   something_else();
 };
+
+[%bs.raw x => x];

--- a/formatTest/unit_tests/expected_output/extensions.re
+++ b/formatTest/unit_tests/expected_output/extensions.re
@@ -69,7 +69,7 @@ while%extend (false) {
   ();
 };
 
-fun%extend () => ();
+[%extend () => ()];
 
 fun%extend
 | None => ()
@@ -99,7 +99,7 @@ let x =
     ();
   };
 
-let x = fun%extend () => ();
+let x = [%extend () => ()];
 
 let x =
   fun%extend
@@ -136,7 +136,7 @@ let x = [%extend1
   }
 ];
 
-let x = [%extend1 fun%extend2 () => ()];
+let x = [%extend1 [%extend2 () => ()]];
 
 let x = [%extend1
   fun%extend2
@@ -191,7 +191,7 @@ let x = {
 let x = {
   ignore();
   %extend1
-  fun%extend2 () => ();
+  [%extend2 () => ()];
   ignore();
 };
 
@@ -251,7 +251,7 @@ let x = {
 let x = {
   ignore();
   %extend1
-  fun%extend2 () => ();
+  [%extend2 () => ()];
   ignore();
 };
 
@@ -307,7 +307,7 @@ let x = {
 let x = {
   ignore();
   %extend1
-  fun%extend2 () => ();
+  [%extend2 () => ()];
 };
 
 let x = {

--- a/formatTest/unit_tests/input/extensions.re
+++ b/formatTest/unit_tests/input/extensions.re
@@ -321,3 +321,5 @@ let () = {
   /* 3. comment attached to next expr */
   something_else();
 };
+
+[%bs.raw x => x];

--- a/src/reason-parser/reason_lexer.mll
+++ b/src/reason-parser/reason_lexer.mll
@@ -919,6 +919,7 @@ and skip_sharp_bang = parse
 
   let inject_es6_fun = function
     | tok :: acc ->
+        print_endline "INJECTING";
       tok :: fake_triple ES6_FUN tok :: acc
     | _ -> assert false
 

--- a/src/reason-parser/reason_lexer.mll
+++ b/src/reason-parser/reason_lexer.mll
@@ -919,7 +919,6 @@ and skip_sharp_bang = parse
 
   let inject_es6_fun = function
     | tok :: acc ->
-        print_endline "INJECTING";
       tok :: fake_triple ES6_FUN tok :: acc
     | _ -> assert false
 

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -159,7 +159,7 @@ let expression_immediate_extension_sugar x =
   | Some (name, expr) ->
     match expr.pexp_desc with
     | Pexp_for _ | Pexp_while _ | Pexp_ifthenelse _
-    | Pexp_fun _ | Pexp_function _ | Pexp_newtype _
+    | Pexp_function _ | Pexp_newtype _
     | Pexp_try _ | Pexp_match _ ->
       (Some name, expr)
     | _ -> (None, x)


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/1937
Fixes https://github.com/facebook/reason/issues/1902