### PR TITLE
Minimal changes to compile with OCaml 4.07

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ common_steps: &common_steps
     - run:
         name: "Initialize opam"
         command: |
+          sudo apt-get install -y m4
           opam init --auto-setup --dot-profile=~/.bash_profile
           opam remote add ocamlorg https://opam.ocaml.org -p 0 || true
           opam remote remove default || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ common_steps: &common_steps
           opam update
           opam install -y jbuilder
           opam install -y menhir.20170712
-          opam pin add -y utop --dev-repo
+          opam install -y utop
     - run:
         name: 'Clean'
         command: make clean-for-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ common_steps: &common_steps
           opam update
           opam install -y jbuilder
           opam install -y menhir.20170712
+          opam pin add -y utop -k git 'https://github.com/hcarty/utop.git#make-it-build-on-4.07'
     - run:
         name: 'Clean'
         command: make clean-for-ci
@@ -91,6 +92,14 @@ jobs:
       - OCAML_VERSION: "4.06.0"
       - NPM_CONFIG_PREFIX: "~/.npm-global"
     <<: *common_steps
+  4.07.0:
+    docker:
+      - image: ocaml/opam2:debian-9-ocaml-4.07
+    environment:
+      - TERM: dumb
+      - OCAML_VERSION: "4.07.x"
+      - NPM_CONFIG_PREFIX: "~/.npm-global"
+    <<: *common_steps
   esy_build:
     docker:
       - image: ocaml/opam:debian-9_ocaml-4.06.0
@@ -145,4 +154,5 @@ workflows:
       - 4.03.0
       - 4.04.0
       - 4.06.0
+      - 4.07.0
       - esy_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ common_steps: &common_steps
           opam update
           opam install -y jbuilder
           opam install -y menhir.20170712
-          opam pin add -y utop -k git 'https://github.com/hcarty/utop.git#make-it-build-on-4.07'
+          opam pin add -y utop --dev-repo
     - run:
         name: 'Clean'
         command: make clean-for-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - eval `opam config env`
   - opam update
 before_script:
-  - opam pin add -y utop -k git 'https://github.com/hcarty/utop.git#make-it-build-on-4.07'
+  - opam pin add -y utop --dev-repo
   - opam pin add -y reason .
   - opam pin add -y rtop .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - eval `opam config env`
   - opam update
 before_script:
+  - opam pin add -y utop -k git 'https://github.com/hcarty/utop.git#make-it-build-on-4.07'
   - opam pin add -y reason .
   - opam pin add -y rtop .
 script:
@@ -20,6 +21,7 @@ env:
   - OCAML_VERSION=4.03.0
   - OCAML_VERSION=4.04.0
   - OCAML_VERSION=4.06.0
+  - OCAML_VERSION=4.07.0+rc1
 notifications:
   email:
     - chenglou@fb.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   - OCAML_VERSION=4.03.0
   - OCAML_VERSION=4.04.0
   - OCAML_VERSION=4.06.0
-  - OCAML_VERSION=4.07.0+rc1
+  - OCAML_VERSION=4.07.0
 notifications:
   email:
     - chenglou@fb.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - eval `opam config env`
   - opam update
 before_script:
-  - opam pin add -y utop --dev-repo
+  - opam install -y utop
   - opam pin add -y reason .
   - opam pin add -y rtop .
 script:

--- a/formatTest/typeCheckedTests/expected_output/comments.rei.4.07.0
+++ b/formatTest/typeCheckedTests/expected_output/comments.rei.4.07.0
@@ -1,0 +1,39 @@
+/* **** comment */
+/*** comment */
+/** docstring */;
+/* comment */
+/** docstring */;
+/*** comment */
+/**** comment */
+/***** comment */
+
+/** */;
+/*** */
+/**** */
+
+/***/
+/****/
+
+/** (** comment *) */;
+/** (*** comment *) */;
+
+/* (** comment *) */
+/* (*** comment *) */
+/* *(*** comment *) */
+
+/* comment **/
+/* comment ***/
+/* comment ****/
+/* comment *****/
+
+/**
+  * Multiline
+  */;
+
+/** Multiline
+  *
+  */;
+
+/**
+  **
+  */;

--- a/formatTest/typeCheckedTests/expected_output/mlVariants.re.4.07.0
+++ b/formatTest/typeCheckedTests/expected_output/mlVariants.re.4.07.0
@@ -1,0 +1,27 @@
+/* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+type polyVariantsInMl = [
+  | `IntTuple(int, int)
+  | `StillAnIntTuple(int, int)
+];
+
+let intTuple = `IntTuple((1, 2));
+let stillAnIntTuple = `StillAnIntTuple((4, 5));
+let sumThem =
+  fun
+  | `IntTuple(x, y) => x + y
+  | `StillAnIntTuple(a, b) => a + b;
+
+type nonrec t =
+  | A(int)
+  | B(bool);
+
+type s = [ | `Poly];
+
+let x: s = `Poly;
+
+/* There's a bug in ocaml 4.06 resulting in an extra Pexp_constraint on the `Poly,
+ * duplicating the core_type.
+ * https://caml.inria.fr/mantis/view.php?id=7758
+ * https://caml.inria.fr/mantis/view.php?id=7344 */
+let x: s = (`Poly: s);

--- a/reason.opam
+++ b/reason.opam
@@ -19,4 +19,4 @@ depends: [
   "result"
   "ocaml-migrate-parsetree"
 ]
-available: [ ocaml-version >= "4.02" & ocaml-version < "4.07" ]
+available: [ ocaml-version >= "4.02" & ocaml-version < "4.08" ]

--- a/rtop.opam
+++ b/rtop.opam
@@ -16,4 +16,4 @@ depends: [
   "reason"
   "utop"   {>= "1.17"}
 ]
-available: [ ocaml-version >= "4.02" & ocaml-version < "4.07" ]
+available: [ ocaml-version >= "4.02" & ocaml-version < "4.08" ]

--- a/src/reason-parser/dune
+++ b/src/reason-parser/dune
@@ -4,8 +4,8 @@
 ; Use select.exe from janestreet/ppx_ast to choose lexer_warning.ml based on ocaml version
 (rule
  (targets lexer_warning.ml)
- (deps ../generate/select.exe lexer_warning.ml-4.06 lexer_warning.ml-default)
- (action (with-stdout-to %{targets} (run ../generate/select.exe lexer_warning.ml-4.06 lexer_warning.ml-default))))
+ (deps ../generate/select.exe lexer_warning.ml-4.07 lexer_warning.ml-4.06 lexer_warning.ml-default)
+ (action (with-stdout-to %{targets} (run ../generate/select.exe lexer_warning.ml-4.07 lexer_warning.ml-4.06 lexer_warning.ml-default))))
 
 (rule
  (targets reason_string.ml)

--- a/src/reason-parser/lexer_warning.ml-4.07
+++ b/src/reason-parser/lexer_warning.ml-4.07
@@ -1,0 +1,3 @@
+let warn_latin1 lexbuf =
+  Location.deprecated (Location.curr lexbuf) "ISO-Latin1 characters in identifiers"
+;;


### PR DESCRIPTION
This is a bit of a hack and won't really scale across lots of OCaml versions.  It builds with OCaml 4.07.0+rc1 though, so it at least unblocks other testing against the soon-to-be latest OCaml release.

If you want to build `rtop` you'll also need https://github.com/diml/utop/pull/238 (or a better equivalent allowing `utop` to build under 4.07).