### PR TITLE
Fix erroneous pattern parsing inside ternary expressions

### DIFF
--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1389,3 +1389,10 @@ foo(~(a :> int));
 foo(~a=?Foo.a);
 
 foo(~a=Foo.a);
+
+/* https://github.com/facebook/reason/issues/2155#issuecomment-422077648 */
+true ? (Update({...a, b: 1}), None) : x;
+true ? {...a, b: 1} : a;
+true ? (a, {...a, b: 1}) : a;
+
+true ? ([x, ...xs]) => f(x, xs) : a;

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -1215,3 +1215,10 @@ foo(~a :> int);
 foo(~Foo.a?);
 
 foo(~Foo.a);
+
+/* https://github.com/facebook/reason/issues/2155#issuecomment-422077648 */
+true ? (Update({...a, b: 1}), None) : x;
+true ? ({...a, b: 1}) : a;
+true ? (a, {...a, b: 1}) : a;
+
+true ? ([x, ...xs]) => f(x, xs) : a;


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/2155

The problem:
```reason
true ? (Update({...a, b: 1}), None) : x;
```
We "over"-parse spread operators inside patterns for better errors.
Because of the parens, semicolon `:` and `...`  now being a valid codepath, the lexer triggers an injection of an `ES6_FUN` token. This is clearly not an es6 style function expression.
As soon as a `...` is reached with a closing `}`, we know that we definitely don't have an es6 function expression. By exiting the lexer's  es6-procedure at this stage, the parser continues it's normal behaviour and parses the correct expression.
