### PR TITLE
Always preserve braces for `Pexp_sequence`

### DIFF
--- a/formatTest/unit_tests/expected_output/ocaml_identifiers.re
+++ b/formatTest/unit_tests/expected_output/ocaml_identifiers.re
@@ -81,3 +81,10 @@ type marshalFields = {. "switch_": string};
 let testMarshalFields: marshalFields = {
   "switch_": "switch",
 };
+
+/* Not an identifier test, but this is testing OCaml -> RE */
+let x =
+  List.map(y => {
+    ();
+    y;
+  });

--- a/formatTest/unit_tests/input/ocaml_identifiers.ml
+++ b/formatTest/unit_tests/input/ocaml_identifiers.ml
@@ -74,3 +74,8 @@ let x = f ~method_:"GET"
 type marshalFields = < switch: string   >  Js.t
 
 let testMarshalFields = ([%bs.obj { switch = "switch" }] : marshalFields)
+
+(* Not an identifier test, but this is testing OCaml -> RE *)
+let x = List.map (fun y ->
+  ();
+  y)

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -6108,6 +6108,9 @@ let printer = object(self:'self)
     match expr.pexp_desc with
     | Pexp_ifthenelse _
     | Pexp_try _ -> false
+    | Pexp_sequence _ ->
+      (* `let ... in` should _always_ preserve braces *)
+      true
     | _ ->
         preserve_braces &&
         Reason_attributes.has_preserve_braces_attrs stylisticAttrs


### PR DESCRIPTION
fixes https://github.com/facebook/reason/issues/2510

cc @cristianoc 

@bobzhang I'll get this merged and build a bspack for BuckleScript once tests pass.