### PR TITLE
More helpful syntax error for trailing semicolon in record

### DIFF
--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -1033,7 +1033,7 @@ let prepend_attrs_to_labels attrs = function
   | x :: xs -> {x with pld_attributes = attrs @ x.pld_attributes} :: xs
 
 let raise_record_trailing_semi_error loc =
-  let msg = "Record entries are separated by comma; we've found a semicolon instead" in
+  let msg = "Record entries are separated by comma; we've found a semicolon instead." in
   raise Reason_syntax_util.(Error(loc, (Syntax_error msg)))
 
 %}

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -1033,9 +1033,7 @@ let prepend_attrs_to_labels attrs = function
   | x :: xs -> {x with pld_attributes = attrs @ x.pld_attributes} :: xs
 
 let raise_record_trailing_semi_error loc =
-  let msg = "Records pairs are delimited by commas. An unexpected trailing semicolon was found.
-Solution: remove the trailing semicolon from the record expression."
-  in
+  let msg = "Record entries are separated by comma; we've found a semicolon instead" in
   raise Reason_syntax_util.(Error(loc, (Syntax_error msg)))
 
 %}

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -2361,8 +2361,16 @@ mark_position_exp
       let msg = "Record construction must have at least one field explicitly set" in
       syntax_error_exp loc msg
     }
-  | LBRACE record_expr RBRACE
-    { let (exten, fields) = $2 in mkexp (Pexp_record(fields, exten)) }
+  | LBRACE record_expr SEMI? RBRACE
+    { match $3 with
+        | Some semiloc ->
+        (* If the record expr ends with a semicolon, show a friendly,
+         * clear message explaining how to fix. *)
+        let msg = "Records pairs are delimited by commas. An unexpected trailing semicolon was found.
+Solution: remove the trailing semicolon from the record expression."
+        in
+        raise Reason_syntax_util.(Error(mklocation $startpos($3) $endpos($3), (Syntax_error msg)))
+        | None -> let (exten, fields) = $2 in mkexp (Pexp_record(fields, exten)) }
   | as_loc(LBRACE) record_expr as_loc(error)
     { unclosed_exp (with_txt $1 "{") (with_txt $3 "}")}
   | LBRACE record_expr_with_string_keys RBRACE

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -2369,8 +2369,7 @@ mark_position_exp
     }
   | LBRACE DOTDOTDOT expr_optional_constraint SEMI RBRACE
     { let loc = mklocation $startpos($4) $endpos($4) in
-      raise_record_trailing_semi_error loc
-    }
+      raise_record_trailing_semi_error loc }
   | LBRACE record_expr RBRACE
     { let (exten, fields) = $2 in mkexp (Pexp_record(fields, exten)) }
   | as_loc(LBRACE) record_expr as_loc(error)
@@ -3403,8 +3402,14 @@ record_expr:
       raise_record_trailing_semi_error loc }
   | non_punned_lbl_expr COMMA?
     { (None, [$1]) }
+  | non_punned_lbl_expr SEMI
+    { let loc = mklocation $startpos($2) $endpos($2) in
+      raise_record_trailing_semi_error loc }
   | lbl_expr lnonempty_list(preceded(COMMA, lbl_expr)) COMMA?
     { (None, $1 :: $2) }
+  | lbl_expr lnonempty_list(preceded(COMMA, lbl_expr)) SEMI
+    { let loc = mklocation $startpos($3) $endpos($3) in
+      raise_record_trailing_semi_error loc }
 ;
 
 %inline non_punned_lbl_expr:


### PR DESCRIPTION
Fixes #1967 in the same style of #1925 