### PR TITLE
Fix parsing of `foo(~a: int)`

### DIFF
--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1374,3 +1374,14 @@ let predicate =
     fun
     | None => false
     | Some(exn) => predicate(exn);
+
+/* https://github.com/facebook/reason/issues/2125 */
+foo(~a);
+
+foo(~a: int);
+
+foo(~a: int);
+
+foo(~(a :> int));
+
+foo(~(a :> int));

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -1200,3 +1200,14 @@ let predicate =
     (fun
       | None => false
       | Some(exn) => predicate(exn));
+
+/* https://github.com/facebook/reason/issues/2125 */
+foo(~a);
+
+foo(~a: int);
+
+foo(~(a: int));
+
+foo(~(a :> int));
+
+foo(~a :> int);


### PR DESCRIPTION
fixes https://github.com/facebook/reason/issues/2125