### PR TITLE
Fix stackoverflow in unparseExprRecurse

### DIFF
--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -612,3 +612,6 @@ ReasonReact.(<> {string("Test")} </>);
   ?id className={Cn.make({"a": b})} onClick>
   {"Submit" |> ste}
 </button>;
+
+// shouldn't result in a stack overflow
+<X y={z->Belt.Option.getWithDefault("")} />;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -489,3 +489,6 @@ ReasonReact.(<> {string("Test")} </>);
 <button ?id className={Cn.make({"a": b})} onClick>
   {"Submit" |> ste}
 </button>;
+
+// shouldn't result in a stack overflow
+<X y={z->Belt.Option.getWithDefault("")} />;

--- a/src/reason-parser/reason_syntax_util.ml
+++ b/src/reason-parser/reason_syntax_util.ml
@@ -395,25 +395,25 @@ let identifier_mapper f super =
   end;
 }
 
-let remove_literal_attrs_mapper_maker super =
+let remove_stylistic_attrs_mapper_maker super =
   let open Ast_404 in
   let open Ast_mapper in
 { super with
   expr = begin fun mapper expr ->
-    let {Reason_attributes.literalAttrs; arityAttrs; docAttrs; stdAttrs; jsxAttrs} =
+    let {Reason_attributes.stylisticAttrs; arityAttrs; docAttrs; stdAttrs; jsxAttrs} =
       Reason_attributes.partitionAttributes ~allowUncurry:false expr.pexp_attributes
     in
-    let expr = if literalAttrs != [] then
+    let expr = if stylisticAttrs != [] then
       { expr with pexp_attributes = arityAttrs @ docAttrs @ stdAttrs @ jsxAttrs }
     else expr
     in
     super.expr mapper expr
   end;
   pat = begin fun mapper pat ->
-    let {Reason_attributes.literalAttrs; arityAttrs; docAttrs; stdAttrs; jsxAttrs} =
+    let {Reason_attributes.stylisticAttrs; arityAttrs; docAttrs; stdAttrs; jsxAttrs} =
       Reason_attributes.partitionAttributes ~allowUncurry:false pat.ppat_attributes
     in
-    let pat = if literalAttrs != [] then
+    let pat = if stylisticAttrs != [] then
       { pat with ppat_attributes = arityAttrs @ docAttrs @ stdAttrs @ jsxAttrs }
     else pat
     in
@@ -421,8 +421,8 @@ let remove_literal_attrs_mapper_maker super =
   end;
 }
 
-let remove_literal_attrs_mapper =
-  remove_literal_attrs_mapper_maker Ast_mapper.default_mapper
+let remove_stylistic_attrs_mapper =
+  remove_stylistic_attrs_mapper_maker Ast_mapper.default_mapper
 
 (** escape_stars_slashes_mapper escapes all stars and slashes in an AST *)
 let escape_stars_slashes_mapper =

--- a/src/reason-parser/reason_syntax_util.mli
+++ b/src/reason-parser/reason_syntax_util.mli
@@ -39,7 +39,7 @@ val syntax_error_extension_node :
   Ast_404.Location.t ->
   string -> string Ast_404.Location.loc * Ast_404.Parsetree.payload
 
-val remove_literal_attrs_mapper : Ast_404.Ast_mapper.mapper
+val remove_stylistic_attrs_mapper : Ast_404.Ast_mapper.mapper
 
 val escape_stars_slashes_mapper :
   Ast_404.Ast_mapper.mapper -> Ast_404.Ast_mapper.mapper

--- a/src/reason-parser/reason_toolchain.ml
+++ b/src/reason-parser/reason_toolchain.ml
@@ -495,7 +495,7 @@ module OCaml_syntax = struct
       (To_current.copy_signature signature)
   let format_implementation_with_comments (structure, _) formatter =
     let structure =
-      Reason_syntax_util.(apply_mapper_to_structure structure remove_literal_attrs_mapper)
+      Reason_syntax_util.(apply_mapper_to_structure structure remove_stylistic_attrs_mapper)
     in
     Pprintast.structure formatter
       (To_current.copy_structure structure)

--- a/src/refmt/reason_implementation_printer.ml
+++ b/src/refmt/reason_implementation_printer.ml
@@ -51,7 +51,7 @@ let print printtype filename parsedAsML output_chan output_formatter =
   )
   | `Binary -> fun (ast, _) ->
     let ast =
-      Reason_syntax_util.(apply_mapper_to_structure ast remove_literal_attrs_mapper)
+      Reason_syntax_util.(apply_mapper_to_structure ast remove_stylistic_attrs_mapper)
     in
     Ast_io.to_channel output_chan filename
       (Ast_io.Impl ((module OCaml_current),


### PR DESCRIPTION
This is an alternative to #2289 that also renames `literalAttrs` to
`stylisticAttrs` as request in #2223's code review