### PR TITLE
Update ternary formatting

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/imperative.re
+++ b/formatTest/typeCheckedTests/expected_output/imperative.re
@@ -61,8 +61,8 @@ let result =
       ();
     }
   )
-  == () ?
-    false : true;
+  == ()
+    ? false : true;
 
 switch (
   try (

--- a/formatTest/typeCheckedTests/expected_output/mutation.re
+++ b/formatTest/typeCheckedTests/expected_output/mutation.re
@@ -39,13 +39,13 @@ switch (numberToSwitchOn) {
 | 0 => holdsAUnit.contents = ()
 | 1 => holdsAUnit.contents = holdsAnInt := 0
 | 2 =>
-  true ?
-    holdsAUnit.contents = () :
-    holdsABool.contents ? () : ()
+  true
+    ? holdsAUnit.contents = ()
+    : holdsABool.contents ? () : ()
 | 3 =>
-  true ?
-    holdsAUnit := () :
-    holdsABool.contents ? () : ()
+  true
+    ? holdsAUnit := ()
+    : holdsABool.contents ? () : ()
 | 4 => true ? holdsAnInt := 40 : ()
 | 5 => holdsAnInt := 40
 | _ => ()

--- a/formatTest/unit_tests/expected_output/extensions.re
+++ b/formatTest/unit_tests/expected_output/extensions.re
@@ -383,8 +383,8 @@ let work = () => {
 
 /* https://github.com/facebook/reason/issues/2032 */
 let predicate =
-  predicate === Functions.alwaysTrue1 ?
-    defaultPredicate :
-    fun%extend
-    | None => false
-    | Some(exn) => predicate(exn);
+  predicate === Functions.alwaysTrue1
+    ? defaultPredicate
+    : fun%extend
+      | None => false
+      | Some(exn) => predicate(exn);

--- a/formatTest/unit_tests/expected_output/if.re
+++ b/formatTest/unit_tests/expected_output/if.re
@@ -80,8 +80,8 @@ if (if (x) {true} else {false}) {
  */
 
 let ternaryResult =
-  something ?
-    callThisFunction(withThisArg) : thatResult;
+  something
+    ? callThisFunction(withThisArg) : thatResult;
 
 let annotatedTernary =
   true && (something ? true : false: bool);
@@ -92,72 +92,73 @@ let annotatedBranch =
 
 /* The following should be... */
 let whatShouldThisBeParsedAs =
-  something ?
-    callThisFunction(withThisArg) :
-    trailingTest ? true : false;
+  something
+    ? callThisFunction(withThisArg)
+    : trailingTest ? true : false;
 
 /* ... it should be parsed as */
 let whatShouldThisBeParsedAs =
-  something ?
-    callThisFunction(withThisArg) :
-    trailingTest ? true : false;
+  something
+    ? callThisFunction(withThisArg)
+    : trailingTest ? true : false;
 
 /* Should *not* be parsed as */
 let whatShouldThisBeParsedAs =
   (
-    something ?
-      callThisFunction(withThisArg) :
-      trailingTest
-  ) ?
-    true : false;
+    something
+      ? callThisFunction(withThisArg)
+      : trailingTest
+  )
+    ? true : false;
 
 let ternaryResult =
-  aaaaaa ?
-    bbbbbbb :
-    ccccc ? ddddddd : eeeee ? fffffff : ggggg;
+  aaaaaa
+    ? bbbbbbb
+    : ccccc ? ddddddd : eeeee ? fffffff : ggggg;
 
 /* Should be parsed as: */
 let ternaryResult =
-  aaaaaa ?
-    bbbbbbb :
-    ccccc ? ddddddd : eeeee ? fffffff : ggggg;
+  aaaaaa
+    ? bbbbbbb
+    : ccccc ? ddddddd : eeeee ? fffffff : ggggg;
 
 let ternaryResult =
   /* The first Parens *must* be preserved! */
-  (x ? y : z) ?
-    bbbbbbb :
-    ccccccc ? ddddddd : eeeeeee ? fffffff : ggggg;
+  (x ? y : z)
+    ? bbbbbbb
+    : ccccccc
+        ? ddddddd : eeeeeee ? fffffff : ggggg;
 
 let ternaryResult =
-  aaaaaaa ?
-    bbbbbbb :
+  aaaaaaa
+    ? bbbbbbb
     /* The second Parens *must* be preserved! */
-    (x ? y : z) ?
-      ddddddd : eeeeeee ? fffffff : ggggg;
+    : (x ? y : z)
+        ? ddddddd : eeeeeee ? fffffff : ggggg;
 
 let ternaryResult =
-  aaaaaaa ?
-    bbbbbbb :
-    x ?
-      y :
-      z ?
-        ddddddd :
-        /* The final parent don't need to be preserved */
-        eeeeeee ? fffffff : x ? y : z;
+  aaaaaaa
+    ? bbbbbbb
+    : x
+        ? y
+        : z
+            ? ddddddd
+            /* The final parent don't need to be preserved */
+            : eeeeeee ? fffffff : x ? y : z;
 
 let addOne = x => x + 1;
 
 let result =
-  addOne(0) + 0 > 1 ?
-    print_string("this wont print") :
-    print_string("this will");
+  addOne(0) + 0 > 1
+    ? print_string("this wont print")
+    : print_string("this will");
 /*
  * Should be parsed as:
  */
 let result =
-  addOne(0) + 0 > 1 ?
-    print_string("this wont print") :
-    print_string("this will");
+  addOne(0) + 0 > 1
+    ? print_string("this wont print")
+    : print_string("this will");
 
 /*
  * Try shouldn't be aliased as ternary!
@@ -192,6 +193,6 @@ let result =
 let res = someExpression ? "true" : "false";
 
 let pngSuffix =
-  pixRation > 1 ?
-    "@" ++ string_of_int(pixRation) ++ "x.png" :
-    ".png";
+  pixRation > 1
+    ? "@" ++ string_of_int(pixRation) ++ "x.png"
+    : ".png";

--- a/formatTest/unit_tests/expected_output/if.re
+++ b/formatTest/unit_tests/expected_output/if.re
@@ -111,6 +111,30 @@ let whatShouldThisBeParsedAs =
   )
     ? true : false;
 
+/* the following shoud be... */
+let ternaryFormatting =
+  something
+    ? notLongEnoughToCauseTwoLineBreaks : other;
+
+/* ideally formatted as
+   let ternaryFormatting =
+     something
+     ? notLongEnoughToCauseTwoLineBreaks
+     : other
+   */
+let ternaryFormatting =
+  something
+    ? notLongEnoughToCauseTwoLineBreaks : other;
+
+/* but is currently formatted as the following (which is less than desirable)
+   let ternaryFormatting =
+     something
+     ? notLongEnoughToCauseTwoLineBreaks : other
+    */
+let ternaryFormatting =
+  something
+    ? notLongEnoughToCauseTwoLineBreaks : other;
+
 let ternaryResult =
   aaaaaa
     ? bbbbbbb

--- a/formatTest/unit_tests/expected_output/infix.re
+++ b/formatTest/unit_tests/expected_output/infix.re
@@ -500,13 +500,13 @@ let containingObject = {
     bigArr.{0} = something + 1 ? hello : goodbye;
     str.[0] = something + 1 ? hello : goodbye;
 
-    (x.contents = something + 1) ?
-      hello : goodbye;
+    (x.contents = something + 1)
+      ? hello : goodbye;
     (x := something + 1) ? hello : goodbye;
     (y = something + 1) ? hello : goodbye;
     (arr[0] = something + 1) ? hello : goodbye;
-    (bigArr.{0} = something + 1) ?
-      hello : goodbye;
+    (bigArr.{0} = something + 1)
+      ? hello : goodbye;
     (str.[0] = something + 1) ? hello : goodbye;
 
     x.contents = something + 1 ? hello : goodbye;
@@ -591,20 +591,20 @@ let containingObject = {
      * Try with ||
      */ x.contents
     || something
-    + 1 ?
-      hello : goodbye;
+    + 1
+      ? hello : goodbye;
     y || something + 1 ? hello : goodbye;
     arr[0] || something + 1 ? hello : goodbye;
-    bigArr.{0} || something + 1 ?
-      hello : goodbye;
+    bigArr.{0} || something + 1
+      ? hello : goodbye;
     str.[0] || something + 1 ? hello : goodbye;
 
-    x.contents || something + 1 ?
-      hello : goodbye;
+    x.contents || something + 1
+      ? hello : goodbye;
     y || something + 1 ? hello : goodbye;
     arr[0] || something + 1 ? hello : goodbye;
-    bigArr.{0} || something + 1 ?
-      hello : goodbye;
+    bigArr.{0} || something + 1
+      ? hello : goodbye;
     str.[0] || something + 1 ? hello : goodbye;
 
     x.contents
@@ -619,20 +619,20 @@ let containingObject = {
      * Try with &&
      */ x.contents
     && something
-    + 1 ?
-      hello : goodbye;
+    + 1
+      ? hello : goodbye;
     y && something + 1 ? hello : goodbye;
     arr[0] && something + 1 ? hello : goodbye;
-    bigArr.{0} && something + 1 ?
-      hello : goodbye;
+    bigArr.{0} && something + 1
+      ? hello : goodbye;
     str.[0] && something + 1 ? hello : goodbye;
 
-    x.contents && something + 1 ?
-      hello : goodbye;
+    x.contents && something + 1
+      ? hello : goodbye;
     y && something + 1 ? hello : goodbye;
     arr[0] && something + 1 ? hello : goodbye;
-    bigArr.{0} && something + 1 ?
-      hello : goodbye;
+    bigArr.{0} && something + 1
+      ? hello : goodbye;
     str.[0] && something + 1 ? hello : goodbye;
 
     x.contents
@@ -707,250 +707,255 @@ let containingObject = {
        * The following
        */
       x.contents =
-        something ?
-          x.contents = somethingElse : goodbye
+        something
+          ? x.contents = somethingElse : goodbye
     );
     y = something ? y = somethingElse : goodbye;
     arr[0] =
-      something ?
-        arr[0] = somethingElse : goodbye;
+      something
+        ? arr[0] = somethingElse : goodbye;
     bigArr.{0} =
-      something ?
-        bigArr.{0} = somethingElse : goodbye;
+      something
+        ? bigArr.{0} = somethingElse : goodbye;
     str.[0] =
-      something ?
-        str.[0] = somethingElse : goodbye;
+      something
+        ? str.[0] = somethingElse : goodbye;
     /*
      * Should be parsed as
      */
     x.contents =
-      something ?
-        x.contents = somethingElse : goodbye;
+      something
+        ? x.contents = somethingElse : goodbye;
     y = something ? y = somethingElse : goodbye;
     arr[0] =
-      something ?
-        arr[0] = somethingElse : goodbye;
+      something
+        ? arr[0] = somethingElse : goodbye;
     bigArr.{0} =
-      something ?
-        bigArr.{0} = somethingElse : goodbye;
+      something
+        ? bigArr.{0} = somethingElse : goodbye;
     str.[0] =
-      something ?
-        str.[0] = somethingElse : goodbye;
+      something
+        ? str.[0] = somethingElse : goodbye;
 
     /** And this */ y :=
       something ? y := somethingElse : goodbye;
     arr[0] :=
-      something ?
-        arr[0] := somethingElse : goodbye;
+      something
+        ? arr[0] := somethingElse : goodbye;
     bigArr.{0} :=
-      something ?
-        bigArr.{0} := somethingElse : goodbye;
+      something
+        ? bigArr.{0} := somethingElse : goodbye;
     str.[0] :=
-      something ?
-        str.[0] := somethingElse : goodbye;
+      something
+        ? str.[0] := somethingElse : goodbye;
 
     /* Should be parsed as */
     y := something ? y := somethingElse : goodbye;
     arr[0] :=
-      something ?
-        arr[0] := somethingElse : goodbye;
+      something
+        ? arr[0] := somethingElse : goodbye;
     bigArr.{0} :=
-      something ?
-        bigArr.{0} := somethingElse : goodbye;
+      something
+        ? bigArr.{0} := somethingElse : goodbye;
     str.[0] :=
-      something ?
-        str.[0] := somethingElse : goodbye;
+      something
+        ? str.[0] := somethingElse : goodbye;
 
     /* The following */
     x :=
-      something ?
-        x.contents =
-          somethingElse ? goodbye : goodbye :
-        goodbye;
+      something
+        ? x.contents =
+            somethingElse ? goodbye : goodbye
+        : goodbye;
     x :=
-      something ?
-        arr[0] =
-          somethingElse ? goodbye : goodbye :
-        goodbye;
+      something
+        ? arr[0] =
+            somethingElse ? goodbye : goodbye
+        : goodbye;
     x :=
-      something ?
-        bigArr.{0} =
-          somethingElse ? goodbye : goodbye :
-        goodbye;
+      something
+        ? bigArr.{0} =
+            somethingElse ? goodbye : goodbye
+        : goodbye;
     x :=
-      something ?
-        str.[0] =
-          somethingElse ? goodbye : goodbye :
-        goodbye;
+      something
+        ? str.[0] =
+            somethingElse ? goodbye : goodbye
+        : goodbye;
     /* Is parsed as */
     x :=
-      something ?
-        x.contents =
-          somethingElse ? goodbye : goodbye :
-        goodbye;
+      something
+        ? x.contents =
+            somethingElse ? goodbye : goodbye
+        : goodbye;
     x :=
-      something ?
-        arr[0] =
-          somethingElse ? goodbye : goodbye :
-        goodbye;
+      something
+        ? arr[0] =
+            somethingElse ? goodbye : goodbye
+        : goodbye;
     x :=
-      something ?
-        bigArr.{0} =
-          somethingElse ? goodbye : goodbye :
-        goodbye;
+      something
+        ? bigArr.{0} =
+            somethingElse ? goodbye : goodbye
+        : goodbye;
     x :=
-      something ?
-        str.[0] =
-          somethingElse ? goodbye : goodbye :
-        goodbye;
+      something
+        ? str.[0] =
+            somethingElse ? goodbye : goodbye
+        : goodbye;
     /* is not the same as */
     x :=
-      something ?
-        (x.contents = somethingElse) ?
-          goodbye : goodbye :
-        goodbye;
+      something
+        ? (x.contents = somethingElse)
+            ? goodbye : goodbye
+        : goodbye;
     x :=
-      something ?
-        (arr[0] = somethingElse) ?
-          goodbye : goodbye :
-        goodbye;
+      something
+        ? (arr[0] = somethingElse)
+            ? goodbye : goodbye
+        : goodbye;
     x :=
-      something ?
-        (bigArr.{0} = somethingElse) ?
-          goodbye : goodbye :
-        goodbye;
+      something
+        ? (bigArr.{0} = somethingElse)
+            ? goodbye : goodbye
+        : goodbye;
     x :=
-      something ?
-        (str.[0] = somethingElse) ?
-          goodbye : goodbye :
-        goodbye;
+      something
+        ? (str.[0] = somethingElse)
+            ? goodbye : goodbye
+        : goodbye;
 
     /**
      * And
      */
     /** These should be parsed the same */
-    something ?
-      somethingElse :
-      x.contents = somethingElse ? x : z;
-    something ?
-      somethingElse :
-      x.contents = somethingElse ? x : z;
+    something
+      ? somethingElse
+      : x.contents = somethingElse ? x : z;
+    something
+      ? somethingElse
+      : x.contents = somethingElse ? x : z;
     /* Not: */
-    something ?
-      somethingElse :
-      (x.contents = somethingElse) ? x : z;
+    something
+      ? somethingElse
+      : (x.contents = somethingElse) ? x : z;
     (
-      something ?
-        somethingElse :
-        x.contents = somethingElse
-    ) ?
-      x : z;
+      something
+        ? somethingElse
+        : x.contents = somethingElse
+    )
+      ? x : z;
 
     /* These should be parsed the same */
-    something ?
-      somethingElse : x := somethingElse ? x : z;
-    something ?
-      somethingElse : x := somethingElse ? x : z;
+    something
+      ? somethingElse
+      : x := somethingElse ? x : z;
+    something
+      ? somethingElse
+      : x := somethingElse ? x : z;
     /* Not: */
-    something ?
-      somethingElse :
-      (x := somethingElse) ? x : z;
+    something
+      ? somethingElse
+      : (x := somethingElse) ? x : z;
     (
-      something ?
-        somethingElse : x := somethingElse
-    ) ?
-      x : z;
+      something
+        ? somethingElse : x := somethingElse
+    )
+      ? x : z;
 
     /** These should be parsed the same */
-    something ?
-      somethingElse : y = somethingElse ? x : z;
-    something ?
-      somethingElse : y = somethingElse ? x : z;
+    something
+      ? somethingElse : y = somethingElse ? x : z;
+    something
+      ? somethingElse : y = somethingElse ? x : z;
     /* Not: */
-    something ?
-      somethingElse : (y = somethingElse) ? x : z;
+    something
+      ? somethingElse
+      : (y = somethingElse) ? x : z;
     (
-      something ?
-        somethingElse : y = somethingElse
-    ) ?
-      x : z;
+      something
+        ? somethingElse : y = somethingElse
+    )
+      ? x : z;
 
     /** These should be parsed the same */
-    something ?
-      somethingElse :
-      arr[0] = somethingElse ? x : arr[0];
-    something ?
-      somethingElse :
-      arr[0] = somethingElse ? x : arr[0];
+    something
+      ? somethingElse
+      : arr[0] = somethingElse ? x : arr[0];
+    something
+      ? somethingElse
+      : arr[0] = somethingElse ? x : arr[0];
     /* Not: */
-    something ?
-      somethingElse :
-      (arr[0] = somethingElse) ? x : z;
+    something
+      ? somethingElse
+      : (arr[0] = somethingElse) ? x : z;
     (
-      something ?
-        somethingElse : arr[0] = somethingElse
-    ) ?
-      x : z;
+      something
+        ? somethingElse : arr[0] = somethingElse
+    )
+      ? x : z;
 
     /** These should be parsed the same */
-    something ?
-      somethingElse :
-      bigArr.{0} = somethingElse ? x : bigArr.{0};
-    something ?
-      somethingElse :
-      bigArr.{0} = somethingElse ? x : bigArr.{0};
+    something
+      ? somethingElse
+      : bigArr.{0} =
+          somethingElse ? x : bigArr.{0};
+    something
+      ? somethingElse
+      : bigArr.{0} =
+          somethingElse ? x : bigArr.{0};
     /* Not: */
-    something ?
-      somethingElse :
-      (bigArr.{0} = somethingElse) ? x : z;
+    something
+      ? somethingElse
+      : (bigArr.{0} = somethingElse) ? x : z;
     (
-      something ?
-        somethingElse :
-        bigArr.{0} = somethingElse
-    ) ?
-      x : z;
+      something
+        ? somethingElse
+        : bigArr.{0} = somethingElse
+    )
+      ? x : z;
 
     /** These should be parsed the same */
-    something ?
-      somethingElse :
-      arr.[0] = somethingElse ? x : arr.[0];
-    something ?
-      somethingElse :
-      arr.[0] = somethingElse ? x : arr.[0];
+    something
+      ? somethingElse
+      : arr.[0] = somethingElse ? x : arr.[0];
+    something
+      ? somethingElse
+      : arr.[0] = somethingElse ? x : arr.[0];
     /* Not: */
-    something ?
-      somethingElse :
-      (str.[0] = somethingElse) ? x : z;
+    something
+      ? somethingElse
+      : (str.[0] = somethingElse) ? x : z;
     (
-      something ?
-        somethingElse : str.[0] = somethingElse
-    ) ?
-      x : z;
+      something
+        ? somethingElse : str.[0] = somethingElse
+    )
+      ? x : z;
 
     /**
      * It creates a totally different meaning when parens group the :
      */
     (
       x.contents =
-        something ?
-          (x.contents = somethingElse: x) : z
+        something
+          ? (x.contents = somethingElse: x) : z
     );
     y = something ? (y = somethingElse: x) : z;
     arr[0] =
-      something ?
-        (arr[0] = somethingElse: x) : z;
+      something
+        ? (arr[0] = somethingElse: x) : z;
     bigArr.{0} =
-      something ?
-        (bigArr.{0} = somethingElse: x) : z;
+      something
+        ? (bigArr.{0} = somethingElse: x) : z;
     str.[0] =
-      something ?
-        (str.[0] = somethingElse: x) : z;
+      something
+        ? (str.[0] = somethingElse: x) : z;
 
     /**
      * Various precedence groupings.
      */
-    true ?
-      true ? false : false : false;
+    true
+      ? true ? false : false : false;
     /* Is the same as */
     true ? true ? false : false : false;
     /*
@@ -964,10 +969,10 @@ let containingObject = {
     x + (- (something = y));
     x + (- something.contents) := y;
     x + (- something) := y;
-    x.contents || something + 1 ?
-      - hello : goodbye;
-    bigArr.{0} || - something + 1 ?
-      hello : goodbye;
+    x.contents || something + 1
+      ? - hello : goodbye;
+    bigArr.{0} || - something + 1
+      ? hello : goodbye;
     let result = - x + (something.contents = y);
 
     /* Prefix minus is actually sugar for regular function identifier ~-*/
@@ -1232,30 +1237,30 @@ something
   | Some(x) => x >>= y
 );
 
-something ?
-  a
-  >>= (
-    fun
+something
+  ? a
+    >>= (
+      fun
+      | None => x >>= y
+      | Some(x) => x >>= y
+    )
+  : fun
     | None => x >>= y
-    | Some(x) => x >>= y
-  ) :
-  fun
-  | None => x >>= y
-  | Some(x) => x >>= y;
+    | Some(x) => x >>= y;
 
-something ?
-  a
-  >>= (
-    fun
-    | None => x >>= y
-    | Some(x) => x >>= y
-  ) :
-  (
-    fun
-    | None => x >>= y
-    | Some(x) => x >>= y
-  )
-  >>= b;
+something
+  ? a
+    >>= (
+      fun
+      | None => x >>= y
+      | Some(x) => x >>= y
+    )
+  : (
+      fun
+      | None => x >>= y
+      | Some(x) => x >>= y
+    )
+    >>= b;
 
 let foo =
   fun
@@ -1276,31 +1281,31 @@ let foo =
   | None => ();
 
 let predicate =
-  predicate === Functions.alwaysTrue1 ?
-    (
-      fun
+  predicate === Functions.alwaysTrue1
+    ? (
+        fun
+        | None => false
+        | Some(exn) => predicate(exn)
+      )
+      >>= foo
+    : fun
       | None => false
-      | Some(exn) => predicate(exn)
-    )
-    >>= foo :
-    fun
-    | None => false
-    | Some(exn) => predicate(exn);
+      | Some(exn) => predicate(exn);
 
 let predicate =
-  predicate === Functions.alwaysTrue1 ?
-    (
-      fun
-      | None => false
-      | Some(exn) => predicate(exn)
-    )
-    >>= foo :
-    bar
-    >>= (
-      fun
-      | None => false
-      | Some(exn) => predicate(exn)
-    );
+  predicate === Functions.alwaysTrue1
+    ? (
+        fun
+        | None => false
+        | Some(exn) => predicate(exn)
+      )
+      >>= foo
+    : bar
+      >>= (
+        fun
+        | None => false
+        | Some(exn) => predicate(exn)
+      );
 
 let (>...) = (a, b) => a + b;
 

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -26,15 +26,15 @@ let y =
             Routes.stateToPath(
               latestComponentBag.state,
             );
-          currentActualPath == pathFromState ?
-            None :
-            dispatchEventless(
-              State.UriNavigated(
-                currentActualPath,
-              ),
-              latestComponentBag,
-              (),
-            );
+          currentActualPath == pathFromState
+            ? None
+            : dispatchEventless(
+                State.UriNavigated(
+                  currentActualPath,
+                ),
+                latestComponentBag,
+                (),
+              );
         },
         (),
       )
@@ -121,11 +121,13 @@ let icon =
 
 <MessengerSharedPhotosAlbumViewPhotoReact
   ref=?{
-    foo##bar === baz ?
-      Some(
-        foooooooooooooooooooooooo(setRefChild),
-      ) :
-      None
+    foo##bar === baz
+      ? Some(
+          foooooooooooooooooooooooo(
+            setRefChild,
+          ),
+        )
+      : None
   }
   key=node##legacy_attachment_id
 />;

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -1365,20 +1365,20 @@ f(~commit=!build);
 
 /* https://github.com/facebook/reason/issues/2032 */
 let predicate =
-  predicate === Functions.alwaysTrue1 ?
-    defaultPredicate :
-    fun
-    | None => false
-    | Some(exn) => predicate(exn);
+  predicate === Functions.alwaysTrue1
+    ? defaultPredicate
+    : fun
+      | None => false
+      | Some(exn) => predicate(exn);
 
 let predicate =
-  predicate === Functions.alwaysTrue1 ?
-    fun
-    | None => false
-    | Some(exn) => predicate(exn) :
-    fun
-    | None => false
-    | Some(exn) => predicate(exn);
+  predicate === Functions.alwaysTrue1
+    ? fun
+      | None => false
+      | Some(exn) => predicate(exn)
+    : fun
+      | None => false
+      | Some(exn) => predicate(exn);
 
 /* https://github.com/facebook/reason/issues/2125 */
 foo(~a);

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -2765,21 +2765,21 @@ let lAtFuncAnnotatedAfterEqual: type a. a => a =
 /* Ternary wrapping comments */
 let ternaryResult =
   /* Before Test */
-  something ?
+  something
     /* Before ifTrue */
-    callThisFunction(withThisArg) :
+    ? callThisFunction(withThisArg)
     /* Before ifFalse */
-    thatResult;
+    : thatResult;
 
 let ternaryResult =
   /* Before Test */
-  something ?
+  something
     /* Before ifTrue */
-    callThisFunction(withThisArg) :
+    ? callThisFunction(withThisArg)
     /* Before ifFalse */
-    trailingTest ?
-      /* before nested ifTrue */ true :
-      /* before nested ifFalse */ false;
+    : trailingTest
+        ? /* before nested ifTrue */ true
+        : /* before nested ifFalse */ false;
 
 let returningATernary = (x, y) =>
   x > y ? "hi" : "by";

--- a/formatTest/unit_tests/input/if.re
+++ b/formatTest/unit_tests/input/if.re
@@ -96,7 +96,29 @@ let whatShouldThisBeParsedAs =
   (something ? callThisFunction(withThisArg):
   trailingTest) ? true : false;
 
+/* the following shoud be... */
+let ternaryFormatting =
+  something ? notLongEnoughToCauseTwoLineBreaks : other
 
+/* ideally formatted as
+let ternaryFormatting =
+  something
+  ? notLongEnoughToCauseTwoLineBreaks
+  : other
+*/
+let ternaryFormatting =
+  something
+  ? notLongEnoughToCauseTwoLineBreaks
+  : other
+
+/* but is currently formatted as the following (which is less than desirable)
+let ternaryFormatting =
+  something
+  ? notLongEnoughToCauseTwoLineBreaks : other
+ */
+let ternaryFormatting =
+  something
+  ? notLongEnoughToCauseTwoLineBreaks : other
 
 let ternaryResult =
   aaaaaa ? bbbbbbb :

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4206,20 +4206,18 @@ let printer = object(self:'self)
       | None -> raise (Invalid_argument "Impossible")
       | Some (tt, ff) ->
         let ifTrue = self#unparseExpr tt in
-        let testItm = self#unparseResolvedRule (
+        let testItem = self#unparseResolvedRule (
           self#ensureExpression e ~reducesOnToken:(Token "?")
         ) in
         let ifFalse = self#unparseResolvedRule (
           self#ensureContainingRule ~withPrecedence:(Token ":") ~reducesAfterRight:ff ()
         ) in
-        let withQuestion =
-          source_map ~loc:e.pexp_loc
-            (makeList ~postSpace:true [testItm; atom "?"])
+        let trueBranch = label ~space:true ~break:`Never (atom "?") ifTrue
         in
-        let trueFalseBranches =
-          makeList ~inline:(true, true) ~break:IfNeed ~sep:(Sep ":") ~postSpace:true ~preSpace:true [ifTrue; ifFalse]
+        let falseBranch = label ~space:true ~break:`Never (atom ":") ifFalse
         in
-        let expr = label ~space:true withQuestion trueFalseBranches in
+        let expr = label ~space:true testItem (makeList ~break:IfNeed ~sep:(Sep " ") ~inline:(true, true) [trueBranch; falseBranch])
+        in
         SpecificInfixPrecedence ({reducePrecedence=Token ":"; shiftPrecedence=Token "?"}, LayoutNode expr)
       )
     | _ -> (


### PR DESCRIPTION
Addresses https://github.com/facebook/reason/issues/2160 and https://github.com/facebook/reason/issues/1987

line breaks for ternaries are now formatted as
```
valueICareAbout > Threshold
  ? value
  : otherValuereallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallylong;
```
or (the slightly less desirable, but better than the current situation)
```
valueICareAbout > Threshold
  ? value : otherValueKindaLongButNotEnoughForBothfohsd;
```
@jordwalke and I spent some time trying to force the above situation in all overflow cases, but had considerable difficulty and we feel that this is still considerably better than the status quo.

nested ternaries are formatted as below (this is different from prettier, but I think considerably more clear): 
```
valueICareAbout > Threshold
  ? value
  : otherValue > thing
      ? thing1
      : thing2reallyreallyreallyreallyreallyreallyreallyreallyreallylong;
```

The snapshot changes are worth looking at to understand how some edge cases are handled (I think it behaves better than prettier).