### PR TITLE
Fix local open printing for `bs.obj`

### DIFF
--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -119,3 +119,6 @@ type y = {
   "height":
     (int, int, int, float, float, float) => unit,
 };
+
+/* https://github.com/facebook/reason/issues/2121 */
+Style.({"container": 3});

--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -121,4 +121,4 @@ type y = {
 };
 
 /* https://github.com/facebook/reason/issues/2121 */
-Style.({"container": 3});
+Style.{"container": 3};

--- a/formatTest/unit_tests/input/bucklescript.re
+++ b/formatTest/unit_tests/input/bucklescript.re
@@ -90,3 +90,6 @@ type y = {
   [@foo barbaz] "width": (int, int, int, float, float, float) => unit,
   [@foo barbaz] "height": (int, int, int, float, float, float) => unit,
 };
+
+/* https://github.com/facebook/reason/issues/2121 */
+Style.( { "container": 3 });

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -3077,6 +3077,16 @@ parenthesized_expr:
     }
   | mod_longident DOT as_loc(LBRACE) record_expr as_loc(error)
     { unclosed_exp (with_txt $3 "{") (with_txt $5 "}") }
+  | as_loc(mod_longident) DOT LBRACE record_expr_with_string_keys RBRACE
+    { let (exten, fields) = $4 in
+      let loc = mklocation $symbolstartpos $endpos in
+      let rec_exp = mkexp ~loc (Pexp_extension (mkloc ("bs.obj") loc,
+             PStr [mkstrexp (mkexp ~loc (Pexp_record(fields, exten))) []]))
+      in
+      mkexp(Pexp_open(Fresh, $1, rec_exp))
+    }
+  | mod_longident DOT as_loc(LBRACE) record_expr_with_string_keys as_loc(error)
+    { unclosed_exp (with_txt $3 "{") (with_txt $5 "}") }
   | as_loc(mod_longident) DOT LBRACKETBAR expr_list BARRBRACKET
     { let loc = mklocation $symbolstartpos $endpos in
       let rec_exp = Exp.mk ~loc ~attrs:[] (Pexp_array $4) in

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4167,7 +4167,8 @@ let printer = object(self:'self)
     | Pexp_tuple _ (* syntax sugar for M.(a, b) *)
     | Pexp_object {pcstr_fields = []} (* syntax sugar for M.{} *)
     | Pexp_construct ( {txt= Lident"::"},Some _)
-    | Pexp_construct ( {txt= Lident"[]"},_) ->
+    | Pexp_construct ( {txt= Lident"[]"},_)
+    | Pexp_extension ( {txt = "bs.obj"}, _ ) ->
       self#simplifyUnparseExpr e (* syntax sugar for M.[x,y] *)
     (* syntax sugar for the rest, wrap with parens to avoid ambiguity.
      * E.g., avoid M.(M2.v) being printed as M.M2.v

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -5751,7 +5751,7 @@ let printer = object(self:'self)
         | ([], Pexp_open (ovf, lid, e)) ->
           ovf == Fresh && self#isSeriesOfOpensFollowedByNonSequencyExpression e
         | ([], Pexp_letexception _) -> false
-        | ([], Pexp_extension _) -> false
+        | ([], Pexp_extension ({txt}, _)) -> txt = "bs.obj"
         | _ -> true
 
   method unparseObject ?wrap:((lwrap,rwrap)=("", "")) ?(withStringKeys=false) l o =


### PR DESCRIPTION
fixes #2121 

This fixes a regression introduced in https://github.com/facebook/reason/pull/1979