### PR TITLE
Use updated Menhir in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ common_steps: &common_steps
         command: |
           opam update
           opam install -y jbuilder
-
           opam install -y menhir
           opam install -y utop
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ common_steps: &common_steps
         command: |
           opam update
           opam install -y jbuilder
-          opam install -y menhir.20170712
+          opam install -y menhir
     - run:
         name: 'Clean'
         command: make clean-for-ci


### PR DESCRIPTION
We can now use an updated Menhir for CI tests given that https://github.com/facebook/reason/pull/2145 is in.