### PR TITLE
Preserve function body braces

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -99,7 +99,11 @@ let x = [@attrEverything] (true && false);
 /**
  * How attribute parsings respond to other syntactic constructs.
  */
-let add = a => [@onRet] a;
+let add = a =>
+  [@onRet]
+  {
+    a;
+  };
 let add = a => [@onRet] a;
 let add = [@onEntireFunction] (a => a);
 
@@ -342,8 +346,18 @@ type classAttributesOnKeys = {
   .
   [@bs.set] key1: string,
   /* The follow two are the same */
-  [@bs.get null] key2: [@onType2] Js.t(int),
-  [@bs.get null] key3: [@onType2] Js.t(int),
+  [@bs.get
+    {
+      null;
+    }
+  ]
+  key2: [@onType2] Js.t(int),
+  [@bs.get
+    {
+      null;
+    }
+  ]
+  key3: [@onType2] Js.t(int),
   key4: Js.t([@justOnInt] int),
 };
 

--- a/formatTest/typeCheckedTests/expected_output/fastPipe.re
+++ b/formatTest/typeCheckedTests/expected_output/fastPipe.re
@@ -26,8 +26,9 @@ let c = true;
 let t3: bool = !a->b->c;
 
 /* parse fast pipe with  underscore application correct */
-let doStuff = (a: int, b: int, c: int): int =>
+let doStuff = (a: int, b: int, c: int): int => {
   a + 2 * b + 3 * c;
+};
 
 let (|.) = (a, f) => f(a);
 
@@ -69,18 +70,16 @@ let saveStatus = Pristine;
 
 let t7: string =
   <Foo>
-    {
-      (
-        switch (saveStatus) {
-        | Pristine => [0]
-        | Saved => [1]
-        | Saving => [2]
-        | Unsaved => [3]
-        }
-      )
-      ->Foo.map(Foo.plusOne)
-      ->Foo.toString
-    }
+    {(
+       switch (saveStatus) {
+       | Pristine => [0]
+       | Saved => [1]
+       | Saving => [2]
+       | Unsaved => [3]
+       }
+     )
+     ->Foo.map(Foo.plusOne)
+     ->Foo.toString}
   </Foo>;
 
 let genItems = f => List.map(f, items);
@@ -99,23 +98,19 @@ let foo = xs => List.concat([xs, xs]);
 
 let t10: string =
   <Foo>
-    {
-      blocks
-      ->foo
-      ->Foo.map(Foo.plusOne)
-      ->Foo.toString
-    }
+    {blocks
+     ->foo
+     ->Foo.map(Foo.plusOne)
+     ->Foo.toString}
   </Foo>;
 
 let t11: string =
   <Foo>
-    {
-      blocks
-      ->foo
-      ->Foo.map(Foo.plusOne)
-      ->Foo.map(Foo.plusOne)
-      ->Foo.toString
-    }
+    {blocks
+     ->foo
+     ->Foo.map(Foo.plusOne)
+     ->Foo.map(Foo.plusOne)
+     ->Foo.toString}
   </Foo>;
 
 let title = "los pilares de la tierra";
@@ -164,11 +159,9 @@ module FooLabeled = {
 
 let t14: string =
   <FooLabeled>
-    {
-      items
-      ->FooLabeled.map(~f=FooLabeled.plusOne)
-      ->FooLabeled.toString
-    }
+    {items
+     ->FooLabeled.map(~f=FooLabeled.plusOne)
+     ->FooLabeled.toString}
   </FooLabeled>;
 
 let c = (a, b) => a + b;

--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -102,29 +102,32 @@ module Namespace = {
 };
 
 module Optional1 = {
-  let createElement = (~required, ~children, ()) =>
+  let createElement = (~required, ~children, ()) => {
     switch (required) {
     | Some(a) => {displayName: a}
     | None => {displayName: "nope"}
     };
+  };
 };
 
 module Optional2 = {
   let createElement =
-      (~optional=?, ~children, ()) =>
+      (~optional=?, ~children, ()) => {
     switch (optional) {
     | Some(a) => {displayName: a}
     | None => {displayName: "nope"}
     };
+  };
 };
 
 module DefaultArg = {
   let createElement =
-      (~default=Some("foo"), ~children, ()) =>
+      (~default=Some("foo"), ~children, ()) => {
     switch (default) {
     | Some(a) => {displayName: a}
     | None => {displayName: "nope"}
     };
+  };
 };
 
 module LotsOfArguments = {
@@ -175,8 +178,9 @@ let notReallyJSX = (~foo, ~bar, children) => {
   displayName: "test",
 };
 
-let fakeRender = (el: component) =>
+let fakeRender = (el: component) => {
   el.displayName;
+};
 
 /* end of setup */
 
@@ -384,7 +388,7 @@ let asd2 = [@foo] [@JSX] video(~test=false, 10);
 let div = (~children) => 1;
 [@JSX] ((() => div)())(~children=[]);
 
-let myFun = () =>
+let myFun = () => {
   <>
     <Namespace.Foo
       intended=true
@@ -405,10 +409,13 @@ let myFun = () =>
       <Foo />
     </Namespace.Foo>
   </>;
+};
 
-let myFun = () => <> </>;
+let myFun = () => {
+  <> </>;
+};
 
-let myFun = () =>
+let myFun = () => {
   <>
     <Namespace.Foo
       intended=true
@@ -429,6 +436,7 @@ let myFun = () =>
       <Foo />
     </Namespace.Foo>
   </>;
+};
 
 /**
  * Children should wrap without forcing attributes to.

--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -14,12 +14,18 @@ class virtual stack ('a) (init) = {
       Some(hd);
     | [] => None
     };
-  pub push = hd => v = [hd, ...v];
-  initializer (
-    print_string("initializing object")
-  );
-  pub explicitOverrideTest = a => a + 1;
-  pri explicitOverrideTest2 = a => a + 1;
+  pub push = hd => {
+    v = [hd, ...v];
+  };
+  initializer {
+    print_string("initializing object");
+  };
+  pub explicitOverrideTest = a => {
+    a + 1;
+  };
+  pri explicitOverrideTest2 = a => {
+    a + 1;
+  };
 };
 
 let tmp = {
@@ -50,10 +56,12 @@ class virtual stackWithAttributes ('a) (init) = {
       Some(hd);
     | [] => None
     };
-  pub push = hd => v = [hd, ...v];
-  initializer (
-    print_string("initializing object")
-  );
+  pub push = hd => {
+    v = [hd, ...v];
+  };
+  initializer {
+    print_string("initializing object");
+  };
 };
 
 class extendedStack ('a) (init) = {
@@ -67,9 +75,15 @@ class extendedStackAcknowledgeOverride
       (init) = {
   inherit (class stack('a))(init);
   val dummy = ();
-  pub implementMe = i => i + 1;
-  pub! explicitOverrideTest = a => a + 2;
-  pri! explicitOverrideTest2 = a => a + 2;
+  pub implementMe = i => {
+    i + 1;
+  };
+  pub! explicitOverrideTest = a => {
+    a + 2;
+  };
+  pri! explicitOverrideTest2 = a => {
+    a + 2;
+  };
 };
 
 let inst = (new extendedStack)([1, 2]);
@@ -133,8 +147,12 @@ let anonClosedObject: {
   x: int,
   y: int,
 } = {
-  pub x = 0;
-  pub y = 0
+  pub x = {
+    0;
+  };
+  pub y = {
+    0;
+  }
 };
 
 let onlyHasX = {pub x = 0};

--- a/formatTest/typeCheckedTests/expected_output/reasonComments.re
+++ b/formatTest/typeCheckedTests/expected_output/reasonComments.re
@@ -94,8 +94,9 @@ let myFunction = /* First arg */
       withFirstArg,
       /* Second Arg */
       andSecondArg,
-    ) =>
-  withFirstArg + andSecondArg; /* After Semi */
+    ) => {
+  withFirstArg + andSecondArg;
+}; /* After Semi */
 
 type point = {
   x: string, /* x field */
@@ -300,7 +301,11 @@ type intPair2 = (
   int,
 );
 
-let result = /**/ (2 + 3);
+let result =
+  /**/
+  {
+    2 + 3;
+  };
 
 /* This is not yet idempotent */
 /* { */
@@ -333,7 +338,9 @@ let blahCurriedX = x =>
   | Black(x) => 0 /* After black */
   | Green(x) => 0; /* After second green */ /* On next line after blahCurriedX def */
 
-let name_equal = (x, y) => x == y;
+let name_equal = (x, y) => {
+  x == y;
+};
 
 let equal = (i1, i2) =>
   i1.contents === i2.contents && true; /* most unlikely first */

--- a/formatTest/typeCheckedTests/expected_output/sequences.re
+++ b/formatTest/typeCheckedTests/expected_output/sequences.re
@@ -23,8 +23,16 @@ let twenty = 20;
  * printed in reduced form because sequences are a *parse* time construct.
  * To ensure these are parsed correctly, adding to an integer.
  */
-let result = 0 + twenty;
-let result = 0 + twenty;
+let result =
+  0
+  + {
+    twenty;
+  };
+let result =
+  0
+  + {
+    twenty;
+  };
 let result = 0 + twenty;
 
 let unitValue = ();
@@ -56,7 +64,9 @@ let cannotPunASingleFieldRecord = {
 };
 let fourty =
   20 + cannotPunASingleFieldRecord.number;
-let thisIsASequenceNotPunedRecord = number;
+let thisIsASequenceNotPunedRecord = {
+  number;
+};
 let fourty = 20 + thisIsASequenceNotPunedRecord;
 
 type recordType = {

--- a/formatTest/typeCheckedTests/expected_output/trailing.re
+++ b/formatTest/typeCheckedTests/expected_output/trailing.re
@@ -172,9 +172,9 @@ class virtual
   ];
   pub virtual implementMe:
     (int, int) => (int, int);
-  initializer (
-    print_string("initializing object")
-  );
+  initializer {
+    print_string("initializing object");
+  };
 };
 
 class extendedStack

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -1,7 +1,8 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
-let run = () =>
+let run = () => {
   TestUtils.printSection("Basic Structures");
+};
 
 while (something) {
   print_string("You're in a while loop");
@@ -233,12 +234,14 @@ let result =
       } else {
         print_string("b >= a");
       };
-  } else if ((a, b) =>
-               if (a > b) {
-                 print_string("b < a");
-               } else {
-                 print_string("a <= b");
-               }) {
+  } else if ({
+               (a, b) =>
+                 if (a > b) {
+                   print_string("b < a");
+                 } else {
+                   print_string("a <= b");
+                 };
+             }) {
     print_string(
       "That could never possibly type check",
     );
@@ -528,9 +531,13 @@ let myTuple: myTupleType = myTuple;
 let myTuple: myTupleType = (one: int, two: int);
 
 /* Now functions that accept a single argument being a tuple look familiar */
-let addValues = (a: int, b: int) => a + b;
+let addValues = (a: int, b: int) => {
+  a + b;
+};
 
-let addValues = (a: int, b: int) => a + b;
+let addValues = (a: int, b: int) => {
+  a + b;
+};
 
 let myFunction = (a: int, b: int): int => a + b;
 

--- a/formatTest/unit_tests/expected_output/extensions.re
+++ b/formatTest/unit_tests/expected_output/extensions.re
@@ -29,25 +29,37 @@ let x = {
   | Some(x) => assert(false)
   | None => ()
   };
-  try%extend (raise(Not_found)) {
+  try%extend (
+    {
+      raise(Not_found);
+    }
+  ) {
   | Not_found => ()
   | Invalid_argument(msg) => prerr_endline(msg)
   };
 };
 
-let x = if%extend (true) {1} else {2};
+let x = {
+  if%extend (true) {1} else {2};
+};
 
-let x =
+let x = {
   switch%extend (None) {
   | Some(x) => assert(false)
   | None => ()
   };
+};
 
-let x =
-  try%extend (raise(Not_found)) {
+let x = {
+  try%extend (
+    {
+      raise(Not_found);
+    }
+  ) {
   | Not_found => ()
   | Invalid_argument(msg) => prerr_endline(msg)
   };
+};
 
 /* At structure level */
 
@@ -108,41 +120,50 @@ let x =
 
 /* With two extensions, alone */
 
-let x = [%extend1
+let x = {
+  %extend1
   try%extend2 () {
   | _ => ()
-  }
-];
+  };
+};
 
-let x = [%extend1
+let x = {
+  %extend1
   switch%extend2 () {
   | _ => ()
-  }
-];
+  };
+};
 
-let x = [%extend1
-  if%extend2 (true) {1} else {2}
-];
+let x = {
+  %extend1
+  if%extend2 (true) {1} else {2};
+};
 
-let x = [%extend1
+let x = {
+  %extend1
   for%extend2 (i in 1 to 10) {
     ();
-  }
-];
+  };
+};
 
-let x = [%extend1
+let x = {
+  %extend1
   while%extend2 (false) {
     ();
-  }
-];
+  };
+};
 
-let x = [%extend1 [%extend2 () => ()]];
+let x = {
+  %extend1
+  [%extend2 () => ()];
+};
 
-let x = [%extend1
+let x = {
+  %extend1
   fun%extend2
   | None => ()
-  | Some(1) => ()
-];
+  | Some(1) => ();
+};
 
 /* With two extensions, first in sequence */
 

--- a/formatTest/unit_tests/expected_output/fastPipe.re
+++ b/formatTest/unit_tests/expected_output/fastPipe.re
@@ -198,11 +198,9 @@ foo##bar
   );
 
 <div>
-  {
-    items
-    ->Belt.Array.map(ReasonReact.string)
-    ->ReasonReact.array
-  }
+  {items
+   ->Belt.Array.map(ReasonReact.string)
+   ->ReasonReact.array}
 </div>;
 
 a->(b->c);

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -1108,14 +1108,15 @@ let server = {
     body
     |> Cohttp_lwt_body.to_string
     >|= (
-      body =>
+      body => {
         Printf.sprintf(
           "okokok",
           uri,
           meth,
           headers,
           body,
-        )
+        );
+      }
     )
     >>= (
       body =>

--- a/formatTest/unit_tests/expected_output/jsx_functor.re
+++ b/formatTest/unit_tests/expected_output/jsx_functor.re
@@ -3,13 +3,15 @@ type elt =
   | Group(list(elt));
 
 module X = {
-  let createElement = (~children=[], ()) =>
+  let createElement = (~children=[], ()) => {
     Text("x");
+  };
 };
 
 module Y = {
-  let createElement = (~children=[], ()) =>
+  let createElement = (~children=[], ()) => {
     Text("y");
+  };
 };
 
 module M =
@@ -18,7 +20,7 @@ module M =
          Y: (module type of Y),
        ) => {
   let createElement =
-      (~name="M", ~id=0, ~children=[], ()) =>
+      (~name="M", ~id=0, ~children=[], ()) => {
     Group(
       [
         Text(name),
@@ -28,6 +30,7 @@ module M =
       ]
       @ children,
     );
+  };
 };
 
 let _ =

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -1,7 +1,8 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
-let run = () =>
+let run = () => {
   TestUtils.printSection("Modules");
+};
 
 /**
  * Modules:
@@ -515,24 +516,42 @@ module M = {
 
 module N = {
   open M;
-  let z = M.(34);
+  let z = {
+    M.(34);
+  };
   let z = {
     open M;
     34;
     35;
   };
+  let z = {
+    M.(34, 35);
+  };
   let z = M.(34, 35);
   let z = M.(34, 35);
-  let z = M.(34, 35);
+  let z = {
+    M.{};
+  };
   let z = M.{};
   let z = M.{};
-  let z = M.{};
-  let z = M.{x: 10};
-  let z = M.[foo, bar];
-  let z = M.[foo, bar];
-  let z = M.{x: 10, y: 20};
-  let z = M.(M2.(value));
-  let z = M.(M2.value);
+  let z = {
+    M.{x: 10};
+  };
+  let z = {
+    M.[foo, bar];
+  };
+  let z = {
+    M.[foo, bar];
+  };
+  let z = {
+    M.{x: 10, y: 20};
+  };
+  let z = {
+    M.(M2.(value));
+  };
+  let z = {
+    M.(M2.value);
+  };
   let z = {
     open! M;
     34;

--- a/formatTest/unit_tests/expected_output/modules_no_semi.re
+++ b/formatTest/unit_tests/expected_output/modules_no_semi.re
@@ -1,7 +1,8 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
-let run = () =>
+let run = () => {
   TestUtils.printSection("Modules");
+};
 
 /**
  * Modules:
@@ -515,24 +516,42 @@ module M = {
 
 module N = {
   open M;
-  let z = M.(34);
+  let z = {
+    M.(34);
+  };
   let z = {
     open M;
     34;
     35;
   };
+  let z = {
+    M.(34, 35);
+  };
   let z = M.(34, 35);
   let z = M.(34, 35);
-  let z = M.(34, 35);
+  let z = {
+    M.{};
+  };
   let z = M.{};
   let z = M.{};
-  let z = M.{};
-  let z = M.{x: 10};
-  let z = M.[foo, bar];
-  let z = M.[foo, bar];
-  let z = M.{x: 10, y: 20};
-  let z = M.(M2.(value));
-  let z = M.(M2.value);
+  let z = {
+    M.{x: 10};
+  };
+  let z = {
+    M.[foo, bar];
+  };
+  let z = {
+    M.[foo, bar];
+  };
+  let z = {
+    M.{x: 10, y: 20};
+  };
+  let z = {
+    M.(M2.(value));
+  };
+  let z = {
+    M.(M2.value);
+  };
   let z = {
     open! M;
     34;

--- a/formatTest/unit_tests/expected_output/polymorphism.re
+++ b/formatTest/unit_tests/expected_output/polymorphism.re
@@ -1,7 +1,8 @@
 /* Copyright (c) 2015-present, Facebook, Inc. All rights reserved. */
 
-let run = () =>
+let run = () => {
   TestUtils.printSection("Polymorphism");
+};
 
 type myType('a) = list('a);
 type myTwoParamType('a, 'b) = ('a, 'b);

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -384,8 +384,12 @@ let onlyDoingThisTopLevelLetToBypassTopLevelSequence = {
 type hasA = {a: int};
 let a = 10;
 let returnsASequenceExpressionWithASingleIdentifier =
-    () => a;
-let thisReturnsA = () => a;
+    () => {
+  a;
+};
+let thisReturnsA = () => {
+  a;
+};
 let thisReturnsAAsWell = () => a;
 
 let recordVal: int = thisReturnsARecord().a;
@@ -992,8 +996,9 @@ let match = "match";
 let method = "method";
 
 let foo =
-    (x, ~x as bar, ~z, ~foo as bar, ~foo as z) =>
+    (x, ~x as bar, ~z, ~foo as bar, ~foo as z) => {
   bar + 2;
+};
 
 let zzz = myFunc(1, 2, [||]);
 

--- a/src/reason-parser/reason_attributes.ml
+++ b/src/reason-parser/reason_attributes.ml
@@ -38,6 +38,9 @@ let rec partitionAttributes ?(partDoc=false) ?(allowUncurry=true) attrs : attrib
   | (({txt="reason.raw_literal"}, _) as attr) :: atTl ->
     let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
     {partition with literalAttrs=attr::partition.literalAttrs}
+  | (({txt="reason.preserve_braces"}, _) as attr) :: atTl ->
+    let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
+    {partition with literalAttrs=attr::partition.literalAttrs}
   | atHd :: atTl ->
     let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
     {partition with stdAttrs=atHd::partition.stdAttrs}
@@ -55,4 +58,10 @@ let extract_raw_literal attrs =
     | attr :: rest -> loop (attr :: acc) rest
   in
   loop [] attrs
+
+let is_preserve_braces_attr ({txt}, _) =
+  txt = "reason.preserve_braces"
+
+let has_preserve_braces_attrs literalAttrs =
+  (List.filter is_preserve_braces_attr literalAttrs) != []
 

--- a/src/reason-parser/reason_attributes.ml
+++ b/src/reason-parser/reason_attributes.ml
@@ -59,6 +59,15 @@ let extract_raw_literal attrs =
   in
   loop [] attrs
 
+let without_literal_attrs attrs =
+  let rec loop acc = function
+    | attr :: rest when (partitionAttributes [attr]).literalAttrs != [] ->
+        loop acc rest
+    | [] -> List.rev acc
+    | attr :: rest -> loop (attr :: acc) rest
+  in
+  loop [] attrs
+
 let is_preserve_braces_attr ({txt}, _) =
   txt = "reason.preserve_braces"
 

--- a/src/reason-parser/reason_heuristics.ml
+++ b/src/reason-parser/reason_heuristics.ml
@@ -102,13 +102,6 @@ let isFastPipe e = match Ast_404.Parsetree.(e.pexp_desc) with
     {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})},
       _
     ) -> true
-  (* | Pexp_apply(
-    {pexp_desc = Pexp_apply(
-      {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})},
-        _
-      )},
-      _
-  ) -> Printf.eprintf "YEP\n%!";true *)
   | _ -> false
 
 let isUnderscoreApplication expr =

--- a/src/reason-parser/reason_heuristics.ml
+++ b/src/reason-parser/reason_heuristics.ml
@@ -102,6 +102,13 @@ let isFastPipe e = match Ast_404.Parsetree.(e.pexp_desc) with
     {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})},
       _
     ) -> true
+  (* | Pexp_apply(
+    {pexp_desc = Pexp_apply(
+      {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})},
+        _
+      )},
+      _
+  ) -> Printf.eprintf "YEP\n%!";true *)
   | _ -> false
 
 let isUnderscoreApplication expr =

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -1089,6 +1089,12 @@ let package_type_of_module_type pmty =
   | _ ->
       err pmty.pmty_loc
         "only module type identifier and 'with type' constraints are supported"
+
+let add_brace_attr expr =
+  let label = Location.mknoloc "reason.preserve_braces" in
+  let payload = PStr [] in
+  {expr with pexp_attributes= (label, payload) :: expr.pexp_attributes }
+
 %}
 
 
@@ -2458,7 +2464,7 @@ class_type_declaration_details:
 braced_expr:
 mark_position_exp
   ( LBRACE seq_expr RBRACE
-    { $2 }
+    { add_brace_attr $2 }
   | LBRACE as_loc(seq_expr) error
     { syntax_error_exp $2.loc "SyntaxError in block" }
   | LBRACE DOTDOTDOT expr_optional_constraint COMMA? RBRACE

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4370,7 +4370,9 @@ let printer = object(self:'self)
         processArguments tail processedAttrs (self#formatChildren components [])
       | (Labelled "children", expr) :: tail ->
           let dotdotdotChild = match expr with
-            | {pexp_attributes = []; pexp_desc = Pexp_apply (funExpr, args)} when printedStringAndFixityExpr funExpr == Normal ->
+            | {pexp_desc = Pexp_apply (funExpr, args)}
+              when printedStringAndFixityExpr funExpr == Normal &&
+                   Reason_attributes.without_literal_attrs expr.pexp_attributes == [] ->
               begin match (self#formatFunAppl ~prefix:(atom "...") ~wrap:("{", "}") ~jsxAttrs:[] ~args ~funExpr ~applicationExpr:expr ()) with
               | [x] -> x
               | xs -> makeList xs
@@ -4408,7 +4410,7 @@ let printer = object(self:'self)
                    (self#formatNonSequencyExpression e)
            | Pexp_apply ({pexp_desc = Pexp_ident _} as funExpr, args)
                 when printedStringAndFixityExpr funExpr == Normal &&
-                     expression.pexp_attributes == [] ->
+                     Reason_attributes.without_literal_attrs expression.pexp_attributes == [] ->
              let lhs = makeList [atom lbl; atom "="] in
              begin match (
                self#formatFunAppl


### PR DESCRIPTION
This is an alternative to #1826 implementing just the brace preservation
code, to make it easier to be reviewed.

I think this is now in a better place to get into the codebase given
that we have `Reason_attributes` outside of `Reason_pprint_ast` and that
we now remove our own attributes before printing to OCaml.

I think we can probably refactor this code further in future PRs, as
well as add other stylistic preservation changes.