### PR TITLE
Add a test case for transitioning from |. to -> in JSX

### DIFF
--- a/formatTest/unit_tests/expected_output/fastPipe.re
+++ b/formatTest/unit_tests/expected_output/fastPipe.re
@@ -183,3 +183,5 @@ window
 </div>;
 
 a->(b->c);
+
+<div> {T.t("value")->ReasonReact.string} </div>;

--- a/formatTest/unit_tests/input/fastPipe.re
+++ b/formatTest/unit_tests/input/fastPipe.re
@@ -149,3 +149,5 @@ window->Webapi.Dom.Window.open_(~url, ~name="authWindow", () => { let x = 1; let
 <div> {items->Belt.Array.map(ReasonReact.string)->ReasonReact.array} </div>;
 
 a->(b->c);
+
+<div> (T.t("value") |. ReasonReact.string) </div>;


### PR DESCRIPTION
After having spent some time today trying to upgrade to the new fast pipe syntax through refmt, this is simply to ensure the transition goes smoothly after the next release 😄 