### PR TITLE
Preserve interleaved whitespace between record expression rows

### DIFF
--- a/formatTest/unit_tests/expected_output/whitespace.re
+++ b/formatTest/unit_tests/expected_output/whitespace.re
@@ -182,6 +182,152 @@ module EdgeCase = {
   let x = 1;
 };
 
+/** Record-like expressions */
+let r = {
+  a: 1,
+
+  b: 2,
+  c: 3,
+};
+
+/* with punning */
+let r = {
+  a,
+
+  b,
+  c,
+};
+
+/* with spread */
+let r = {
+  ...x,
+
+  a: 1,
+
+  b: 2,
+  c: 3,
+};
+
+/* comments */
+let r = {
+  ...x,
+
+  /* a */
+  a: 1,
+
+  /* b */
+  /* c */
+
+  /* d */
+  b: 2,
+  /* e */
+
+  c: 3,
+
+  /* f */
+  d,
+
+  e,
+};
+
+/* string keys */
+let x = {
+  "a": 1,
+
+  "b": 2,
+  "c": 3,
+};
+
+/* string keys punning */
+let x = {
+  "a": a,
+
+  "b": b,
+  "c": c,
+};
+
+/* string keys with spread */
+let x = {
+  ...x,
+
+  "a": 1,
+
+  "b": 2,
+  "c": 3,
+};
+
+/* string keys with comments */
+let x = {
+  ...x,
+
+  /* a */
+  "a": 1,
+
+  /* b */
+  /* c */
+
+  /* d */
+  "b": 2,
+  /* e */
+
+  "c": 3,
+
+  /* f */
+  "d": d,
+
+  "e": e,
+};
+
+let make = _children => {
+  ...component,
+
+  initialState: () => {
+    posts: [],
+    activeRoute:
+      urlToRoute(
+        ReasonReact.Router.dangerouslyGetInitialUrl(),
+      ),
+  },
+
+  didMount: self => {
+    let watcherID =
+      ReasonReact.Router.watchUrl(url =>
+        self.send(
+          ChangeRoute(urlToRoute(url)),
+        )
+      );
+    self.onUnmount(() =>
+      ReasonReact.Router.unwatchUrl(watcherID)
+    );
+  },
+
+  reducer: (action, state) =>
+    switch (action) {
+    | ChangeRoute(activeRoute) =>
+      ReasonReact.Update({
+        ...state,
+        activeRoute,
+      })
+    | FetchCats => ReasonReact.NoUpdate
+    },
+
+  render: ({state: {posts, activeRoute}}) =>
+    <div>
+      <h1>
+        <a href="/">
+          {ReasonReact.string("Instagram")}
+        </a>
+      </h1>
+      {
+        switch (activeRoute) {
+        | Default => <Grid posts />
+        | Detail(postId) =>
+          <Single posts postId />
+        }
+      }
+    </div>,
+};
+
 let f = (a, b) => a + b;
 /* this comment sticks at the end */
 

--- a/formatTest/unit_tests/input/whitespace.re
+++ b/formatTest/unit_tests/input/whitespace.re
@@ -31,7 +31,7 @@ module Comments = {
   /* wow another one below too */
 
   let add = Test.x;
-  
+
 
   /* this
      is
@@ -185,6 +185,137 @@ module EdgeCase = {
   /* c */
 
   let x = 1;
+};
+
+/** Record-like expressions */
+let r = {
+  a: 1,
+
+  b: 2,
+  c: 3,
+};
+
+/* with punning */
+let r = {
+  a,
+
+  b,
+  c,
+};
+
+/* with spread */
+let r = {
+  ...x,
+
+  a: 1,
+
+  b: 2,
+  c: 3,
+};
+
+/* comments */
+let r = {
+  ...x,
+
+  /* a */
+  a: 1,
+
+  /* b */
+  /* c */
+
+  /* d */
+  b: 2,
+  /* e */
+
+  c: 3,
+
+  /* f */
+  d,
+
+  e,
+};
+
+/* string keys */
+let x = {
+  "a": 1,
+
+  "b": 2,
+  "c": 3,
+};
+
+/* string keys punning */
+let x = {
+  "a",
+
+  "b",
+  "c"
+};
+
+/* string keys with spread */
+let x = {
+  ...x,
+
+  "a": 1,
+
+  "b": 2,
+  "c": 3,
+};
+
+/* string keys with comments */
+let x = {
+  ...x,
+
+  /* a */
+  "a": 1,
+
+  /* b */
+  /* c */
+
+  /* d */
+  "b": 2,
+  /* e */
+
+  "c": 3,
+
+  /* f */
+  "d",
+
+  "e",
+};
+
+let make = _children => {
+  ...component,
+
+  initialState: () => {
+    posts: [],
+    activeRoute: urlToRoute(ReasonReact.Router.dangerouslyGetInitialUrl()),
+  },
+
+  didMount: self => {
+    let watcherID =
+      ReasonReact.Router.watchUrl(url =>
+        self.send(ChangeRoute(urlToRoute(url)))
+      );
+    self.onUnmount(() => ReasonReact.Router.unwatchUrl(watcherID));
+  },
+
+  reducer: (action, state) =>
+    switch (action) {
+    | ChangeRoute(activeRoute) =>
+      ReasonReact.Update({...state, activeRoute})
+    | FetchCats => ReasonReact.NoUpdate
+    },
+
+  render: ({state: {posts, activeRoute}}) =>
+    <div>
+      <h1> <a href="/"> {ReasonReact.string("Instagram")} </a> </h1>
+      {
+        switch (activeRoute) {
+        | Default => <Grid posts />
+        | Detail(postId) => <Single posts postId />
+        }
+      }
+    </div>,
 };
 
 let f = (a, b) => a + b;

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -3616,7 +3616,7 @@ string_literal_expr_maybe_punned_with_comma:
   { let loc = mklocation $startpos $endpos in
     let (s, _, d) = $1 in
     let lident_lident_loc = mkloc (Lident s) loc in
-    let exp = mkexp (Pexp_ident lident_lident_loc) in
+    let exp = mkexp ~loc (Pexp_ident lident_lident_loc) in
     (lident_lident_loc, exp)
   }
   | STRING COLON expr COMMA
@@ -3634,7 +3634,7 @@ string_literal_expr_maybe_punned:
     let lident_lident_loc = mkloc (Lident s) loc in
     let exp = match $2 with
       | Some x -> x
-      | None -> mkexp (Pexp_ident lident_lident_loc)
+      | None -> mkexp ~loc (Pexp_ident lident_lident_loc)
     in
     (lident_lident_loc, exp)
   }


### PR DESCRIPTION
Allows whitespace interleaving between rows of record expressions.
It's hard to see the forest through the trees when scanning through Reason code containing record expression with rows packed on top of each other. By preserving one newline (if the user wrote n >= 1),
the code becomes much clearer to read and a pleasure to write. This also aligns user's expectations in terms of the output that Prettier produces.

Example:
```reason
let make = _children => {
  ...component,

  initialState: () => {
    posts: [],
    activeRoute: urlToRoute(ReasonReact.Router.dangerouslyGetInitialUrl()),
  },

  didMount: self => {
    let watcherID =
      ReasonReact.Router.watchUrl(url =>
        self.send(ChangeRoute(urlToRoute(url)))
      );
    self.onUnmount(() => ReasonReact.Router.unwatchUrl(watcherID));
  },

  reducer: (action, state) =>
    switch (action) {
    | ChangeRoute(activeRoute) => ReasonReact.Update({...state, activeRoute})
    | FetchCats => ReasonReact.NoUpdate
    },

  render: ({state: {posts, activeRoute}}) =>
    <div>
      <h1> <a href="/"> {ReasonReact.string("Instagram")} </a> </h1>
      {
        switch (activeRoute) {
        | Default => <Grid posts />
        | Detail(postId) => <Single posts postId />
        }
      }
    </div>,
};
```