### PR TITLE
Parse fast pipe with underscore sugar correct.

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/fastPipe.re
+++ b/formatTest/typeCheckedTests/expected_output/fastPipe.re
@@ -32,3 +32,5 @@ let doStuff = (a: int, b: int, c: int): int =>
 let (|.) = (a, f) => f(a);
 
 let t4: int = 5->doStuff(1, _, 7);
+let t5: int =
+  5->doStuff(1, _, 7)->doStuff(1, _, 7);

--- a/formatTest/typeCheckedTests/expected_output/fastPipe.re
+++ b/formatTest/typeCheckedTests/expected_output/fastPipe.re
@@ -24,3 +24,11 @@ let c = true;
 
 /* parses as !(a->b->c) */
 let t3: bool = !a->b->c;
+
+/* parse fast pipe with  underscore application correct */
+let doStuff = (a: int, b: int, c: int): int =>
+  a + 2 * b + 3 * c;
+
+let (|.) = (a, f) => f(a);
+
+let t4: int = 5->doStuff(1, _, 7);

--- a/formatTest/typeCheckedTests/input/fastPipe.re
+++ b/formatTest/typeCheckedTests/input/fastPipe.re
@@ -30,3 +30,4 @@ let doStuff = (a: int, b: int, c: int): int => {
 let (|.) = (a, f) => f(a);
 
 let t4: int = 5->doStuff(1, _, 7);
+let t5: int = 5->doStuff(1, _, 7)->doStuff(1, _, 7);

--- a/formatTest/typeCheckedTests/input/fastPipe.re
+++ b/formatTest/typeCheckedTests/input/fastPipe.re
@@ -21,3 +21,12 @@ let c = true;
 
 /* parses as !(a->b->c) */
 let t3: bool = !a->b->c;
+
+/* parse fast pipe with  underscore application correct */
+let doStuff = (a: int, b: int, c: int): int => {
+  a + 2 * b + 3 * c;
+};
+
+let (|.) = (a, f) => f(a);
+
+let t4: int = 5->doStuff(1, _, 7);


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/2117

Parse
```
5->doStuff(3, _, 7)
```
as
```
5->(__x => doStuff(3, __x, 7))
```