### PR TITLE
Bump allowed utop version to support OCaml 4.08

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -8,7 +8,7 @@
     "@opam/fix": "*",
     "@opam/ocamlfind": "*",
     "@opam/menhir": " >= 20170418.0.0",
-    "@opam/utop": " >= 1.17.0 < 2.3.0",
+    "@opam/utop": " >= 1.17.0 < 2.5.0",
     "@opam/merlin-extend": " >= 0.4",
     "@opam/result": "*",
     "@opam/ocaml-migrate-parsetree": "*",


### PR DESCRIPTION
This is needed to get oni2 to build on 4.08.1. See https://github.com/onivim/oni2/pull/801.

I have now idea how reason was made to build on 4.08.1 without bumping utop...