### PR TITLE
Allow whitespace interleaving between recursive type declarations

### DIFF
--- a/formatTest/unit_tests/expected_output/whitespace.re
+++ b/formatTest/unit_tests/expected_output/whitespace.re
@@ -326,6 +326,59 @@ let make = _children => {
     </div>,
 };
 
+// Recursive types
+// Also create another form for splicing in nodes into otherwise fixed length sets.
+type elem('t) =
+  | Empty: elem(empty)
+constraint 't = ('st, 'a) => 'subtree
+and subtree('t) =
+  | EmptyInstance: subtree(empty);
+
+// Also create another form for splicing in nodes into otherwise fixed length sets.
+type elem('t) =
+  | Empty: elem(empty)
+constraint 't = ('st, 'a) => 'subtree
+
+and subtree('t) =
+  | EmptyInstance: subtree(empty);
+
+type elem('t) =
+  | Empty: elem(empty)
+constraint 't = ('st, 'a) => 'subtree
+// trailing comment
+
+// leading comment
+and subtree('t) =
+  | EmptyInstance: subtree(empty);
+
+type elem('t) =
+  | Empty: elem(empty)
+constraint 't = ('st, 'a) => 'subtree
+// trailing comment
+
+// in between
+
+// leading comment
+and subtree('t) =
+  | EmptyInstance: subtree(empty);
+
+// with attrs
+type elem('t) =
+  | Empty: elem(empty)
+constraint 't = ('st, 'a) => 'subtree
+[@attr]
+and subtree('t) =
+  | EmptyInstance: subtree(empty);
+
+// with attrs
+type elem('t) =
+  | Empty: elem(empty)
+constraint 't = ('st, 'a) => 'subtree
+
+[@attr]
+and subtree('t) =
+  | EmptyInstance: subtree(empty);
+
 let f = (a, b) => a + b;
 /* this comment sticks at the end */
 

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -2336,6 +2336,7 @@ type recursiveType =
   | Blah
   /* Second variant of first mutually recursive */
   | Another(option(anotherRecursiveType))
+
 /*
  * Commenting second of two mutually recursive types.
  */

--- a/formatTest/unit_tests/input/whitespace.re
+++ b/formatTest/unit_tests/input/whitespace.re
@@ -318,6 +318,59 @@ let make = _children => {
     </div>,
 };
 
+// Recursive types
+// Also create another form for splicing in nodes into otherwise fixed length sets.
+type elem('t) =
+  | Empty: elem(empty)
+constraint 't = ('st, 'a) => 'subtree
+and subtree('t) =
+  | EmptyInstance: subtree(empty);
+
+// Also create another form for splicing in nodes into otherwise fixed length sets.
+type elem('t) =
+  | Empty: elem(empty)
+constraint 't = ('st, 'a) => 'subtree
+
+and subtree('t) =
+  | EmptyInstance: subtree(empty);
+
+type elem('t) =
+  | Empty: elem(empty)
+constraint 't = ('st, 'a) => 'subtree
+// trailing comment
+
+// leading comment
+and subtree('t) =
+  | EmptyInstance: subtree(empty);
+
+type elem('t) =
+  | Empty: elem(empty)
+constraint 't = ('st, 'a) => 'subtree
+// trailing comment
+
+// in between
+
+// leading comment
+and subtree('t) =
+  | EmptyInstance: subtree(empty);
+
+// with attrs
+type elem('t) =
+  | Empty: elem(empty)
+constraint 't = ('st, 'a) => 'subtree
+[@attr]
+and subtree('t) =
+  | EmptyInstance: subtree(empty);
+
+// with attrs
+type elem('t) =
+  | Empty: elem(empty)
+constraint 't = ('st, 'a) => 'subtree
+
+[@attr]
+and subtree('t) =
+  | EmptyInstance: subtree(empty);
+
 let f = (a, b) => a + b;
 /* this comment sticks at the end */
 

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -2678,9 +2678,18 @@ let printer = object(self:'self)
           match tl with
             (* Exactly one type *)
             | [] -> first
-            | tlhd::tltl -> makeList ~indent:0 ~inline:(true, true) ~break:Always_rec (
-                first::(List.map (formatOneTypeDefStandard (atom "and")) (tlhd::tltl))
-              )
+            | _::_ as typeList ->
+                let items = (hd.ptype_loc, first)::(List.map (fun ptyp ->
+                    (ptyp.ptype_loc, formatOneTypeDefStandard (atom "and") ptyp)
+                  ) typeList
+                ) in
+                makeList ~indent:0 ~inline:(true, true) ~break:Always_rec (
+                  groupAndPrint
+                    ~xf:snd
+                    ~getLoc:fst
+                    ~comments:self#comments
+                    items
+                )
 
   method type_variant_leaf ?opt_ampersand:(a=false) ?polymorphic:(p=false) = self#type_variant_leaf1 a p true
   method type_variant_leaf_nobar ?opt_ampersand:(a=false) ?polymorphic:(p=false) = self#type_variant_leaf1 a p false


### PR DESCRIPTION
Preserves whitespace between recursive type declarations. While working with a certain recursive type-heavy codebase, it occurred to me how terse/unstructured the code was.
Allowing whitespace interleaving, directed by the programmer, makes a world of difference when needed.

Example:
```reason
type elem('t) =
  | Empty: elem(empty)
constraint 't = ('st, 'a) => 'subtree

and subtree('t) =
  | EmptyInstance: subtree(empty);
```