### PR TITLE
Supreme printing of anonymous functions as props in jsx.

### DIFF
--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -416,6 +416,13 @@ switch (foo) {
 />;
 
 <div
+  onClick={(e): event => {
+    doStuff();
+    bar(foo);
+  }}
+/>;
+
+<div
   onClick={(e, e2): event => {
     doStuff();
     bar(foo);

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -17,28 +17,27 @@ let y =
   <Routes
     path={Routes.stateToPath(state)}
     isHistorical=true
-    onHashChange={
-      (_oldPath, _oldUrl, newUrl) =>
-        updater(
-          (latestComponentBag, _) => {
-            let currentActualPath =
-              Routes.hashOfUri(newUrl);
-            let pathFromState =
-              Routes.stateToPath(
-                latestComponentBag.state,
-              );
-            currentActualPath == pathFromState ?
-              None :
-              dispatchEventless(
-                State.UriNavigated(
-                  currentActualPath,
-                ),
-                latestComponentBag,
-                (),
-              );
-          },
-          (),
-        )
+    onHashChange={(_oldPath, _oldUrl, newUrl) =>
+      updater(
+        (latestComponentBag, _) => {
+          let currentActualPath =
+            Routes.hashOfUri(newUrl);
+          let pathFromState =
+            Routes.stateToPath(
+              latestComponentBag.state,
+            );
+          currentActualPath == pathFromState ?
+            None :
+            dispatchEventless(
+              State.UriNavigated(
+                currentActualPath,
+              ),
+              latestComponentBag,
+              (),
+            );
+        },
+        (),
+      )
     }
   />;
 
@@ -342,3 +341,63 @@ switch (foo) {
 };
 
 <div> ...c </div>;
+
+<div onClick={event => handleChange(event)} />;
+<div
+  onClick={eventWithLongIdent =>
+    handleChange(eventWithLongIdent)
+  }
+/>;
+<div
+  onClick={event => {
+    Js.log(event);
+    handleChange(event);
+  }}
+/>;
+
+<UncurriedDiv
+  onClick={(. event) => {
+    Js.logU(. event);
+    handleChange(. event);
+  }}
+/>;
+
+<UncurriedDiv
+  onClick={(. eventUncurried) =>
+    handleChange(. eventUncurried)
+  }
+/>;
+
+<StaticDiv
+  onClick={(
+    foo,
+    bar,
+    baz,
+    lineBreak,
+    identifier,
+  ) => {
+    doStuff(foo, bar, baz);
+    bar(lineBreak, identifier);
+  }}
+/>;
+
+<StaticDiv
+  onClick={(
+    foo,
+    bar,
+    baz,
+    lineBreak,
+    identifier,
+  ) =>
+    bar(lineBreak, identifier)
+  }
+/>;
+
+<AttrDiv
+  onClick={[@bar] event => handleChange(event)}
+/>;
+<AttrDiv
+  onClick={[@bar] eventLongIdentifier =>
+    handleChange(eventLongIdentifier)
+  }
+/>;

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -449,7 +449,44 @@ switch (foo) {
     baz,
     superLongIdent,
     breakLine,
+  ): (
+    event,
+    event2,
+    event3,
+    event4,
+    event5,
+  ) => {
+    doStuff();
+    bar(foo);
+  }}
+/>;
+
+<div
+  onClick={(
+    foo,
+    bar,
+    baz,
+    superLongIdent,
+    breakLine,
   ): event =>
+    doStuff()
+  }
+/>;
+
+<div
+  onClick={(
+    foo,
+    bar,
+    baz,
+    superLongIdent,
+    breakLine,
+  ): (
+    event,
+    event2,
+    event3,
+    event4,
+    event5,
+  ) =>
     doStuff()
   }
 />;

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -401,3 +401,48 @@ switch (foo) {
     handleChange(eventLongIdentifier)
   }
 />;
+
+<StaticDivNamed
+  onClick={(
+    ~foo,
+    ~bar,
+    ~baz,
+    ~lineBreak,
+    ~identifier,
+    (),
+  ) =>
+    bar(lineBreak, identifier)
+  }
+/>;
+
+<div
+  onClick={(e, e2): event => {
+    doStuff();
+    bar(foo);
+  }}
+/>;
+
+<div
+  onClick={(
+    foo,
+    bar,
+    baz,
+    superLongIdent,
+    breakLine,
+  ): event => {
+    doStuff();
+    bar(foo);
+  }}
+/>;
+
+<div
+  onClick={(
+    foo,
+    bar,
+    baz,
+    superLongIdent,
+    breakLine,
+  ): event =>
+    doStuff()
+  }
+/>;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -277,3 +277,48 @@ switch(foo) {
 
 <AttrDiv onClick={[@bar] (event) => handleChange(event)} />;
 <AttrDiv onClick={[@bar] (eventLongIdentifier) => handleChange(eventLongIdentifier)} />;
+
+<StaticDivNamed
+  onClick={(
+    ~foo,
+    ~bar,
+    ~baz,
+    ~lineBreak,
+    ~identifier,
+    ()
+  ) =>
+    bar(lineBreak, identifier)
+  }
+/>;
+
+<div
+  onClick={(e, e2): event => {
+    doStuff();
+    bar(foo);
+  }}
+/>;
+
+<div
+  onClick={(
+    foo,
+    bar,
+    baz,
+    superLongIdent,
+    breakLine,
+  ): event => {
+    doStuff();
+    bar(foo);
+  }}
+/>;
+
+<div
+  onClick={(
+    foo,
+    bar,
+    baz,
+    superLongIdent,
+    breakLine,
+  ): event =>
+    doStuff()
+  }
+/>;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -325,7 +325,44 @@ switch(foo) {
     baz,
     superLongIdent,
     breakLine,
+  ): (
+    event,
+    event2,
+    event3,
+    event4,
+    event5,
+  ) => {
+    doStuff();
+    bar(foo);
+  }}
+/>;
+
+<div
+  onClick={(
+    foo,
+    bar,
+    baz,
+    superLongIdent,
+    breakLine,
   ): event =>
+    doStuff()
+  }
+/>;
+
+<div
+  onClick={(
+    foo,
+    bar,
+    baz,
+    superLongIdent,
+    breakLine,
+  ): (
+    event,
+    event2,
+    event3,
+    event4,
+    event5,
+  ) =>
     doStuff()
   }
 />;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -239,3 +239,41 @@ switch(foo) {
 };
 
 <div>...c</div>;
+
+<div onClick={(event) => handleChange(event)} />;
+<div onClick={(eventWithLongIdent) => handleChange(eventWithLongIdent)} />;
+<div
+  onClick={(event) => {
+    Js.log(event);
+    handleChange(event);
+  }}
+/>;
+
+<UncurriedDiv
+  onClick={(. event) => {
+    Js.logU(. event);
+    handleChange(. event);
+  }}
+/>;
+
+<UncurriedDiv
+  onClick={(. eventUncurried) =>
+    handleChange(. eventUncurried)
+  }
+/>;
+
+<StaticDiv
+  onClick={(foo, bar, baz, lineBreak, identifier) => {
+    doStuff(foo, bar, baz);
+    bar(lineBreak, identifier);
+  }}
+/>;
+
+<StaticDiv
+  onClick={(foo, bar, baz, lineBreak, identifier) => {
+    bar(lineBreak, identifier)
+  }}
+/>;
+
+<AttrDiv onClick={[@bar] (event) => handleChange(event)} />;
+<AttrDiv onClick={[@bar] (eventLongIdentifier) => handleChange(eventLongIdentifier)} />;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -292,6 +292,13 @@ switch(foo) {
 />;
 
 <div
+  onClick={(e): event => {
+    doStuff();
+    bar(foo);
+  }}
+/>;
+
+<div
   onClick={(e, e2): event => {
     doStuff();
     bar(foo);


### PR DESCRIPTION
Provides better printing for `Pexp_fun` expressions passed as props in jsx.
* less unnecessary whitespace 
* tries to inline the arguments on the same line of the prop as much as possible
* brace hugging 
* better readability

tldr

BEFORE:
```reason
<div
  onClick={
    event => {
      Js.log(event);
      handleChange(event);
    }
  }
/>;
```

AFTER:
```reason
<div
  onClick={event => {             /* `event` stays on the same line of onClick */
    Js.log(event);
    handleChange(event);
  }}                             /* }} brace hugging */
/>;
``` 