### PR TITLE
Fix warnings in build config files

### DIFF
--- a/src/reason-parser/vendor/cmdliner/dune
+++ b/src/reason-parser/vendor/cmdliner/dune
@@ -1,0 +1,5 @@
+(library
+ (name ReasonCmdliner)
+ (public_name reason.cmdliner)
+  (wrapped false)
+  (flags :standard -w -3-27-32-35-50))

--- a/src/reason-parser/vendor/cmdliner/jbuild
+++ b/src/reason-parser/vendor/cmdliner/jbuild
@@ -1,6 +1,0 @@
-(jbuild_version 1)
-
-(library
- ((name reason.cmdliner)
-  (wrapped false)
-  (flags (:standard -w -3-27-32-35-50))))

--- a/src/reason-parser/vendor/easy_format/dune
+++ b/src/reason-parser/vendor/easy_format/dune
@@ -1,0 +1,5 @@
+(library
+ (name ReasonEasyFormat)
+ (public_name reason.easy_format)
+  (wrapped false)
+  (flags (:standard -w -9-27)))

--- a/src/reason-parser/vendor/easy_format/jbuild
+++ b/src/reason-parser/vendor/easy_format/jbuild
@@ -1,7 +1,0 @@
-(jbuild_version 1)
-
-(library
- ((name reason.easy_format)
-  (public_name reason.easy_format)
-  (wrapped false)
-  (flags (:standard -w -9-27))))

--- a/src/rtop/dune
+++ b/src/rtop/dune
@@ -8,7 +8,7 @@
  (public_name rtop)
  (modules reason_util reason_utop reason_toploop)
  (wrapped false)
- (libraries menhirLib reason.easy_format reason utop ocaml-migrate-parsetree))
+ (libraries compiler-libs.common menhirLib reason.easy_format reason utop ocaml-migrate-parsetree))
 
 (executable
  (name rtop)


### PR DESCRIPTION
It's important to keep the public library names the same because tools like sketch and rtop assume they will be named as they always have been. But the builds are issuing warnings about the public names being incorrect so let's clean those up.