### PR TITLE
Remove extra space before class type signature

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -299,7 +299,7 @@ module type HasAttrs = {
     pub bar: int
   };
   [@sigItem]
-  class fooBar : (int) => foo;
+  class fooBar: (int) => foo;
   /**Floating comment text should be removed*/;
   /**Floating comment text should be removed*/;
 };

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -278,7 +278,7 @@ module HasTupleClasses: {
   /**
    * exportedClass.
    */
-  class exportedClass :
+  class exportedClass:
     (int) =>
     {
       pub x: int;
@@ -287,7 +287,7 @@ module HasTupleClasses: {
   /**
    * anotherExportedClass.
    */
-  class anotherExportedClass ('a, 'b) :
+  class anotherExportedClass ('a, 'b):
     (('a, 'b)) =>
     {
       pub pr: ('a, 'b)
@@ -398,8 +398,8 @@ class addablePoint2:
   };
 
 module type T = {
-  class virtual cl ('a) : {}
-  and cl2 : {};
+  class virtual cl ('a): {}
+  and cl2: {};
 };
 
 let privacy = {pri x = c => 5 + c};

--- a/formatTest/unit_tests/expected_output/whitespace.rei
+++ b/formatTest/unit_tests/expected_output/whitespace.rei
@@ -218,16 +218,16 @@ class type x = {
 [%%obj {a: 1}];
 
 /** doc attached */
-class reason : ocaml;
+class reason: ocaml;
 
 /** doc attached with whitespace */
 
-class reason : ocaml;
+class reason: ocaml;
 
 /** doc attached with whitespace and comment */
 
 /* test */
-class reason : ocaml;
+class reason: ocaml;
 
 /** doc attached */
 module rec X1: Y1

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4175,6 +4175,7 @@ let printer = object(self:'self)
          ?attachTo
          ~arrow
          ?(sweet=false)
+         ?(spaceBeforeArrow=true)
          prefixText
          bindingLabel
          patternList
@@ -4211,7 +4212,7 @@ let printer = object(self:'self)
       match partitioning with
         | None when sweet ->
           makeList
-            ~pad:(false, true)
+            ~pad:(false, spaceBeforeArrow)
             ~wrap:("", arrow)
             ~indent:(settings.space * settings.indentWrappedPatternArgs)
             ~postSpace:true
@@ -4255,7 +4256,7 @@ let printer = object(self:'self)
 
             *)
           makeList
-            ~pad:(true, true)
+            ~pad:(true, spaceBeforeArrow)
             ~wrap:(prefixText, arrow)
             ~indent:(settings.space * settings.indentWrappedPatternArgs)
             ~postSpace:true
@@ -4270,7 +4271,7 @@ let printer = object(self:'self)
             ~space:true
             (
               makeList
-                ~pad:(true, true)
+                ~pad:(true, spaceBeforeArrow)
                 ~wrap:(prefixText, arrow)
                 ~indent:(settings.space * settings.indentWrappedPatternArgs)
                 ~postSpace:true
@@ -6298,6 +6299,7 @@ let printer = object(self:'self)
               let (firstToken, pattern, patternAux) = self#class_opening class_keyword txt x.pci_virt ls in
               let withColon = self#wrapCurriedFunctionBinding
                 ~arrow:":"
+                ~spaceBeforeArrow:false
                 firstToken
                 pattern
                 patternAux


### PR DESCRIPTION
This is a follow-up PR to #1966 and #1969 that removes the space between the class type name and the colon.