### PR TITLE
Fix OPAM 2 warning: `Synopsis should start with a capital and not end…

### DIFF
--- a/rtop.opam
+++ b/rtop.opam
@@ -17,7 +17,7 @@ depends: [
   "reason"
   "utop"   {>= "1.17"}
 ]
-synopsis: "rtop: Reason toplevel"
+synopsis: "Reason toplevel"
 description:
   "rtop is the toplevel (or REPL) for Reason, based on utop (https://github.com/diml/utop)."
 


### PR DESCRIPTION
… with a dot`