### PR TITLE
Only wrap `Pexp_function` in parens when necessary

### DIFF
--- a/formatTest/unit_tests/expected_output/extensions.re
+++ b/formatTest/unit_tests/expected_output/extensions.re
@@ -359,3 +359,11 @@ let work = () => {
 /** header */
 %raw
 "console.log(42)";
+
+/* https://github.com/facebook/reason/issues/2032 */
+let predicate =
+  predicate === Functions.alwaysTrue1 ?
+    defaultPredicate :
+    fun%extend
+    | None => false
+    | Some(exn) => predicate(exn);

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -1273,3 +1273,30 @@ let foo =
       | Some(_) => ()
     )
   | None => ();
+
+let predicate =
+  predicate === Functions.alwaysTrue1 ?
+    (
+      fun
+      | None => false
+      | Some(exn) => predicate(exn)
+    )
+    >>= foo :
+    fun
+    | None => false
+    | Some(exn) => predicate(exn);
+
+let predicate =
+  predicate === Functions.alwaysTrue1 ?
+    (
+      fun
+      | None => false
+      | Some(exn) => predicate(exn)
+    )
+    >>= foo :
+    bar
+    >>= (
+      fun
+      | None => false
+      | Some(exn) => predicate(exn)
+    );

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -1204,3 +1204,72 @@ let foo = (a, b) => a =- b;
 
 let (=><) = (a, b) => a + b;
 let x = a =>< b;
+
+let foo =
+  fun
+  | None => x >>= y
+  | Some(x) => x >>= y;
+
+something
+>>= (
+  fun
+  | None => x >>= y
+  | Some(x) => x >>= y
+);
+
+(
+  fun
+  | None => x >>= y
+  | Some(x) => x >>= y
+)
+>>= bar;
+
+something
+>>= (
+  fun
+  | None => x >>= y
+  | Some(x) => x >>= y
+);
+
+something ?
+  a
+  >>= (
+    fun
+    | None => x >>= y
+    | Some(x) => x >>= y
+  ) :
+  fun
+  | None => x >>= y
+  | Some(x) => x >>= y;
+
+something ?
+  a
+  >>= (
+    fun
+    | None => x >>= y
+    | Some(x) => x >>= y
+  ) :
+  (
+    fun
+    | None => x >>= y
+    | Some(x) => x >>= y
+  )
+  >>= b;
+
+let foo =
+  fun
+  | None => ()
+  | Some(x) => (
+      fun
+      | None => ()
+      | Some(_) => ()
+    );
+
+let foo =
+  fun
+  | Some(x) => (
+      fun
+      | None => ()
+      | Some(_) => ()
+    )
+  | None => ();

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1365,3 +1365,12 @@ let predicate =
     fun
     | None => false
     | Some(exn) => predicate(exn);
+
+let predicate =
+  predicate === Functions.alwaysTrue1 ?
+    fun
+    | None => false
+    | Some(exn) => predicate(exn) :
+    fun
+    | None => false
+    | Some(exn) => predicate(exn);

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1357,3 +1357,11 @@ type foo = (~a: bool=?) => int;
 
 /* https://github.com/facebook/reason/issues/2070 */
 f(~commit=!build);
+
+/* https://github.com/facebook/reason/issues/2032 */
+let predicate =
+  predicate === Functions.alwaysTrue1 ?
+    defaultPredicate :
+    fun
+    | None => false
+    | Some(exn) => predicate(exn);

--- a/formatTest/unit_tests/input/extensions.re
+++ b/formatTest/unit_tests/input/extensions.re
@@ -105,7 +105,7 @@ let x = fun%extend
 
  /* With two extensions, alone */
 
-let x = { 
+let x = {
   %extend1
   try%extend2 () { | _ => () };
 };
@@ -144,7 +144,7 @@ let x = {
 
  /* With two extensions, first in sequence */
 
-let x = { 
+let x = {
   %extend1
   try%extend2 () { | _ => () };
   ignore();
@@ -195,7 +195,7 @@ let x = {
 
  /* With two extensions, in sequence */
 
-let x = { 
+let x = {
   ignore();
   %extend1
   try%extend2 () { | _ => () };
@@ -248,7 +248,7 @@ let x = {
 
  /* With two extensions, second in sequence */
 
-let x = { 
+let x = {
   ignore();
   %extend1
   try%extend2 () { | _ => () };
@@ -329,3 +329,11 @@ let work = () => { open Syntax; let%bind name = x; name; };
 /** header */
 %raw
 "console.log(42)";
+
+/* https://github.com/facebook/reason/issues/2032 */
+let predicate =
+  predicate === Functions.alwaysTrue1 ?
+    defaultPredicate :
+    (fun%extend
+      | None => false
+      | Some(exn) => predicate(exn));

--- a/formatTest/unit_tests/input/infix.re
+++ b/formatTest/unit_tests/input/infix.re
@@ -975,3 +975,21 @@ let foo =
 fun
   | Some(x) => (fun | None => () | Some(_) => ())
   | None => ();
+
+let predicate =
+  predicate === Functions.alwaysTrue1 ?
+    (fun
+      | None => false
+      | Some(exn) => predicate(exn)) >>= foo :
+    (fun
+      | None => false
+      | Some(exn) => predicate(exn));
+
+let predicate =
+  predicate === Functions.alwaysTrue1 ?
+    (fun
+      | None => false
+      | Some(exn) => predicate(exn)) >>= foo :
+    bar >>= (fun
+      | None => false
+      | Some(exn) => predicate(exn));

--- a/formatTest/unit_tests/input/infix.re
+++ b/formatTest/unit_tests/input/infix.re
@@ -921,3 +921,57 @@ let foo = (a, b) => a =- b;
 
 let (=><) = (a, b) => a + b;
 let x = a =>< b;
+
+let foo =
+  fun
+  | None => x >>= y
+  | Some(x) => x >>= y;
+
+something
+>>= (
+  fun
+  | None => x >>= y
+  | Some(x) => x >>= y
+);
+
+(fun
+| None => x >>= y
+| Some(x) => x >>= y)
+>>= bar ;
+
+something >>=
+  fun
+  | None => x >>= y
+  | Some(x) => x >>= y;
+
+something ?
+a >>= (
+  fun
+  | None => x >>= y
+  | Some(x) => x >>= y
+) : (
+  fun
+  | None => x >>= y
+  | Some(x) => x >>= y
+);
+
+something ?
+a >>= (
+  fun
+  | None => x >>= y
+  | Some(x) => x >>= y
+) : (
+  fun
+  | None => x >>= y
+  | Some(x) => x >>= y
+) >>= b;
+
+let foo =
+fun
+  | None => ()
+  | Some(x) => fun | None => () | Some(_) => ();
+
+let foo =
+fun
+  | Some(x) => (fun | None => () | Some(_) => ())
+  | None => ();

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -1191,3 +1191,12 @@ let predicate =
     (fun
       | None => false
       | Some(exn) => predicate(exn));
+
+let predicate =
+  predicate === Functions.alwaysTrue1 ?
+    (fun
+      | None => false
+      | Some(exn) => predicate(exn)) :
+    (fun
+      | None => false
+      | Some(exn) => predicate(exn));

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -1183,3 +1183,11 @@ type foo = ~a:bool=? => int;
 
 /* https://github.com/facebook/reason/issues/2070 */
 f(~commit=!build);
+
+/* https://github.com/facebook/reason/issues/2032 */
+let predicate =
+  predicate === Functions.alwaysTrue1 ?
+    defaultPredicate :
+    (fun
+      | None => false
+      | Some(exn) => predicate(exn));


### PR DESCRIPTION
fixes #2032

before:

```reason
let predicate =
  predicate === Functions.alwaysTrue1 ?
    defaultPredicate :
    (
      fun
      | None => false
      | Some(exn) => predicate(exn)
    );
```

after:

```reason
let predicate =
  predicate === Functions.alwaysTrue1 ?
    defaultPredicate :
    fun
    | None => false
    | Some(exn) => predicate(exn);
```