### PR TITLE
Fix printing of fragments inside JSX props

### DIFF
--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -709,3 +709,5 @@ let v =
          }),
   }
 />;
+
+<A someProp={<> {React.string("Hello")} </>} />;

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -711,3 +711,5 @@ let v =
 />;
 
 <A someProp={<> {React.string("Hello")} </>} />;
+
+<A someProp=?{<> {React.string("Hi")} </>} />;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -562,3 +562,5 @@ let v =
     name: x |> Option.map(x => {let y = x; y ++ y})
   }}
 />;
+
+<A someProp={ <> {React.string("Hello")} </> } />;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -564,3 +564,5 @@ let v =
 />;
 
 <A someProp={ <> {React.string("Hello")} </> } />;
+
+<A someProp=?{ <> {React.string("Hi")} </> } />;

--- a/src/reason-parser/reason_declarative_lexer.mll
+++ b/src/reason-parser/reason_declarative_lexer.mll
@@ -506,6 +506,14 @@ rule token state = parse
       set_lexeme_length lexbuf 1;
       LBRACE
     }
+  | "{<>" {
+    set_lexeme_length lexbuf 1;
+    LBRACE
+  }
+  | "{<>}" {
+    set_lexeme_length lexbuf 2;
+    LBRACELESS
+  }
   | "</" blank* ((uppercase_or_lowercase (identchar|'.')* ) as tag) blank* ">"
     { LESSSLASHIDENTGREATER tag }
   | "]"  { RBRACKET }

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4439,10 +4439,16 @@ let printer = object(self:'self)
           in
           processArguments tail processedAttrs (Some [dotdotdotChild])
       | (Optional lbl, expression) :: tail ->
+        let {jsxAttrs; _} = partitionAttributes expression.pexp_attributes in
+        let value_has_jsx = jsxAttrs != [] in
         let nextAttr =
           match expression.pexp_desc with
           | Pexp_ident ident when isPunnedJsxArg lbl ident ->
               makeList ~break:Layout.Never [atom "?"; atom lbl]
+           | Pexp_construct _ when value_has_jsx ->
+               label
+                (makeList ~break:Layout.Never [atom lbl; atom "=?"])
+                (self#inline_braces#simplifyUnparseExpr ~wrap:("{","}") expression)
           | _ ->
               label
                 (makeList ~break:Layout.Never [atom lbl; atom "=?"])

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4448,8 +4448,9 @@ let printer = object(self:'self)
                 (makeList ~break:Layout.Never [atom lbl; atom "=?"])
                 (self#dont_preserve_braces#simplifyUnparseExpr ~wrap:("{","}") expression) in
         processArguments tail (nextAttr :: processedAttrs) children
-
       | (Labelled lbl, expression) :: tail ->
+         let {jsxAttrs; _} = partitionAttributes expression.pexp_attributes in
+         let value_has_jsx = jsxAttrs != [] in
          let nextAttr =
            match expression.pexp_desc with
            | Pexp_ident ident when isPunnedJsxArg lbl ident -> atom lbl
@@ -4486,6 +4487,10 @@ let printer = object(self:'self)
                  | Infix str when requireNoSpaceFor str -> self#unparseExpr expression
                  | _ -> self#dont_preserve_braces#simplifyUnparseExpr ~wrap:("{","}") expression)
              in label lhs rhs
+           | Pexp_construct _ when value_has_jsx ->
+               label
+                (makeList [atom lbl; atom "="])
+                (self#inline_braces#simplifyUnparseExpr ~wrap:("{","}") expression)
            | Pexp_record _
            | Pexp_construct _
            | Pexp_array _


### PR DESCRIPTION
This is a fix for the ticket I started at the Reason Conf US workshop.

Got some time today to finish dealing with the idempotent parsing case.