### PR TITLE
Add flag rename_labels to toggle renaming of labels in function defin…

### DIFF
--- a/formatTest/unit_tests/expected_output/ocaml_identifiers.re
+++ b/formatTest/unit_tests/expected_output/ocaml_identifiers.re
@@ -12,20 +12,20 @@ module V = {
 module R = {
   type r = {mutable method: int};
 
-  let foo = {method: 4};
+  let foo = {method_: 4};
 
-  let x = foo.method;
+  let x = foo.method_;
 
-  let () = foo.method = 42;
+  let () = foo.method_ = 42;
 
   let y =
     switch (foo) {
-    | {method} => method
+    | {method_: method} => method
     };
 
   let z =
     switch (foo) {
-    | {method: 12} => 21
+    | {method_: 12} => 21
     };
 };
 
@@ -69,7 +69,8 @@ module O = {
 
 /* Function parameter labels */
 module L = {
-  let f = (~method) => ignore(method);
+  let f = (~method_ as method) =>
+    ignore(method);
 };
 
 /* Module types */
@@ -90,14 +91,14 @@ type method = string;
 [@other_attr: method]
 type foo = {method};
 
-let f = (~method) => Js.log(method);
+let f = (~method_ as method) => Js.log(method);
 
-let x = f(~method="GET");
+let x = f(~method_="GET");
 
 type marshalFields = {. "switch_": string};
 
 let testMarshalFields: marshalFields = {
-  "switch_": "switch",
+  "switch": "switch",
 };
 
 /* Not an identifier test, but this is testing OCaml -> RE */

--- a/formatTest/unit_tests/expected_output/ocaml_identifiers.re
+++ b/formatTest/unit_tests/expected_output/ocaml_identifiers.re
@@ -10,7 +10,7 @@ module V = {
 
 /* Record fields */
 module R = {
-  type r = {mutable method: int};
+  type r = {mutable method_: int};
 
   let foo = {method_: 4};
 
@@ -89,7 +89,7 @@ type method = string;
 
 [@some_attr: type_]
 [@other_attr: method]
-type foo = {method};
+type foo = {method_: method};
 
 let f = (~method_ as method) => Js.log(method);
 

--- a/formatTest/unit_tests/expected_output/ocaml_identifiers.re
+++ b/formatTest/unit_tests/expected_output/ocaml_identifiers.re
@@ -95,7 +95,7 @@ let f = (~method_ as method) => Js.log(method);
 
 let x = f(~method_="GET");
 
-type marshalFields = {. "switch_": string};
+type marshalFields = {. "switch": string};
 
 let testMarshalFields: marshalFields = {
   "switch": "switch",

--- a/src/reason-parser/reason_syntax_util.cppo.ml
+++ b/src/reason-parser/reason_syntax_util.cppo.ml
@@ -377,8 +377,8 @@ let map_core_type f typ =
     | Ptyp_var var -> Ptyp_var (f var)
     | Ptyp_arrow (lbl, t1, t2) ->
       let lbl' = match lbl with
-        | Labelled s -> Labelled (f s)
-        | Optional s -> Optional (f s)
+        | Labelled s when !rename_labels -> Labelled (f s)
+        | Optional s when !rename_labels -> Optional (f s)
         | lbl -> lbl
       in
       Ptyp_arrow (lbl', t1, t2)
@@ -488,7 +488,7 @@ let map_label label = map_arg_label f label in
       { type_decl with ptype_name = map_name type_decl.ptype_name }
     in
     let type_decl'' = match type_decl'.ptype_kind with
-    | Ptype_record lst ->
+    | Ptype_record lst when !rename_labels ->
       { type_decl'
         with ptype_kind = Ptype_record (List.map (fun lbl ->
           { lbl with pld_name = map_name lbl.pld_name })

--- a/src/reason-parser/reason_syntax_util.cppo.ml
+++ b/src/reason-parser/reason_syntax_util.cppo.ml
@@ -384,7 +384,7 @@ let map_core_type f typ =
       Ptyp_arrow (lbl', t1, t2)
     | Ptyp_constr (lid, typs) ->
       Ptyp_constr (map_lident f lid, typs)
-    | Ptyp_object (fields, closed_flag) ->
+    | Ptyp_object (fields, closed_flag) when !rename_labels ->
       Ptyp_object (List.map (fun (s, attrs, typ) -> f s, attrs, typ) fields, closed_flag)
     | Ptyp_class (lid, typs) ->
       Ptyp_class (map_lident f lid, typs)


### PR DESCRIPTION
…ition/application and records.

The flag `rename_labels` can  be used to turn on/off renaming of labels for function definition/application (i.e. the labels of named arguments) and record creation/access (i.e. the labels of records).

Issues:
- https://github.com/facebook/reason/issues/2523
- https://github.com/reasonml/reason-react/pull/505

Relevant diffs:
- https://github.com/facebook/reason/commit/ec2c797f9ea82517e63c785d9cabf5a2e677babc
- https://github.com/facebook/reason/commit/91a51913f08523dbe6d784d69af1ef0152c0bfea
- https://github.com/facebook/reason/commit/d0bd920124027fd95290af6ee5e79b9da6887ebb
