### PR TITLE
Remove `build` constraints from Dune in opam files

### DIFF
--- a/reason.opam
+++ b/reason.opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml"         {>= "4.02" & < "4.09"}
-  "dune"          {build & >= "1.4"}
+  "dune"          {>= "1.4"}
   "ocamlfind"     {build}
   "menhir"        {>= "20170418"}
   "merlin-extend" {>= "0.4"}

--- a/rtop.opam
+++ b/rtop.opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml"  {>= "4.02" & < "4.09"}
-  "dune"   {build}
+  "dune"   {>= "1.4"}
   "reason"
   "utop"   {>= "1.17"}
 ]


### PR DESCRIPTION
The opam repository folks wants this gone