### PR TITLE
Fix the build for newer versions of ocaml-migrate-parsetree

### DIFF
--- a/src/reason-parser-tests/testOprint.ml
+++ b/src/reason-parser-tests/testOprint.ml
@@ -19,6 +19,8 @@
  * not a super easy path to "test it out", but this setup is hopefully not too complicated.
  *)
 
+open Migrate_parsetree
+
 module Convert = Migrate_parsetree.Convert (Migrate_parsetree.OCaml_404) (Migrate_parsetree.OCaml_current)
 module ConvertBack = Migrate_parsetree.Convert (Migrate_parsetree.OCaml_current) (Migrate_parsetree.OCaml_404)
 
@@ -46,4 +48,3 @@ let main () =
   print_string result
 
 let () = main ()
-

--- a/src/reason-parser/reason_attributes.ml
+++ b/src/reason-parser/reason_attributes.ml
@@ -1,3 +1,4 @@
+open Migrate_parsetree
 open Ast_404
 open Location
 open Parsetree

--- a/src/reason-parser/reason_heuristics.ml
+++ b/src/reason-parser/reason_heuristics.ml
@@ -1,3 +1,5 @@
+open Migrate_parsetree
+
 let is_punned_labelled_expression e lbl =
   let open Ast_404.Parsetree in
   match e.pexp_desc with

--- a/src/reason-parser/reason_oprint.cppo.ml
+++ b/src/reason-parser/reason_oprint.cppo.ml
@@ -85,6 +85,7 @@
 *)
 
 #ifdef BS_NO_COMPILER_PATCH
+open Migrate_parsetree
 open Ast_404
 #endif
 

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -48,7 +48,8 @@
 (* The parser definition *)
 
 %{
-open Migrate_parsetree.OCaml_404.Ast
+open Migrate_parsetree
+open OCaml_404.Ast
 open Reason_syntax_util
 open Location
 open Asttypes
@@ -1372,19 +1373,19 @@ conflicts.
 (* Entry points *)
 
 %start implementation                   (* for implementation files *)
-%type <Ast_404.Parsetree.structure> implementation
+%type <Migrate_parsetree.Ast_404.Parsetree.structure> implementation
 %start interface                        (* for interface files *)
-%type <Ast_404.Parsetree.signature> interface
+%type <Migrate_parsetree.Ast_404.Parsetree.signature> interface
 %start toplevel_phrase                  (* for interactive use *)
-%type <Ast_404.Parsetree.toplevel_phrase> toplevel_phrase
+%type <Migrate_parsetree.Ast_404.Parsetree.toplevel_phrase> toplevel_phrase
 %start use_file                         (* for the #use directive *)
-%type <Ast_404.Parsetree.toplevel_phrase list> use_file
+%type <Migrate_parsetree.Ast_404.Parsetree.toplevel_phrase list> use_file
 %start parse_core_type
-%type <Ast_404.Parsetree.core_type> parse_core_type
+%type <Migrate_parsetree.Ast_404.Parsetree.core_type> parse_core_type
 %start parse_expression
-%type <Ast_404.Parsetree.expression> parse_expression
+%type <Migrate_parsetree.Ast_404.Parsetree.expression> parse_expression
 %start parse_pattern
-%type <Ast_404.Parsetree.pattern> parse_pattern
+%type <Migrate_parsetree.Ast_404.Parsetree.pattern> parse_pattern
 
 (* Instead of reporting an error directly, productions specified
  * below will be reduced first and poped up in the stack to a higher

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -48,6 +48,7 @@
 
 module Easy_format = Vendored_easy_format
 
+open Migrate_parsetree
 open Ast_404
 open Asttypes
 open Location

--- a/src/reason-parser/reason_pprint_ast.mli
+++ b/src/reason-parser/reason_pprint_ast.mli
@@ -1,3 +1,4 @@
+open Migrate_parsetree
 open Ast_404.Parsetree
 
 val configure :

--- a/src/reason-parser/reason_syntax_util.cppo.ml
+++ b/src/reason-parser/reason_syntax_util.cppo.ml
@@ -15,6 +15,7 @@
 *)
 
 #ifdef BS_NO_COMPILER_PATCH
+open Migrate_parsetree
 open Ast_404
 #endif
 

--- a/src/reason-parser/reason_syntax_util.cppo.mli
+++ b/src/reason-parser/reason_syntax_util.cppo.mli
@@ -13,6 +13,7 @@
   BuckleScript; ping @chenglou and a few others and we'll keep them synced up by
   patching the right parts, through the power of types(tm)
 *)
+open Migrate_parsetree
 
 val ml_to_reason_swap : string -> string
 


### PR DESCRIPTION
This fixes the build on the current master with `ocaml-migrate-parsetree` v1.3.0, which produces some warnings for code relying on e.g. `Ast_404` at the toplevel.