### PR TITLE
Fix Azure for pull requests. Use the REST API to download artifacts.

### DIFF
--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -24,23 +24,21 @@ steps:
           if [[ $REST_BUILDS_RESP =~ (\"id\":)([^,]*) ]]; then LATEST_BUILD_ID="${BASH_REMATCH[2]}"; else LATEST_BUILD_ID=""; fi
         }
         fetchLatestBuild
-        fetchArtifactURLFor() {
-          BUILD_ID="$1"
-          REST_ART="https://dev.azure.com/$ORG/$PROJ/_apis/build/builds/$BUILD_ID/artifacts?artifactName=$ART_NAME&api-version=4.1"
+        fetchArtifactURL() {
+          REST_ART="https://dev.azure.com/$ORG/$PROJ/_apis/build/builds/$LATEST_BUILD_ID/artifacts?artifactName=$ART_NAME&api-version=4.1"
           if [[ $(curl $REST_ART) =~ (downloadUrl\":\")([^\"]*) ]]; then LATEST_ART_URL="${BASH_REMATCH[2]}"; else LATEST_ART_URL=""; fi
         }
-        downloadArtifactFor() {
-          ART_URL="$1"
+        downloadArtifact() {
           curl "$LATEST_ART_URL" > "${STAGING_DIRECTORY_UNIX}/$ART_NAME.zip"
           cd $STAGING_DIRECTORY_UNIX
           unzip "$ART_NAME.zip"
         }
-        fetchArtifactURLFor "$LATEST_BUILD_ID"
+        fetchArtifactURL
         echo "Using Dependency cache for buildID: $LATEST_BUILD_ID"
         echo "Build log for build that produced the cache: $LATEST_BUILD_PAGE"
         echo "Build badge for build that produced the cache: $LATEST_BUILD_BADGE"
         echo "Build artifact from build that produced the cache: $LATEST_ART_URL"
-        downloadArtifactFor "$LATEST_ART_URL"
+        downloadArtifact
       
 
   - bash: 'mkdir -p $(ESY__CACHE_INSTALL_PATH)'

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -35,12 +35,13 @@ steps:
         curl "$ART_URL" > "${STAGING_DIRECTORY_UNIX}/cache-${AGENT_OS}-install.zip"
         cd $STAGING_DIRECTORY_UNIX
         unzip "cache-${AGENT_OS}-install.zip"
+        ls $STAGING_DIRECTORY_UNIX
         
       
 
   - bash: 'mkdir -p $(ESY__CACHE_INSTALL_PATH)'
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
-    displayName: '[Cache][Restore] Create cache directory'
+    displayName: '[Cache][Restore] Create esy cache directory'
 
   # - bash: 'cd $(ESY__NPM_ROOT) && tar -xf $(STAGING_DIRECTORY_UNIX)/cache-$(Agent.OS)-install/npm-cache.tar -C .'
   #   continueOnError: true

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -12,31 +12,36 @@ steps:
     inputs:
       targetType: 'inline' # Optional. Options: filePath, inline
       script: |
-        ORG="reasonml"
-        REST_BUILDS="https://dev.azure.com/$ORG/$SYSTEM_TEAMPROJECT/"'_apis/build/builds?deletedFilter=excludeDeleted&statusFilter=completed&resultFilter=succeeded&queryOrder=finishTimeDescending&$top=1&api-version=4.1'
-        REST_BUILDS_RESP=$(curl "$REST_BUILDS")
 
-        if [[ $REST_BUILDS_RESP =~ (\"web\":\{\"href\":\")([^\"]*) ]]; then BUILD_PAGE="${BASH_REMATCH[2]}"; else BUILD_PAGE=""; fi
-        if [[ $REST_BUILDS_RESP =~ (\"badge\":\{\"href\":\")([^\"]*) ]]; then BUILD_BADGE="${BASH_REMATCH[2]}"; else BUILD_BADGE=""; fi
-        if [[ $REST_BUILDS_RESP =~ (\"id\":)([^,]*) ]]; then BUILD_ID="${BASH_REMATCH[2]}"; else BUILD_ID=""; fi
-
-
-
+        ORG="$SYSTEM_COLLECTIONID"
+        PROJ="$SYSTEM_TEAMPROJECT"
         ART_NAME="cache-${AGENT_OS}-install"
-        REST_ART="https://dev.azure.com/$ORG/$SYSTEM_TEAMPROJECT/_apis/build/builds/$BUILD_ID/artifacts?artifactName=$ART_NAME&api-version=4.1"
-        if [[ $(curl $REST_ART) =~ (downloadUrl\":\")([^\"]*) ]]; then ART_URL="${BASH_REMATCH[2]}"; else ART_URL=""; fi
-
-
-        echo "Using Dependency cache for buildID: $BUILD_ID"
-        echo "Build log for build that produced the cache: $BUILD_PAGE"
-        echo "Build badge for build that produced the cache: $BUILD_BADGE"
-        echo "Build artifact from build that produced the cache: $ART_URL"
-
-        curl "$ART_URL" > "${STAGING_DIRECTORY_UNIX}/$ART_NAME.zip"
-        cd $STAGING_DIRECTORY_UNIX
-        unzip "$ART_NAME.zip"
-        ls $STAGING_DIRECTORY_UNIX
-        
+        fetchLatestBuild() {
+          REST_BUILDS="https://dev.azure.com/$ORG/$PROJ/"'_apis/build/builds?deletedFilter=excludeDeleted&statusFilter=completed&resultFilter=succeeded&queryOrder=finishTimeDescending&$top=1&api-version=4.1'
+          REST_BUILDS_RESP=$(curl "$REST_BUILDS")
+          if [[ $REST_BUILDS_RESP =~ (\"web\":\{\"href\":\")([^\"]*) ]]; then LATEST_BUILD_PAGE="${BASH_REMATCH[2]}"; else LATEST_BUILD_PAGE=""; fi
+          if [[ $REST_BUILDS_RESP =~ (\"badge\":\{\"href\":\")([^\"]*) ]]; then LATEST_BUILD_BADGE="${BASH_REMATCH[2]}"; else LATEST_BUILD_BADGE=""; fi
+          if [[ $REST_BUILDS_RESP =~ (\"id\":)([^,]*) ]]; then LATEST_BUILD_ID="${BASH_REMATCH[2]}"; else LATEST_BUILD_ID=""; fi
+        }
+        fetchLatestBuild
+        printLatestBuild
+        fetchArtifactURLFor() {
+          BUILD_ID="$1"
+          REST_ART="https://dev.azure.com/$ORG/$PROJ/_apis/build/builds/$BUILD_ID/artifacts?artifactName=$ART_NAME&api-version=4.1"
+          if [[ $(curl $REST_ART) =~ (downloadUrl\":\")([^\"]*) ]]; then LATEST_ART_URL="${BASH_REMATCH[2]}"; else LATEST_ART_URL=""; fi
+        }
+        downloadArtifactFor() {
+          ART_URL="$1"
+          curl "$LATEST_ART_URL" > "${STAGING_DIRECTORY_UNIX}/$ART_NAME.zip"
+          cd $STAGING_DIRECTORY_UNIX
+          unzip "$ART_NAME.zip"
+        }
+        fetchArtifactURLFor "$LATEST_BUILD_ID"
+        echo "Using Dependency cache for buildID: $LATEST_BUILD_ID"
+        echo "Build log for build that produced the cache: $LATEST_BUILD_PAGE"
+        echo "Build badge for build that produced the cache: $LATEST_BUILD_BADGE"
+        echo "Build artifact from build that produced the cache: $LATEST_ART_URL"
+        downloadArtifactFor "$LATEST_ART_URL"
       
 
   - bash: 'mkdir -p $(ESY__CACHE_INSTALL_PATH)'

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -22,8 +22,8 @@ steps:
 
 
 
-        REST_ART="https://dev.azure.com/$ORG/$SYSTEM_TEAMPROJECT/_apis/build/builds/$BUILD_ID/artifacts?artifactName=$ART&api-version=4.1"
-        ART="cache-${AGENT_OS}-install"
+        ART_NAME="cache-${AGENT_OS}-install"
+        REST_ART="https://dev.azure.com/$ORG/$SYSTEM_TEAMPROJECT/_apis/build/builds/$BUILD_ID/artifacts?artifactName=$ART_NAME&api-version=4.1"
         if [[ $(curl $REST_ART) =~ (downloadUrl\":\")([^\"]*) ]]; then ART_URL="${BASH_REMATCH[2]}"; else ART_URL=""; fi
 
 
@@ -32,9 +32,9 @@ steps:
         echo "Build badge for build that produced the cache: $BUILD_BADGE"
         echo "Build artifact from build that produced the cache: $ART_URL"
 
-        curl "$ART_URL" > "${STAGING_DIRECTORY_UNIX}/cache-${AGENT_OS}-install.zip"
+        curl "$ART_URL" > "${STAGING_DIRECTORY_UNIX}/$ART_NAME.zip"
         cd $STAGING_DIRECTORY_UNIX
-        unzip "cache-${AGENT_OS}-install.zip"
+        unzip "$ART_NAME.zip"
         ls $STAGING_DIRECTORY_UNIX
         
       

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -7,7 +7,7 @@ steps:
     inputs:
         buildType: 'specific'
         project: '$(System.TeamProject)'
-        pipelineId: '2'
+        definitionId: '2'
         branchName: 'refs/heads/master'
         buildVersionToDownload: 'latestFromBranch'
         downloadType: 'single'

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -5,7 +5,6 @@ steps:
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
     displayName: '[Cache][Restore] Restoring build cache using REST API'
     continueOnError: true
-    workingDirectory: '$(STAGING_DIRECTORY)'
     inputs:
       targetType: 'inline' # Optional. Options: filePath, inline
       script: |
@@ -17,6 +16,8 @@ steps:
         if [[ $REST_BUILDS_RESP =~ (\"badge\":\{\"href\":\")([^\"]*) ]]; then BUILD_BADGE="${BASH_REMATCH[2]}"; else BUILD_BADGE=""; fi
         if [[ $REST_BUILDS_RESP =~ (\"id\":)([^,]*) ]]; then BUILD_ID="${BASH_REMATCH[2]}"; else BUILD_ID=""; fi
 
+
+
         REST_ART="https://dev.azure.com/$ORG/$SYSTEM_TEAMPROJECT/_apis/build/builds/$BUILD_ID/artifacts?artifactName=$ART&api-version=4.1"
         ART="cache-${AGENT_OS}-install"
         if [[ $(curl $REST_ART) =~ (downloadUrl\":\")([^\"]*) ]]; then ART_URL="${BASH_REMATCH[2]}"; else ART_URL=""; fi
@@ -27,7 +28,8 @@ steps:
         echo "Build Badge: $BUILD_BADGE"
         echo "Build Artifact: $ART_URL"
 
-        curl "$ART_URL" > ./cache-$(Agent.OS)-install.zip
+        curl "$ART_URL" > $(STAGING_DIRECTORY_UNIX)/cache-$(Agent.OS)-install.zip
+        cd $(STAGING_DIRECTORY_UNIX)
         gunzip cache-$(Agent.OS)-install.zip
         
       

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -12,12 +12,12 @@ steps:
     inputs:
       targetType: 'inline' # Optional. Options: filePath, inline
       script: |
-
-        ORG="$SYSTEM_COLLECTIONID"
+        # If org name is reasonml then REST_BASE will be: https://dev.azure.com/reasonml/
+        REST_BASE="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}"
         PROJ="$SYSTEM_TEAMPROJECT"
         ART_NAME="cache-${AGENT_OS}-install"
         fetchLatestBuild() {
-          REST_BUILDS="https://dev.azure.com/$ORG/$PROJ/"'_apis/build/builds?deletedFilter=excludeDeleted&statusFilter=completed&resultFilter=succeeded&queryOrder=finishTimeDescending&$top=1&api-version=4.1'
+          REST_BUILDS="$REST_BASE/$PROJ/"'_apis/build/builds?deletedFilter=excludeDeleted&statusFilter=completed&resultFilter=succeeded&queryOrder=finishTimeDescending&$top=1&api-version=4.1'
           echo "Rest call for builds: $REST_BUILDS"
           REST_BUILDS_RESP=$(curl "$REST_BUILDS")
           if [[ $REST_BUILDS_RESP =~ (\"web\":\{\"href\":\")([^\"]*) ]]; then LATEST_BUILD_PAGE="${BASH_REMATCH[2]}"; else LATEST_BUILD_PAGE=""; fi
@@ -26,7 +26,7 @@ steps:
         }
         fetchLatestBuild
         fetchArtifactURL() {
-          REST_ART="https://dev.azure.com/$ORG/$PROJ/_apis/build/builds/$LATEST_BUILD_ID/artifacts?artifactName=$ART_NAME&api-version=4.1"
+          REST_ART="$REST_BASE/$PROJ/_apis/build/builds/$LATEST_BUILD_ID/artifacts?artifactName=$ART_NAME&api-version=4.1"
           echo "Rest call for artifacts: $REST_ART"
           if [[ $(curl $REST_ART) =~ (downloadUrl\":\")([^\"]*) ]]; then LATEST_ART_URL="${BASH_REMATCH[2]}"; else LATEST_ART_URL=""; fi
         }

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -24,7 +24,6 @@ steps:
           if [[ $REST_BUILDS_RESP =~ (\"id\":)([^,]*) ]]; then LATEST_BUILD_ID="${BASH_REMATCH[2]}"; else LATEST_BUILD_ID=""; fi
         }
         fetchLatestBuild
-        printLatestBuild
         fetchArtifactURLFor() {
           BUILD_ID="$1"
           REST_ART="https://dev.azure.com/$ORG/$PROJ/_apis/build/builds/$BUILD_ID/artifacts?artifactName=$ART_NAME&api-version=4.1"

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -5,14 +5,14 @@ steps:
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
     displayName: '[Cache][Restore] Restore install'
     inputs:
-        buildType: 'specific'
-        project: '$(System.TeamProject)'
-        definition: '$(Build.DefinitionName)'
+        buildType: specific'
+        project: $(System.TeamProject)
+        pipelineId: $(System.DefinitionId)
         branchName: 'refs/heads/master'
         buildVersionToDownload: 'latestFromBranch'
         downloadType: 'single'
         artifactName: 'cache-$(Agent.OS)-install'
-        downloadPath: '$(STAGING_DIRECTORY)'
+        downloadPath: $(STAGING_DIRECTORY)
     continueOnError: true
 
   - bash: 'mkdir -p $(ESY__CACHE_INSTALL_PATH)'
@@ -31,6 +31,6 @@ steps:
 
   - bash: 'rm -rf *'
     continueOnError: true
-    workingDirectory: '$(STAGING_DIRECTORY)'
+    workingDirectory: $(STAGING_DIRECTORY)
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
     displayName: '[Cache][Restore] Clean up'

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -18,6 +18,7 @@ steps:
         ART_NAME="cache-${AGENT_OS}-install"
         fetchLatestBuild() {
           REST_BUILDS="https://dev.azure.com/$ORG/$PROJ/"'_apis/build/builds?deletedFilter=excludeDeleted&statusFilter=completed&resultFilter=succeeded&queryOrder=finishTimeDescending&$top=1&api-version=4.1'
+          echo "Rest call for builds: $REST_BUILDS"
           REST_BUILDS_RESP=$(curl "$REST_BUILDS")
           if [[ $REST_BUILDS_RESP =~ (\"web\":\{\"href\":\")([^\"]*) ]]; then LATEST_BUILD_PAGE="${BASH_REMATCH[2]}"; else LATEST_BUILD_PAGE=""; fi
           if [[ $REST_BUILDS_RESP =~ (\"badge\":\{\"href\":\")([^\"]*) ]]; then LATEST_BUILD_BADGE="${BASH_REMATCH[2]}"; else LATEST_BUILD_BADGE=""; fi
@@ -26,6 +27,7 @@ steps:
         fetchLatestBuild
         fetchArtifactURL() {
           REST_ART="https://dev.azure.com/$ORG/$PROJ/_apis/build/builds/$LATEST_BUILD_ID/artifacts?artifactName=$ART_NAME&api-version=4.1"
+          echo "Rest call for artifacts: $REST_ART"
           if [[ $(curl $REST_ART) =~ (downloadUrl\":\")([^\"]*) ]]; then LATEST_ART_URL="${BASH_REMATCH[2]}"; else LATEST_ART_URL=""; fi
         }
         downloadArtifact() {

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -2,7 +2,7 @@
 
 steps:
   - bash: 'mkdir -p $(STAGING_DIRECTORY_UNIX)'
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
     displayName: '[Cache][Publish] Create cache directory'
 
   - task: Bash@3
@@ -27,14 +27,14 @@ steps:
         if [[ $(curl $REST_ART) =~ (downloadUrl\":\")([^\"]*) ]]; then ART_URL="${BASH_REMATCH[2]}"; else ART_URL=""; fi
 
 
-        echo "Build ID: $BUILD_ID"
-        echo "Build Page: $BUILD_PAGE"
-        echo "Build Badge: $BUILD_BADGE"
-        echo "Build Artifact: $ART_URL"
+        echo "Using Dependency cache for buildID: $BUILD_ID"
+        echo "Build log for build that produced the cache: $BUILD_PAGE"
+        echo "Build badge for build that produced the cache: $BUILD_BADGE"
+        echo "Build artifact from build that produced the cache: $ART_URL"
 
-        curl "$ART_URL" > $(STAGING_DIRECTORY_UNIX)/cache-$(Agent.OS)-install.zip
-        cd $(STAGING_DIRECTORY_UNIX)
-        unzip cache-$(Agent.OS)-install.zip
+        curl "$ART_URL" > "${STAGING_DIRECTORY_UNIX}/cache-${AGENT_OS}-install.zip
+        cd $STAGING_DIRECTORY_UNIX
+        unzip "cache-${AGENT_OS}-install.zip"
         
       
 

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -32,7 +32,7 @@ steps:
         echo "Build badge for build that produced the cache: $BUILD_BADGE"
         echo "Build artifact from build that produced the cache: $ART_URL"
 
-        curl "$ART_URL" > "${STAGING_DIRECTORY_UNIX}/cache-${AGENT_OS}-install.zip
+        curl "$ART_URL" > "${STAGING_DIRECTORY_UNIX}/cache-${AGENT_OS}-install.zip"
         cd $STAGING_DIRECTORY_UNIX
         unzip "cache-${AGENT_OS}-install.zip"
         

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -2,6 +2,10 @@
 
 steps:
   - task: Bash@3
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+    displayName: '[Cache][Restore] Restoring build cache using REST API'
+    continueOnError: true
+    workingDirectory: '$(STAGING_DIRECTORY)'
     inputs:
       targetType: 'inline' # Optional. Options: filePath, inline
       script: |
@@ -13,8 +17,6 @@ steps:
         if [[ $REST_BUILDS_RESP =~ (\"badge\":\{\"href\":\")([^\"]*) ]]; then BUILD_BADGE="${BASH_REMATCH[2]}"; else BUILD_BADGE=""; fi
         if [[ $REST_BUILDS_RESP =~ (\"id\":)([^,]*) ]]; then BUILD_ID="${BASH_REMATCH[2]}"; else BUILD_ID=""; fi
 
-
-
         REST_ART="https://dev.azure.com/$ORG/$SYSTEM_TEAMPROJECT/_apis/build/builds/$BUILD_ID/artifacts?artifactName=$ART&api-version=4.1"
         ART="cache-${AGENT_OS}-install"
         if [[ $(curl $REST_ART) =~ (downloadUrl\":\")([^\"]*) ]]; then ART_URL="${BASH_REMATCH[2]}"; else ART_URL=""; fi
@@ -23,23 +25,12 @@ steps:
         echo "Build ID: $BUILD_ID"
         echo "Build Page: $BUILD_PAGE"
         echo "Build Badge: $BUILD_BADGE"
-        echo "Build Artifact: $REST_ART"
+        echo "Build Artifact: $ART_URL"
+
+        curl "$ART_URL" > ./cache-$(Agent.OS)-install.zip
+        gunzip cache-$(Agent.OS)-install.zip
         
       
-  
-  - task: DownloadBuildArtifacts@0
-    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
-    displayName: '[Cache][Restore] Restore install'
-    inputs:
-        buildType: 'specific'
-        project: '$(System.TeamProject)'
-        pipeline: '$(Build.DefinitionName)'
-        branchName: 'refs/heads/master'
-        buildVersionToDownload: 'latestFromBranch'
-        downloadType: 'single'
-        artifactName: 'cache-$(Agent.OS)-install'
-        downloadPath: '$(STAGING_DIRECTORY)'
-    continueOnError: true
 
   - bash: 'mkdir -p $(ESY__CACHE_INSTALL_PATH)'
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -30,7 +30,7 @@ steps:
 
         curl "$ART_URL" > $(STAGING_DIRECTORY_UNIX)/cache-$(Agent.OS)-install.zip
         cd $(STAGING_DIRECTORY_UNIX)
-        gunzip cache-$(Agent.OS)-install.zip
+        unzip cache-$(Agent.OS)-install.zip
         
       
 

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -7,7 +7,7 @@ steps:
     inputs:
         buildType: 'specific'
         project: '$(System.TeamProject)'
-        pipeline: '$(Build.DefinitionName)'
+        pipelineId: '2'
         branchName: 'refs/heads/master'
         buildVersionToDownload: 'latestFromBranch'
         downloadType: 'single'

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -5,14 +5,14 @@ steps:
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
     displayName: '[Cache][Restore] Restore install'
     inputs:
-        buildType: specific'
-        project: $(System.TeamProject)
-        pipelineId: $(System.DefinitionId)
+        buildType: 'specific'
+        project: '$(System.TeamProject)'
+        pipeline: 'facebook_reason'
         branchName: 'refs/heads/master'
         buildVersionToDownload: 'latestFromBranch'
         downloadType: 'single'
         artifactName: 'cache-$(Agent.OS)-install'
-        downloadPath: $(STAGING_DIRECTORY)
+        downloadPath: '$(STAGING_DIRECTORY)'
     continueOnError: true
 
   - bash: 'mkdir -p $(ESY__CACHE_INSTALL_PATH)'
@@ -31,6 +31,6 @@ steps:
 
   - bash: 'rm -rf *'
     continueOnError: true
-    workingDirectory: $(STAGING_DIRECTORY)
+    workingDirectory: '$(STAGING_DIRECTORY)'
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
     displayName: '[Cache][Restore] Clean up'

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -7,7 +7,7 @@ steps:
     inputs:
         buildType: 'specific'
         project: '$(System.TeamProject)'
-        pipeline: 'facebook_reason'
+        pipeline: '$(Build.DefinitionName)'
         branchName: 'refs/heads/master'
         buildVersionToDownload: 'latestFromBranch'
         downloadType: 'single'

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -1,13 +1,39 @@
 # Steps for restoring project cache
 
 steps:
+  - task: Bash@3
+    inputs:
+      targetType: 'inline' # Optional. Options: filePath, inline
+      script: |
+        ORG="reasonml"
+        REST_BUILDS="https://dev.azure.com/$ORG/$SYSTEM_TEAMPROJECT/"'_apis/build/builds?deletedFilter=excludeDeleted&statusFilter=completed&resultFilter=succeeded&queryOrder=finishTimeDescending&$top=1&api-version=4.1'
+        REST_BUILDS_RESP=$(curl "$REST_BUILDS")
+
+        if [[ $REST_BUILDS_RESP =~ (\"web\":\{\"href\":\")([^\"]*) ]]; then BUILD_PAGE="${BASH_REMATCH[2]}"; else BUILD_PAGE=""; fi
+        if [[ $REST_BUILDS_RESP =~ (\"badge\":\{\"href\":\")([^\"]*) ]]; then BUILD_BADGE="${BASH_REMATCH[2]}"; else BUILD_BADGE=""; fi
+        if [[ $REST_BUILDS_RESP =~ (\"id\":)([^,]*) ]]; then BUILD_ID="${BASH_REMATCH[2]}"; else BUILD_ID=""; fi
+
+
+
+        REST_ART="https://dev.azure.com/$ORG/$SYSTEM_TEAMPROJECT/_apis/build/builds/$BUILD_ID/artifacts?artifactName=$ART&api-version=4.1"
+        ART="cache-${AGENT_OS}-install"
+        if [[ $(curl $REST_ART) =~ (downloadUrl\":\")([^\"]*) ]]; then ART_URL="${BASH_REMATCH[2]}"; else ART_URL=""; fi
+
+
+        echo "Build ID: $BUILD_ID"
+        echo "Build Page: $BUILD_PAGE"
+        echo "Build Badge: $BUILD_BADGE"
+        echo "Build Artifact: $REST_ART"
+        
+      
+  
   - task: DownloadBuildArtifacts@0
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
     displayName: '[Cache][Restore] Restore install'
     inputs:
         buildType: 'specific'
         project: '$(System.TeamProject)'
-        definitionId: '2'
+        pipeline: '$(Build.DefinitionName)'
         branchName: 'refs/heads/master'
         buildVersionToDownload: 'latestFromBranch'
         downloadType: 'single'

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -7,7 +7,7 @@ steps:
     inputs:
         buildType: 'specific'
         project: '$(System.TeamProject)'
-        pipeline: '$(Build.DefinitionName)'
+        definition: '$(Build.DefinitionName)'
         branchName: 'refs/heads/master'
         buildVersionToDownload: 'latestFromBranch'
         downloadType: 'single'

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -1,6 +1,10 @@
 # Steps for restoring project cache
 
 steps:
+  - bash: 'mkdir -p $(STAGING_DIRECTORY_UNIX)'
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    displayName: '[Cache][Publish] Create cache directory'
+
   - task: Bash@3
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
     displayName: '[Cache][Restore] Restoring build cache using REST API'

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ let ocaml_syntax =
 ## License
 
 See Reason license in [LICENSE.txt](LICENSE.txt).
+
 Works that are forked from other projects are under their original licenses.
 
 ## Credit

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ let ocaml_syntax =
 ## License
 
 See Reason license in [LICENSE.txt](LICENSE.txt).
-
 Works that are forked from other projects are under their original licenses.
 
 ## Credit


### PR DESCRIPTION
It turns out we can't reliably download artifacts using the old method for pull requests. Something about permissions. With the REST API all artifacts can be downloaded publicly. Let's use it. 