### PR TITLE
Support OCaml 4.11

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -9,7 +9,7 @@
     "@opam/ocamlfind": "*",
     "@opam/menhir": " >= 20170418.0.0",
     "@opam/utop": " >= 1.17.0 < 2.5.0",
-    "@opam/merlin-extend": " >= 0.4",
+    "@opam/merlin-extend": " >= 0.6",
     "@opam/result": "*",
     "@opam/ocaml-migrate-parsetree": "*",
     "@opam/dune": "< 2.0.0"

--- a/formatTest/test.sh
+++ b/formatTest/test.sh
@@ -14,7 +14,7 @@ OCAML_VERSION=`echo $(ocaml -version) | egrep -o '[0-9]+.[0-9]+.[0-9]+' | head -
 OCAML_VERSION=${OCAML_VERSION:-"4.02.3"}
 
 case ${OCAML_VERSION} in
-4.10.*) OCAML_VERSION=4.09.0;; # Outputs from OCaml 4.10 are exepected to be the same as OCaml 4.09
+4.10.*|4.11.*) OCAML_VERSION=4.09.0;; # Outputs from OCaml 4.10 / 4.11 are exepected to be the same as OCaml 4.09
 esac
 
 unameOut="$(uname -s)"

--- a/reason.opam
+++ b/reason.opam
@@ -12,11 +12,11 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml"         {>= "4.02" & < "4.11"}
+  "ocaml"         {>= "4.02" & < "4.12"}
   "dune"          {>= "1.4"}
   "ocamlfind"     {build}
   "menhir"        {>= "20170418"}
-  "merlin-extend" {>= "0.4"}
+  "merlin-extend" {>= "0.5"}
   "fix"
   "result"
   "ocaml-migrate-parsetree"

--- a/reason.opam
+++ b/reason.opam
@@ -16,7 +16,7 @@ depends: [
   "dune"          {>= "1.4"}
   "ocamlfind"     {build}
   "menhir"        {>= "20170418"}
-  "merlin-extend" {>= "0.5"}
+  "merlin-extend" {>= "0.6"}
   "fix"
   "result"
   "ocaml-migrate-parsetree"

--- a/rtop.opam
+++ b/rtop.opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml"  {>= "4.02" & < "4.11"}
+  "ocaml"  {>= "4.02" & < "4.12"}
   "dune"   {>= "1.4"}
   "reason"
   "utop"   {>= "1.17"}

--- a/src/reason-parser/dune
+++ b/src/reason-parser/dune
@@ -5,13 +5,15 @@
 
 (rule
  (targets ocaml_util.ml)
- (deps ../generate/select.exe ocaml_util.ml-4.10 ocaml_util.ml-4.09 ocaml_util.ml-4.08
-   ocaml_util.ml-4.07 ocaml_util.ml-4.06 ocaml_util.ml-default)
+ (deps ../generate/select.exe ocaml_util.ml-4.11 ocaml_util.ml-4.10
+   ocaml_util.ml-4.09 ocaml_util.ml-4.08 ocaml_util.ml-4.07
+   ocaml_util.ml-4.06 ocaml_util.ml-default)
  (action
   (with-stdout-to
    %{targets}
-   (run ../generate/select.exe ocaml_util.ml-4.10 ocaml_util.ml-4.09 ocaml_util.ml-4.08
-     ocaml_util.ml-4.07 ocaml_util.ml-4.06 ocaml_util.ml-default))))
+   (run ../generate/select.exe ocaml_util.ml-4.11 ocaml_util.ml-4.10
+     ocaml_util.ml-4.09 ocaml_util.ml-4.08 ocaml_util.ml-4.07
+     ocaml_util.ml-4.06 ocaml_util.ml-default))))
 
 (rule
  (targets reason_string.ml)

--- a/src/reason-parser/ocaml_util.ml-4.11
+++ b/src/reason-parser/ocaml_util.ml-4.11
@@ -1,0 +1,11 @@
+let warn_latin1 lexbuf =
+  Location.deprecated (Location.curr lexbuf) "ISO-Latin1 characters in identifiers"
+;;
+
+let print_loc ppf loc =
+  Location.print_loc ppf loc
+
+
+let print_error loc f ppf x =
+  let error = Location.error_of_printer ~loc f x in
+  Location.print_report ppf error

--- a/src/reason-parser/reason_heuristics.ml
+++ b/src/reason-parser/reason_heuristics.ml
@@ -6,7 +6,13 @@ let is_punned_labelled_expression e lbl =
   | Pexp_ident { txt }
   | Pexp_constraint ({pexp_desc = Pexp_ident { txt }}, _)
   | Pexp_coerce ({pexp_desc = Pexp_ident { txt }}, _, _)
-    -> txt = Longident.parse lbl
+    ->
+     begin match Longident.unflatten [ lbl ] with
+     | Some lid ->
+       txt = lid
+     | None ->
+       false
+     end
   | _ -> false
 
 (* We manually check the length of `Thing.map(foo, bar, baz`,

--- a/src/reason-parser/reason_heuristics.ml
+++ b/src/reason-parser/reason_heuristics.ml
@@ -5,14 +5,8 @@ let is_punned_labelled_expression e lbl =
   match e.pexp_desc with
   | Pexp_ident { txt }
   | Pexp_constraint ({pexp_desc = Pexp_ident { txt }}, _)
-  | Pexp_coerce ({pexp_desc = Pexp_ident { txt }}, _, _)
-    ->
-     begin match Longident.unflatten [ lbl ] with
-     | Some lid ->
-       txt = lid
-     | None ->
-       false
-     end
+  | Pexp_coerce ({pexp_desc = Pexp_ident { txt }}, _, _) ->
+    (Reason_syntax_util.parse_lid lbl) = txt
   | _ -> false
 
 (* We manually check the length of `Thing.map(foo, bar, baz`,

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -2711,11 +2711,11 @@ jsx_arguments:
 
 jsx_start_tag_and_args:
   as_loc(LESSIDENT) jsx_arguments
-     { let name = Longident.unflatten (String.split_on_char '.' $1.txt) |> Option.get in
+     { let name = parse_lid $1.txt in
       (jsx_component {$1 with txt = name} $2, name)
     }
   | LESS as_loc(LIDENT) jsx_arguments
-    { let name = Longident.unflatten (String.split_on_char '.' $2.txt) |> Option.get in
+    { let name = parse_lid $2.txt in
       (jsx_component {$2 with txt = name} $3, name)
     }
   | LESS as_loc(mod_ext_longident) jsx_arguments
@@ -2762,7 +2762,7 @@ jsx:
     { let (component, start) = $1 in
       let loc = mklocation $startpos($4) $endpos in
       (* TODO: Make this tag check simply a warning *)
-      let endName = Longident.unflatten (String.split_on_char '.' $4) |> Option.get in
+      let endName = parse_lid $4 in
       let _ = ensureTagsAreEqual start endName loc in
       let siblings = if List.length $3 > 0 then $3 else [] in
       component [
@@ -2775,7 +2775,7 @@ jsx:
     { let (component, start) = $1 in
       let loc = mklocation $symbolstartpos $endpos in
       (* TODO: Make this tag check simply a warning *)
-      let endName = Longident.unflatten (String.split_on_char '.' $4) |> Option.get in
+      let endName = parse_lid $4 in
       let _ = ensureTagsAreEqual start endName loc in
       let child = $3 in
       component [
@@ -2803,7 +2803,7 @@ jsx_without_leading_less:
     let (component, start) = $1 in
     let loc = mklocation $symbolstartpos $endpos in
     (* TODO: Make this tag check simply a warning *)
-    let endName = Longident.unflatten (String.split_on_char '.' $4) |> Option.get in
+    let endName = parse_lid $4 in
     let _ = ensureTagsAreEqual start endName loc in
     let siblings = if List.length $3 > 0 then $3 else [] in
     component [
@@ -2815,7 +2815,7 @@ jsx_without_leading_less:
     let (component, start) = $1 in
     let loc = mklocation $symbolstartpos $endpos in
     (* TODO: Make this tag check simply a warning *)
-    let endName = Longident.unflatten (String.split_on_char '.' $4) |> Option.get in
+    let endName = parse_lid $4 in
     let _ = ensureTagsAreEqual start endName loc in
     let child = $3 in
     component [

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -2711,11 +2711,11 @@ jsx_arguments:
 
 jsx_start_tag_and_args:
   as_loc(LESSIDENT) jsx_arguments
-     { let name = Longident.parse $1.txt in
+     { let name = Longident.unflatten (String.split_on_char '.' $1.txt) |> Option.get in
       (jsx_component {$1 with txt = name} $2, name)
     }
   | LESS as_loc(LIDENT) jsx_arguments
-    { let name = Longident.parse $2.txt in
+    { let name = Longident.unflatten (String.split_on_char '.' $2.txt) |> Option.get in
       (jsx_component {$2 with txt = name} $3, name)
     }
   | LESS as_loc(mod_ext_longident) jsx_arguments
@@ -2762,7 +2762,7 @@ jsx:
     { let (component, start) = $1 in
       let loc = mklocation $startpos($4) $endpos in
       (* TODO: Make this tag check simply a warning *)
-      let endName = Longident.parse $4 in
+      let endName = Longident.unflatten (String.split_on_char '.' $4) |> Option.get in
       let _ = ensureTagsAreEqual start endName loc in
       let siblings = if List.length $3 > 0 then $3 else [] in
       component [
@@ -2775,7 +2775,7 @@ jsx:
     { let (component, start) = $1 in
       let loc = mklocation $symbolstartpos $endpos in
       (* TODO: Make this tag check simply a warning *)
-      let endName = Longident.parse $4 in
+      let endName = Longident.unflatten (String.split_on_char '.' $4) |> Option.get in
       let _ = ensureTagsAreEqual start endName loc in
       let child = $3 in
       component [
@@ -2803,7 +2803,7 @@ jsx_without_leading_less:
     let (component, start) = $1 in
     let loc = mklocation $symbolstartpos $endpos in
     (* TODO: Make this tag check simply a warning *)
-    let endName = Longident.parse $4 in
+    let endName = Longident.unflatten (String.split_on_char '.' $4) |> Option.get in
     let _ = ensureTagsAreEqual start endName loc in
     let siblings = if List.length $3 > 0 then $3 else [] in
     component [
@@ -2815,7 +2815,7 @@ jsx_without_leading_less:
     let (component, start) = $1 in
     let loc = mklocation $symbolstartpos $endpos in
     (* TODO: Make this tag check simply a warning *)
-    let endName = Longident.parse $4 in
+    let endName = Longident.unflatten (String.split_on_char '.' $4) |> Option.get in
     let _ = ensureTagsAreEqual start endName loc in
     let child = $3 in
     component [

--- a/src/reason-parser/reason_single_parser.ml
+++ b/src/reason-parser/reason_single_parser.ml
@@ -196,7 +196,7 @@ let rec decompose_token pos0 split =
   | [] -> None
   | '=' :: tl ->
     let eq = (Reason_parser.EQUAL, pcur, pnext) in
-    let (revFirstTwo, tl, pcur, pnext) = match tl with
+    let (revFirstTwo, tl, pcur, _pnext) = match tl with
     | '?' :: tlTl ->
       [(Reason_parser.QUESTION, pcur, pnext); eq], tlTl, pnext, (advance pnext 1)
     | _ -> [eq], tl, pcur, pnext
@@ -214,7 +214,7 @@ let rec decompose_token pos0 split =
         (match common_remaining_infix_token pcur tl with
         | None -> None (* Couldn't parse the non-empty tail - invalidates whole thing *)
         | Some(r) -> Some(List.rev (r :: less)))
-  | '>' :: tl ->
+  | '>' :: _tl ->
       (* Recurse to take advantage of all the logic in case the remaining
        * begins with an equal sign. *)
       let gt_tokens, rest_split, prest = split_greaters [] pcur split in
@@ -235,7 +235,7 @@ let list_init len f = List.rev (init_tailrec_aux [] 0 len f)
 
 let explode s = list_init (String.length s) (String.get s)
 
-let rec try_split_label (tok_kind, pos0, posn) =
+let try_split_label (tok_kind, pos0, _posn) =
   match tok_kind with
   | Reason_parser.INFIXOP0 s ->
     (match decompose_token pos0 (explode s) with

--- a/src/reason-parser/reason_syntax_util.cppo.ml
+++ b/src/reason-parser/reason_syntax_util.cppo.ml
@@ -756,3 +756,8 @@ module Clflags = struct
   let fast = unsafe
 #endif
 end
+
+let parse_lid s =
+  match Longident.unflatten (String.split_on_char '.' s) with
+  | Some lid -> lid
+  | None -> failwith (Format.asprintf "parse_lid: unable to parse '%s' to longident" s)

--- a/src/reason-parser/reason_syntax_util.cppo.ml
+++ b/src/reason-parser/reason_syntax_util.cppo.ml
@@ -758,6 +758,10 @@ module Clflags = struct
 end
 
 let parse_lid s =
+#if OCAML_VERSION >= (4, 6, 0)
   match Longident.unflatten (String.split_on_char '.' s) with
   | Some lid -> lid
   | None -> failwith (Format.asprintf "parse_lid: unable to parse '%s' to longident" s)
+#else
+ Longident.parse s
+#endif

--- a/src/reason-parser/reason_syntax_util.cppo.mli
+++ b/src/reason-parser/reason_syntax_util.cppo.mli
@@ -99,3 +99,5 @@ module Clflags : sig
   val fast : bool ref
 #endif
 end
+
+val parse_lid : string -> Longident.t


### PR DESCRIPTION
This is an early PR that will hopefully allow us to support OCaml 4.11 when it's out (it's in alpha right now).

This is not expected to build, as it's currently dependent on https://github.com/let-def/merlin-extend/pull/13 being merged.