### PR TITLE
Adds @opam/charInfo_width to includePackges

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -75,6 +75,7 @@
         "@opam/react",
         "@opam/result",
         "@opam/seq",
+	"@opam/charInfo_width",
         "@opam/utop",
         "@opam/zed",
         "ocaml"


### PR DESCRIPTION
Noticed it was missing while trying to get back npm prebuilts