### PR TITLE
Fix braces removal in JSX props when having a pipe-first call containing a callback

### DIFF
--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -667,3 +667,13 @@ let v =
     })
   }
 />;
+
+<Component
+  prop={
+    name:
+      x->Option.map(x => {
+        let y = x;
+        y ++ y;
+      }),
+  }
+/>;

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -658,3 +658,12 @@ let v =
       }}
     </B>
   </A>;
+
+<Component
+  prop={
+    x->Option.map(x => {
+      let y = x;
+      y ++ y;
+    })
+  }
+/>;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -537,4 +537,10 @@ let v =
   prop={
     x->Option.map(x => {let y = x; y ++ y})
   }
-/>
+/>;
+
+<Component
+  prop={{
+    name: x->Option.map(x => {let y = x; y ++ y})
+  }}
+/>;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -532,3 +532,9 @@ let v =
       }}
     </B>
   </A>;
+
+<Component
+  prop={
+    x->Option.map(x => {let y = x; y ++ y})
+  }
+/>

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3753,7 +3753,7 @@ let printer = object(self:'self)
               {exp with pexp_loc = { exp.pexp_loc with loc_end = loc_end } }
             in
             makeList (
-              self#formatFunAppl
+              self#reset_request_braces#formatFunAppl
                 ?prefix
                 ~jsxAttrs:[]
                 ~args


### PR DESCRIPTION
Fixes #2471