### PR TITLE
Preserve named args when formatting fast pipe sugar.

### DIFF
--- a/formatTest/unit_tests/expected_output/fastPipe.re
+++ b/formatTest/unit_tests/expected_output/fastPipe.re
@@ -155,3 +155,21 @@ ReasonReact.Router.watchUrl(url =>
 ReasonReact.Router.watchUrl(url =>
   Route.urlToRoute(url)->ChangeView->self.send
 );
+
+window
+->Webapi.Dom.Window.open_(
+    ~url,
+    ~name="authWindow",
+    ~features=params,
+  );
+
+window
+->Webapi.Dom.Window.open_(
+    ~url,
+    ~name="authWindow",
+    () => {
+      let x = 1;
+      let y = 2;
+      x + y;
+    },
+  );

--- a/formatTest/unit_tests/input/fastPipe.re
+++ b/formatTest/unit_tests/input/fastPipe.re
@@ -141,3 +141,7 @@ blocks->(blocks => {"blocks": blocks});
 
 ReasonReact.Router.watchUrl(url => Route.urlToRoute(url)->ChangeView->(self.send));
 ReasonReact.Router.watchUrl(url => Route.urlToRoute(url)->ChangeView->self.send);
+
+window->Webapi.Dom.Window.open_(~url, ~name="authWindow", ~features=params);
+
+window->Webapi.Dom.Window.open_(~url, ~name="authWindow", () => { let x = 1; let y = 2; x + y; });

--- a/src/reason-parser/reason_heuristics.ml
+++ b/src/reason-parser/reason_heuristics.ml
@@ -103,3 +103,18 @@ let isFastPipe e = match Ast_404.Parsetree.(e.pexp_desc) with
       _
     ) -> true
   | _ -> false
+
+let isUnderscoreApplication expr =
+  let open Ast_404.Parsetree in
+  match expr with
+  | {pexp_attributes = []; pexp_desc = Pexp_fun(
+        Nolabel,
+        None,
+        {
+          ppat_desc = Ppat_var({txt = "__x"});
+          ppat_attributes = []
+        },
+        _
+      )
+    } -> true
+  | _ -> false


### PR DESCRIPTION
Preserves named arg formatting under fast pipe sugar.

```
window->Webapi.Dom.Window.open_(~url, ~name="authWindow", ~features=params);
```