### PR TITLE
Make CI green

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ common_steps: &common_steps
     - run:
         name: "Install deps"
         command: |
+          sudo apt-get install -y pkg-config
           opam update
           opam install -y dune
           opam install -y menhir

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ common_steps: &common_steps
     - run:
         name: "Install deps"
         command: |
-          sudo apt-get install -y pkg-config
+          sudo apt-get install -y pkg-config libncurses5-dev
           opam update
           opam install -y dune
           opam install -y menhir

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,8 +11,3 @@ steps:
   inputs:
     versionSpec: '8.x'
   displayName: 'Install Node.js'
-
-- script: |
-    npm install
-    npm run build
-  displayName: 'npm install and build'


### PR DESCRIPTION
Seeing errors on master of the form:
```
#=== ERROR while compiling conf-pkg-config.1.1 ================================#
"pkg-config": command not found.
```

(Also impacting PRs - specifically for the 4.02 builds).

This was addressed by installing the `pkg-config` and `ncurses` packages. Not sure why this is needed now - perhaps the docker images were updated?

I also took out a build step in azure-pipelines that isn't applicable at the moment - it was trying to `npm install` and `npm build` but that doesn't make sense for this project.