### PR TITLE
Workaround for jsx lexer trick disrupting Pexp_override parsing

### DIFF
--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1344,3 +1344,10 @@ let x: int = 1;
 let x: float = +. 1;
 
 foo(~a=?-1);
+
+/*
+   https://github.com/facebook/reason/issues/1992
+   Pexp_override
+ */
+let z = {<state: 0, x: y>};
+let z = {<>};

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -1170,3 +1170,10 @@ let x: int=+1;
 let x: float =+. 1;
 
 foo(~a=?-1);
+
+/*
+  https://github.com/facebook/reason/issues/1992
+  Pexp_override
+*/
+let z = {<state: 0, x: y>};
+let z = {<>};

--- a/src/reason-parser/reason_lexer.mll
+++ b/src/reason-parser/reason_lexer.mll
@@ -521,6 +521,18 @@ rule token = parse
     let buf = Lexing.lexeme lexbuf in
     LESSIDENT (String.sub buf 1 (String.length buf - 1))
   }
+  (* Allow parsing of Pexp_override:
+   * let z = {<state: 0, x: y>};
+   *
+   * Make sure {<state is emitted as LBRACELESS.
+   * This contrasts with jsx:
+   * in a jsx context {<div needs to be LBRACE LESS (two tokens)
+   * for a valid parse.
+   *)
+  | "{<" uppercase_or_lowercase identchar* blank*  ":" {
+    set_lexeme_length lexbuf 2;
+    LBRACELESS
+  }
   | "{<" uppercase_or_lowercase (identchar | '.') * {
     (* allows parsing of `{<Text` in <Description term={<Text text="Age" />}> as correct jsx *)
     set_lexeme_length lexbuf 1;


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/1992