### PR TITLE
Preserve semicolon printing in seq-expr inside jsx-children

### DIFF
--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -621,3 +621,21 @@ ReasonReact.(<> {string("Test")} </>);
 <div style={getStyle()}>
   {ReasonReact.string("BugTest")}
 </div>;
+
+<div>
+  {
+    let left = limit->Int.toString;
+    {j|$left characters left|j}->React.string;
+  }
+</div>;
+
+<View style=styles##backgroundImageWrapper>
+  {
+    let uri = "/images/header-background.png";
+    <Image
+      resizeMode=`contain
+      style=styles##backgroundImage
+      uri
+    />;
+  }
+</View>;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -494,3 +494,21 @@ ReasonReact.(<> {string("Test")} </>);
 <X y={z->Belt.Option.getWithDefault("")} />;
 
 <div style={getStyle()}> {ReasonReact.string("BugTest")} </div>;
+
+<div>
+  {
+    let left = limit->Int.toString;
+    {j|$left characters left|j}->React.string;
+  }
+</div>;
+
+<View style=styles##backgroundImageWrapper>
+  {
+    let uri = "/images/header-background.png";
+    <Image
+      resizeMode=`contain
+      style=styles##backgroundImage
+      uri
+    />
+  }
+</View>;

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -6271,7 +6271,11 @@ let printer = object(self:'self)
     | head :: remaining ->
         self#formatChildren
           remaining
-          (self#inline_braces#simplifyUnparseExpr ~inline:true ~wrap:("{", "}") head :: processedRev)
+          (self
+            #dont_preserve_braces (* the brace logic is handled here *)
+            #simplifyUnparseExpr ~inline:true ~wrap:("{", "}")
+            head
+           :: processedRev)
     | [] -> match processedRev with
         | [] -> None
         | _::_ -> Some (List.rev processedRev)


### PR DESCRIPTION
Fixes #2293