### PR TITLE
Prepare release 3.5.4

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,14 @@
+## 3.5.4
+
+Fixes:
+- Fix regression where keywords were not renamed correctly (@cristianoc) [#2520](https://github.com/facebook/reason/pull/2520)
+- Fix regression where quoted object attributes / labeled arguments weren't renamed correctly (@anmonteiro) [#2509](https://github.com/facebook/reason/pull/2509)
+- Fix issue where JSX braces break into multiple lines (@anmonteiro) [#2503](https://github.com/facebook/reason/pull/2503)
+
+Others:
+- Improve bspacks process for 4.06 and add esy workflow for building refmt.js
+
+
 ## 3.5.3
 - 🎉 MUCH better parsing error locations - more reliable autocomplete 🎉 (@let-def)[https://github.com/let-def] ([#2439](https://github.com/facebook/reason/pull/2439))
 - Rebased the better error recovery diff onto 4.09 OCaml [@anmonteiro](https://github.com/anmonteiro) ([#2480](https://github.com/facebook/reason/pull/2480))

--- a/esy.json
+++ b/esy.json
@@ -2,7 +2,7 @@
   "name": "reason-cli",
   "notes": "This is just the dev package config (also built as globally installable reason-cli). See ./refmt.json ./rtop.json for individual release package configs.",
   "license": "MIT",
-  "version": "3.5.1",
+  "version": "3.5.4",
   "dependencies": {
     "ocaml": " >= 4.2.0 < 4.10.0",
     "@opam/fix": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "reason",
-	"version": "3.5.0",
+	"version": "3.5.4",
 	"description": "Simple, fast & type safe code that leverages the JavaScript & OCaml ecosystems",
 	"repository": {
 		"type": "git",

--- a/reason.json
+++ b/reason.json
@@ -1,6 +1,6 @@
 {
   "name": "@esy-ocaml/reason",
-  "version": "3.5.1",
+  "version": "3.5.4",
   "license": "MIT",
   "description": "Native Compiler Support for Reason: Simple, fast & type safe code that leverages the JavaScript & OCaml ecosystems",
   "repository": {


### PR DESCRIPTION
Steps I used to verify everything:

```
# Use the bspacks workflow, which takes the version number from reason.json
cd bspacks
BSPACK_EXE=~/Projects/bucklescript/jscomp/bin/bspack.exe ./reason_bspack406.sh

cat build/refmt_api.ml | grep 3.5.4
let version = "3.5.4"
# 30574 "src/reason-parser/reason_parser.ml"
# 31534 "src/reason-parser/reason_parser.ml"
# 34584 "src/reason-parser/reason_parser.ml"
# 38544 "src/reason-parser/reason_parser.ml"
```