### PR TITLE
Fix `module type of` formatting

### DIFF
--- a/formatTest/unit_tests/expected_output/syntax.rei
+++ b/formatTest/unit_tests/expected_output/syntax.rei
@@ -28,3 +28,9 @@ let myRecordWithFunctions: adders;
  * Public result.
  */
 let result: int;
+
+/* https://github.com/facebook/reason/issues/1614 */
+module Event:
+  (module type of {
+     include ReactEventRe;
+   });

--- a/formatTest/unit_tests/expected_output/syntax.rei
+++ b/formatTest/unit_tests/expected_output/syntax.rei
@@ -30,7 +30,6 @@ let myRecordWithFunctions: adders;
 let result: int;
 
 /* https://github.com/facebook/reason/issues/1614 */
-module Event:
-  (module type of {
-     include ReactEventRe;
-   });
+module Event: (module type of {
+  include ReactEventRe;
+});

--- a/formatTest/unit_tests/input/syntax.rei
+++ b/formatTest/unit_tests/input/syntax.rei
@@ -27,3 +27,6 @@ let myRecordWithFunctions: adders;
  * Public result.
  */
 let result: int;
+
+/* https://github.com/facebook/reason/issues/1614 */
+module Event: (module type of { include ReactEventRe; });

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4236,6 +4236,19 @@ let printer = object(self:'self)
     let letPattern = (label ~space:true (atom labelOpener) bindingPattern) in
     (formatTypeConstraint letPattern typeConstraint)
 
+  method formatModuleTypeOfSignatureBinding labelOpener bindingPattern typeConstraint =
+    let letPattern = makeList
+        ~break:IfNeed
+        ~inline:(true, true)
+        [(atom labelOpener);
+         makeList
+           ~pad:(true, false)
+           [bindingPattern; atom ":"]]
+    in
+    makeList
+      ~inline:(true, true)
+      ~break:Always
+      [letPattern; makeList ~wrap:("  ", "") [typeConstraint]]
 
   (*
      The [bindingLabel] is either the function name (if let binding) or first
@@ -6438,7 +6451,9 @@ let printer = object(self:'self)
             in
             let layout =
               self#attach_std_item_attrs stdAttrs @@
-              self#formatSimpleSignatureBinding
+              (match pmd.pmd_type.pmty_desc with
+               | Pmty_typeof _ -> self#formatModuleTypeOfSignatureBinding
+               | _ -> self#formatSimpleSignatureBinding)
                 "module"
                 (atom pmd.pmd_name.txt)
                 (self#module_type pmd.pmd_type)


### PR DESCRIPTION
fixes https://github.com/facebook/reason/issues/1614

~This is definitely a little hacky and special-cased, but it also looks like we _want_ to special case this particular pattern.~

EDIT: Not as hacky now, and it prints much nicer.