### PR TITLE
Format fragments in context of local opens correct

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -616,3 +616,15 @@ type editorConfiguration = {
   [@bs.optional]
   rtlMoveVisually: bool,
 };
+
+module Fmt = {
+  let barBaz = () => ();
+
+  type record = {x: int};
+};
+
+Fmt.([@foo] barBaz());
+Fmt.([@foo] {x: 1});
+Fmt.([@foo] [1, 2, 3]);
+Fmt.([@foo] (1, 2, 3));
+Fmt.([@foo] {val x = 10});

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -511,3 +511,15 @@ type editorConfiguration = {
       The default is false on Windows, and true on other platforms. */
   rtlMoveVisually: bool,
 };
+
+module Fmt = {
+  let barBaz = () => ();
+
+  type record = {x: int};
+};
+
+Fmt.([@foo] barBaz());
+Fmt.([@foo] {x: 1});
+Fmt.([@foo] [1, 2, 3]);
+Fmt.([@foo] (1, 2, 3));
+Fmt.([@foo] {val x = 10});

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -497,3 +497,5 @@ switch (foo) {
    | Red => ReasonReact.string("red")
    }}
 </div>;
+
+ReasonReact.(<> {string("Test")} </>);

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -373,3 +373,5 @@ switch(foo) {
     | Red => ReasonReact.string("red")
     }}
 </div>;
+
+ReasonReact.(<> {string("Test")} </>);

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4164,17 +4164,18 @@ let printer = object(self:'self)
      *
      * (Also see https://github.com/facebook/Reason/issues/114)
      *)
-    match e.pexp_desc with
-    | Pexp_record _ (* syntax sugar for M.{x:1} *)
-    | Pexp_tuple _ (* syntax sugar for M.(a, b) *)
-    | Pexp_object {pcstr_fields = []} (* syntax sugar for M.{} *)
-    | Pexp_construct ( {txt= Lident"::"},Some _)
-    | Pexp_construct ( {txt= Lident"[]"},_)
-    | Pexp_extension ( {txt = "bs.obj"}, _ ) ->
+    match e.pexp_attributes, e.pexp_desc with
+    | [], Pexp_record _ (* syntax sugar for M.{x:1} *)
+    | [], Pexp_tuple _ (* syntax sugar for M.(a, b) *)
+    | [], Pexp_object {pcstr_fields = []} (* syntax sugar for M.{} *)
+    | [], Pexp_construct ( {txt= Lident"::"},Some _)
+    | [], Pexp_construct ( {txt= Lident"[]"},_)
+    | [], Pexp_extension ( {txt = "bs.obj"}, _ ) ->
       self#simplifyUnparseExpr e (* syntax sugar for M.[x,y] *)
     (* syntax sugar for the rest, wrap with parens to avoid ambiguity.
      * E.g., avoid M.(M2.v) being printed as M.M2.v
-    *)
+     * Or ReasonReact.(<> {string("Test")} </>);
+     *)
     | _ -> makeList ~wrap:("(",")") ~break:IfNeed [self#unparseExpr e]
 
   (*


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/2216

**Before**
```reason
ReasonReact.<> {ReasonReact.string("test") } </>
```

**After**
```reason
ReasonReact.(<> {ReasonReact.string("test") } </>)
```