### PR TITLE
Format doc comments on variant leafs smoother

### DIFF
--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -674,3 +674,12 @@ Delete({
 });
 
 let x: t = `Poly;
+
+/* Format doc attrs consistent: https://github.com/facebook/reason/issues/2187 */
+type t =
+  | /** This is some documentation that might be fairly long and grant a line break */
+    A
+  | /** Shorter docs */
+    B
+  | /** Some more longer docs over here that make sense to break lines on too */
+    C;

--- a/formatTest/unit_tests/input/variants.re
+++ b/formatTest/unit_tests/input/variants.re
@@ -411,3 +411,12 @@ Delete({pub x = methodOne; pub y = methodTwo; pub z = methodThisBreaks});
 `Delete({pub x = methodOne; pub y = methodTwo; pub z = methodThisBreaks});
 
 let x: t = `Poly;
+
+/* Format doc attrs consistent: https://github.com/facebook/reason/issues/2187 */
+type t =
+  | /** This is some documentation that might be fairly long and grant a line break */
+    A
+  | /** Shorter docs */
+    B
+  | /** Some more longer docs over here that make sense to break lines on too */
+    C;

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -2701,7 +2701,7 @@ let printer = object(self:'self)
    * not parsed or printed correctly. *)
   method type_variant_leaf1 opt_ampersand polymorphic print_bar x =
     let {pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes} = x in
-    let {stdAttrs} = partitionAttributes pcd_attributes in
+    let {stdAttrs; docAttrs} = partitionAttributes ~partDoc:true pcd_attributes in
     let ampersand_helper i arg =
       let ct = self#core_type arg in
       let ct = match arg.ptyp_desc with
@@ -2764,10 +2764,18 @@ let printer = object(self:'self)
     let prefix = if polymorphic then "`" else "" in
     let sourceMappedName = atom ~loc:pcd_name.loc (prefix ^ pcd_name.txt) in
     let sourceMappedNameWithAttributes =
-      match stdAttrs with
+      let layout = match stdAttrs with
       | [] -> sourceMappedName
       | stdAttrs ->
         formatAttributed sourceMappedName (self#attributes stdAttrs)
+      in
+      match docAttrs with
+      | [] -> layout
+      | docAttrs ->
+        makeList ~break:Always ~inline:(true, true) [
+          makeList (self#attributes docAttrs);
+          layout
+        ]
     in
     let constructorName = makeList ~postSpace:true [sourceMappedNameWithAttributes] in
     let everything = match (args, gadtRes) with


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/2187
Improves readability of doc comments on variant leaves.

Before:
```reason
type myVariant =
  | /** super long doc comment forcing line break */
    A
  | /** second short doc comment */ B
```
After:
```reason
type myVariant =
  | /** super long doc comment forcing line break */
    A
  | /** second short doc comment */
    B;
```