### PR TITLE
Fix printing of numeric ranges

### DIFF
--- a/formatTest/test.sh
+++ b/formatTest/test.sh
@@ -361,17 +361,6 @@ function typecheck_test() {
             warning "  ⊘ FAILED\n"
             return 1
         fi
-      debug "  Generating output again: refmt --print-width 50 --print re $OUTPUT/$FILE 2>&1 > $OUTPUT/$FILE.formatted"
-      refmt $EXTRA_FLAGS --print-width 50 --print re $OUTPUT/$FILE 2>&1 > $OUTPUT/$FILE.formatted
-      $DIFF $OUTPUT/$FILE $OUTPUT/$FILE
-      if ! [[ $? -eq 0 ]]; then
-          warning "  ⊘ FAILED\n"
-          info "  ${INFO}$OUTPUT/$FILE${RESET}"
-          info "  second round of formatting doesn't match first (not idempotent)"
-          info "  run a diff on $OUTPUT/$FILE $OUTPUT/$FILE"
-          echo ""
-          return 1
-      fi
     fi
 
     if [ "$FILE" != "$(basename $FILE .re)" ]; then

--- a/formatTest/typeCheckedTests/expected_output/patternMatching.re
+++ b/formatTest/typeCheckedTests/expected_output/patternMatching.re
@@ -178,6 +178,20 @@ switch (Some(1)) {
 | _ => 3
 };
 
+let myInt = 100;
+/* Numeric ranges are rejected by the type checker, but validly parsed so drop
+ * this in an annotation to test the parsing. */
+[@something? 1 .. 2]
+let rangeInt = 0;
+
+let myChar = 'x';
+let rangeChar =
+  switch (myChar) {
+  | 'a' .. 'b' => "a to b"
+  | 'b' .. 'z' => "b to z"
+  | c => "something else"
+  };
+
 /* with parens around direct list pattern in constructor pattern */
 switch (None) {
 | Some([]) => ()

--- a/formatTest/typeCheckedTests/input/patternMatching.re
+++ b/formatTest/typeCheckedTests/input/patternMatching.re
@@ -154,6 +154,20 @@ switch (Some(1)) {
 | _ => 3
 };
 
+let myInt = 100;
+/* Numeric ranges are rejected by the type checker, but validly parsed so drop this in
+ * an annotationto test the parsing. */
+[@something? 1 .. 2]
+let rangeInt = 0;
+
+let myChar = 'x';
+let rangeChar =
+  switch(myChar) {
+    | 'a'..'b' => "a to b"
+    | 'b' .. 'z' => "b to z"
+    | c => "something else"
+  };
+
 /* with parens around direct list pattern in constructor pattern */
 switch (None) {
 | Some([]) => ()

--- a/formatTest/typeCheckedTests/input/patternMatching.re
+++ b/formatTest/typeCheckedTests/input/patternMatching.re
@@ -155,8 +155,8 @@ switch (Some(1)) {
 };
 
 let myInt = 100;
-/* Numeric ranges are rejected by the type checker, but validly parsed so drop this in
- * an annotationto test the parsing. */
+/* Numeric ranges are rejected by the type checker, but validly parsed so drop
+ * this in an annotation to test the parsing. */
 [@something? 1 .. 2]
 let rangeInt = 0;
 

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -123,7 +123,7 @@ let lazy true = 10;
 let lazy #x = 10;
 let lazy `Variant = 10;
 let lazy `variant = 10;
-let lazy '0'..'9' = 10;
+let lazy '0' .. '9' = 10;
 let lazy (lazy true) = 10;
 let lazy [%extend] = 10;
 

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -3747,6 +3747,10 @@ mark_position_pat
     { let attrs, cst = $1 in mkpat ~attrs (Ppat_constant cst) }
   | signed_constant DOTDOT signed_constant
     { mkpat (Ppat_interval (snd $1, snd $3)) }
+  | signed_constant DOT signed_constant {
+    syntax_error (mklocation $startpos $endpos) "Constant ranges must be separated with spaces around the ..";
+     mkpat (Ppat_interval (snd $1, snd $3))
+  }
   | as_loc(constr_longident)
     { mkpat (Ppat_construct ($1, None)) }
   | name_tag

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3380,7 +3380,7 @@ let printer = object(self:'self)
             let raw_literal, _ = extract_raw_literal x.ppat_attributes in
             (self#constant ?raw_literal c)
           | Ppat_interval (c1, c2) ->
-            makeList [self#constant c1; atom ".."; self#constant c2]
+            makeList ~postSpace:true [self#constant c1; atom ".."; self#constant c2]
           | Ppat_variant (l, None) -> makeList[atom "`"; atom l]
           | Ppat_constraint (p, ct) ->
               formatPrecedence (formatTypeConstraint (self#pattern p) (self#core_type ct))


### PR DESCRIPTION

    Print numeric ranges to a valid parse. Custom error message on invalid
    parse.

    Summary: This prints numeric ranges to a valid parse (even though they
    wouldn't type check anyways, it's nice for ppx extension patterns).
    Also, I added a custom error message in IDEs for when you forget to include a
    space between the numers, but it recovers to something sensible.

    Test Plan:

    Reviewers:

    CC:
