### PR TITLE
Set up error messages properly in non-recoverable mode

### DIFF
--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -2870,6 +2870,8 @@ mark_position_exp
       | _ -> $2
       in mkinfix $1 op $3
     }
+  | E as_loc(infix_operator) error
+    { expecting (with_txt $2 "expression after infix operator") }
   | as_loc(subtractive) expr %prec prec_unary
     { mkuminus $1 $2 }
   | as_loc(additive) expr %prec prec_unary


### PR DESCRIPTION
This PR takes advantage of the currently set up infrastructure for recoverable mode and avoids bailing out whenever we need to handle an error. Instead, it keeps reducing until we catch an exception with the right kind of error coming from the parser.

This enables many more error messages for free that were disabled until now.

Also fixes #2114 for example.