### PR TITLE
Windows: Fix ocamlmerlin-reason execution on Windows

### DIFF
--- a/src/reason-merlin/ocamlmerlin_reason.ml
+++ b/src/reason-merlin/ocamlmerlin_reason.ml
@@ -84,6 +84,12 @@ end
 
 let () =
   let open Extend_main in
+  let _ = match Sys.win32 with
+  | true ->
+    set_binary_mode_in stdin true;
+    set_binary_mode_out stdout true;
+  | _ -> ()
+  in
   extension_main
     ~reader:(Reader.make_v0 (module Reason_reader : V0))
     (Description.make_v0 ~name:"reason" ~version:"0.1")


### PR DESCRIPTION
__Issue:__ When running `ocamlmerlin-reason` on Windows from `merlin`, the `ocamlmerlin-reason` process fails at the handshake step. This can be seen running `ocamlmerlin-reason` directly from the shell:

```
E:\merlin-test [master ≡ +4 ~3 -0 !]> E:\reason\_esy\default\store\i\reason_dev-3.3.7-a1797764\bin\ocamlmerlin-reason.exe
MERLINEXTEND002Fatal error: exception Failure("output_value: not a binary channel")
```

`ocamlmerlin-reason` is able to output a string ("MERLINEXTEND002"), but fails when running `output_value`.

__Defect:__ On Windows, the default stdin/stdout channels are _text_ channels instead of _binary_ channels. Marshalling functions like `output_value` will fail on text channels as above.

__Fix:__ On Windows, set both the stdin/stdout to binary mode before doing any I/O. This allows `ocamlmerlin-reason` to successfully handshake and integrate with `merlin`.

Note that `merlin` itself works because it explicitly creates the pipes to talk to the extend process via `Unix.pipe` and `in_channel_of_descr`/`out_channel_of_descr` which are always binary channels.
