### PR TITLE
Fix precedence printing of `a->(b##c)`

### DIFF
--- a/formatTest/unit_tests/expected_output/fastPipe.re
+++ b/formatTest/unit_tests/expected_output/fastPipe.re
@@ -109,3 +109,7 @@ foo->([@attr] f(.))->([@attr] g(.));
 - 1->foo;
 !foo->bar;
 (!foo)->bar;
+
+a->(b##c);
+
+a->b##c;

--- a/formatTest/unit_tests/input/fastPipe.re
+++ b/formatTest/unit_tests/input/fastPipe.re
@@ -109,3 +109,7 @@ foo->([@attr] f(.))->([@attr] g(.));
 -1->foo;
 !foo->bar;
 (!foo)->bar;
+
+a->(b##c);
+
+(a->b)##c;


### PR DESCRIPTION
This change makes the formatting of fast pipe nodes reuse the same logic that we use elsewhere to format infix operators.

With this change I hope to mitigate future edge cases that would appear because of this custom fast pipe logic.