### PR TITLE
Force parens around Ptyp_arrow type constraints with named args.

### DIFF
--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1409,3 +1409,12 @@ let foo = (~not) => ();
 let foo = (~not: string) => ();
 
 foo(~not: string);
+
+/* https://github.com/facebook/reason/issues/2141 */
+let testCallNamedArgs =
+    (foo: ((int, ~b: int) => int), a, b) =>
+  foo(~a, ~b);
+
+let testCallNamedArgs =
+    (foo: ((int, ~b: int=?) => int), a, b) =>
+  foo(~a, ~b);

--- a/formatTest/unit_tests/input/syntax.re
+++ b/formatTest/unit_tests/input/syntax.re
@@ -1235,3 +1235,10 @@ let foo = (~not) => ();
 let foo = (~not: string) => ();
 
 foo(~not: string);
+
+/* https://github.com/facebook/reason/issues/2141 */
+let testCallNamedArgs = (foo: ((int, ~b: int) => int), a, b) =>
+  foo(~a, ~b);
+
+let testCallNamedArgs = (foo: ((int, ~b: int=?) => int), a, b) =>
+  foo(~a, ~b);

--- a/src/reason-parser/reason_heuristics.ml
+++ b/src/reason-parser/reason_heuristics.ml
@@ -136,3 +136,20 @@ let isFastPipeWithNonSimpleJSXChild e = match Ast_404.Parsetree.(e.pexp_desc) wi
       [_; Nolabel, fe]
     ) when isUnderscoreApplication fe -> true
   | _ -> false
+
+(* let testCallNamedArgs = (foo: ((int, ~b: int) => int), a, b) => foo;
+ * until we support the parenless constraint in the parser on foo, this
+ * utility can be used to determine if we need to force parens on a Ptyp_arrow
+ * constraint.
+ * See: https://github.com/facebook/reason/issues/2141
+ *)
+let arrowSegmentsContainsLabel x =
+  let open Ast_404.Parsetree in
+  let rec aux = function
+  | { ptyp_desc = Ptyp_arrow (l, _, ct2)} ->
+      begin match l with
+      | Labelled _ | Optional _ -> true
+      | Nolabel ->  aux ct2
+      end
+  | _ -> false
+  in aux x

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3198,6 +3198,16 @@ let printer = object(self:'self)
           ) ->
             (makeList ~postSpace:true [atom "module"; atom unpack.txt],
              self#typ_package ~mod_prefix:false lid cstrs)
+        | (p, {ptyp_desc = Ptyp_arrow _ }) ->
+            (* https://github.com/facebook/reason/issues/2141 *)
+            let forceParens = Reason_heuristics.arrowSegmentsContainsLabel ct in
+            (
+              self#pattern p,
+              let ctl = self#core_type ct in
+              if forceParens then
+                makeTup [ctl]
+              else ctl
+            )
         | _ ->
           (self#pattern p, self#core_type ct)
         end in


### PR DESCRIPTION
See https://github.com/facebook/reason/issues/2141

There's a bug in the grammar: the parser tries to parse tuples with named
arguments, resulting in an exception crashing refmt.

```reason
let testCallNamedArgs = (foo: (~a: int, ~b: int) => int), a, b) => foo;

(~a: int, ~b: int) => int /* interpreted as a Ptyp_tuple */
```

To unbreak master refmt, this patch forces parens around the Ptyp_arrow
constraint. With parens the correct ast is parsed.
```reason
let testCallNamedArgs = (foo: ((int, ~b: int) => int), a, b) => foo;
```

The parsing without parens will be addressed asap in a different PR.