### PR TITLE
Format inline records with parens in outcome printer

### DIFF
--- a/formatTest/oprintTests/expected_output/inlineRecord.re
+++ b/formatTest/oprintTests/expected_output/inlineRecord.re
@@ -1,6 +1,6 @@
-type t0 = T0 { t0: int, };
-type t1 = A { x: int, } | B | C { c1: string, c2: string, };
+type t0 = T0({ t0: int, });
+type t1 = A({ x: int, }) | B | C({ c1: string, c2: string, });
 type t2(_) =
-    D { x: int, }: t2(int)
-  | E { f: int => int, }: t2(int => int)
+    D({ x: int, }): t2(int)
+  | E({ f: int => int, }): t2(int => int)
   | F(unit): t2(unit);

--- a/src/reason-parser/reason_oprint.cppo.ml
+++ b/src/reason-parser/reason_oprint.cppo.ml
@@ -806,7 +806,7 @@ and print_out_constr ppf (name, tyl,ret_type_opt) =
       | [] ->
           pp_print_string ppf name
       | [Otyp_record lbls] ->
-        fprintf ppf "@[<2>%s {%a@;<1 -2>}@]" name
+        fprintf ppf "@[<2>%s({%a@;<1 -2>})@]" name
           (print_list_init print_out_label (fun ppf -> fprintf ppf "@ ")) lbls
       | _ ->
           fprintf ppf "@[<2>%s(%a)@]" name
@@ -817,7 +817,7 @@ and print_out_constr ppf (name, tyl,ret_type_opt) =
       | [] ->
           fprintf ppf "@[<2>%s:@ %a@]" name print_simple_out_type ret_type
       | [Otyp_record lbls] ->
-        fprintf ppf "@[<2>%s {%a@;<1 -2>}: %a@]" name
+        fprintf ppf "@[<2>%s({%a@;<1 -2>}): %a@]" name
           (print_list_init print_out_label (fun ppf -> fprintf ppf "@ ")) lbls
           print_simple_out_type ret_type
       | _ ->


### PR DESCRIPTION
This is a followup to the syntax change added in #2363, but for the
outcome printer