### PR TITLE
#2170 FIX: Refmt link typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Aaaanyways, to install `refmt.js`: `npm install reason`.
 
 Here's the API, with pseudo type annotations:
 
--   `parseRE(code: string): astAndComments`: parse Reason code
--   `parseREI(code: string): astAndComments`: parse Reason interface code
--   `printRE(data: astAndComments): string`: print Reason code
--   `printREI(data: astAndComments): string`: print Reason interface code
--   `parseML(code)`, `parseMLI(code)`, `printML(data)`, `printMLI(data)`: same as above, but for the OCaml syntax
+- `parseRE(code: string): astAndComments`: parse Reason code
+- `parseREI(code: string): astAndComments`: parse Reason interface code
+- `printRE(data: astAndComments): string`: print Reason code
+- `printREI(data: astAndComments): string`: print Reason interface code
+- `parseML(code)`, `parseMLI(code)`, `printML(data)`, `printMLI(data)`: same as above, but for the OCaml syntax
 
 The type `string` is self-descriptive. The type `astAndComments` returned by the `parse*` functions is an opaque data structure; you will only use it as input to the `print*` functions. For example:
 
@@ -71,17 +71,17 @@ The `parse*` functions potentially throw an error of this shape:
 
 We're spoiled with more APIs on the native side. To use Reason from OPAM as a native library, you have [these functions](https://github.com/facebook/reason/blob/5a253048e8077c4597a8935adbed7aa22bfff647/src/reason_toolchain.ml#L141-L157). So:
 
--   `Reason_toolchain.RE.implementation_with_comments`
--   `Reason_toolchain.RE.interface_with_comments`
--   `Reason_toolchain.RE.print_interface_with_comments`
--   `Reason_toolchain.ML.implementation_with_comments`
--   etc.
+- `Reason_toolchain.RE.implementation_with_comments`
+- `Reason_toolchain.RE.interface_with_comments`
+- `Reason_toolchain.RE.print_interface_with_comments`
+- `Reason_toolchain.ML.implementation_with_comments`
+- etc.
 
 The `ML` parsing functions might throw [`Syntaxerr.Error error`](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Syntaxerr.html). The `RE` parsing functions might throw:
 
--   [`Reason_syntax_util.Error`](https://github.com/facebook/reason/blob/6e99ea5aae3791359b1e356060691f7b5b596365/src/reason-parser/reason_syntax_util.ml#L456) (docs on `Location.t` [here](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Location.html))
--   [`Syntaxerr.Error`](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Syntaxerr.html).
--   [`Reason_lexer.Error`](https://github.com/facebook/reason/blob/6e99ea5aae3791359b1e356060691f7b5b596365/src/reason-parser/reason_lexer.mll#L84).
+- [`Reason_syntax_util.Error`](https://github.com/facebook/reason/blob/6e99ea5aae3791359b1e356060691f7b5b596365/src/reason-parser/reason_syntax_util.ml#L456) (docs on `Location.t` [here](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Location.html))
+- [`Syntaxerr.Error`](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Syntaxerr.html).
+- [`Reason_lexer.Error`](https://github.com/facebook/reason/blob/6e99ea5aae3791359b1e356060691f7b5b596365/src/reason-parser/reason_lexer.mll#L84).
 
 Example usage:
 

--- a/README.md
+++ b/README.md
@@ -24,27 +24,27 @@ See the [src folder's README](https://github.com/facebook/reason/tree/master/src
 
 ### JavaScript API
 
-We expose a `refmt.js` for you to use on the web. Again, for local development, please use the native `refmt` that comes with the installation [here](https://reasonml.github.io/docs/en/global-installation.html). It's an order of magnitude faster than the JS version. Don't use the JS version unless you know what you're doing. Let's keep our ecosystem fast please.
+We expose a `refmt.js` for you to use on the web. Again, for local development, please use the native `refmt` that comes with the installation [here](https://reasonml.github.io/docs/en/installation.html). It's an order of magnitude faster than the JS version. Don't use the JS version unless you know what you're doing. Let's keep our ecosystem fast please.
 
 Aaaanyways, to install `refmt.js`: `npm install reason`.
 
 Here's the API, with pseudo type annotations:
 
-- `parseRE(code: string): astAndComments`: parse Reason code
-- `parseREI(code: string): astAndComments`: parse Reason interface code
-- `printRE(data: astAndComments): string`: print Reason code
-- `printREI(data: astAndComments): string`: print Reason interface code
-- `parseML(code)`, `parseMLI(code)`, `printML(data)`, `printMLI(data)`: same as above, but for the OCaml syntax
+-   `parseRE(code: string): astAndComments`: parse Reason code
+-   `parseREI(code: string): astAndComments`: parse Reason interface code
+-   `printRE(data: astAndComments): string`: print Reason code
+-   `printREI(data: astAndComments): string`: print Reason interface code
+-   `parseML(code)`, `parseMLI(code)`, `printML(data)`, `printMLI(data)`: same as above, but for the OCaml syntax
 
 The type `string` is self-descriptive. The type `astAndComments` returned by the `parse*` functions is an opaque data structure; you will only use it as input to the `print*` functions. For example:
 
 ```js
-const refmt = require('reason')
+const refmt = require('reason');
 
 // convert the ocaml syntax to reason syntax
 const ast = refmt.parseML('let f a = 1');
 const result = refmt.printRE(ast);
-console.log(result) // prints `let f = (a) => 1`
+console.log(result); // prints `let f = (a) => 1`
 ```
 
 The `parse*` functions potentially throw an error of this shape:
@@ -71,16 +71,17 @@ The `parse*` functions potentially throw an error of this shape:
 
 We're spoiled with more APIs on the native side. To use Reason from OPAM as a native library, you have [these functions](https://github.com/facebook/reason/blob/5a253048e8077c4597a8935adbed7aa22bfff647/src/reason_toolchain.ml#L141-L157). So:
 
-- `Reason_toolchain.RE.implementation_with_comments`
-- `Reason_toolchain.RE.interface_with_comments`
-- `Reason_toolchain.RE.print_interface_with_comments`
-- `Reason_toolchain.ML.implementation_with_comments`
-- etc.
+-   `Reason_toolchain.RE.implementation_with_comments`
+-   `Reason_toolchain.RE.interface_with_comments`
+-   `Reason_toolchain.RE.print_interface_with_comments`
+-   `Reason_toolchain.ML.implementation_with_comments`
+-   etc.
 
 The `ML` parsing functions might throw [`Syntaxerr.Error error`](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Syntaxerr.html). The `RE` parsing functions might throw:
-- [`Reason_syntax_util.Error`](https://github.com/facebook/reason/blob/6e99ea5aae3791359b1e356060691f7b5b596365/src/reason-parser/reason_syntax_util.ml#L456) (docs on `Location.t` [here](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Location.html))
-- [`Syntaxerr.Error`](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Syntaxerr.html).
-- [`Reason_lexer.Error`](https://github.com/facebook/reason/blob/6e99ea5aae3791359b1e356060691f7b5b596365/src/reason-parser/reason_lexer.mll#L84).
+
+-   [`Reason_syntax_util.Error`](https://github.com/facebook/reason/blob/6e99ea5aae3791359b1e356060691f7b5b596365/src/reason-parser/reason_syntax_util.ml#L456) (docs on `Location.t` [here](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Location.html))
+-   [`Syntaxerr.Error`](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Syntaxerr.html).
+-   [`Reason_lexer.Error`](https://github.com/facebook/reason/blob/6e99ea5aae3791359b1e356060691f7b5b596365/src/reason-parser/reason_lexer.mll#L84).
 
 Example usage:
 
@@ -102,7 +103,6 @@ let ocaml_syntax =
 See Reason license in [LICENSE.txt](LICENSE.txt).
 
 Works that are forked from other projects are under their original licenses.
-
 
 ## Credit
 


### PR DESCRIPTION
Issue #2170 

Typo at refmt installation link in Readme
