### PR TITLE
Rtop: make `show` directive work on remapped operators

### DIFF
--- a/src/reason-parser/reason_syntax_util.mli
+++ b/src/reason-parser/reason_syntax_util.mli
@@ -14,6 +14,8 @@
   patching the right parts, through the power of types(tm)
 *)
 
+val reason_to_ml_swap : string -> string
+
 val ml_to_reason_swap : string -> string
 
 val escape_string : string -> string


### PR DESCRIPTION
Fixes #1766 

Since I was touching `rtop` in #2146, might as well fix this one too.

Before:
```reason
Reason # #show (^);
let ( ++ ): (string, string) => string;
Reason # #show (++);
Unknown element.
Reason # #toggle_syntax;
OCaml # #show (^);;
let ( ++ ): (string, string) => string;
OCaml # #show (++);;
Unknown element.
OCaml # #toggle_syntax;;
Reason # #show (++);
Unknown element.
```

After:

```reason
Reason # #show (^);
external ( ^ ): ref('a) => 'a = "%field0";
Reason # #show (++);
let ( ++ ): (string, string) => string;
Reason # #toggle_syntax;
OCaml # #show (^);;
val ( ^ ) : string -> string -> string
OCaml # #show (++);;
Unknown element.
OCaml # #toggle_syntax;;
Reason # #show (++);
let ( ++ ): (string, string) => string;
```