### PR TITLE
Better handling of longidents in JSX

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -370,12 +370,10 @@ let asd =
   [@foo] <One test=true foo=2> "a" "b" </One>;
 let asd2 =
   [@foo]
-  [@JSX]
-  One.createElementobvioustypo(
-    ~test=false,
-    ~children=["a", "b"],
-    (),
-  );
+  <One.createElementobvioustypo test=false>
+    "a"
+    "b"
+  </One.createElementobvioustypo>;
 
 let span =
     (~test: bool, ~foo: int, ~children, ()) => 1;

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -721,3 +721,7 @@ let v =
     four={msg##errorText}
   />
 </ActionButton>;
+
+<Foo.bar />;
+
+<Foo.Bar.baz arg="hello" />;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -574,3 +574,7 @@ let v =
   }>
   <InactionText three={msg##prop} four={msg##errorText} />
 </ActionButton>;
+
+<Foo.bar />;
+
+<Foo.Bar.baz arg="hello" />;

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -891,17 +891,18 @@ let rewriteFunctorApp module_name elt loc =
   else
     mkexp ~loc (Pexp_ident {txt=Ldot (module_name, elt); loc})
 
-let jsx_component module_name attrs children loc =
-  let rec getFirstPart = function
-    | Lident fp -> fp
-    | Ldot (fp, _) -> getFirstPart fp
-    | Lapply (fp, _) -> getFirstPart fp in
-  let firstPart = getFirstPart module_name.txt in
-  let element_fn = if String.get firstPart 0 != '_' && firstPart = String.capitalize_ascii firstPart then
-    (* firstPart will be non-empty so the 0th access is fine. Modules can't start with underscore *)
-    rewriteFunctorApp module_name.txt "createElement" module_name.loc
-  else
-    mkexp ~loc:module_name.loc (Pexp_ident(mkloc (Lident firstPart) module_name.loc))
+let jsx_component lid attrs children loc =
+  let is_module_name = function
+    | Lident s
+    | Ldot (_, s) ->
+      (* s will be non-empty so the 0th access is fine. Modules can't start with underscore *)
+       String.get s 0 != '_' && s = String.capitalize_ascii s
+    | Lapply (_, _) -> true
+  in
+  let element_fn = if is_module_name lid.txt then
+      rewriteFunctorApp lid.txt "createElement" lid.loc
+    else
+      mkexp ~loc:lid.loc (Pexp_ident lid)
   in
   let body = mkexp(Pexp_apply(element_fn, attrs @ children)) ~loc in
   let attribute = ({txt = "JSX"; loc = loc}, PStr []) in

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3409,12 +3409,13 @@ let printer = object(self:'self)
       | _ :: rest -> hasSingleNonLabelledUnitAndIsAtTheEnd rest
       in
       if hasLabelledChildrenLiteral && hasSingleNonLabelledUnitAndIsAtTheEnd l then
-        let moduleNameList = List.rev (List.tl (List.rev (Longident.flatten loc.txt))) in
-        if moduleNameList != [] then
-          if Longident.last loc.txt = "createElement" then
-            Some (self#formatJSXComponent (String.concat "." moduleNameList) l)
-          else None
-        else Some (self#formatJSXComponent (Longident.last loc.txt) l)
+        match loc.txt with
+        | Ldot (moduleLid, "createElement") ->
+          Some (self#formatJSXComponent
+                  (String.concat "." (Longident.flatten moduleLid)) l)
+        | lid ->
+          Some (self#formatJSXComponent
+                  (String.concat "." (Longident.flatten lid)) l)
       else None
     )
     | (Pexp_apply (


### PR DESCRIPTION
The treatement of longidents in JSX is currently .... curious. 

- `<foo a=b>children</foo>` turns into `foo(~a=b,~children,())`
- `<Foo a=b>children</foo>` turns into `Foo.createElement(~a=b,~children,())`
- `<Foo.Bar a=b>children</foo>` turns into `Foo.Bar.createElement(~a=b,~children,())`
- `<Foo.bar a=b>children</foo>` either refuses to parses or turns into `Foo.bar.createElement(~a=b,~children,())` (depending on the context).

`Foo.bar.createElement` is not a valid longident (there is no way to create such longidents for *values* (there are for types, due to inline records, but that's out of scope). This will give a type error `Unknown *module* Foo.bar`, which is nonsense.

I propose to do the expected thing, which is to turn `<Foo.bar a=b>children</foo>` into `Foo.bar(~a=b,~children,())`. I fixed the printers to recover the syntactic sugar and added appropriate tests.

That new form is not handled by either versions of reasonReact's ppx vendored for tests. I did not try to fix that.