### PR TITLE
update ocaml version constraint to allow 4.08, bump package version to 3.4.2, add test script for esy, update README.md and HISTORY.md

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@ Improvements:
 - Parse and print parentheses around inline record declarations ([2363](https://github.com/facebook/reason/pull/2363))
 - Proper outcome printing (for editor and build) of inline records ([2336](https://github.com/facebook/reason/pull/2336))
 - Proper outcome printing of types with inline records (parentheses) ([2370](https://github.com/facebook/reason/pull/2370))
+- changes for OCaml 4.08 compatibility ([2345](https://github.com/facebook/reason/pull/2345))
 
 ## 3.4.1
 

--- a/esy.json
+++ b/esy.json
@@ -2,9 +2,9 @@
   "name": "reason-dev",
   "notes": "This is just the dev package config. See ./scripts/esy/ for release package configs",
   "license": "MIT",
-  "version": "3.4.0",
+  "version": "3.4.2",
   "dependencies": {
-    "ocaml": " >= 4.2.0 < 4.8.0",
+    "ocaml": " >= 4.2.0 < 4.9.0",
     "@opam/ocamlfind": "*",
     "@opam/menhir": " >= 20170418.0.0",
     "@opam/utop": " >= 1.17.0 < 2.3.0",
@@ -31,5 +31,8 @@
       ["esy-installer", "reason.install"],
       ["esy-installer", "rtop.install"]
     ]
+  },
+  "scripts": {
+    "test": "esy x make test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "reason",
-	"version": "3.4.0",
+	"version": "3.4.2",
 	"description": "Simple, fast & type safe code that leverages the JavaScript & OCaml ecosystems",
 	"repository": {
 		"type": "git",

--- a/src/README.md
+++ b/src/README.md
@@ -45,6 +45,7 @@ git clone https://github.com/facebook/reason.git
 cd reason
 esy install
 esy build
+esy test
 ```
 
 ##### Editors
@@ -56,6 +57,8 @@ works with `esy` projects, loading all the right dependencies.
 
 You can run commands as if you had installed Reason by prefixing commands with `esy x` ("esy execute").
 For example `esy x make test`
+
+Tests specifically can also be run via the `esy test` (which is configured via the scripts field in esy.json file in the repository root)
 
 For more, see the [esy documentation](https://github.com/esy-ocaml/esy).
 
@@ -74,7 +77,7 @@ The generated artifacts are in `_build`. All the binaries are in `_build/install
 
 To do some one-off tests, try `echo "let a = 1" | _build/install/default/bin/refmt`
 
-`make test` (make sure to follow the repo pinning instructions above!). The tests will output the difference between the expected syntax formatting and the actual one, if any.
+`make test` or if using esy, `esy test` (make sure to follow the repo pinning instructions above!). The tests will output the difference between the expected syntax formatting and the actual one, if any.
 
 Small exception: testing your changes in `rtop` is a little complicated, but you usually don't need to test it. If you do, you might have seen that your changes of the parser or printer don't affect `rtop` when you run it. Instead, you need to do `opam pin add -y reason .` and _then_ run `rtop` to see the Reason changes reflected.
 

--- a/src/refmt/esy.json
+++ b/src/refmt/esy.json
@@ -1,13 +1,13 @@
 {
   "name": "@esy-ocaml/reason",
-  "version": "3.4.0",
+  "version": "3.4.2",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/reason.git"
   },
   "dependencies": {
-    "ocaml": " >= 4.2.0  < 4.8.0",
+    "ocaml": " >= 4.2.0  < 4.9.0",
     "@opam/ocamlfind": "*",
     "@opam/menhir": " >= 20170418.0.0",
     "@opam/merlin-extend": " >= 0.3",

--- a/src/rtop/esy.json
+++ b/src/rtop/esy.json
@@ -13,14 +13,12 @@
     "@opam/result": "*",
     "@opam/dune": "*",
     "@esy-ocaml/reason": "^3.2.0",
-    "@opam/utop": " >= 1.17.0"
-  },
-  "peerDependencies": {
-    "ocaml": " >= 4.2.0  < 4.8.0"
+    "@opam/utop": " >= 1.17.0",
+    "ocaml": " >= 4.2.0 < 4.9.0"
   },
   "devDependencies": {
-    "@esy-ocaml/merlin": "*",
-    "ocaml": "~4.6.0"
+    "@opam/merlin": "*",
+    "ocaml": "~4.8.0"
   },
   "esy": {
     "build": [


### PR DESCRIPTION
Bumped ocaml version constraints now that https://github.com/facebook/reason/pull/2345 is released. It looks like there were already notes written up for 3.4.2 so I bumped to that version as this seems fine for a patch version.