### PR TITLE
Revert "Syntax sugar `["literal_string"]` for SHARPOPs `##` and `#=` …

### DIFF
--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -839,4 +839,4 @@ it("should remove parens", a => {
 });
 
 /* https://github.com/facebook/reason/issues/1554 */
-curNode^["childNodes"];
+(curNode^)##childNodes;

--- a/formatTest/unit_tests/expected_output/bucklescript.re
+++ b/formatTest/unit_tests/expected_output/bucklescript.re
@@ -4,59 +4,59 @@ bla #= Some(10);
 
 bla #= someFunc(Some(10));
 
-test["var"] = Some(-10);
+test##var #= Some(-10);
 
 obj##.prop;
 
 obj##.prod := exp;
 
-preview["style"]["border"] =
-  Js.string("1px black dashed");
+preview##style##border
+#= Js.string("1px black dashed");
 
-(preview##(style["border"]) #= args)(somenum);
+(preview##(style##border) #= args)(somenum);
 
-x["y"]["z"] = xxxx["yyyy"]["zzzz"];
+x##y##z #= xxxx##yyyy##zzzz;
 
 let result =
   js_method_run1((!react)#createElement, foo);
 
-add(zz["yy"], xx["ww"]);
+add(zz##yy, xx##ww);
 
 /* These should print the same */
-let res = x["y"] + z["q"]; /* AST */
-let res = x["y"] + z["q"]; /* Minimum parens */
+let res = x##y + z##q; /* AST */
+let res = x##y + z##q; /* Minimum parens */
 
 /* These should print the same */
-let res = y + z["q"]["a"]; /* AST */
-let res = y + z["q"]["a"]; /* Min parens */
+let res = y + z##q##a; /* AST */
+let res = y + z##q##a; /* Min parens */
 
 /* Make sure it's actually parsed as left precedence
  * and that is maintained when printed */
-let res = z##(q["a"]); /* AST */
-let res = z##(q["a"]); /* Min parens */
+let res = z##(q##a); /* AST */
+let res = z##(q##a); /* Min parens */
 
 /* These should print the same */
-let res = !x["y"]; /* AST */
-let res = !x["y"]; /* Minimum parens */
+let res = !x##y; /* AST */
+let res = !x##y; /* Minimum parens */
 
 /* These should print the same */
-let res = !z["q"]["a"]; /* AST */
-let res = !z["q"]["a"]; /* Min parens */
+let res = !z##q##a; /* AST */
+let res = !z##q##a; /* Min parens */
 
 /* These should print the same */
-let res = ?!!x["y"]; /* AST */
-let res = ?!!x["y"]; /* Minimum parens */
+let res = ?!!x##y; /* AST */
+let res = ?!!x##y; /* Minimum parens */
 
 /* These should print the same */
-let res = ?!!z##(q["a"]); /* AST */
-let res = ?!!z##(q["a"]); /* Min parens */
+let res = ?!!z##(q##a); /* AST */
+let res = ?!!z##(q##a); /* Min parens */
 
-res #= ?!!z["q"];
-res #= ?!!z##(q["a"]);
+res #= ?!!z##q;
+res #= ?!!z##(q##a);
 
-let result = myFunction(x(y)["z"], a(b) #= c);
+let result = myFunction(x(y)##z, a(b) #= c);
 
-(!x)["y"]##(b["c"]);
+(!x)##y##(b##c);
 
 type a = {. "foo": bar};
 
@@ -75,7 +75,7 @@ let b = {
 let c = {
   "a": a,
   "b": b,
-  "func": a => a["c"] = func(10),
+  "func": a => a##c #= func(10),
 };
 
 let d = {

--- a/formatTest/unit_tests/expected_output/fastPipe.re
+++ b/formatTest/unit_tests/expected_output/fastPipe.re
@@ -59,19 +59,19 @@ foo !== bar->baz;
 x |> y >>= foo->bar->baz;
 let m = f => foo->bar->f;
 
-obj["x"]->foo->bar;
+obj##x->foo->bar;
 
 event->target[0];
 
 event->target[0];
 
-event->target["value"];
+event->target##value;
 
-event->target["value"];
+event->target##value;
 
-event->target["value"][0];
+event->target##value[0];
 
-event->(target["value"][0]);
+event->(target##value[0]);
 
 event->target(foo);
 
@@ -85,21 +85,17 @@ foo->bar := baz;
 
 foo->bar === baz;
 
-event->target["value"](foo);
+event->target##value(foo);
 
 event->target##(value(foo));
 
 (foo^)->bar;
 
-location["streets"].foo[1];
+location##streets.foo[1];
 
-event->target^["value"];
+(event->target^)##value;
 
 event->target^ #= value;
-
-event["target"].{0};
-
-event->target.{0};
 
 foo->f(. a, b);
 foo->f(. a, b)->g(. c, d);
@@ -114,9 +110,9 @@ foo->([@attr] f(.))->([@attr] g(.));
 !foo->bar;
 (!foo)->bar;
 
-a->(b["c"]);
+a->(b##c);
 
-a->b["c"];
+a->b##c;
 
 (
   switch (saveStatus) {
@@ -192,7 +188,7 @@ Foo.Bar.reactClass->setNavigationOptions(
   ),
 );
 
-foo["bar"]
+foo##bar
 ->setNavigationOptions(
     NavigationOptions.t(
       ~title="Title",

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -121,13 +121,13 @@ let icon =
 
 <MessengerSharedPhotosAlbumViewPhotoReact
   ref=?{
-    foo["bar"] === baz ?
+    foo##bar === baz ?
       Some(
         foooooooooooooooooooooooo(setRefChild),
       ) :
       None
   }
-  key=node["legacy_attachment_id"]
+  key=node##legacy_attachment_id
 />;
 
 /* punning */
@@ -248,21 +248,21 @@ let (/></) = (a, b) => a + b;
 let x = foo /></ bar;
 
 /* https://github.com/facebook/reason/issues/870 */
-<div onClick=this["handleClick"]>
+<div onClick=this##handleClick>
   <> foo </>
 </div>;
 
-<div onClick=this["handleClick"]>
+<div onClick=this##handleClick>
   <> {foo(bar)} </>
 </div>;
 
 /* function application */
-<div onClick=this["handleClick"]>
+<div onClick=this##handleClick>
   <> {foo(bar)} </>
 </div>;
 
 /* tuple, not function application */
-<div onClick=this["handleClick"]>
+<div onClick=this##handleClick>
   <> foo bar </>
 </div>;
 

--- a/formatTest/unit_tests/expected_output/sharpop.re
+++ b/formatTest/unit_tests/expected_output/sharpop.re
@@ -1,14 +1,14 @@
 foo #= bar[0];
 
-foo["bar"][0] = 3;
+foo##bar[0] = 3;
 
-foo["bar"][0]["baz"][1] = 3;
+foo##bar[0]##baz[1] = 3;
 
-foo["bar"][0]["baz"][1];
+foo##bar[0]##baz[1];
 
-foo["bar"] = bar[0];
+foo##bar #= bar[0];
 
-foo["bar"]["baz"] = bar["baz"][0];
+foo##bar##baz #= bar##baz[0];
 
 foo[bar + 1];
 
@@ -21,23 +21,3 @@ foo.[bar + 1] = 1;
 foo.{bar + 1} = 1;
 
 foo[bar + 1] = 1;
-
-bla #= Constr(x);
-
-bla #= M.(someFunc(Some(10)));
-
-bla["foo"] = 3;
-
-bla["foo"][0] = 3;
-
-bla["foo"].qux["x"] = 3;
-
-bla["foo"].qux[0]["bar"] = 3;
-
-bla[0]["foo"].qux[0]["bar"] = 3;
-
-bla[0]["foo"].qux[0].[0]["bar"] = 3;
-
-bla[0]["foo"].qux[0].{0}["bar"] = 3;
-
-bla[0]["foo"].qux[0].{0, 1, 2}["bar"] = 3;

--- a/formatTest/unit_tests/input/fastPipe.re
+++ b/formatTest/unit_tests/input/fastPipe.re
@@ -97,10 +97,6 @@ event->target##(value(foo));
 
 event->target^ #= value;
 
-event##target.{0};
-
-event->target.{0};
-
 foo->f(. a, b);
 foo->f(. a, b)->g(. c, d);
 foo->([@attr] f(. a, b))->([@attr2] f(. a, b));

--- a/formatTest/unit_tests/input/sharpop.re
+++ b/formatTest/unit_tests/input/sharpop.re
@@ -21,23 +21,3 @@ foo.[bar + 1] = 1;
 foo.{bar + 1} = 1;
 
 foo[bar + 1] = 1;
-
-bla #= (Constr(x));
-
-bla #= M.(someFunc(Some(10)));
-
-bla["foo"] = 3;
-
-bla["foo"][0] = 3;
-
-bla["foo"].qux["x"] = 3;
-
-bla["foo"].qux[0]["bar"] = 3;
-
-bla[0]["foo"].qux[0]["bar"] = 3;
-
-bla[0]["foo"].qux[0].[0]["bar"] = 3;
-
-bla[0]["foo"].qux[0].{0}["bar"] = 3;
-
-bla[0]["foo"].qux[0].{0,1,2}["bar"] = 3;

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -2887,20 +2887,10 @@ mark_position_exp
   | simple_expr DOT as_loc(label_longident) EQUAL expr
     { mkexp(Pexp_setfield($1, $3, $5)) }
   | simple_expr LBRACKET expr RBRACKET EQUAL expr
-    { let {pexp_attributes;  pexp_desc } = $3 in
-      match pexp_desc with
-      | Pexp_constant(Pconst_string (label,_)) ->
-        let loc = mklocation $startpos($3) $endpos($3) in
-        let label_exp = mkexp ~attrs:pexp_attributes (Pexp_ident (mkloc (Lident label) loc)) ~loc in
-        mkinfixop
-          (mkinfixop $1 (mkoperator (ghloc "##")) label_exp)
-          (mkoperator (ghloc "#="))
-          $6
-      | _ ->
-        let loc = mklocation $symbolstartpos $endpos in
-        let exp = Pexp_ident(array_function ~loc "Array" "set") in
-        mkexp(Pexp_apply(mkexp ~ghost:true ~loc exp,
-                         [Nolabel,$1; Nolabel,$3; Nolabel,$6]))
+    { let loc = mklocation $symbolstartpos $endpos in
+      let exp = Pexp_ident(array_function ~loc "Array" "set") in
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc exp,
+                       [Nolabel,$1; Nolabel,$3; Nolabel,$6]))
     }
   | simple_expr DOT LBRACKET expr RBRACKET EQUAL expr
     { let loc = mklocation $symbolstartpos $endpos in
@@ -3038,16 +3028,9 @@ parenthesized_expr:
                        mkexp(Pexp_object(Cstr.mk pat []))))
     }
   | E LBRACKET expr RBRACKET
-    { let {pexp_attributes;  pexp_desc } = $3 in
-      match pexp_desc with
-      | Pexp_constant(Pconst_string (label,_)) ->
-        let loc = mklocation $startpos($3) $endpos($3) in
-        let label_exp = mkexp ~attrs:pexp_attributes (Pexp_ident (mkloc (Lident label) loc)) ~loc in
-        mkinfixop $1 (mkoperator (ghloc "##")) label_exp
-      | _ ->
-        let loc = mklocation $symbolstartpos $endpos in
-        let exp = Pexp_ident(array_function ~loc "Array" "get") in
-        mkexp(Pexp_apply(mkexp ~ghost:true ~loc exp, [Nolabel,$1; Nolabel,$3]))
+    { let loc = mklocation $symbolstartpos $endpos in
+      let exp = Pexp_ident(array_function ~loc "Array" "get") in
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc exp, [Nolabel,$1; Nolabel,$3]))
     }
   | E as_loc(LBRACKET) expr as_loc(error)
     { unclosed_exp (with_txt $2 "(") (with_txt $4 ")") }


### PR DESCRIPTION
…(#2051)"

This reverts commit 2d2a5dadbef9b608c671b6073ac20bfdcafccf20.


Revert this for now, pending a new design document coming in the next few days.