### PR TITLE
Recover jsx component near arrow of pattern match.

### DIFF
--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -1201,3 +1201,6 @@ let x = a >< b;
 let (=-) = (a, b) => a + b;
 
 let foo = (a, b) => a =- b;
+
+let (=><) = (a, b) => a + b;
+let x = a =>< b;

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -336,3 +336,7 @@ let x = foo /></ bar;
 <Foo bar=M.[]> M.[] </Foo>;
 
 <Foo bar=M.[]> ...M.[] </Foo>;
+
+switch (foo) {
+| `Variant => <Component />
+};

--- a/formatTest/unit_tests/input/infix.re
+++ b/formatTest/unit_tests/input/infix.re
@@ -918,3 +918,6 @@ let x = a >< b;
 let (=-) = (a, b) => a + b;
 
 let foo = (a, b) => a =- b;
+
+let (=><) = (a, b) => a + b;
+let x = a =>< b;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -233,3 +233,7 @@ let x = foo /></ bar;
 <Foo bar=M.[]> M.[] </Foo>;
 
 <Foo bar=M.[]> ...M.[] </Foo>;
+
+switch(foo) {
+| `Variant =><Component />
+};

--- a/src/reason-parser/reason_lexer.mll
+++ b/src/reason-parser/reason_lexer.mll
@@ -502,6 +502,11 @@ rule token = parse
   | ","  { COMMA }
   | "->" { MINUSGREATER }
   | "=>" { EQUALGREATER }
+  (* allow lexing of | `Variant =><Component /> *)
+  | "=><" uppercase_or_lowercase (identchar | '.') * {
+    set_lexeme_length lexbuf 2;
+    EQUALGREATER
+  }
   | "#"  { SHARP }
   | "."  { DOT }
   | ".." { DOTDOT }


### PR DESCRIPTION
```reason
switch(foo) {
  | `Variant =><Component />
};
```

`=><` isn't an infix operator in this context and should be parsed as jsx.