### PR TITLE
add specific test file for OCaml 4.06.1

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/mlVariants.re.4.06.1
+++ b/formatTest/typeCheckedTests/expected_output/mlVariants.re.4.06.1
@@ -1,0 +1,27 @@
+/* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
+
+type polyVariantsInMl = [
+  | `IntTuple(int, int)
+  | `StillAnIntTuple(int, int)
+];
+
+let intTuple = `IntTuple((1, 2));
+let stillAnIntTuple = `StillAnIntTuple((4, 5));
+let sumThem =
+  fun
+  | `IntTuple(x, y) => x + y
+  | `StillAnIntTuple(a, b) => a + b;
+
+type nonrec t =
+  | A(int)
+  | B(bool);
+
+type s = [ | `Poly];
+
+let x: s = `Poly;
+
+/* There's a bug in ocaml 4.06 resulting in an extra Pexp_constraint on the `Poly,
+ * duplicating the core_type.
+ * https://caml.inria.fr/mantis/view.php?id=7758
+ * https://caml.inria.fr/mantis/view.php?id=7344 */
+let x: s = (`Poly: s);


### PR DESCRIPTION
This is only useful for local development on the 4.06.1 switch, so I understand
if you don't want to get it in. It seems we can't move the CI to run on 4.06.1
for now because there isn't a 4.06.1 Docker image yet.