### PR TITLE
Correctly parse prefix ops in labeled parameters

### DIFF
--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1354,3 +1354,6 @@ let z = {<>};
 
 /* https://github.com/facebook/reason/issues/2056 */
 type foo = (~a: bool=?) => int;
+
+/* https://github.com/facebook/reason/issues/2070 */
+f(~commit=!build);

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -1180,3 +1180,6 @@ let z = {<>};
 
 /* https://github.com/facebook/reason/issues/2056 */
 type foo = ~a:bool=? => int;
+
+/* https://github.com/facebook/reason/issues/2070 */
+f(~commit=!build);

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -1032,11 +1032,12 @@ let raise_record_trailing_semi_error loc =
   let msg = "Record entries are separated by comma; we've found a semicolon instead." in
   raise Reason_syntax_util.(Error(loc, (Syntax_error msg)))
 
-let parse_infix_with_eql {txt; loc} expr =
+let parse_infix_with_eql ({txt; loc} as op) expr =
   let s = (String.sub txt 1 (String.length txt - 1)) in
   match s with
   | "-" | "-." -> mkuminus (mkloc s loc) expr
-  | _ -> mkuplus (mkloc s loc) expr
+  | "+" | "+." -> mkuplus (mkloc s loc) expr
+  | _ -> mkexp(Pexp_apply(mkoperator {op with txt = s}, [Nolabel, expr]))
 
 let record_exp_spread_msg =
   "Records can only have one `...` spread, at the beginning.


### PR DESCRIPTION
fixes #2070