### PR TITLE
Massage default checked-in menhir message

### DIFF
--- a/src/reason-parser/reason_parser_explain.ml
+++ b/src/reason-parser/reason_parser_explain.ml
@@ -61,7 +61,7 @@ let message env (token, startp, endp) =
     let m = Reason_parser_message.message state in
     if m = "<YOUR SYNTAX ERROR MESSAGE HERE>\n" then
       (* Milder unknown syntax error message *)
-      "<syntax error>"
+      Reason_syntax_util.default_error_message
     else m
   with Not_found ->
   (* Identify a keyword used as an identifier *)
@@ -75,4 +75,4 @@ let message env (token, startp, endp) =
   try token_specific_message token
   with Not_found ->
     (* TODO: we don't know what to say *)
-    "<syntax error>"
+    Reason_syntax_util.default_error_message

--- a/src/reason-parser/reason_parser_explain.ml
+++ b/src/reason-parser/reason_parser_explain.ml
@@ -57,7 +57,12 @@ let token_specific_message = function
 let message env (token, startp, endp) =
   let state = Interp.current_state_number env in
   (* Is there a message for this specific state ? *)
-  try Reason_parser_message.message state
+  try
+    let m = Reason_parser_message.message state in
+    if m = "<YOUR SYNTAX ERROR MESSAGE HERE>\n" then
+      (* Milder unknown syntax error message *)
+      "<syntax error>"
+    else m
   with Not_found ->
   (* Identify a keyword used as an identifier *)
   try keyword_confused_with_ident state token

--- a/src/reason-parser/reason_syntax_util.ml
+++ b/src/reason-parser/reason_syntax_util.ml
@@ -495,9 +495,11 @@ let findMenhirErrorMessage loc =
       | [] -> NoMenhirMessagesError
     in find !menhirMessagesError
 
+let default_error_message = "<syntax error>"
+
 let add_error_message err =
   let msg = try
-    ignore (find_substring "<syntax error>" err.msg 0);
+    ignore (find_substring default_error_message err.msg 0);
     [MenhirMessagesError {err with msg = "A syntax error occurred. Help us improve this message: https://github.com/facebook/reason/blob/master/src/README.md#add-a-menhir-error-message"}]
   with
   | Not_found -> [MenhirMessagesError err]

--- a/src/reason-parser/reason_syntax_util.mli
+++ b/src/reason-parser/reason_syntax_util.mli
@@ -96,6 +96,8 @@ type menhirError =
 
 val findMenhirErrorMessage : Ast_404.Location.t -> menhirError
 
+val default_error_message : string
+
 val add_error_message : menhirMessagesError -> unit
 
 val location_is_before : Ast_404.Location.t -> Ast_404.Location.t -> bool


### PR DESCRIPTION
Replaces `<YOUR SYNTAX ERROR MESSAGE HERE>\n` with `<syntax error>`.

Fixes #2003