### PR TITLE
Fix fast pipe formatting for `a->(b->c)`

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/fastPipe.re
+++ b/formatTest/typeCheckedTests/expected_output/fastPipe.re
@@ -170,3 +170,8 @@ let t14: string =
       ->FooLabeled.toString
     }
   </FooLabeled>;
+
+let c = (a, b) => a + b;
+let a = 1;
+let b = 2;
+let t: int = a->(b->c);

--- a/formatTest/typeCheckedTests/input/fastPipe.re
+++ b/formatTest/typeCheckedTests/input/fastPipe.re
@@ -148,3 +148,8 @@ module FooLabeled = {
 
 let t14: string =
   <FooLabeled> {items->FooLabeled.map(~f=FooLabeled.plusOne)->FooLabeled.toString} </FooLabeled>;
+
+let c = (a, b) => a + b;
+let a = 1;
+let b = 2;
+let t: int = a->(b->c);

--- a/formatTest/unit_tests/expected_output/fastPipe.re
+++ b/formatTest/unit_tests/expected_output/fastPipe.re
@@ -181,3 +181,5 @@ window
     ->ReasonReact.array
   }
 </div>;
+
+a->(b->c);

--- a/formatTest/unit_tests/input/fastPipe.re
+++ b/formatTest/unit_tests/input/fastPipe.re
@@ -147,3 +147,5 @@ window->Webapi.Dom.Window.open_(~url, ~name="authWindow", ~features=params);
 window->Webapi.Dom.Window.open_(~url, ~name="authWindow", () => { let x = 1; let y = 2; x + y; });
 
 <div> {items->Belt.Array.map(ReasonReact.string)->ReasonReact.array} </div>;
+
+a->(b->c);


### PR DESCRIPTION
This diff also makes fast pipe `SpecificInfixPrecedence` by default,
instead of `Simple`, as recent bugs have shown that fast pipe formatting
is definitely not simple!

By having fast pipe be `SpecificInfixPrecedence` by default again, it
eliminates hopefully the last class of bugs that we hav seen recently.