### PR TITLE
Update bspack workflow for distributing BS6 compatible artifacts

### DIFF
--- a/bspacks/README.md
+++ b/bspacks/README.md
@@ -1,12 +1,56 @@
-This subdirectory is used for packing up the entire Reason `refmt` into a single file through BuckleScript's [bspack](https://github.com/bloomberg/bucklescript/blob/master/jscomp/core/bspack_main.ml), thus discarding all intermediate steps needed to build Reason, except for the final `refmt` binary compilation.
+This subdirectory is used for packing up the entire Reason `refmt` into a
+single file through BuckleScript's
+[bspack](https://github.com/bloomberg/bucklescript/blob/master/jscomp/core/bspack_main.ml),
+thus discarding all intermediate steps needed to build Reason, except for the
+final `refmt` binary compilation.
 
-This makes our installation much friendlier to e.g. Windows. BuckleScript currently includes the three bundles in its own repo, thus making Reason first-class (Btw, BS also uses a few other pieces of code from Reason, in its vendor/reason folder and jscomp/reason_outcome_printer).
+This makes our installation much friendlier to e.g. Windows. BuckleScript
+currently includes the three bundles in its own repo, thus making Reason
+first-class (Btw, BS also uses a few other pieces of code from Reason, in its
+vendor/reason folder and jscomp/reason_outcome_printer).
 
-## Build
+## Build (4.06 / BuckleScript v6 and above)
 
-This whole process needs to happen with OCaml 4.02.3, so make sure you switch to that version first:
+We use this workflow for building `build/refmt_api.ml` and
+`build/refmt_binary.ml` so we can easily vendor Reason for newer BuckleScript
+releases.  More details on that are in the [BuckleScript
+CONTRIBUTING](https://github.com/BuckleScript/CONTRIBUTING.md) file.
+
+For inlining the right version number in the bundle, the script uses
+`../reason.json` as the source of truth.
+
+**Note:** Currently you will need to build BuckleScript yourself to get access
+to the `bspack.exe` executable. Also we skip the building of the `refmt.js`
+artifact entirely here. Will maybe added back later as soon as we need it!
+
+**Instructions:**
+
+```
+cd bspacks
+
+opam switch 4.06.1
+
+./downloadSomeDependencies.sh
+
+# Point to your locally built bspack.exe
+BSPACK_EXE=~/Projects/bucklescript/jscomp/bin/bspack.exe ./reason_bspack406.sh
+```
+
+The bspacked files are also compiled to make sure that the bundle actually
+compiles. You should then find all the relevant `.ml` files in the `./build`
+directory, ready to be copied over to BuckleScript.
+
+## Legacy Build (4.02 / BuckleScript v5 and below)
+
+> This is an old workflow which also seem to be broken since `reerror` was
+> merged. We discourage the use, unless you really need to build bspacked
+> bundles for 4.02 based BuckleScript versions
+
+This whole process needs to happen with OCaml 4.02.3, so make sure you switch
+to that version first:
 
 ```sh
+# Then switch to the right ocaml version and install all deps
 opam switch 4.02.3
 ```
 

--- a/bspacks/downloadSomeDependencies.sh
+++ b/bspacks/downloadSomeDependencies.sh
@@ -1,8 +1,14 @@
 THIS_SCRIPT_DIR="$(cd "$( dirname "$0" )" && pwd)"
 
-echo "**This script is switching you to ocaml 4.02.3 for the subsequent bspacking. Please switch back to your own version afterward. Thanks!**\n"
-# switch to 4.02.3. Bspacking means we're sending the final bundle to BuckleScript, which is still on 4.02
-opam switch 4.02.3
+if [ -z ${OCAML_VERSION+x} ]; then
+  echo "OCAML_VERSION not defined, defaulting to '4.06.1'..."
+  OCAML_VERSION=4.06.1
+fi
+
+echo "**This script is switching you to ocaml ${OCAML_VERSION} for the subsequent bspacking. Please switch back to your own version afterward. Thanks!**\n"
+
+# switch to 4.06.1. Bspacking means we're sending the final bundle to BuckleScript, which is still on 4.02
+opam switch $OCAML_VERSION 
 
 # =============
 # first step, build ocaml-migrate-parsetree

--- a/bspacks/reason_bspack.sh
+++ b/bspacks/reason_bspack.sh
@@ -1,3 +1,9 @@
+# Legacy Note:
+# This script is used for older 4.02 based bspacking processes.
+#
+# Use reason_bspack406.sh for bspacking refmt_api and refmt_binary for
+# BuckleScript v6 and above (OCaml 4.06 based)!
+
 # exit if anything goes wrong
 set -e
 

--- a/bspacks/reason_bspack406.sh
+++ b/bspacks/reason_bspack406.sh
@@ -129,7 +129,7 @@ $BSPACK_EXE \
 
 
 # This hack is required since the emitted code by bspack somehow adds 
-# 'Migrate_parsetree__Ast...' instead of 'Migrate_parsetree_Ast...'
+# 'Migrate_parsetree_Ast...' instead of 'Migrate_parsetree__Ast...'
 sed -i'.bak' -e 's/Migrate_parsetree__Ast_404/Migrate_parsetree.Ast_404/' build/*.ml
 
 # the `-no-alias-deps` flag is important. Not sure why...

--- a/bspacks/reason_bspack406.sh
+++ b/bspacks/reason_bspack406.sh
@@ -129,7 +129,6 @@ $BSPACK_EXE \
 
 
 # This hack is required since the emitted code by bspack somehow adds 
-# 'Migrate_parsetree_Ast...' instead of 'Migrate_parsetree__Ast...'
 sed -i'.bak' -e 's/Migrate_parsetree__Ast_404/Migrate_parsetree.Ast_404/' build/*.ml
 
 # the `-no-alias-deps` flag is important. Not sure why...

--- a/bspacks/reason_bspack406.sh
+++ b/bspacks/reason_bspack406.sh
@@ -1,0 +1,140 @@
+# NOTE:
+# --------
+# This script is derived from the original `./reason_bspack.sh`
+# which is based on the 4.02 based BuckleScript bspack version. The script also
+# does way more than this file, such as creating an closure-optimized refmt.js
+# file.
+#
+# What this file is about:
+# -----
+# For BuckleScript v6 and above (based on 4.06),
+# we want to be able to build the `refmt_api` and `refmt_binary` build
+# artifacts by leveraging an up to date bspack version.
+# 
+# bspack itself is not vendored in bs-platform anymore, so the user of this
+# script has to provide the bspack binary themselves (most likely as a local
+# build from the bucklescript repo)
+#
+# We use the env variable BSPACK_EXE to populate the bspack path.
+#
+# Example Usage:
+# -------
+# cd bspacks/
+# BSPACK_EXE=~/Projects/bucklescript/jscomp/bin/bspack.exe bash reason_bspack406.sh
+
+# exit if anything goes wrong
+set -e
+
+# this script does 2 independent things:
+# - pack the whole repo into a single refmt file for vendoring into bucklescript
+# - generate the js version of refmt for web usage
+
+THIS_SCRIPT_DIR="$(cd "$( dirname "$0" )" && pwd)"
+
+# Automatically read the version from reason.json, so that dune builds the right Package.ml file (version, git_version, etc.)
+export version=$(cat ../reason.json \
+  | grep version \
+  | head -1 \
+  | awk -F: '{ print $2 }' \
+  | sed 's/[",]//g')
+
+echo "**This script is switching you to ocaml 4.06.1 for the subsequent bspacking. Please switch back to your own version afterward. Thanks!**\n"
+opam switch 4.06.1
+eval $(opam config env)
+
+
+if [ -z ${BSPACK_EXE+x} ]; then
+  echo "Missing env variable 'BSPACK_EXE'"
+  echo "Example Usage:"
+  echo "BSPACK_EXE=~/bucklescript/jscomp/bin/bspack.exe bash reason_bspack406.sh"
+  exit 1
+fi
+
+echo "Using bspack located at '${BSPACK_EXE}'..."
+
+# Because OCaml 4.06 doesn't come with the `Result` module, it also needed stubbing out.
+resultStub="module Result = struct type ('a, 'b) result = Ok of 'a | Error of 'b end open Result"
+
+menhirSuggestedLib=`menhir --suggest-menhirLib`
+
+# generated from the script ./downloadSomeDependencies.sh
+ocamlMigrateParseTreeTargetDir="$THIS_SCRIPT_DIR/ocaml-migrate-parsetree/_build/default/src"
+reasonTargetDir="$THIS_SCRIPT_DIR/.."
+buildDir="$THIS_SCRIPT_DIR/build"
+
+REFMT_BINARY="$buildDir/refmt_binary"
+REFMT_API="$buildDir/refmt_api"
+REFMT_API_ENTRY="$buildDir/refmt_api_entry"
+REFMT_API_FINAL="$buildDir/refmt_api_final"
+REFMT_PRE_CLOSURE="$buildDir/refmt_pre_closure"
+
+REFMT_CLOSURE="$reasonTargetDir/refmt"
+
+# clean some artifacts
+rm -f "$REFMT_CLOSURE.*"
+rm -rf $buildDir
+mkdir $buildDir
+
+pushd $THIS_SCRIPT_DIR
+# rebuild the project in case it was stale
+make clean -C ../
+make pre_release -C ../
+make build -C ../
+
+# =============
+# last step for the first task , we're done generating the single file that'll
+# be coped over to bucklescript. On BS' side, it'll use a single compile command
+# to turn this into a binary, like in
+# https://github.com/BuckleScript/bucklescript/blob/2ad2310f18567aa13030cdf32adb007d297ee717/jscomp/bin/Makefile#L29
+# =============
+$BSPACK_EXE \
+  -main-export Refmt_impl \
+  -prelude-str "$resultStub" \
+  -I "$menhirSuggestedLib" \
+  -I "$reasonTargetDir" \
+  -I "$reasonTargetDir/_build/default/src/ppx/"                               \
+  -I "$reasonTargetDir/_build/default/src/reason-merlin/"                     \
+  -I "$reasonTargetDir/_build/default/src/reason-parser/"                     \
+  -I "$reasonTargetDir/_build/default/src/reason-parser/vendor/easy_format/"  \
+  -I "$reasonTargetDir/_build/default/src/reason-parser/vendor/cmdliner/"     \
+  -I "$reasonTargetDir/_build/default/src/refmt/"                             \
+  -I "$reasonTargetDir/_build/default/src/refmttype/"                         \
+  -I "$ocamlMigrateParseTreeTargetDir" \
+  -bs-MD \
+  -o "$REFMT_BINARY.ml"
+
+# =============
+# Now, second task. Packing the repo again but with a new entry file, for JS
+# consumption
+# =============
+
+# this one is left here as an intermediate file for the subsequent steps. We
+# disregard the usual entry point that is refmt_impl above (which takes care of
+# terminal flags parsing, etc.) and swap it with a new entry point, refmtJsApi (see below)
+$BSPACK_EXE \
+  -bs-main Reason_toolchain \
+  -prelude-str "$resultStub" \
+  -prelude "$reasonTargetDir/_build/default/src/refmt/package.ml" \
+  -I "$menhirSuggestedLib" \
+  -I "$reasonTargetDir/_build/default/src/ppx/"                               \
+  -I "$reasonTargetDir/_build/default/src/reason-merlin/"                     \
+  -I "$reasonTargetDir/_build/default/src/reason-parser/"                     \
+  -I "$reasonTargetDir/_build/default/src/reason-parser/vendor/easy_format/"  \
+  -I "$reasonTargetDir/_build/default/src/reason-parser/vendor/cmdliner/"     \
+  -I "$reasonTargetDir/_build/default/src/refmt/"                             \
+  -I "$reasonTargetDir/_build/default/src/refmttype/"                         \
+  -I "$ocamlMigrateParseTreeTargetDir" \
+  -bs-MD \
+  -o "$REFMT_API.ml"
+
+
+# This hack is required since the emitted code by bspack somehow adds 
+# 'Migrate_parsetree__Ast...' instead of 'Migrate_parsetree_Ast...'
+sed -i'.bak' -e 's/Migrate_parsetree__Ast_404/Migrate_parsetree.Ast_404/' build/*.ml
+
+# the `-no-alias-deps` flag is important. Not sure why...
+# remove warning 40 caused by ocaml-migrate-parsetree
+ocamlc -g -no-alias-deps -w -40 -I +compiler-libs ocamlcommon.cma "$REFMT_API.ml" -o "$REFMT_API.byte"
+
+# build REFMT_BINARY into an actual binary too. For testing purposes at the end
+ocamlc -g -no-alias-deps -w -40 -I +compiler-libs ocamlcommon.cma "$REFMT_BINARY.ml" -o "$REFMT_BINARY.byte"

--- a/bspacks/refmtJsApi.ml
+++ b/bspacks/refmtJsApi.ml
@@ -1,3 +1,9 @@
+(*
+ * Note: This file is currently broken, since Reason removed
+ * Refmt_api.Reason_syntax_util.Error in favor of Reerror's `Printexc.to_string e`
+*)
+open Js_of_ocaml
+
 module RE = Refmt_api.Reason_toolchain.RE
 module ML = Refmt_api.Reason_toolchain.ML
 

--- a/bspacks/refmtJsApi.ml
+++ b/bspacks/refmtJsApi.ml
@@ -2,7 +2,6 @@
  * Note: This file is currently broken, since Reason removed
  * Refmt_api.Reason_syntax_util.Error in favor of Reerror's `Printexc.to_string e`
 *)
-open Js_of_ocaml
 
 module RE = Refmt_api.Reason_toolchain.RE
 module ML = Refmt_api.Reason_toolchain.ML


### PR DESCRIPTION
We need a way to easily distribute bspacked `reason_api.ml` and `reason_binary.ml` files for BuckleScript v6 and above (4.06), mostly because we want to keep the Reason JS playground bundle up to date with most recent Reason releases.

This PR keeps the original workflow alive (with slight adaptions in the README), but marks it as a legacy build workflow (BuckleScript will not support 4.02 in the future). Right now the 4.02 bspack instructions fail, mostly due to breaking updates to Reason, but it's still good to keep everything around for now.

The new workflow is introduced as `bspacks/reason_bspack406.sh` script, which needs `BSPACK_EXE` to be defined (pointing to a locally built bspack for now). Example usage calls can be found in the script comments.

Also, the 406 script takes the version from the `reason.json` file (since it looks like the source of truth for Reason version numbers). Easier for the user to not make mistakes.

Any feedback would be valuable.

@thangngoc89 