### PR TITLE
Drop parens around Pexp_fun in argument position

### DIFF
--- a/formatTest/unit_tests/expected_output/pexpFun.re
+++ b/formatTest/unit_tests/expected_output/pexpFun.re
@@ -1,0 +1,89 @@
+let x =
+  switch (x) {
+  | Bar =>
+    ReasonReact.UpdateWithSideEffects(
+      {...state, click: click + 1},
+      self => {
+        let _ = 1;
+        apply(bar);
+      },
+      "foo",
+    )
+  | Foo => ()
+  };
+
+let x =
+  switch (x) {
+  | Bar =>
+    ReasonReact.UpdateWithSideEffects(
+      self => {
+        let _ = 1;
+        apply(bar);
+      },
+    )
+  | Foo => ()
+  };
+
+Mod.Update(
+  (acc, curr) => {
+    let x = 1;
+    string_of_int(curr);
+  },
+  "",
+  lst,
+);
+
+Mod.Update(
+  (acc, curr): string => {
+    let x = 1;
+    string_of_int(curr);
+  },
+  "",
+  lst,
+);
+
+Mod.Update(
+  [@foo] [@bar] (acc, curr) => {
+    let x = 1;
+    string_of_int(curr);
+  },
+  "",
+  lst,
+);
+
+Mod.Update(
+  [@foo] [@bar] curr => string_of_int(curr),
+  "",
+  lst,
+);
+
+Mod.Update(
+  [@foo] [@bar] [@baz] [@something] [@do] curr =>
+    string_of_int(curr),
+  "",
+  lst,
+);
+
+Mod.Update(
+  (
+    acc,
+    curr,
+    lkdjf,
+    lskdfj,
+    sdfljk,
+    slkdjf,
+    skdjf,
+    sdlkfj,
+  ): string => {
+    let x = 1;
+    string_of_int(curr);
+  },
+  "",
+  lst,
+);
+
+Mod.Update(
+  (acc, curr) => string_of_int(curr),
+  "",
+  lst,
+);

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1284,10 +1284,10 @@ Thing.map(
   foo,
   bar,
   baz,
-  [@attr]
-  ((abc, z) => MyModuleBlah.toList(argument)),
-  [@attr]
-  ((abc, z) => MyModuleBlah.toList(argument)),
+  [@attr] (abc, z) =>
+    MyModuleBlah.toList(argument),
+  [@attr] (abc, z) =>
+    MyModuleBlah.toList(argument),
 );
 
 Js.Option.andThen((. w) => w#getThing());

--- a/formatTest/unit_tests/input/pexpFun.re
+++ b/formatTest/unit_tests/input/pexpFun.re
@@ -1,0 +1,77 @@
+let x =
+  switch (x) {
+  | Bar =>
+    ReasonReact.UpdateWithSideEffects(
+      {...state, click: click + 1},
+      self => {
+        let _ = 1;
+        apply(bar);
+      },
+      "foo",
+    )
+  | Foo => ()
+  };
+
+let x =
+  switch (x) {
+  | Bar =>
+    ReasonReact.UpdateWithSideEffects(
+      self => {
+        let _ = 1;
+        apply(bar);
+      },
+    )
+  | Foo => ()
+  };
+
+Mod.Update(
+  (acc, curr) => {
+    let x = 1;
+    string_of_int(curr);
+  },
+  "",
+  lst,
+);
+
+Mod.Update(
+  (acc, curr): string => {
+    let x = 1;
+    string_of_int(curr);
+  },
+  "",
+  lst,
+);
+
+Mod.Update(
+  [@foo] [@bar]
+  (acc, curr) => {
+    let x = 1;
+    string_of_int(curr);
+  },
+  "",
+  lst,
+);
+
+Mod.Update(
+  [@foo] [@bar]
+  (curr) => string_of_int(curr),
+  "",
+  lst,
+);
+
+Mod.Update(
+  [@foo] [@bar] [@baz] [@something] [@do] curr => string_of_int(curr),
+  "",
+  lst,
+);
+
+Mod.Update(
+   (acc, curr, lkdjf, lskdfj, sdfljk, slkdjf, skdjf, sdlkfj): string => {
+    let x = 1;
+    string_of_int(curr);
+  },
+  "",
+  lst,
+);
+
+Mod.Update((acc, curr) => string_of_int(curr), "", lst);


### PR DESCRIPTION
Before
```reason
  switch (action, state) {
  | Click =>
    ReasonReact.UpdateWithSideEffects(
      {...state, click: click + 1},
      (
        self => {
          let _ = 1;
          apply(bar);
        }
      )
    )
```
After
```reason
  switch (action, state) {
  | Click =>
    ReasonReact.UpdateWithSideEffects(
      {...state, click: click + 1},
      self => {
        let _ = 1;
        apply(bar);
      }
    )
```