### PR TITLE
Beautiful printing of Pexp_function expressions as jsx props

### DIFF
--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -277,3 +277,11 @@ let x = foo /></ bar;
 <div> foo </div>;
 
 <div />;
+
+<Component
+  accept=(
+    fun
+    | Foo => true
+    | Bar => false
+  )
+/>;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -178,3 +178,11 @@ let x = foo /></ bar;
 <div>foo</ div>;
 
 <div> </ div >;
+
+<Component
+  accept=(
+    fun
+    | Foo => true
+    | Bar => false
+  )
+/>;

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4012,6 +4012,7 @@ let printer = object(self:'self)
            | Pexp_match _
            | Pexp_extension _
            | Pexp_fun _
+           | Pexp_function _
            | Pexp_apply _ -> label (makeList [atom lbl; atom "="]) (self#simplifyUnparseExpr expression)
            | _ -> makeList ([atom lbl; atom "="; self#simplifyUnparseExpr expression])
          in


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/2023

```reason
/* Before */
<Component
  accept=(
           fun
           | Foo => true
           | Bar => false
         )
/>

/* After */
<Component
  accept=(
    fun
    | Foo => true
    | Bar => false
  )
/>
```