### PR TITLE
Fix: Failure("input_value: not a binary channel")

### DIFF
--- a/src/refmt/printer_maker.ml
+++ b/src/refmt/printer_maker.ml
@@ -40,7 +40,7 @@ let ocamlBinaryParser use_stdin filename =
     match use_stdin with
       | true -> stdin
       | false ->
-          let file_chan = open_in filename in
+          let file_chan = open_in_bin filename in
           seek_in file_chan 0;
           file_chan
   in
@@ -58,7 +58,7 @@ let reasonBinaryParser use_stdin filename =
     match use_stdin with
       | true -> stdin
       | false ->
-          let file_chan = open_in filename in
+          let file_chan = open_in_bin filename in
           seek_in file_chan 0;
           file_chan
   in


### PR DESCRIPTION
To test the ppx @jfrolich output reason to binary and convert back. This was failling on windows. On Unixes open_in and open_in_bin behave the same not on windows accondingly to [this thread](https://www.developpez.net/forums/d861244/autres-langages/langages-fonctionnels/caml/input_value-not-binary-channel/) in french (please use google translate)

This PR when merged should close https://github.com/reasonml-community/graphql_ppx/pull/87

Also a grep showed 2 more `open_in`. Should I fix it also ?