### PR TITLE
Preserve braces around fast pipe with exp application inside jsx children

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/fastPipe.re
+++ b/formatTest/typeCheckedTests/expected_output/fastPipe.re
@@ -34,3 +34,139 @@ let (|.) = (a, f) => f(a);
 let t4: int = 5->doStuff(1, _, 7);
 let t5: int =
   5->doStuff(1, _, 7)->doStuff(1, _, 7);
+
+module Foo = {
+  let createElement = (~children, ()) =>
+    List.hd(children) ++ "test";
+
+  let map = (xs, f) => List.map(f, xs);
+
+  let plusOne = x => x + 1;
+
+  let toString = lst =>
+    List.fold_left(
+      (acc, curr) =>
+        acc ++ string_of_int(curr),
+      "",
+      lst,
+    );
+};
+
+let items = [1, 2, 3];
+
+let t6: string =
+  <Foo>
+    {items->Foo.map(Foo.plusOne)->Foo.toString}
+  </Foo>;
+
+type saveStatus =
+  | Pristine
+  | Saved
+  | Saving
+  | Unsaved;
+
+let saveStatus = Pristine;
+
+let t7: string =
+  <Foo>
+    {
+      (
+        switch (saveStatus) {
+        | Pristine => [0]
+        | Saved => [1]
+        | Saving => [2]
+        | Unsaved => [3]
+        }
+      )
+      ->Foo.map(Foo.plusOne)
+      ->Foo.toString
+    }
+  </Foo>;
+
+let genItems = f => List.map(f, items);
+
+let t8: string =
+  <Foo>
+    {genItems(Foo.plusOne)->Foo.toString}
+  </Foo>;
+
+let blocks = [1, 2, 3];
+
+let t9: string =
+  <Foo> blocks->(b => Foo.toString(b)) </Foo>;
+
+let foo = xs => List.concat([xs, xs]);
+
+let t10: string =
+  <Foo>
+    {
+      blocks
+      ->foo
+      ->Foo.map(Foo.plusOne)
+      ->Foo.toString
+    }
+  </Foo>;
+
+let t11: string =
+  <Foo>
+    {
+      blocks
+      ->foo
+      ->Foo.map(Foo.plusOne)
+      ->Foo.map(Foo.plusOne)
+      ->Foo.toString
+    }
+  </Foo>;
+
+let title = "los pilares de la tierra";
+
+let t12: string =
+  <Foo>
+    (title === "" ? [1, 2, 3] : blocks)
+    ->Foo.toString
+  </Foo>;
+
+type change =
+  | Change(list(int));
+
+type this = {send: change => string};
+
+let change = x => Change(x);
+
+let self = {
+  send: x =>
+    switch (x) {
+    | Change(xs) => Foo.toString(xs)
+    },
+};
+
+let urlToRoute = x => [x, x, x];
+
+let t13: string =
+  urlToRoute(1)->change->(self.send);
+
+module FooLabeled = {
+  let createElement = (~children, ()) =>
+    List.hd(children) ++ "test";
+
+  let map = (xs, ~f) => List.map(f, xs);
+
+  let plusOne = x => x + 1;
+
+  let toString = lst =>
+    List.fold_left(
+      (acc, curr) =>
+        acc ++ string_of_int(curr),
+      "",
+      lst,
+    );
+};
+
+let t14: string =
+  <FooLabeled>
+    {
+      items
+      ->FooLabeled.map(~f=FooLabeled.plusOne)
+      ->FooLabeled.toString
+    }
+  </FooLabeled>;

--- a/formatTest/typeCheckedTests/input/fastPipe.re
+++ b/formatTest/typeCheckedTests/input/fastPipe.re
@@ -31,3 +31,120 @@ let (|.) = (a, f) => f(a);
 
 let t4: int = 5->doStuff(1, _, 7);
 let t5: int = 5->doStuff(1, _, 7)->doStuff(1, _, 7);
+
+module Foo = {
+  let createElement = (~children, ()) =>
+    List.hd(children) ++ "test";
+
+  let map = (xs, f) => List.map(f, xs);
+
+  let plusOne = x => x + 1;
+
+  let toString = lst =>
+    List.fold_left(
+      (acc, curr) =>
+        acc ++ (string_of_int(curr)),
+      "",
+      lst
+    );
+};
+
+let items = [1, 2, 3];
+
+let t6: string =
+  <Foo> {items->Foo.map(Foo.plusOne)->Foo.toString} </Foo>;
+
+type saveStatus =
+  | Pristine
+  | Saved
+  | Saving
+  | Unsaved;
+
+let saveStatus = Pristine;
+
+let t7: string =
+  <Foo>
+    {
+      (
+        switch (saveStatus) {
+        | Pristine => [0]
+        | Saved => [1]
+        | Saving => [2]
+        | Unsaved => [3]
+        }
+      )
+      ->Foo.map(Foo.plusOne)
+      ->Foo.toString
+    }
+  </Foo>;
+
+let genItems = (f) => List.map(f, items);
+
+let t8: string =
+  <Foo>
+    {genItems(Foo.plusOne)->Foo.toString}
+  </Foo>;
+
+let blocks = [1, 2, 3];
+
+let t9: string =
+  <Foo>
+    blocks->(b => Foo.toString(b))
+  </Foo>;
+
+let foo = (xs) => List.concat([xs, xs]);
+
+let t10: string =
+  <Foo>
+    {blocks->foo->Foo.map(Foo.plusOne)->Foo.toString}
+  </Foo>;
+
+let t11: string =
+  <Foo>
+    {blocks->foo->Foo.map(Foo.plusOne)->Foo.map(Foo.plusOne)->Foo.toString}
+  </Foo>;
+
+let title = "los pilares de la tierra";
+
+let t12: string =
+  <Foo>(title === "" ? [1, 2, 3]: blocks)->Foo.toString</Foo>
+
+type change =
+  | Change(list(int));
+
+type this = {
+  send: change => string
+};
+
+let change = x => Change(x);
+
+let self = {
+  send: x =>
+    switch (x) {
+    | Change(xs) => Foo.toString(xs)
+    },
+};
+
+let urlToRoute = (x) => [x, x, x];
+
+let t13: string = urlToRoute(1)->change->(self.send);
+
+module FooLabeled = {
+  let createElement = (~children, ()) =>
+    List.hd(children) ++ "test";
+
+  let map = (xs, ~f) => List.map(f, xs);
+
+  let plusOne = x => x + 1;
+
+  let toString = lst =>
+    List.fold_left(
+      (acc, curr) =>
+        acc ++ (string_of_int(curr)),
+      "",
+      lst
+    );
+};
+
+let t14: string =
+  <FooLabeled> {items->FooLabeled.map(~f=FooLabeled.plusOne)->FooLabeled.toString} </FooLabeled>;

--- a/formatTest/unit_tests/expected_output/fastPipe.re
+++ b/formatTest/unit_tests/expected_output/fastPipe.re
@@ -173,3 +173,11 @@ window
       x + y;
     },
   );
+
+<div>
+  {
+    items
+    ->Belt.Array.map(ReasonReact.string)
+    ->ReasonReact.array
+  }
+</div>;

--- a/formatTest/unit_tests/input/fastPipe.re
+++ b/formatTest/unit_tests/input/fastPipe.re
@@ -145,3 +145,5 @@ ReasonReact.Router.watchUrl(url => Route.urlToRoute(url)->ChangeView->self.send)
 window->Webapi.Dom.Window.open_(~url, ~name="authWindow", ~features=params);
 
 window->Webapi.Dom.Window.open_(~url, ~name="authWindow", () => { let x = 1; let y = 2; x + y; });
+
+<div> {items->Belt.Array.map(ReasonReact.string)->ReasonReact.array} </div>;

--- a/src/reason-parser/reason_heuristics.ml
+++ b/src/reason-parser/reason_heuristics.ml
@@ -111,17 +111,8 @@ let isFastPipe e = match Ast_404.Parsetree.(e.pexp_desc) with
  * preserved in this case. *)
 let isFastPipeWithApplicationJSXChild e = match Ast_404.Parsetree.(e.pexp_desc) with
   | Pexp_apply(
-    {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})},
-       [Nolabel, {pexp_desc = Pexp_apply(
-        {pexp_desc =
-          Pexp_apply(
-            {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})},
-            _
-          )
-        },
-        _
-        )};
-      _]
+      {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})},
+      [Nolabel, {pexp_desc = Pexp_apply(_)}; _]
     ) -> true
   | _ -> false
 

--- a/src/reason-parser/reason_heuristics.ml
+++ b/src/reason-parser/reason_heuristics.ml
@@ -104,6 +104,27 @@ let isFastPipe e = match Ast_404.Parsetree.(e.pexp_desc) with
     ) -> true
   | _ -> false
 
+
+(* <div> {items->Belt.Array.map(ReasonReact.string)->ReasonReact.array} </div>;
+ * An application with fast pipe inside jsx children requires special treatment.
+ * Jsx children don't allow expression application, hence we need the braces
+ * preserved in this case. *)
+let isFastPipeWithApplicationJSXChild e = match Ast_404.Parsetree.(e.pexp_desc) with
+  | Pexp_apply(
+    {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})},
+       [Nolabel, {pexp_desc = Pexp_apply(
+        {pexp_desc =
+          Pexp_apply(
+            {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})},
+            _
+          )
+        },
+        _
+        )};
+      _]
+    ) -> true
+  | _ -> false
+
 let isUnderscoreApplication expr =
   let open Ast_404.Parsetree in
   match expr with


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/2131

An application with fast pipe inside jsx children requires special treatment.
Jsx children don't allow expression application, hence we need the braces preserved in this case.

```reason
<div> {items->Belt.Array.map(ReasonReact.string)->ReasonReact.array} </div>
```
Without the braces the ast would look like
`items->Belt.Array.map; (ReasonReact.string)->ReasonReact.array;`