### PR TITLE
Syntax sugar `["literal_string"]` for SHARPOPs `##` and `#=`

### DIFF
--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -832,4 +832,4 @@ it("should remove parens", a => {
 });
 
 /* https://github.com/facebook/reason/issues/1554 */
-(curNode^)##childNodes;
+curNode^["childNodes"];

--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -20,20 +20,20 @@ x##y##z #= xxxx##yyyy##zzzz;
 let result =
   js_method_run1((!react)#createElement, foo);
 
-add(zz##yy, xx##ww);
+add(zz["yy"], xx["ww"]);
 
 /* These should print the same */
-let res = x##y + z##q; /* AST */
-let res = x##y + z##q; /* Minimum parens */
+let res = x["y"] + z["q"]; /* AST */
+let res = x["y"] + z["q"]; /* Minimum parens */
 
 /* These should print the same */
-let res = y + z##q##a; /* AST */
-let res = y + z##q##a; /* Min parens */
+let res = y + z["q"]["a"]; /* AST */
+let res = y + z["q"]["a"]; /* Min parens */
 
 /* Make sure it's actually parsed as left precedence
  * and that is maintained when printed */
-let res = z##(q##a); /* AST */
-let res = z##(q##a); /* Min parens */
+let res = z##(q["a"]); /* AST */
+let res = z##(q["a"]); /* Min parens */
 
 /* These should print the same */
 let res = !x##y; /* AST */
@@ -44,12 +44,12 @@ let res = !z##q##a; /* AST */
 let res = !z##q##a; /* Min parens */
 
 /* These should print the same */
-let res = ?!!x##y; /* AST */
-let res = ?!!x##y; /* Minimum parens */
+let res = ?!!x["y"]; /* AST */
+let res = ?!!x["y"]; /* Minimum parens */
 
 /* These should print the same */
-let res = ?!!z##(q##a); /* AST */
-let res = ?!!z##(q##a); /* Min parens */
+let res = ?!!z##(q["a"]); /* AST */
+let res = ?!!z##(q["a"]); /* Min parens */
 
 res #= ?!!z##q;
 res #= ?!!z##(q##a);

--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -4,18 +4,18 @@ bla #= Some(10);
 
 bla #= someFunc(Some(10));
 
-test##var #= Some(-10);
+test["var"] = Some(-10);
 
 obj##.prop;
 
 obj##.prod := exp;
 
-preview##style##border
-#= Js.string("1px black dashed");
+preview["style"]["border"] =
+  Js.string("1px black dashed");
 
-(preview##(style##border) #= args)(somenum);
+(preview##(style["border"]) #= args)(somenum);
 
-x##y##z #= xxxx##yyyy##zzzz;
+x["y"]["z"] = xxxx["yyyy"]["zzzz"];
 
 let result =
   js_method_run1((!react)#createElement, foo);
@@ -36,12 +36,12 @@ let res = z##(q["a"]); /* AST */
 let res = z##(q["a"]); /* Min parens */
 
 /* These should print the same */
-let res = !x##y; /* AST */
-let res = !x##y; /* Minimum parens */
+let res = !x["y"]; /* AST */
+let res = !x["y"]; /* Minimum parens */
 
 /* These should print the same */
-let res = !z##q##a; /* AST */
-let res = !z##q##a; /* Min parens */
+let res = !z["q"]["a"]; /* AST */
+let res = !z["q"]["a"]; /* Min parens */
 
 /* These should print the same */
 let res = ?!!x["y"]; /* AST */
@@ -51,12 +51,12 @@ let res = ?!!x["y"]; /* Minimum parens */
 let res = ?!!z##(q["a"]); /* AST */
 let res = ?!!z##(q["a"]); /* Min parens */
 
-res #= ?!!z##q;
-res #= ?!!z##(q##a);
+res #= ?!!z["q"];
+res #= ?!!z##(q["a"]);
 
-let result = myFunction(x(y)##z, a(b) #= c);
+let result = myFunction(x(y)["z"], a(b) #= c);
 
-(!x)##y##(b##c);
+(!x)["y"]##(b["c"]);
 
 type a = {. "foo": bar};
 
@@ -75,7 +75,7 @@ let b = {
 let c = {
   "a": a,
   "b": b,
-  "func": a => a##c #= func(10),
+  "func": a => a["c"] = func(10),
 };
 
 let d = {

--- a/formatTest/unit_tests/expected_output/fastPipe.re
+++ b/formatTest/unit_tests/expected_output/fastPipe.re
@@ -59,7 +59,7 @@ foo !== bar->baz;
 x |> y >>= foo->bar->baz;
 let m = f => foo->bar->f;
 
-obj##x->foo->bar;
+obj["x"]->foo->bar;
 
 event->target[0];
 

--- a/formatTest/unit_tests/expected_output/fastPipe.re
+++ b/formatTest/unit_tests/expected_output/fastPipe.re
@@ -65,13 +65,13 @@ event->target[0];
 
 event->target[0];
 
-event->target##value;
+event->target["value"];
 
-event->target##value;
+event->target["value"];
 
-event->target##value[0];
+event->target["value"][0];
 
-event->(target##value[0]);
+event->(target["value"][0]);
 
 event->target(foo);
 
@@ -85,17 +85,21 @@ foo->bar := baz;
 
 foo->bar === baz;
 
-event->target##value(foo);
+event->target["value"](foo);
 
 event->target##(value(foo));
 
 (foo^)->bar;
 
-location##streets.foo[1];
+location["streets"].foo[1];
 
 (event->target^)##value;
 
 event->target^ #= value;
+
+event["target"].{0};
+
+event->target.{0};
 
 foo->f(. a, b);
 foo->f(. a, b)->g(. c, d);

--- a/formatTest/unit_tests/expected_output/fastPipe.re
+++ b/formatTest/unit_tests/expected_output/fastPipe.re
@@ -192,7 +192,7 @@ Foo.Bar.reactClass->setNavigationOptions(
   ),
 );
 
-foo##bar
+foo["bar"]
 ->setNavigationOptions(
     NavigationOptions.t(
       ~title="Title",

--- a/formatTest/unit_tests/expected_output/fastPipe.re
+++ b/formatTest/unit_tests/expected_output/fastPipe.re
@@ -93,7 +93,7 @@ event->target##(value(foo));
 
 location["streets"].foo[1];
 
-(event->target^)##value;
+event->target^["value"];
 
 event->target^ #= value;
 
@@ -114,9 +114,9 @@ foo->([@attr] f(.))->([@attr] g(.));
 !foo->bar;
 (!foo)->bar;
 
-a->(b##c);
+a->(b["c"]);
 
-a->b##c;
+a->b["c"];
 
 (
   switch (saveStatus) {

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -121,13 +121,13 @@ let icon =
 
 <MessengerSharedPhotosAlbumViewPhotoReact
   ref=?{
-    foo##bar === baz ?
+    foo["bar"] === baz ?
       Some(
         foooooooooooooooooooooooo(setRefChild),
       ) :
       None
   }
-  key=node##legacy_attachment_id
+  key=node["legacy_attachment_id"]
 />;
 
 /* punning */
@@ -248,21 +248,21 @@ let (/></) = (a, b) => a + b;
 let x = foo /></ bar;
 
 /* https://github.com/facebook/reason/issues/870 */
-<div onClick=this##handleClick>
+<div onClick=this["handleClick"]>
   <> foo </>
 </div>;
 
-<div onClick=this##handleClick>
+<div onClick=this["handleClick"]>
   <> {foo(bar)} </>
 </div>;
 
 /* function application */
-<div onClick=this##handleClick>
+<div onClick=this["handleClick"]>
   <> {foo(bar)} </>
 </div>;
 
 /* tuple, not function application */
-<div onClick=this##handleClick>
+<div onClick=this["handleClick"]>
   <> foo bar </>
 </div>;
 

--- a/formatTest/unit_tests/expected_output/sharpop.re
+++ b/formatTest/unit_tests/expected_output/sharpop.re
@@ -25,3 +25,19 @@ foo[bar + 1] = 1;
 bla #= Constr(x);
 
 bla #= M.(someFunc(Some(10)));
+
+bla["foo"] = 3;
+
+bla["foo"][0] = 3;
+
+bla["foo"].qux["x"] = 3;
+
+bla["foo"].qux[0]["bar"] = 3;
+
+bla[0]["foo"].qux[0]["bar"] = 3;
+
+bla[0]["foo"].qux[0].[0]["bar"] = 3;
+
+bla[0]["foo"].qux[0].{0}["bar"] = 3;
+
+bla[0]["foo"].qux[0].{0, 1, 2}["bar"] = 3;

--- a/formatTest/unit_tests/expected_output/sharpop.re
+++ b/formatTest/unit_tests/expected_output/sharpop.re
@@ -1,14 +1,14 @@
 foo #= bar[0];
 
-foo##bar[0] = 3;
+foo["bar"][0] = 3;
 
-foo##bar[0]##baz[1] = 3;
+foo["bar"][0]["baz"][1] = 3;
 
-foo##bar[0]##baz[1];
+foo["bar"][0]["baz"][1];
 
-foo##bar #= bar[0];
+foo["bar"] = bar[0];
 
-foo##bar##baz #= bar##baz[0];
+foo["bar"]["baz"] = bar["baz"][0];
 
 foo[bar + 1];
 
@@ -21,3 +21,7 @@ foo.[bar + 1] = 1;
 foo.{bar + 1} = 1;
 
 foo[bar + 1] = 1;
+
+bla #= Constr(x);
+
+bla #= M.(someFunc(Some(10)));

--- a/formatTest/unit_tests/input/fastPipe.re
+++ b/formatTest/unit_tests/input/fastPipe.re
@@ -97,6 +97,10 @@ event->target##(value(foo));
 
 event->target^ #= value;
 
+event##target.{0};
+
+event->target.{0};
+
 foo->f(. a, b);
 foo->f(. a, b)->g(. c, d);
 foo->([@attr] f(. a, b))->([@attr2] f(. a, b));

--- a/formatTest/unit_tests/input/sharpop.re
+++ b/formatTest/unit_tests/input/sharpop.re
@@ -21,3 +21,7 @@ foo.[bar + 1] = 1;
 foo.{bar + 1} = 1;
 
 foo[bar + 1] = 1;
+
+bla #= (Constr(x));
+
+bla #= M.(someFunc(Some(10)));

--- a/formatTest/unit_tests/input/sharpop.re
+++ b/formatTest/unit_tests/input/sharpop.re
@@ -25,3 +25,19 @@ foo[bar + 1] = 1;
 bla #= (Constr(x));
 
 bla #= M.(someFunc(Some(10)));
+
+bla["foo"] = 3;
+
+bla["foo"][0] = 3;
+
+bla["foo"].qux["x"] = 3;
+
+bla["foo"].qux[0]["bar"] = 3;
+
+bla[0]["foo"].qux[0]["bar"] = 3;
+
+bla[0]["foo"].qux[0].[0]["bar"] = 3;
+
+bla[0]["foo"].qux[0].{0}["bar"] = 3;
+
+bla[0]["foo"].qux[0].{0,1,2}["bar"] = 3;

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -7613,10 +7613,7 @@ let printer = object(self:'self)
     let formattedFunExpr = match funExpr.pexp_desc with
       (* fast pipe chain or sharpop chain as funExpr, no parens needed, we know how to parse *)
       | Pexp_apply ({pexp_desc = Pexp_ident {txt = Lident s}}, _)
-        when requireNoSpaceFor s ->
-        self#unparseExpr funExpr
-      | Pexp_apply ({pexp_desc = Pexp_ident {txt = Lident "#="}}, _) ->
-        formatPrecedence ~loc:funExpr.pexp_loc (self#unparseExpr funExpr)
+        when requireNoSpaceFor s -> self#unparseExpr funExpr
       | Pexp_field _ -> self#unparseExpr funExpr
       | _ -> self#simplifyUnparseExpr funExpr
     in

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -7570,6 +7570,16 @@ let printer = object(self:'self)
     (* If there was a JSX attribute BUT JSX component wasn't detected,
        that JSX attribute needs to be pretty printed so it doesn't get
        lost *)
+    let isLeftSharpEqual = match funExpr.pexp_desc with
+      | Pexp_apply ({pexp_desc = Pexp_ident {txt = Lident "#="}}, _) -> true
+      | _ -> false
+    in
+    let formattedFunExpr =
+      if isLeftSharpEqual then
+        formatPrecedence ~loc:funExpr.pexp_loc (self#simplifyUnparseExpr funExpr)
+      else
+        self#simplifyUnparseExpr funExpr
+    in
     let maybeJSXAttr = List.map self#attribute jsxAttrs in
     let categorizeFunApplArgs args =
       let reverseArgs = List.rev args in

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -2050,7 +2050,7 @@ let isSingleArgParenApplication = function
   | _ -> false
 
 let rec isChainOfSugarGetExprs = function
-  | {pexp_desc = (Pexp_apply (eFun, (_,e1)::(_, e2)::xs))} ->
+  | {pexp_desc = (Pexp_apply (eFun, (_,e1)::(_, e2)::_))} ->
       if printedStringAndFixityExpr eFun = Infix "##" then begin
         match e1.pexp_desc, e2.pexp_desc with
         | Pexp_ident {txt = Lident _}, Pexp_ident {txt = Lident _} -> true

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -7582,16 +7582,6 @@ let printer = object(self:'self)
     (* If there was a JSX attribute BUT JSX component wasn't detected,
        that JSX attribute needs to be pretty printed so it doesn't get
        lost *)
-    let isLeftSharpEqual = match funExpr.pexp_desc with
-      | Pexp_apply ({pexp_desc = Pexp_ident {txt = Lident "#="}}, _) -> true
-      | _ -> false
-    in
-    let formattedFunExpr =
-      if isLeftSharpEqual then
-        formatPrecedence ~loc:funExpr.pexp_loc (self#simplifyUnparseExpr funExpr)
-      else
-        self#simplifyUnparseExpr funExpr
-    in
     let maybeJSXAttr = List.map self#attribute jsxAttrs in
     let categorizeFunApplArgs args =
       let reverseArgs = List.rev args in
@@ -7608,6 +7598,8 @@ let printer = object(self:'self)
       | Pexp_apply ({pexp_desc = Pexp_ident {txt = Lident s}}, _)
         when requireNoSpaceFor s ->
         self#unparseExpr funExpr
+      | Pexp_apply ({pexp_desc = Pexp_ident {txt = Lident "#="}}, _) ->
+        formatPrecedence ~loc:funExpr.pexp_loc (self#unparseExpr funExpr)
       | Pexp_field _ -> self#unparseExpr funExpr
       | _ -> self#simplifyUnparseExpr funExpr
     in


### PR DESCRIPTION
This is a proposal for `["string_literals"]` sugar for `##` and `#=`, stemming from a discussion with @chenglou.

The change is fully backwards compatible, meaning `foo##bar` will still parse just fine. `foo["bar"]` parsed before too but it's invalid array access, and without this PR it will result in a type error anyway.

Before:

```rust
foo##bar;

foo##bar #= baz;

/* slightly contrived: */
foo##bar##baz #= bar##baz[0];
```

After:

```rust
foo["bar"];

foo["bar"] = baz;

/* slightly contrived: */
foo["bar"]["baz"] = bar["baz"][0];
```

If everyone's on board, I suggest merging #2050 before this PR, so that we'll get some nice precedence fixes for free (see my comments inline below).

**TODOs**:

- [x] Currently, `#=` is only printed as `=` if the left expr is a chain of `##` applications. This can be relaxed to account for e.g. `foo##bar[0]##baz[2] = "1px black dashed";`, i.e. array access. 
  ~~- This is only useful once #2050 is in. I have a local branch with #2050 and this PR and it works great.~~ Done
- [x] Think about relaxing it as well for `.` record accesses
