### PR TITLE
Upgrade to Dune 1.4 and add Menhir `--infer`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ common_steps: &common_steps
         command: |
           sudo apt-get install -y m4
           opam init --auto-setup --dot-profile=~/.bash_profile
-          opam remote add ocamlorg https://opam.ocaml.org -p 0 || true
+          opam remote add ocamlorg https://opam.ocaml.org || true
           opam remote remove default || true
     - run:
         name: "Install deps"
@@ -63,7 +63,7 @@ version: 2
 jobs:
   4.02.3:
     docker:
-      - image: ocaml/opam:debian-9_ocaml-4.02.3
+      - image: ocaml/opam2:debian-9-ocaml-4.02.3
     environment:
       - TERM: dumb
       - OCAML_VERSION: "4.02.3"
@@ -71,7 +71,7 @@ jobs:
     <<: *common_steps
   4.03.0:
     docker:
-      - image: ocaml/opam:debian-9_ocaml-4.03.0
+      - image: ocaml/opam2:debian-9-ocaml-4.03
     environment:
       - TERM: dumb
       - OCAML_VERSION: "4.03.0"
@@ -79,7 +79,7 @@ jobs:
     <<: *common_steps
   4.04.0:
     docker:
-      - image: ocaml/opam:debian-9_ocaml-4.04.0
+      - image: ocaml/opam2:debian-9-ocaml-4.04
     environment:
       - TERM: dumb
       - OCAML_VERSION: "4.04.0"
@@ -87,7 +87,7 @@ jobs:
     <<: *common_steps
   4.06.0:
     docker:
-      - image: ocaml/opam:debian-9_ocaml-4.06.0
+      - image: ocaml/opam2:debian-9-ocaml-4.06
     environment:
       - TERM: dumb
       - OCAML_VERSION: "4.06.0"
@@ -103,7 +103,7 @@ jobs:
     <<: *common_steps
   esy_build:
     docker:
-      - image: ocaml/opam:debian-9_ocaml-4.06.0
+      - image: ocaml/opam2:debian-9-ocaml-4.06
     environment:
       - TERM: dumb
       - NPM_CONFIG_PREFIX: "~/.npm-global"
@@ -116,6 +116,10 @@ jobs:
             sudo apt-get install -y nodejs
             mkdir -p ~/.npm-global
             npm config set prefix $NPM_CONFIG_PREFIX
+      - run:
+          name: "Install m4"
+          command: |
+            sudo apt-get install -y m4
       - restore_cache:
           <<: *esy_cache_key
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ common_steps: &common_steps
         name: "Install deps"
         command: |
           opam update
-          opam install -y jbuilder
+          opam install -y dune
           opam install -y menhir
           opam install -y utop
     - run:

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 1.1)
+(lang dune 1.4)
 
 
-(using menhir 1.0)
+(using menhir 2.0)

--- a/reason.opam
+++ b/reason.opam
@@ -12,7 +12,7 @@ build: [
 ]
 build-test: [["dune" "runtest" "-p" name "-j" jobs]]
 depends: [
-  "dune"                    {build}
+  "dune"                    {build & >= "1.4"}
   "ocamlfind"               {build}
   "menhir"                  {>= "20170418"}
   "merlin-extend"           {>= "0.3"}

--- a/src/reason-parser/dune
+++ b/src/reason-parser/dune
@@ -23,15 +23,14 @@
  ))
 
 ; Previously, make preprocess.
-(rule
- (targets reason_parser.cmly reason_parser.ml reason_parser.mli)
- (deps reason_parser.mly reason_parser.messages)
- (action
-  (run menhir --strict
-       --unused-tokens
-       --fixed-exception
-       --table
-       --cmly reason_parser.mly)))
+(menhir
+ (modules reason_parser reason_parser.messages)
+ (infer true)
+ (flags --strict
+        --unused-tokens
+        --fixed-exception
+        --table
+        --cmly))
 
 ; (menhir
  ; ; (targets reason_parser.cmly reason_parser.ml reason_parser.mli)


### PR DESCRIPTION
Dune has added support for Menhir's `--infer` flag in 1.4, which provides much better error messages during development in the parser.