### PR TITLE
ReasonReact JSX fragment

### DIFF
--- a/miscTests/reactjs_jsx_ppx_tests/expected_v2_1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v2_1.re
@@ -17,6 +17,7 @@ module Bar = {
 };
 module ReasonReact = {
   let element = (~key=?, ~ref=?, component) => 1;
+  let fragment = children => 1;
 };
 let divRef = ReactDOMRe.createElement("div", [||]);
 "=== DOM component ===";
@@ -177,3 +178,34 @@ ReasonReact.element(
   Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]),
 );
 ReasonReact.element(Foo.make([||]));
+"=== Fragment ===";
+ReactDOMRe.createElement(ReasonReact.fragment, [||]);
+ReactDOMRe.createElement(ReasonReact.fragment, [|1|]);
+ReactDOMRe.createElement(
+  ReasonReact.fragment,
+  [|
+    ReactDOMRe.createElement(
+      ReasonReact.fragment,
+      [|ReactDOMRe.createElement("div", [||])|],
+    ),
+  |],
+);
+ReactDOMRe.createElement(
+  ReasonReact.fragment,
+  [|ReactDOMRe.createElement(ReasonReact.fragment, [||]), 2|],
+);
+ReactDOMRe.createElement(
+  ReasonReact.fragment,
+  [|ReasonReact.element(Foo.make([|1|]))|],
+);
+ReactDOMRe.createElement(
+  ReasonReact.fragment,
+  [|
+    ReactDOMRe.createElement(
+      "div",
+      ~props=
+        ReactDOMRe.props(~comp=ReasonReact.element(Bar.make(divRef)), ()),
+      ReactDOMRe.createElement("li", [||]),
+    ),
+  |],
+);

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v2_2.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v2_2.re
@@ -18,6 +18,7 @@ module Bar = {
 };
 module ReasonReact = {
   let element = (~key=?, ~ref=?, component) => 1;
+  let fragment = children => 1;
 };
 let divRef = ReactDOMRe.createElement("div", [||]);
 "=== DOM component ===";
@@ -178,3 +179,34 @@ ReasonReact.element(
   Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]),
 );
 ReasonReact.element(Foo.make([||]));
+"=== Fragment ===";
+ReactDOMRe.createElement(ReasonReact.fragment, [||]);
+ReactDOMRe.createElement(ReasonReact.fragment, [|1|]);
+ReactDOMRe.createElement(
+  ReasonReact.fragment,
+  [|
+    ReactDOMRe.createElement(
+      ReasonReact.fragment,
+      [|ReactDOMRe.createElement("div", [||])|],
+    ),
+  |],
+);
+ReactDOMRe.createElement(
+  ReasonReact.fragment,
+  [|ReactDOMRe.createElement(ReasonReact.fragment, [||]), 2|],
+);
+ReactDOMRe.createElement(
+  ReasonReact.fragment,
+  [|ReasonReact.element(Foo.make([|1|]))|],
+);
+ReactDOMRe.createElement(
+  ReasonReact.fragment,
+  [|
+    ReactDOMRe.createElement(
+      "div",
+      ~props=
+        ReactDOMRe.props(~comp=ReasonReact.element(Bar.make(divRef)), ()),
+      ReactDOMRe.createElement("li", [||]),
+    ),
+  |],
+);

--- a/miscTests/reactjs_jsx_ppx_tests/expected_v2_3.re
+++ b/miscTests/reactjs_jsx_ppx_tests/expected_v2_3.re
@@ -18,6 +18,7 @@ module Bar = {
 };
 module ReasonReact = {
   let element = (~key=?, ~ref=?, component) => 1;
+  let fragment = children => 1;
 };
 let divRef = ReactDOMRe.createElement("div", [||]);
 "=== DOM component ===";
@@ -178,3 +179,34 @@ ReasonReact.element(
   Foo.Bar.make(~className="hello", [|ReasonReact.element(Bar.make([||]))|]),
 );
 ReasonReact.element(Foo.make([||]));
+"=== Fragment ===";
+ReactDOMRe.createElement(ReasonReact.fragment, [||]);
+ReactDOMRe.createElement(ReasonReact.fragment, [|1|]);
+ReactDOMRe.createElement(
+  ReasonReact.fragment,
+  [|
+    ReactDOMRe.createElement(
+      ReasonReact.fragment,
+      [|ReactDOMRe.createElement("div", [||])|],
+    ),
+  |],
+);
+ReactDOMRe.createElement(
+  ReasonReact.fragment,
+  [|ReactDOMRe.createElement(ReasonReact.fragment, [||]), 2|],
+);
+ReactDOMRe.createElement(
+  ReasonReact.fragment,
+  [|ReasonReact.element(Foo.make(1))|],
+);
+ReactDOMRe.createElement(
+  ReasonReact.fragment,
+  [|
+    ReactDOMRe.createElement(
+      "div",
+      ~props=
+        ReactDOMRe.props(~comp=ReasonReact.element(Bar.make(divRef)), ()),
+      ReactDOMRe.createElement("li", [||]),
+    ),
+  |],
+);

--- a/miscTests/reactjs_jsx_ppx_tests/test1.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test1.re
@@ -23,6 +23,7 @@ module Bar = {
 
 module ReasonReact = {
   let element (~key=?, ~ref=?, component) = 1;
+  let fragment (children) = 1;
 };
 
 let divRef = <div />;
@@ -121,3 +122,17 @@ let divRef = <div />;
   correct ReasonReact-specific call */
 
 ([@JSX] Foo.make(~children=[], ()));
+
+"=== Fragment ===";
+
+<> </>;
+
+<> 1 </>;
+
+<> <> <div /> </> </>;
+
+<> <> </> 2 </>;
+
+<> <Foo> 1 </Foo> </>;
+
+<> <div comp=(<Bar> ...divRef </Bar>)> ...<li /> </div> </>;

--- a/miscTests/reactjs_jsx_ppx_tests/test2.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test2.re
@@ -24,6 +24,7 @@ module Bar = {
 
 module ReasonReact = {
   let element (~key=?, ~ref=?, component) = 1;
+  let fragment (children) = 1;
 };
 
 let divRef = <div />;
@@ -121,3 +122,17 @@ let divRef = <div />;
   correct ReasonReact-specific call */
 
 ([@JSX] Foo.make(~children=[], ()));
+
+"=== Fragment ===";
+
+<> </>;
+
+<> 1 </>;
+
+<> <> <div /> </> </>;
+
+<> <> </> 2 </>;
+
+<> <Foo> 1 </Foo> </>;
+
+<> <div comp=(<Bar> ...divRef </Bar>)> ...<li /> </div> </>;

--- a/miscTests/reactjs_jsx_ppx_tests/test3.re
+++ b/miscTests/reactjs_jsx_ppx_tests/test3.re
@@ -24,6 +24,7 @@ module Bar = {
 
 module ReasonReact = {
   let element (~key=?, ~ref=?, component) = 1;
+  let fragment (children) = 1;
 };
 
 let divRef = <div />;
@@ -121,3 +122,17 @@ let divRef = <div />;
   correct ReasonReact-specific call */
 
 ([@JSX] Foo.make(~children=[], ()));
+
+"=== Fragment ===";
+
+<> </>;
+
+<> 1 </>;
+
+<> <> <div /> </> </>;
+
+<> <> </> 2 </>;
+
+<> <Foo> 1 </Foo> </>;
+
+<> <div comp=(<Bar> ...divRef </Bar>)> ...<li /> </div> </>;


### PR DESCRIPTION
Non-breaking, unless you were (ab)using the fragment syntax before in ReasonReact, which didn't work reliably due to formatting errors anyway (fixed recently).