### PR TITLE
Fix JSX removing semicolons

### DIFF
--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -623,21 +623,17 @@ ReasonReact.(<> {string("Test")} </>);
 </div>;
 
 <div>
-  {
-    let left = limit->Int.toString;
-    {j|$left characters left|j}->React.string;
-  }
+  {let left = limit->Int.toString;
+   {j|$left characters left|j}->React.string}
 </div>;
 
 <View style=styles##backgroundImageWrapper>
-  {
-    let uri = "/images/header-background.png";
-    <Image
-      resizeMode=`contain
-      style=styles##backgroundImage
-      uri
-    />;
-  }
+  {let uri = "/images/header-background.png";
+   <Image
+     resizeMode=`contain
+     style=styles##backgroundImage
+     uri
+   />}
 </View>;
 
 <div>
@@ -650,3 +646,15 @@ ReasonReact.(<> {string("Test")} </>);
          {ReasonReact.string("bar")}
        </span>}
 </div>;
+
+let v =
+  <A>
+    <B>
+      ...{_ => {
+        let renderX = x =>
+          {let y = x ++ x;
+           <div key=y />};
+        renderX("foo");
+      }}
+    </B>
+  </A>;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -519,3 +519,16 @@ ReasonReact.(<> {string("Test")} </>);
       <span> {ReasonReact.string(foo)} </span>}
     : <span> {ReasonReact.string("bar")} </span>}
 </div>;
+
+let v =
+  <A>
+    <B>
+      ...{_ => {
+        let renderX = x => {
+          let y = x ++ x;
+          <div key=y />;
+        };
+        renderX("foo");
+      }}
+    </B>
+  </A>;

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -6096,7 +6096,7 @@ let printer = object(self:'self)
           ~inline:(true, inline_braces)
           ~wrap:("{", "}")
           ~postSpace:true
-          ~sep:(if inline_braces then NoSep else (SepFinal (";", ";")))
+          ~sep:(if inline_braces then (Sep ";") else (SepFinal (";", ";")))
           (self#letList x)
       in
       Some layout
@@ -6272,11 +6272,7 @@ let printer = object(self:'self)
     | head :: remaining ->
         self#formatChildren
           remaining
-          (self
-            #dont_preserve_braces (* the brace logic is handled here *)
-            #simplifyUnparseExpr ~inline:true ~wrap:("{", "}")
-            head
-           :: processedRev)
+          (self#inline_braces#simplifyUnparseExpr ~inline:true ~wrap:("{", "}") head :: processedRev)
     | [] -> match processedRev with
         | [] -> None
         | _::_ -> Some (List.rev processedRev)


### PR DESCRIPTION
Turns out we can have our cake and eat it too. This fixes e.g. #2384 and a few others, resulting from a bug I introduced in #2223 