### PR TITLE
Beautiful printing of JSX prop and module open

### DIFF
--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -319,3 +319,13 @@ let x = foo /></ bar;
     "xxxxxxxxxxxxxxxxxxxxxx",
   )
 />;
+
+<C
+  prop=M.(
+    Foo(
+      "xxxxxxxxxxxxxxxxxxxxxx",
+      "xxxxxxxxxxxxxxxxxxxxxx",
+      "xxxxxxxxxxxxxxxxxxxxxx",
+    )
+  )
+/>;

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -285,3 +285,12 @@ let x = foo /></ bar;
     | Bar => false
   )
 />;
+
+/* Actual */
+<C
+  prop=M.{
+    a: "xxxxxxxxxxxxxxxxxxxxxx",
+    b: "xxxxxxxxxxxxxxxxxxxxxx",
+    c: "xxxxxxxxxxxxxxxxxxxxxx",
+  }
+/>;

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -286,11 +286,36 @@ let x = foo /></ bar;
   )
 />;
 
-/* Actual */
 <C
   prop=M.{
     a: "xxxxxxxxxxxxxxxxxxxxxx",
     b: "xxxxxxxxxxxxxxxxxxxxxx",
     c: "xxxxxxxxxxxxxxxxxxxxxx",
   }
+/>;
+
+<C
+  prop=M.[
+    "xxxxxxxxxxxxxxxxxxxxxx",
+    "xxxxxxxxxxxxxxxxxxxxxx",
+    "xxxxxxxxxxxxxxxxxxxxxx",
+  ]
+/>;
+
+<C
+  prop=M.(
+    [|
+      "xxxxxxxxxxxxxxxxxxxxxx",
+      "xxxxxxxxxxxxxxxxxxxxxx",
+      "xxxxxxxxxxxxxxxxxxxxxx",
+    |]
+  )
+/>;
+
+<C
+  prop=M.(
+    "xxxxxxxxxxxxxxxxxxxxxx",
+    "xxxxxxxxxxxxxxxxxxxxxx",
+    "xxxxxxxxxxxxxxxxxxxxxx",
+  )
 />;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -218,3 +218,11 @@ let x = foo /></ bar;
     "xxxxxxxxxxxxxxxxxxxxxx",
   )
 />;
+
+<C
+  prop=M.(Foo(
+    "xxxxxxxxxxxxxxxxxxxxxx",
+    "xxxxxxxxxxxxxxxxxxxxxx",
+    "xxxxxxxxxxxxxxxxxxxxxx",
+  ))
+/>;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -186,3 +186,12 @@ let x = foo /></ bar;
     | Bar => false
   )
 />;
+
+/* Actual */
+<C
+  prop=M.{
+         a: "xxxxxxxxxxxxxxxxxxxxxx",
+         b: "xxxxxxxxxxxxxxxxxxxxxx",
+         c: "xxxxxxxxxxxxxxxxxxxxxx",
+       }
+/>;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -187,11 +187,34 @@ let x = foo /></ bar;
   )
 />;
 
-/* Actual */
 <C
   prop=M.{
          a: "xxxxxxxxxxxxxxxxxxxxxx",
          b: "xxxxxxxxxxxxxxxxxxxxxx",
          c: "xxxxxxxxxxxxxxxxxxxxxx",
        }
+/>;
+
+<C
+  prop=M.[
+         "xxxxxxxxxxxxxxxxxxxxxx",
+         "xxxxxxxxxxxxxxxxxxxxxx",
+         "xxxxxxxxxxxxxxxxxxxxxx",
+       ]
+/>;
+
+<C
+  prop=M.[|
+         "xxxxxxxxxxxxxxxxxxxxxx",
+         "xxxxxxxxxxxxxxxxxxxxxx",
+         "xxxxxxxxxxxxxxxxxxxxxx",
+       |]
+/>;
+
+<C
+  prop=M.(
+    "xxxxxxxxxxxxxxxxxxxxxx",
+    "xxxxxxxxxxxxxxxxxxxxxx",
+    "xxxxxxxxxxxxxxxxxxxxxx",
+  )
 />;

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4005,6 +4005,12 @@ let printer = object(self:'self)
            | _ when isJSXComponent expression  ->
                label (atom (lbl ^ "="))
                      (makeList ~break:IfNeed ~wrap:("{", "}") [(self#simplifyUnparseExpr expression)])
+           | Pexp_open (ovf, lid, e)
+             when self#isSeriesOfOpensFollowedByNonSequencyExpression expression ->
+             label (makeList [atom lbl;
+                              atom "=";
+                              (label (self#longident_loc lid) (atom "."))])
+                   (self#simplifyUnparseExpr e)
            | Pexp_record _
            | Pexp_construct _
            | Pexp_array _


### PR DESCRIPTION
fixes #2026

Before:

```reason
<C
  prop=M.{
         a: "xxxxxxxxxxxxxxxxxxxxxx",
         b: "xxxxxxxxxxxxxxxxxxxxxx",
         c: "xxxxxxxxxxxxxxxxxxxxxx",
       }
/>;
```

After:

```reason
<C
  prop=M.{
    a: "xxxxxxxxxxxxxxxxxxxxxx",
    b: "xxxxxxxxxxxxxxxxxxxxxx",
    c: "xxxxxxxxxxxxxxxxxxxxxx",
  }
/>;
```