### PR TITLE
Inline braces in JSX

### DIFF
--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -713,3 +713,11 @@ let v =
 <A someProp={<> {React.string("Hello")} </>} />;
 
 <A someProp=?{<> {React.string("Hi")} </>} />;
+
+<ActionButton
+  one={!validated} two={msg##errorText}>
+  <InactionText
+    three={msg##prop}
+    four={msg##errorText}
+  />
+</ActionButton>;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -566,3 +566,11 @@ let v =
 <A someProp={ <> {React.string("Hello")} </> } />;
 
 <A someProp=?{ <> {React.string("Hi")} </> } />;
+
+<ActionButton
+  one={!validated}
+  two={
+    msg##errorText;
+  }>
+  <InactionText three={msg##prop} four={msg##errorText} />
+</ActionButton>;

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4416,6 +4416,7 @@ let printer = object(self:'self)
 
           </tag>           *)
   method formatJSXComponent componentName ?closeComponentName args =
+    let self = self#inline_braces in
     let rec processArguments arguments processedAttrs children =
       match arguments with
       | (Labelled "children", {pexp_desc = Pexp_construct (_, None)}) :: tail ->
@@ -4448,7 +4449,7 @@ let printer = object(self:'self)
            | Pexp_construct _ when value_has_jsx ->
                label
                 (makeList ~break:Layout.Never [atom lbl; atom "=?"])
-                (self#inline_braces#simplifyUnparseExpr ~wrap:("{","}") expression)
+                (self#simplifyUnparseExpr ~wrap:("{","}") expression)
           | _ ->
               label
                 (makeList ~break:Layout.Never [atom lbl; atom "=?"])
@@ -4496,7 +4497,7 @@ let printer = object(self:'self)
            | Pexp_construct _ when value_has_jsx ->
                label
                 (makeList [atom lbl; atom "="])
-                (self#inline_braces#simplifyUnparseExpr ~wrap:("{","}") expression)
+                (self#simplifyUnparseExpr ~wrap:("{","}") expression)
            | Pexp_record _
            | Pexp_construct _
            | Pexp_array _


### PR DESCRIPTION
This is a fix for the last regression reported by BuckleScript v7 that can be fixed in this repo.

The remaining one is a JSX PPX regression that doesn't live in this repo anymore.

fixes https://github.com/facebook/reason/issues/2493
fixes https://github.com/facebook/reason/issues/2502