### PR TITLE
Don't lex ^| as infix op inside [|a^|], it's a deref

### DIFF
--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -1309,3 +1309,5 @@ a >... b;
 let not = x => !x;
 
 let other = x => not(x);
+
+let derefInsideArray = [|a^|];

--- a/formatTest/unit_tests/input/infix.re
+++ b/formatTest/unit_tests/input/infix.re
@@ -1002,3 +1002,5 @@ a >... b;
 let not = (x) => !x;
 
 let other = (x) => not(x);
+
+let derefInsideArray = [|a^|];

--- a/src/reason-parser/reason_lexer.mll
+++ b/src/reason-parser/reason_lexer.mll
@@ -620,6 +620,9 @@ rule token = parse
   | '\\'? '^' ('\\' '.')? operator_chars*
             { match lexeme_without_comment lexbuf with
               | "^." -> set_lexeme_length lexbuf 1; POSTFIXOP("^")
+              | "^|" ->
+                  (* ^| is not an infix op in [|a^|] *)
+                  set_lexeme_length lexbuf 1; POSTFIXOP("^")
               | "^" -> POSTFIXOP("^")
               | op -> INFIXOP1(unescape_operator op) }
   | "++" operator_chars*


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/1895

`[|a^|]` wouldn't parse, because of `^|` being seen as an infix operator.
Disables the `^|` as infix operator in favour of correct lexing/parsing of `[|a^|]`.
This follows the same behaviour of `^.` which is also disabled as infix op.