### PR TITLE
Update Getting Started link to point to the new page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple, fast & type safe code that leverages the JavaScript & OCaml ecosystems.
 
 [![Build Status](https://travis-ci.org/facebook/reason.svg?branch=master)](https://travis-ci.org/facebook/reason) [![CircleCI](https://circleci.com/gh/facebook/reason/tree/master.svg?style=svg)](https://circleci.com/gh/facebook/reason/tree/master)
 
-## [Getting Started](https://reasonml.github.io/docs/en/quickstart-javascript.html)
+## [Getting Started](https://reasonml.github.io/docs/en/installation)
 
 ## [Community](https://reasonml.github.io/docs/en/community.html)
 


### PR DESCRIPTION
The location of the Getting Started guide changed, and the previous link simply loads a page that points users to the new page. Might as well just take them directly to the new location.