### PR TITLE
Slightly better breaking of unary prefix symbols.

### DIFF
--- a/formatTest/errorTests/expected_output/syntaxError.re
+++ b/formatTest/errorTests/expected_output/syntaxError.re
@@ -1,3 +1,3 @@
 File "syntaxError.re", line 1, characters 9-10:
 Error: File "syntaxError.re", line 1, characters 9-10:
-Error: Syntax error
+       Error: Syntax error

--- a/formatTest/typeCheckedTests/expected_output/unary.re
+++ b/formatTest/typeCheckedTests/expected_output/unary.re
@@ -1,0 +1,88 @@
+type result('a, 'b) =
+  | Ok('a)
+  | Error('b);
+
+let returnsAResultToBeUnwrapped = (a, b, c) =>
+  switch (a, b, c) {
+  | (None, Some(i), Some(j)) => Ok((i, j))
+  | (Some(i), Some(j), None) =>
+    Ok(("hi", "bye"))
+  | _ =>
+    Error(
+      Invalid_argument(
+        "This is not a valid argument",
+      ),
+    )
+  };
+
+let returnsAnIntegerResultNotWrapped = (a, b, c) =>
+  switch (a, b, c) {
+  | (None, Some(i), Some(j)) => 0
+  | (Some(i), Some(j), None) => (-1)
+  | _ => 100
+  };
+
+let returnsABoolReturnValueNoResult = (a, b, c) =>
+  switch (a, b, c) {
+  | (None, Some(i), Some(j)) => true
+  | (Some(i), Some(j), None) => false
+  | _ => false
+  };
+
+let (!!) = res =>
+  switch (res) {
+  | Ok(o) => o
+  | Error(e) => raise(e)
+  };
+
+let result =
+  !!returnsAResultToBeUnwrapped(
+      Some(
+        "this realy long string will make things wrap",
+      ),
+      Some(
+        "this realy long string will make things wrap",
+      ),
+      Some(
+        "this realy long string will make things wrap",
+      ),
+    );
+
+let result =
+  - returnsAnIntegerResultNotWrapped(
+      Some(
+        "this realy long string will make things wrap",
+      ),
+      Some(
+        "this realy long string will make things wrap",
+      ),
+      Some(
+        "this realy long string will make things wrap",
+      ),
+    );
+
+let result =
+  + returnsAnIntegerResultNotWrapped(
+      Some(
+        "this realy long string will make things wrap",
+      ),
+      Some(
+        "this realy long string will make things wrap",
+      ),
+      Some(
+        "this realy long string will make things wrap",
+      ),
+    );
+
+let result =
+  !returnsABoolReturnValueNoResult(
+     Some(
+       "this realy long string will make things wrap",
+     ),
+     Some(
+       "this realy long string will make things wrap",
+     ),
+     Some(
+       "this realy long string will make things wrap",
+     ),
+   );

--- a/formatTest/typeCheckedTests/input/unary.re
+++ b/formatTest/typeCheckedTests/input/unary.re
@@ -1,0 +1,51 @@
+
+
+type result('a, 'b) = Ok('a) | Error('b);
+
+let returnsAResultToBeUnwrapped = (a, b, c) => switch(a, b, c) {
+  | (None, Some(i), Some(j)) => Ok((i, j));
+  | (Some(i), Some(j), None) => Ok(("hi", "bye"));
+  | _ => Error(Invalid_argument("This is not a valid argument"))
+};
+
+let returnsAnIntegerResultNotWrapped = (a, b, c) => switch(a,b, c) {
+  | (None, Some(i), Some(j)) => 0
+  | (Some(i), Some(j), None) => -1
+  | _ => 100
+};
+
+let returnsABoolReturnValueNoResult = (a, b, c) => switch(a,b, c) {
+  | (None, Some(i), Some(j)) => true
+  | (Some(i), Some(j), None) => false
+  | _ => false
+};
+
+let (!!) = res => switch(res) {
+  | Ok(o) => o
+  | Error(e) => raise(e)
+};
+
+
+let result = !!returnsAResultToBeUnwrapped(
+  Some("this realy long string will make things wrap"),
+  Some("this realy long string will make things wrap"),
+  Some("this realy long string will make things wrap")
+);
+
+let result = -returnsAnIntegerResultNotWrapped(
+  Some("this realy long string will make things wrap"),
+  Some("this realy long string will make things wrap"),
+  Some("this realy long string will make things wrap")
+)
+
+let result = +returnsAnIntegerResultNotWrapped(
+  Some("this realy long string will make things wrap"),
+  Some("this realy long string will make things wrap"),
+  Some("this realy long string will make things wrap")
+)
+
+let result = !returnsABoolReturnValueNoResult(
+  Some("this realy long string will make things wrap"),
+  Some("this realy long string will make things wrap"),
+  Some("this realy long string will make things wrap")
+);

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4068,7 +4068,7 @@ let printer = object(self:'self)
           self#ensureContainingRule ~withPrecedence:prec ~reducesAfterRight:rightExpr ()
         ) in
         SpecificInfixPrecedence
-          ({reducePrecedence=prec; shiftPrecedence = prec}, LayoutNode (label ~space:forceSpace (atom prefixStr) rightItm))
+          ({reducePrecedence=prec; shiftPrecedence = prec}, LayoutNode (label ~indent:0 ~break:`Never ~space:forceSpace (atom prefixStr) rightItm))
         | (UnaryPostfix postfixStr, [(Nolabel, leftExpr)]) ->
           let forceSpace = match leftExpr.pexp_desc with
             | Pexp_apply (ee, _) ->
@@ -4118,7 +4118,7 @@ let printer = object(self:'self)
           let rightItm = self#unparseResolvedRule (
             self#ensureContainingRule ~withPrecedence:prec ~reducesAfterRight:rightExpr ()
           ) in
-          let expr = label ~space:true (atom printedIdent) rightItm in
+          let expr = label ~indent:0 ~break:`Never ~space:true (atom printedIdent) rightItm in
           SpecificInfixPrecedence ({reducePrecedence=prec; shiftPrecedence=Token printedIdent}, LayoutNode expr)
         | (UnaryMinusPrefix printedIdent as x, [(Nolabel, rightExpr)])
         | (UnaryNotPrefix printedIdent as x, [(Nolabel, rightExpr)]) ->
@@ -4133,7 +4133,7 @@ let printer = object(self:'self)
           let rightItm = self#unparseResolvedRule (
             self#ensureContainingRule ~withPrecedence:prec ~reducesAfterRight:rightExpr ()
           ) in
-          let expr = label ~space:forceSpace (atom printedIdent) rightItm in
+          let expr = label ~break:`Never ~indent:0 ~space:forceSpace (atom printedIdent) rightItm in
           SpecificInfixPrecedence ({reducePrecedence=prec; shiftPrecedence=Token printedIdent}, LayoutNode expr)
         (* Will need to be rendered in self#expression as (~-) x y z. *)
         | (_, _) ->


### PR DESCRIPTION
Summary:
Before these would break like:

```
!!
  myFunction(
    foo,
    bar
  )

```
But now they break like

```
!!myFunction(
    foo,
    bar
  )

```

This is still not ideal, but it's an improvement.

Also, one downside is that now broken nots are not aligned to two characters.

```
let res =
  !myFunction(
     foo,
     bar
   )

```

However, I think that is better than what was there previously.

```
let res =
  !
    myFunction(
      foo,
      bar
    )

```

This doesn't come up with unary minus, or even unary operators that are of
character length two. It's mostly about `!`. I'd say this is still an
improvement.

To fix the remaining issue seems pretty invasive at the moment.

For a better fix, I might suggest a pass that prepends unary operators to
function names in certain cases, and then running the printer as if these unary
prefixes didn't even exist (in those cases).

Test Plan:

Reviewers:

CC: