### PR TITLE
Attempt to fix the braces removal in JSX props

### DIFF
--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -658,3 +658,12 @@ let v =
       }}
     </B>
   </A>;
+
+<Component
+  prop={
+    x->Option.map(x => {
+      let y = x;
+      y ++ y;
+    })
+  }
+/>;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -532,3 +532,9 @@ let v =
       }}
     </B>
   </A>;
+
+<Component
+  prop={
+    x->Option.map(x => {let y = x; y ++ y})
+  }
+/>

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -7848,11 +7848,7 @@ let printer = object(self:'self)
                * });
                *)
             let (leftWrap, rightWrap) as wrap = ("=> ", ")" ^ rightWrap) in
-            let wrap = if self#should_preserve_requested_braces retCb then
-              (leftWrap ^ "{", "}" ^ rightWrap)
-            else
-              wrap
-            in
+            let wrap =  (leftWrap ^ "{", "}" ^ rightWrap) in
             let right =
               source_map ~loc:retCb.pexp_loc
                 (makeList ~break:Always_rec ~wrap ~sep:(SepFinal (";", ";")) xs)


### PR DESCRIPTION
This is a very empirical attempt, I'm not exactly sure if it's a safe patch.

I basically just modified the printer bit by bit until I found something that'd fix my test case.

I also tried to change the `dont_preserve_braces` in the `Pexp_apply` case in `formatJSXComponent` but it seemed to be a bit more aggressive. The issue does seem to flow down from there though.

Fixes #2471