### PR TITLE
Fix formatting of GADT declaration in outcome printer

### DIFF
--- a/formatTest/oprintTests/basic.re
+++ b/formatTest/oprintTests/basic.re
@@ -139,3 +139,4 @@ let (!=) = 0;
 
 let (!==) = 0;
 
+type foobar(_) = | Foo('a): foobar(unit);

--- a/src/reason-parser/reason_oprint.ml
+++ b/src/reason-parser/reason_oprint.ml
@@ -806,7 +806,7 @@ and print_out_constr ppf (name, tyl,ret_type_opt) =
       | [] ->
           fprintf ppf "@[<2>%s:@ %a@]" name print_simple_out_type ret_type
       | _ ->
-          fprintf ppf "@[<2>%s(%a) :%a@]" name
+          fprintf ppf "@[<2>%s(%a): %a@]" name
             (print_typlist print_simple_out_type ",") tyl
             print_simple_out_type ret_type
       end


### PR DESCRIPTION
Before:

```reason
Reason # type foobar(_) = | Foo('a): foobar(unit);
type foobar(_) = Foo('a) :foobar(unit);
```

After:

```reason
Reason # type foobar(_) = | Foo('a): foobar(unit);
type foobar(_) = Foo('a): foobar(unit);
```