### PR TITLE
Relax semicolon requirement in more cases

### DIFF
--- a/formatTest/unit_tests/expected_output/modules_no_semi.re
+++ b/formatTest/unit_tests/expected_output/modules_no_semi.re
@@ -597,3 +597,33 @@ let foo =
 
 let f =
     (module M: M with type x = x and type y = y) => M.x;
+
+let test = b => {
+  if (b) {
+    ignore();
+  };
+
+  while (x) {
+    compute();
+  };
+
+  try (x()) {
+  | _ => log()
+  };
+
+  switch (test) {
+  | A => ()
+  | B => ()
+  };
+
+  for (x in 0 to 10) {
+    print_int(x);
+    print_string(" ");
+  };
+
+  assert(true);
+
+  lazy true;
+
+  Fun.ignore();
+};

--- a/formatTest/unit_tests/input/modules_no_semi.re
+++ b/formatTest/unit_tests/input/modules_no_semi.re
@@ -469,3 +469,33 @@ module type T = [%test extension]
 let foo (type a, (module X): (module X_t with type t =a)) = X.a
 
 let f = ((module M): (module M with type x = x and type y = y)) => M.x
+
+let test = b => {
+  if (b) {
+    ignore();
+  }
+
+  while (x) {
+    compute()
+  }
+
+  try (x()) {
+    | _ => log()
+  }
+
+  switch (test) {
+    | A => ()
+    | B => ()
+  }
+
+  for (x in 0 to 10) {
+    print_int(x)
+    print_string(" ")
+  }
+
+  assert(true)
+
+  lazy true
+
+  Fun.ignore()
+}

--- a/src/reason-parser/reason_toolchain.ml
+++ b/src/reason-parser/reason_toolchain.ml
@@ -610,6 +610,15 @@ module Reason_syntax = struct
     | Reason_parser.EXCEPTION
     | Reason_parser.INCLUDE
     | Reason_parser.DOCSTRING _
+    | Reason_parser.LIDENT _
+    | Reason_parser.UIDENT _
+    | Reason_parser.IF
+    | Reason_parser.WHILE
+    | Reason_parser.FOR
+    | Reason_parser.SWITCH
+    | Reason_parser.TRY
+    | Reason_parser.ASSERT
+    | Reason_parser.LAZY
     | Reason_parser.LBRACKETAT -> true
     | _ -> false
 


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/2011

Extends the approach of https://github.com/facebook/reason/pull/1887, to allow semi-less reason in the context of:
- if
- while
- for
- switch
- for
- lazy
- assert

@let-def is this ok? Or am I opening Pandora's box?