### PR TITLE
Don't remove semis in blocks inside ternary expressions as jsx children

### DIFF
--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -639,3 +639,14 @@ ReasonReact.(<> {string("Test")} </>);
     />;
   }
 </View>;
+
+<div>
+  {true
+     ? {
+       let foo = "foo"; // don't remove semi
+       <span> {ReasonReact.string(foo)} </span>;
+     }
+     : <span>
+         {ReasonReact.string("bar")}
+       </span>}
+</div>;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -512,3 +512,10 @@ ReasonReact.(<> {string("Test")} </>);
     />
   }
 </View>;
+
+<div>
+  {true
+    ? {let foo = "foo"; // don't remove semi
+      <span> {ReasonReact.string(foo)} </span>}
+    : <span> {ReasonReact.string("bar")} </span>}
+</div>;

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4217,12 +4217,12 @@ let printer = object(self:'self)
       match detectTernary l with
       | None -> raise (Invalid_argument "Impossible")
       | Some (tt, ff) ->
-        let ifTrue = self#unparseExpr tt in
+        let ifTrue = self#reset_request_braces#unparseExpr tt in
         let testItem = self#unparseResolvedRule (
-          self#ensureExpression e ~reducesOnToken:(Token "?")
+          self#reset_request_braces#ensureExpression e ~reducesOnToken:(Token "?")
         ) in
         let ifFalse = self#unparseResolvedRule (
-          self#ensureContainingRule ~withPrecedence:(Token ":") ~reducesAfterRight:ff ()
+          self#reset_request_braces#ensureContainingRule ~withPrecedence:(Token ":") ~reducesAfterRight:ff ()
         ) in
         let trueBranch = label ~space:true ~break:`Never (atom "?") ifTrue
         in


### PR DESCRIPTION
Fix https://github.com/facebook/reason/issues/2349