### PR TITLE
Preemptive changes for OMP that supports OCaml 4.08

### DIFF
--- a/src/reason-parser/reason_lexer.mll
+++ b/src/reason-parser/reason_lexer.mll
@@ -327,7 +327,7 @@ let preprocessor = ref None
 
 open Format
 
-let report_error ppf = function
+let format_error ppf = function
   | Illegal_character c ->
       fprintf ppf "Illegal character (%s)" (Char.escaped c)
   | Illegal_escape s ->
@@ -348,14 +348,9 @@ let report_error ppf = function
   | Invalid_literal s ->
       fprintf ppf "Invalid literal %s" s
 
-let () =
-  Location.register_error_of_exn
-    (function
-      | Error (err, loc) ->
-          Some (Location.error_of_printer loc report_error err)
-      | _ ->
-          None
-    )
+let report_error ppf ~loc err =
+  Format.fprintf ppf "@[%a@]@." Location.report_error
+    (Location.error_of_printer loc format_error err)
 
 }
 

--- a/src/reason-parser/reason_syntax_util.cppo.ml
+++ b/src/reason-parser/reason_syntax_util.cppo.ml
@@ -489,17 +489,11 @@ type error = Syntax_error of string
 
 exception Error of Location.t * error
 
-let report_error ppf (Syntax_error err) =
-  Format.(fprintf ppf "%s" err)
-
-let () =
-  Location.register_error_of_exn
-    (function
-     | Error (loc, err) ->
-        Some (Location.error_of_printer loc report_error err)
-     | _ ->
-        None
-     )
+let report_error ppf ~loc (Syntax_error err) =
+  Format.fprintf ppf "@[%a@]@." Location.report_error
+    (Location.error_of_printer loc (fun ppf e ->
+      Format.(fprintf ppf "%s" e))
+      err)
 
 let map_first f = function
   | [] -> invalid_arg "Syntax_util.map_first: empty list"

--- a/src/reason-parser/reason_syntax_util.cppo.mli
+++ b/src/reason-parser/reason_syntax_util.cppo.mli
@@ -91,6 +91,8 @@ type error = Syntax_error of string
 
 exception Error of Ast_404.Location.t * error
 
+val report_error : Format.formatter -> loc:Location.t -> error -> unit
+
 val map_first : ('a -> 'a) -> 'a list -> 'a list
 
 val map_last : ('a -> 'a) -> 'a list -> 'a list

--- a/src/refmt/refmt_impl.ml
+++ b/src/refmt/refmt_impl.ml
@@ -92,9 +92,12 @@ let refmt
     | _ -> `Ok (List.iter (fun file -> refmt_single (Some file)) input_files)
   with
   | Printer_maker.Invalid_config msg -> `Error (true, msg)
-  | exn ->
-          Location.report_exception Format.err_formatter exn;
-          exit 1
+  | Reason_syntax_util.Error (loc, error) ->
+    Reason_syntax_util.report_error Format.err_formatter ~loc error;
+    exit 1
+  | Reason_lexer.Error (error, loc) ->
+    Reason_lexer.report_error Format.err_formatter ~loc error;
+    exit 1
 
 let top_level_info =
   let doc = "Reason's Parser & Pretty-printer" in


### PR DESCRIPTION
At the Mirage retreat this week I was talking to @armael regarding OCaml Migrate Parsetree support for OCaml 4.08 (related issue/comment: https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues/50#issuecomment-467164936).

Apparently, the error type has changed in 4.08 and calling into `Location.register_error_of_exn` is not going to work with the next version of OMP that snapshots the `Location` module.

Therefore we worked together on preemptively fixing this such that Reason can support OCaml 4.08 once OMP does.

Test plan: Current tests include error tests that are still passing.