### PR TITLE
Fix inconsistent printing of opening extension expressions.

### DIFF
--- a/formatTest/unit_tests/expected_output/extensions.re
+++ b/formatTest/unit_tests/expected_output/extensions.re
@@ -349,3 +349,9 @@ let () = {
 };
 
 [%bs.raw x => x];
+
+let work = () => {
+  open Syntax;
+  let%bind name = x;
+  name;
+};

--- a/formatTest/unit_tests/input/extensions.re
+++ b/formatTest/unit_tests/input/extensions.re
@@ -323,3 +323,5 @@ let () = {
 };
 
 [%bs.raw x => x];
+
+let work = () => { open Syntax; let%bind name = x; name; }

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -5385,6 +5385,7 @@ let printer = object(self:'self)
         | ([], Pexp_open (ovf, lid, e)) ->
           ovf == Fresh && self#isSeriesOfOpensFollowedByNonSequencyExpression e
         | ([], Pexp_letexception _) -> false
+        | ([], Pexp_extension _) -> false
         | _ -> true
 
   method unparseObject ?wrap:((lwrap,rwrap)=("", "")) ?(withStringKeys=false) l o =


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/1978

The `open` expr `open Syntax` in the example contains an extension as child expression.
This is a "sequency" expression and should not be formatted with the
open syntax sugar.

The following should be formatted as is:
```reason
let work = () => {
  open Syntax;
  let%bind name = x;
  name;
};
```