### PR TITLE
Fix stackoverflow in unparseExprRecurse

### DIFF
--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -573,3 +573,6 @@ ReasonReact.(<> {string("Test")} </>);
 </Animated>;
 
 <div callback={reduce(() => !state)} />;
+
+// shouldn't result in a stack overflow
+<X y={z->Belt.Option.getWithDefault("")} />;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -469,3 +469,6 @@ ReasonReact.(<> {string("Test")} </>);
 </Animated>;
 
 <div callback={reduce(() => !state)} />;
+
+// shouldn't result in a stack overflow
+<X y={z->Belt.Option.getWithDefault("")} />

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3923,7 +3923,9 @@ let printer = object(self:'self)
       partitionAttributes ~allowUncurry:(Reason_heuristics.bsExprCanBeUncurried x) x.pexp_attributes
     in
     let () = if uncurried then Hashtbl.add uncurriedTable x.pexp_loc true in
-    let x = {x with pexp_attributes = (literalAttrs @ arityAttrs @ stdAttrs @ jsxAttrs) } in
+    let x = {x with pexp_attributes = (
+      (if preserve_braces then literalAttrs else [])
+      @ arityAttrs @ stdAttrs @ jsxAttrs) } in
     (* If there's any attributes, recurse without them, then apply them to
        the ends of functions, or simplify infix printings then append. *)
     if stdAttrs != [] then


### PR DESCRIPTION
When braces shouldn't be preserved, literal attributes shouldn't be
passed down the chain. If they are we get an infinite loop inside
unparseExprRecurse.