### PR TITLE
Fix precedence of infix ops in the presence of fast pipe

### DIFF
--- a/formatTest/unit_tests/expected_output/fastPipe.re
+++ b/formatTest/unit_tests/expected_output/fastPipe.re
@@ -105,3 +105,7 @@ foo->f(.)->g(.);
 foo->([@attr] f(.))->([@attr] g(.));
 
 ("some-string" ++ "another")->more;
+(-1)->foo;
+- 1->foo;
+!foo->bar;
+(!foo)->bar;

--- a/formatTest/unit_tests/expected_output/fastPipe.re
+++ b/formatTest/unit_tests/expected_output/fastPipe.re
@@ -103,3 +103,5 @@ foo->([@attr] f(. a, b))->([@attr2] f(. a, b));
 foo->f(.);
 foo->f(.)->g(.);
 foo->([@attr] f(.))->([@attr] g(.));
+
+("some-string" ++ "another")->more;

--- a/formatTest/unit_tests/input/fastPipe.re
+++ b/formatTest/unit_tests/input/fastPipe.re
@@ -105,3 +105,7 @@ foo->f(.)->g(.);
 foo->([@attr] f(.))->([@attr] g(.));
 
 ("some-string" ++ "another")->more;
+(-1)->foo;
+-1->foo;
+!foo->bar;
+(!foo)->bar;

--- a/formatTest/unit_tests/input/fastPipe.re
+++ b/formatTest/unit_tests/input/fastPipe.re
@@ -103,3 +103,5 @@ foo->([@attr] f(. a, b))->([@attr2] f(. a, b));
 foo->f(.);
 foo->f(.)->g(.);
 foo->([@attr] f(.))->([@attr] g(.));
+
+("some-string" ++ "another")->more;

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3638,14 +3638,13 @@ let printer = object(self:'self)
       type t = node list
 
       let formatNode ?(first=false) {exp; args; uncurried} =
-        let parens = match (first, exp.pexp_desc) with
-        | true, Pexp_apply ({
-              pexp_desc = Pexp_ident({txt = Longident.Lident("^")})},
-              _
-            ) -> true
-        | true, _ -> false
-        | _, Pexp_apply _ -> true
-        | _, _ -> false
+        let parens = match (exp.pexp_desc) with
+        | Pexp_apply (e,_) -> (match printedStringAndFixityExpr e with
+          | UnaryPostfix "^" -> true
+          | Infix printedIdent -> higherPrecedenceThan (Token fastPipeToken) (Token printedIdent)
+          | _ -> not first
+        )
+        | _ -> false
         in
         let layout = match args with
         | [] -> self#unparseExpr exp

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3640,9 +3640,9 @@ let printer = object(self:'self)
       let formatNode ?(first=false) {exp; args; uncurried} =
         let parens = match (exp.pexp_desc) with
         | Pexp_apply (e,_) -> (match printedStringAndFixityExpr e with
-          | UnaryPostfix "^" -> true
           | Infix printedIdent -> higherPrecedenceThan (Token fastPipeToken) (Token printedIdent)
-          | _ -> not first
+          | Normal -> not first
+          | _ -> true
         )
         | _ -> false
         in


### PR DESCRIPTION
this fixes a regression introduced in https://github.com/facebook/reason/pull/2087