### PR TITLE
for_completion: handle end of token situation

### DIFF
--- a/src/reason-parser/reason_lexer.mll
+++ b/src/reason-parser/reason_lexer.mll
@@ -1024,14 +1024,17 @@ and skip_sharp_bang = parse
   let completion_ident_pos = ref Lexing.dummy_pos
 
   let token lexbuf =
-    let before = lexbuf.Lexing.lex_curr_p.Lexing.pos_cnum in
+    let space_start = lexbuf.Lexing.lex_curr_p.Lexing.pos_cnum in
     let token = token lexbuf in
-    let after = lexbuf.Lexing.lex_start_p.Lexing.pos_cnum in
+    let token_start = lexbuf.Lexing.lex_start_p.Lexing.pos_cnum in
+    let token_stop = lexbuf.Lexing.lex_curr_p.Lexing.pos_cnum in
     if !completion_ident_offset > min_int &&
-       before <= !completion_ident_offset &&
-       after >= !completion_ident_offset then (
+       space_start <= !completion_ident_offset &&
+       token_stop >= !completion_ident_offset then (
       match token with
-      | LIDENT _ | UIDENT _ when after = !completion_ident_offset -> token
+      | LIDENT _ | UIDENT _ when token_start <= !completion_ident_offset ->
+          completion_ident_offset := min_int;
+          token
       | _ ->
         queued_tokens := save_triple lexbuf token :: !queued_tokens;
         completion_ident_offset := min_int;


### PR DESCRIPTION
When completing, `ocamlmerlin-reason` inserts an identifier if there is not one yet under the cursor.

The rationale is that completion will introduce an identifier in the buffer. So when starting completion on whitespace, an empty identifier is introduced.
This let the parser produce an AST as if the completion was already done. Then merlin can use the type information around this identifier to guide completion.

Unfortunately, the current code doesn't handle the case where the cursor is right at the end of an existing identifier: it will introduce a second one, confusing the parser.