### PR TITLE
Fix printing of Ptyp_poly with an empty string list (Ppat_constraint).

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/mlVariants.re
+++ b/formatTest/typeCheckedTests/expected_output/mlVariants.re
@@ -15,3 +15,13 @@ let sumThem =
 type nonrec t =
   | A(int)
   | B(bool);
+
+type s = [ | `Poly];
+
+let x: s = `Poly;
+
+/* There's a bug in ocaml resulting in a Pexp_constraint on the `Poly
+ * duplicating the core_type.
+ * https://caml.inria.fr/mantis/view.php?id=7758
+ * https://caml.inria.fr/mantis/view.php?id=7344 */
+let x: s = (`Poly: s);

--- a/formatTest/typeCheckedTests/expected_output/mlVariants.re.4.06.0
+++ b/formatTest/typeCheckedTests/expected_output/mlVariants.re.4.06.0
@@ -24,4 +24,4 @@ let x: s = `Poly;
  * duplicating the core_type.
  * https://caml.inria.fr/mantis/view.php?id=7758
  * https://caml.inria.fr/mantis/view.php?id=7344 */
-let x: s = `Poly;
+let x: s = (`Poly: s);

--- a/formatTest/typeCheckedTests/input/mlVariants.ml
+++ b/formatTest/typeCheckedTests/input/mlVariants.ml
@@ -14,3 +14,13 @@ let sumThem = function
   | `StillAnIntTuple (a, b) -> a + b
 
 type nonrec t = A of int | B of bool
+
+type s = [ `Poly ]
+
+let x = (`Poly: s)
+
+(* There's a bug in ocaml resulting in a Pexp_constraint on the `Poly
+ * duplicating the core_type.
+ * https://caml.inria.fr/mantis/view.php?id=7758
+ * https://caml.inria.fr/mantis/view.php?id=7344 *)
+let x : s = `Poly

--- a/formatTest/typeCheckedTests/input/mlVariants.ml
+++ b/formatTest/typeCheckedTests/input/mlVariants.ml
@@ -19,7 +19,7 @@ type s = [ `Poly ]
 
 let x = (`Poly: s)
 
-(* There's a bug in ocaml resulting in a Pexp_constraint on the `Poly
+(* There's a bug in ocaml 4.06 resulting in an extra Pexp_constraint on the `Poly,
  * duplicating the core_type.
  * https://caml.inria.fr/mantis/view.php?id=7758
  * https://caml.inria.fr/mantis/view.php?id=7344 *)

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -672,3 +672,5 @@ Delete({
   pub y = methodTwo;
   pub z = methodThisBreaks
 });
+
+let x: t = `Poly;

--- a/formatTest/unit_tests/input/variants.re
+++ b/formatTest/unit_tests/input/variants.re
@@ -409,3 +409,5 @@ Delete({pub x = methodOne; pub y = methodTwo; pub z = methodThisBreaks});
 `Delete([|someLongStuf, someOtherLongStuff, okokokok|]);
 `Delete([someLongStuf, someOtherLongStuff, okokokok, ...veryES6]);
 `Delete({pub x = methodOne; pub y = methodTwo; pub z = methodThisBreaks});
+
+let x: t = `Poly;

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -2398,13 +2398,16 @@ let printer = object(self:'self)
               ~break:IfNeed ~sep:(Sep "=>") [lhs; rhs]
           in source_map ~loc:x.ptyp_loc normalized
         | Ptyp_poly (sl, ct) ->
-          let poly =
+          let ct = self#core_type ct in
+          let poly = match sl with
+          | [] -> ct
+          | sl ->
             makeList ~break:IfNeed [
               makeList ~postSpace:true [
                 makeList ~postSpace:true (List.map (fun x -> self#tyvar x) sl);
                 atom ".";
               ];
-              self#core_type ct;
+              ct
             ]
           in source_map ~loc:x.ptyp_loc poly
         | _ -> self#non_arrowed_core_type x


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/2017

There's a bug in Ocaml 4.06 resulting in
``let x: t = `Poly``
being parsed as
``let x: t = (`Poly: t)``

The constraint is duplicated.
See https://caml.inria.fr/mantis/view.php?id=7758 and https://caml.inria.fr/mantis/view.php?id=7344
for more background.

The bug in our printer ``let x : .t = (`Poly: t)`` (notice the erroneous dot) has been fixed.