### PR TITLE
print closing rbrace jsx precedence simple callbacks

### DIFF
--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -571,3 +571,5 @@ ReasonReact.(<> {string("Test")} </>);
     />;
   }}
 </Animated>;
+
+<div callback={reduce(() => !state)} />;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -467,3 +467,5 @@ ReasonReact.(<> {string("Test")} </>);
      }
   }
 </Animated>;
+
+<div callback={reduce(() => !state)} />;

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -7614,8 +7614,12 @@ let printer = object(self:'self)
               List.mem lastIdent ["test"; "describe"; "it"; "expect"] -> true
           | _ -> false
           in
-          let returnValueCallback = makeList ~break:(if forceBreak then Always else IfNeed) ~wrap:("=> ", ")") [x] in
-
+          let returnValueCallback =
+            makeList
+              ~break:(if forceBreak then Always else IfNeed)
+              ~wrap:("=> ", ")" ^ rightWrap)
+              [x]
+          in
           let argsWithCallbackArgs = List.concat [(List.map self#label_x_expression_param args); [theCallbackArg]] in
           let left = label
             theFunc


### PR DESCRIPTION
Before:

```reason
<Component callback={reduce(() => !state) />
```

After:
```reason
<Component callback={reduce(() => !state)} />
```