### PR TITLE
Fix `foo(~Foo.a)` becoming `foo(~Fooa=Foo.a);

### DIFF
--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1385,3 +1385,7 @@ foo(~a: int);
 foo(~(a :> int));
 
 foo(~(a :> int));
+
+foo(~a=?Foo.a);
+
+foo(~a=Foo.a);

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -1211,3 +1211,7 @@ foo(~(a: int));
 foo(~(a :> int));
 
 foo(~a :> int);
+
+foo(~Foo.a?);
+
+foo(~Foo.a);


### PR DESCRIPTION
fixes #2128 