### PR TITLE
Make "external f: 'a => 'b;" shortcut for empty string

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -405,9 +405,10 @@ type reactClass;
 
 /* "react-dom" shouldn't spread the attribute over multiple lines */
 [@bs.val] [@bs.module "react-dom"]
-external render: (reactElement, element) => unit;
+external render: (reactElement, element) => unit =
+  "render";
 
-[@bs.module "f"] external f: int => int;
+[@bs.module "f"] external f: int => int = "f";
 
 [@bs.val] [@bs.module "react"] [@bs.splice]
 external createCompositeElementInternalHack:
@@ -460,8 +461,8 @@ external readFileSync2:
 external debounce:
   (int, [@bs.meth] unit) => unit;
 
-external debounce:
-  (int, [@bs.meth] unit) => unit;
+external debounce: (int, [@bs.meth] unit) => unit =
+  "debounce";
 
 external debounce:
   (int, [@bs.meth] unit) => unit;

--- a/formatTest/unit_tests/expected_output/uncurried.re
+++ b/formatTest/unit_tests/expected_output/uncurried.re
@@ -142,7 +142,8 @@ type timerId;
 
 [@bs.val]
 external setTimeout:
-  ((. unit) => unit, int) => timerId;
+  ((. unit) => unit, int) => timerId =
+  "setTimeout";
 
 let id =
   setTimeout((.) => Js.log("hello"), 1000);

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -1615,12 +1615,11 @@ structure_item:
     | item_attributes
       EXTERNAL as_loc(val_ident) COLON core_type EQUAL primitive_declaration
       { let loc = mklocation $symbolstartpos $endpos in
-        let prim = if $7 = [""] then [$3.txt] else $7 in
-        mkstr (Pstr_primitive (Val.mk $3 $5 ~prim ~attrs:$1 ~loc)) }
+        mkstr (Pstr_primitive (Val.mk $3 $5 ~prim:$7 ~attrs:$1 ~loc)) }
     | item_attributes
       EXTERNAL as_loc(val_ident) COLON core_type SEMI
       { let loc = mklocation $symbolstartpos $endpos in
-        mkstr (Pstr_primitive (Val.mk $3 $5 ~prim:[$3.txt] ~attrs:$1 ~loc)) }
+        mkstr (Pstr_primitive (Val.mk $3 $5 ~prim:[""] ~attrs:$1 ~loc)) }
     | type_declarations
       { let (nonrec_flag, tyl) = $1 in mkstr(Pstr_type (nonrec_flag, tyl)) }
     | str_type_extension
@@ -1822,13 +1821,12 @@ signature_item:
   | item_attributes
     EXTERNAL as_loc(val_ident) COLON core_type EQUAL primitive_declaration
     { let loc = mklocation $symbolstartpos $endpos in
-      let prim = if $7 = [""] then [$3.txt] else $7 in
-      Psig_value (Val.mk $3 $5 ~prim ~attrs:$1 ~loc)
+      Psig_value (Val.mk $3 $5 ~prim:$7 ~attrs:$1 ~loc)
     }
   | item_attributes
     EXTERNAL as_loc(val_ident) COLON core_type SEMI
     { let loc = mklocation $symbolstartpos $endpos in
-      Psig_value (Val.mk $3 $5 ~prim:[$3.txt] ~attrs:$1 ~loc)
+      Psig_value (Val.mk $3 $5 ~prim:[""] ~attrs:$1 ~loc)
     }
   | type_declarations
     { let (nonrec_flag, tyl) = $1 in Psig_type (nonrec_flag, tyl) }

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -6511,7 +6511,6 @@ let printer = object(self:'self)
     let primDecl =
       match vd.pval_prim with
       | [""] -> lblBefore
-      | _ when vd.pval_prim = [vd.pval_name.txt] -> lblBefore
       | _ ->
         let frstHalf = makeList ~postSpace:true [lblBefore; atom "="] in
         let sndHalf = makeSpacedBreakableInlineList (List.map self#constant_string vd.pval_prim) in


### PR DESCRIPTION
This is a followup to #2464 based on the discussion in there.