### PR TITLE
Remove extra space before external type definition

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -332,7 +332,7 @@ let myFun =
 /* Bucklescript FFI item attributes */
 
 [@bs.val]
-external imul : (int, int) => int = "Math.imul";
+external imul: (int, int) => int = "Math.imul";
 
 module Js = {
   type t('a);
@@ -391,13 +391,13 @@ type reactClass;
 
 /* "react-dom" shouldn't spread the attribute over multiple lines */
 [@bs.val] [@bs.module "react-dom"]
-external render : (reactElement, element) => unit =
+external render: (reactElement, element) => unit =
   "render";
 
-[@bs.module "f"] external f : int => int = "f";
+[@bs.module "f"] external f: int => int = "f";
 
 [@bs.val] [@bs.module "react"] [@bs.splice]
-external createCompositeElementInternalHack :
+external createCompositeElementInternalHack:
   (
     reactClass,
     {.. "reasonProps": 'props},
@@ -406,18 +406,18 @@ external createCompositeElementInternalHack :
   reactElement =
   "createElement";
 
-external add_nat : (int, int) => int =
+external add_nat: (int, int) => int =
   "add_nat_bytecode" "add_nat_native";
 
 [@bs.module "Bar"]
 [@ocaml.deprecated
   "Use bar instead. It's a much cooler function. This string needs to be a little long"
 ]
-external foo : bool => bool = "";
+external foo: bool => bool = "";
 
 /* Attributes on an entire polymorphic variant leaf */
 [@bs.module "fs"]
-external readFileSync :
+external readFileSync:
   (
     ~name: string,
     [@bs.string] [
@@ -429,7 +429,7 @@ external readFileSync :
   "";
 
 [@bs.module "fs"]
-external readFileSync2 :
+external readFileSync2:
   (
     ~name: string,
     [@bs.string] [
@@ -444,20 +444,19 @@ external readFileSync2 :
 [@test [@attr]
        [%%extension]];
 
-external debounce :
-  (int, [@bs.meth] unit) => unit =
+external debounce: (int, [@bs.meth] unit) => unit =
   "";
 
-external debounce :
+external debounce:
   int => [@bs.meth] (unit => unit) =
   "";
 
-external debounce :
+external debounce:
   (int, [@bs.meth] (unit => unit)) =>
   [@bs.meth] (unit => unit) =
   "";
 
-external debounce :
+external debounce:
   (
     int,
     [@bs.meth] (unit => unit),
@@ -466,7 +465,7 @@ external debounce :
   [@bs.meth] (unit => unit) =
   "";
 
-external debounce :
+external debounce:
   (
     int,
     [@bs.meth] (unit => unit),

--- a/formatTest/typeCheckedTests/expected_output/attributes.rei
+++ b/formatTest/typeCheckedTests/expected_output/attributes.rei
@@ -24,20 +24,20 @@ type reactClass;
 type reactElement;
 
 [@bs.val] [@bs.module "React"]
-external createClassInternalHack :
+external createClassInternalHack:
   t('classSpec) => reactClass =
   "createClass";
 
 [@bs.send.pipe: array('a)]
-external map : (. ('a => 'b)) => array('b) = "";
+external map: (. ('a => 'b)) => array('b) = "";
 
 [@bs.val] [@bs.module "react"]
-external createClassInternalHack :
+external createClassInternalHack:
   t('classSpec) => reactClass =
   "createClass";
 
 [@bs.val] [@bs.module "react"] [@bs.splice]
-external createCompositeElementInternalHack :
+external createCompositeElementInternalHack:
   (
     reactClass,
     t({.. reasonProps: 'props}),

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -981,7 +981,7 @@ let A | B | C = X;
 /** External function declaration
  *
  */
-external f : int => int = "foo";
+external f: int => int = "foo";
 
 let x = {contents: 0};
 

--- a/formatTest/unit_tests/expected_output/uncurried.re
+++ b/formatTest/unit_tests/expected_output/uncurried.re
@@ -141,7 +141,7 @@ add(. 2, [@bs] 3);
 type timerId;
 
 [@bs.val]
-external setTimeout :
+external setTimeout:
   ((. unit) => unit, int) => timerId =
   "setTimeout";
 

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -5839,8 +5839,11 @@ let printer = object(self:'self)
   *)
   method primitive_declaration vd =
     let lblBefore =
-      label ~space:true
-        (makeList ~postSpace:true [atom "external"; protectIdentifier vd.pval_name.txt; atom ":"])
+      label
+        ~space:true
+        (makeList
+           ~sepLeft:false
+           [(makeList ~postSpace:true [atom "external"; protectIdentifier vd.pval_name.txt]); (atom ":")])
         (self#core_type vd.pval_type)
     in
     let frstHalf = makeList ~postSpace:true [lblBefore; atom "="] in

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -5842,7 +5842,6 @@ let printer = object(self:'self)
       label
         ~space:true
         (makeList
-           ~sepLeft:false
            [(makeList ~postSpace:true [atom "external"; protectIdentifier vd.pval_name.txt]); (atom ":")])
         (self#core_type vd.pval_type)
     in


### PR DESCRIPTION
This is a follow-up to #1966, this time removing the extra space before type
definitions for external declarations.