### PR TITLE
Fix attributes on patterns

### DIFF
--- a/formatTest/test.sh
+++ b/formatTest/test.sh
@@ -180,6 +180,7 @@ function unit_test() {
     FILEEXT="${FILENAME##*.}"
 
 
+    OUTPUT_NOT_GENERATED="0"
     info "Unit Test: $FILE"
     if [ "$(basename $FILE)" != "$(basename $FILE .ml)" ] || [ "$(basename $FILE)" != "$(basename $FILE .mli)" ]; then
         if [ "$(basename $FILE)" != "$(basename $FILE .ml)" ]; then
@@ -219,7 +220,7 @@ function unit_test() {
         OFILE="${VERSION_SPECIFIC_FILE}"
     fi
 
-    if [[ -z ${OUTPUT_NOT_GENERATED+x} ]]; then
+    if [ "$OUTPUT_NOT_GENERATED" == "0" ]; then
       debug "  Comparing results:  diff $EXPECTED_OUTPUT/$OFILE $OUTPUT/$FILE"
 
       $DIFF $EXPECTED_OUTPUT/$OFILE $OUTPUT/$FILE
@@ -243,7 +244,7 @@ function unit_test() {
         return 1
       else
         success "  ☑ PASS"
-        echo
+        echo ""
       fi
     fi
 }
@@ -258,6 +259,7 @@ function idempotent_test() {
     FILEEXT="${FILENAME##*.}"
 
     info "Idempotent Test: $FILE"
+    OUTPUT_NOT_GENERATED=0
     if [ "$(basename $FILE)" != "$(basename $FILE .ml)" ] || [ "$(basename $FILE)" != "$(basename $FILE .mli)" ]; then
         if [ "$(basename $FILE)" != "$(basename $FILE .ml)" ]; then
           SUFFIX=".re"
@@ -273,7 +275,7 @@ function idempotent_test() {
         if [ "$MIN_VERSION" != "$BASE_NAME" ] && [ "$(version "$OCAML_VERSION")" -lt "$(version "$MIN_VERSION")" ]
         then
           notice "  ☒ IGNORED REFMT STEP: Requires OCaml >= $MIN_VERSION"
-          OUTPUT_NOT_GENERATED=1
+          OUTPUT_NOT_GENERATED="1"
         else
           debug "  Converting $FILE to $REFILE:"
 
@@ -295,7 +297,7 @@ function idempotent_test() {
       refmt $EXTRA_FLAGS --print-width 50 --print re $OUTPUT/$FILE 2>&1 > $OUTPUT/$FILE.formatted
     fi
 
-    if [[ -z ${OUTPUT_NOT_GENERATED+x} ]]; then
+    if [ "$OUTPUT_NOT_GENERATED" == "0" ]; then
       $DIFF $OUTPUT/$FILE $OUTPUT/$FILE.formatted
       if ! [[ $? -eq 0 ]]; then
           warning "⊘ FAILED\n"

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -599,10 +599,10 @@ module Callbacks = {
 };
 
 let test = {
-  let x = 1;
+  let _x = 1;
   [@attr1]
   open Callbacks;
-  let s = "hello" ++ "!";
+  let _s = "hello" ++ "!";
   [@attr2] Callbacks.("hello" ++ "!");
 };
 

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -697,55 +697,60 @@ let nonpunned_lbl_i' =
     (~lbl as [@ATTR] (lblNonpunned: int)) => lblNonpunned;
 
 let defaulted_punnned_lbl_a =
-    (~lbl as [@ATTR] lbl=0) => lbl;
+    (~lbl as [@ATTR] lbl=0, ()) => lbl;
 let defaulted_punnned_lbl_b =
-    (~lbl as [@ATTR] (lbl: int)=0) => lbl;
+    (~lbl as [@ATTR] (lbl: int)=0, ()) => lbl;
 let defaulted_punnned_lbl_c =
-    (~lbl as [@ATTR] [@ATTR2] lbl=0) => lbl;
+    (~lbl as [@ATTR] [@ATTR2] lbl=0, ()) => lbl;
 let defaulted_punnned_lbl_d =
-    (~lbl as [@ATTR] ([@ATTR2] lbl: int)=0) => lbl;
+    (~lbl as [@ATTR] ([@ATTR2] lbl: int)=0, ()) => lbl;
 let defaulted_punnned_lbl_e =
-    (~lbl as [@ATTR] [@ATTR2] (lbl: int)=0) => lbl;
+    (~lbl as [@ATTR] [@ATTR2] (lbl: int)=0, ()) => lbl;
 
 let defaulted_punnned_lbl_f =
-    (~lbl as [@ATTR] lbl: int=0) => lbl;
+    (~lbl as [@ATTR] lbl: int=0, ()) => lbl;
 let defaulted_punnned_lbl_g =
-    (~lbl as [@ATTR] lbl: int=0) => lbl;
+    (~lbl as [@ATTR] lbl: int=0, ()) => lbl;
 let defaulted_punnned_lbl_h =
-    (~lbl as [@ATTR] (lbl: int)=0) => lbl;
+    (~lbl as [@ATTR] (lbl: int)=0, ()) => lbl;
 /** Attributes have lower precedence than type constraint. The following should
  * be printed identically.  */
 let defaulted_punnned_lbl_i =
-    (~lbl as [@ATTR] lbl: int=0) => lbl;
+    (~lbl as [@ATTR] lbl: int=0, ()) => lbl;
 let defaulted_punnned_lbl_i' =
-    (~lbl as [@ATTR] (lbl: int)=0) => lbl;
+    (~lbl as [@ATTR] (lbl: int)=0, ()) => lbl;
 
 let defaulted_nonpunned_lbla =
-    (~lbl as [@ATTR] lblNonpunned=0) => lblNonpunned;
+    (~lbl as [@ATTR] lblNonpunned=0, ()) => lblNonpunned;
 let defaulted_nonpunned_lbl_b =
-    (~lbl as [@ATTR] (lblNonpunned: int)=0) => lblNonpunned;
+    (~lbl as [@ATTR] (lblNonpunned: int)=0, ()) => lblNonpunned;
 let defaulted_nonpunned_lbl_c =
-    (~lbl as [@ATTR] [@ATTR2] lblNonpunned=0) => lblNonpunned;
+    (
+      ~lbl as [@ATTR] [@ATTR2] lblNonpunned=0,
+      (),
+    ) => lblNonpunned;
 let defaulted_nonpunned_lbl_d =
     (
       ~lbl as [@ATTR] ([@ATTR2] lblNonpunned: int)=0,
+      (),
     ) => lblNonpunned;
 let defaulted_nonpunned_lbl_e =
     (
       ~lbl as [@ATTR] [@ATTR2] (lblNonpunned: int)=0,
+      (),
     ) => lblNonpunned;
 
 let defaulted_nonpunned_lbl_f =
-    (~lbl as [@ATTR] lblNonpunned: int=0) => lblNonpunned;
+    (~lbl as [@ATTR] lblNonpunned: int=0, ()) => lblNonpunned;
 let defaulted_nonpunned_lbl_g =
-    (~lbl as [@ATTR] lblNonpunned: int=0) => lblNonpunned;
+    (~lbl as [@ATTR] lblNonpunned: int=0, ()) => lblNonpunned;
 let defaulted_nonpunned_lbl_h =
-    (~lbl as [@ATTR] (lblNonpunned: int)=0) => lblNonpunned;
+    (~lbl as [@ATTR] (lblNonpunned: int)=0, ()) => lblNonpunned;
 
 let defaulted_nonpunned_lbl_i =
-    (~lbl as [@ATTR] lblNonpunned: int=0) => lblNonpunned;
+    (~lbl as [@ATTR] lblNonpunned: int=0, ()) => lblNonpunned;
 let defaulted_nonpunned_lbl_i' =
-    (~lbl as [@ATTR] (lblNonpunned: int)=0) => lblNonpunned;
+    (~lbl as [@ATTR] (lblNonpunned: int)=0, ()) => lblNonpunned;
 
 /* Won't parse: let [@attr] x1 : int = xInt; */
 let xInt = 0;

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -642,3 +642,128 @@ Fmt.([@foo] {x: 1});
 Fmt.([@foo] [1, 2, 3]);
 Fmt.([@foo] (1, 2, 3));
 Fmt.([@foo] {val x = 10});
+
+/**
+ * Attributes are associate with the identifier, function call, constructor
+ * appcation or constructor application pattern in front of it - up until a
+ * type constraint, an | (or) or an 'as'.
+ */
+
+let punnned_lbl_a = (~lbl as [@ATTR] lbl) => lbl;
+let punnned_lbl_b = (~lbl as [@ATTR] (lbl: int)) => lbl;
+let punnned_lbl_c =
+    (~lbl as [@ATTR] [@ATTR2] lbl) => lbl;
+let punnned_lbl_d =
+    (~lbl as [@ATTR] ([@ATTR2] lbl: int)) => lbl;
+let punnned_lbl_e =
+    (~lbl as [@ATTR] [@ATTR2] (lbl: int)) => lbl;
+
+let punnned_lbl_f = (~lbl as [@ATTR] lbl: int) => lbl;
+let punnned_lbl_g = (~lbl as [@ATTR] lbl: int) => lbl;
+let punnned_lbl_h = (~lbl as [@ATTR] (lbl: int)) => lbl;
+/** Attributes have lower precedence than type constraint. The following should
+ * be printed identically.  */
+let punnned_lbl_i = (~lbl as [@ATTR] lbl: int) => lbl;
+let punnned_lbl_i' =
+    (~lbl as [@ATTR] (lbl: int)) => lbl;
+
+let nonpunned_lbla =
+    (~lbl as [@ATTR] lblNonpunned) => lblNonpunned;
+let nonpunned_lbl_b =
+    (~lbl as [@ATTR] (lblNonpunned: int)) => lblNonpunned;
+let nonpunned_lbl_c =
+    (~lbl as [@ATTR] [@ATTR2] lblNonpunned) => lblNonpunned;
+let nonpunned_lbl_d =
+    (
+      ~lbl as
+        [@ATTR] ([@ATTR2] lblNonpunned: int),
+    ) => lblNonpunned;
+let nonpunned_lbl_e =
+    (
+      ~lbl as
+        [@ATTR] [@ATTR2] (lblNonpunned: int),
+    ) => lblNonpunned;
+
+let nonpunned_lbl_f =
+    (~lbl as [@ATTR] lblNonpunned: int) => lblNonpunned;
+let nonpunned_lbl_g =
+    (~lbl as [@ATTR] lblNonpunned: int) => lblNonpunned;
+let nonpunned_lbl_h =
+    (~lbl as [@ATTR] (lblNonpunned: int)) => lblNonpunned;
+
+let nonpunned_lbl_i =
+    (~lbl as [@ATTR] lblNonpunned: int) => lblNonpunned;
+let nonpunned_lbl_i' =
+    (~lbl as [@ATTR] (lblNonpunned: int)) => lblNonpunned;
+
+/* Won't parse: let [@attr] x1 : int = xInt; */
+let xInt = 0;
+
+/**
+  Attribute on the pattern node inside of constraint
+  pattern (
+    Ppat_constraint(
+      pattern(@xxx, Ppat_var "x"),
+      coretype
+    )
+  )
+  This will get sugared to `let ([@attr] x2) : int = xInt`
+*/
+let ([@attr] x2): int = xInt;
+/**
+  Attribute on the pattern holding the constraint:
+  pattern(
+    @xxx
+    Ppat_constraint(
+      pattern(Pexpident "x"),
+      coretype
+    )
+  )
+*/
+let [@attr] (x3: int) = xInt;
+let [@attr] ([@attr0] x4: int) = xInt;
+let [@attr] ([@attr0] x5: int) = xInt;
+
+type eitherOr('a, 'b) =
+  | Either('a)
+  | Or('b);
+let [@attr] Either(a) | Or(a) = Either("hi");
+// Can drop the the parens around Either.
+let [@attr] Either(a) | Or(a) = Either("hi");
+// Can drop the parens around Or.
+let Either(b) | [@attr] Or(b) = Either("hi");
+// Should keep the parens around both
+let [@attr] (Either(a) | Or(a)) = Either("hi");
+
+// Should keep the parens
+let [@attr] (_x as xAlias) = 10;
+// Should drop the parens
+let [@attr] _x as xAlias' = 10;
+
+/**
+  Attribute on the expression node inside of constraint
+  expression(
+    Pexp_constraint(
+      expression(@xxx, Pexpident "x"),
+      coretype
+    )
+  )
+*/
+let _ = ([@xxx] xInt: int); // This should format the same
+let _ = ([@xxx] xInt: int); // This should format the same
+
+/**
+  Attribute on the expression holding the constraint:
+  expression(
+    @xxx
+    Pexp_constraint(
+      expression(Pexpident "x"),
+      coretype
+    )
+  )
+*/
+let _ = [@xxx] (xInt: int); // This should format the same
+
+[@foo? [@attr] (x: int)];
+[@foo? [@attr] ([@bar] x: int)];
+[@foo? [@attr] (Either("hi") | Or("hi"))];

--- a/formatTest/typeCheckedTests/expected_output/attributes.re
+++ b/formatTest/typeCheckedTests/expected_output/attributes.re
@@ -696,6 +696,57 @@ let nonpunned_lbl_i =
 let nonpunned_lbl_i' =
     (~lbl as [@ATTR] (lblNonpunned: int)) => lblNonpunned;
 
+let defaulted_punnned_lbl_a =
+    (~lbl as [@ATTR] lbl=0) => lbl;
+let defaulted_punnned_lbl_b =
+    (~lbl as [@ATTR] (lbl: int)=0) => lbl;
+let defaulted_punnned_lbl_c =
+    (~lbl as [@ATTR] [@ATTR2] lbl=0) => lbl;
+let defaulted_punnned_lbl_d =
+    (~lbl as [@ATTR] ([@ATTR2] lbl: int)=0) => lbl;
+let defaulted_punnned_lbl_e =
+    (~lbl as [@ATTR] [@ATTR2] (lbl: int)=0) => lbl;
+
+let defaulted_punnned_lbl_f =
+    (~lbl as [@ATTR] lbl: int=0) => lbl;
+let defaulted_punnned_lbl_g =
+    (~lbl as [@ATTR] lbl: int=0) => lbl;
+let defaulted_punnned_lbl_h =
+    (~lbl as [@ATTR] (lbl: int)=0) => lbl;
+/** Attributes have lower precedence than type constraint. The following should
+ * be printed identically.  */
+let defaulted_punnned_lbl_i =
+    (~lbl as [@ATTR] lbl: int=0) => lbl;
+let defaulted_punnned_lbl_i' =
+    (~lbl as [@ATTR] (lbl: int)=0) => lbl;
+
+let defaulted_nonpunned_lbla =
+    (~lbl as [@ATTR] lblNonpunned=0) => lblNonpunned;
+let defaulted_nonpunned_lbl_b =
+    (~lbl as [@ATTR] (lblNonpunned: int)=0) => lblNonpunned;
+let defaulted_nonpunned_lbl_c =
+    (~lbl as [@ATTR] [@ATTR2] lblNonpunned=0) => lblNonpunned;
+let defaulted_nonpunned_lbl_d =
+    (
+      ~lbl as [@ATTR] ([@ATTR2] lblNonpunned: int)=0,
+    ) => lblNonpunned;
+let defaulted_nonpunned_lbl_e =
+    (
+      ~lbl as [@ATTR] [@ATTR2] (lblNonpunned: int)=0,
+    ) => lblNonpunned;
+
+let defaulted_nonpunned_lbl_f =
+    (~lbl as [@ATTR] lblNonpunned: int=0) => lblNonpunned;
+let defaulted_nonpunned_lbl_g =
+    (~lbl as [@ATTR] lblNonpunned: int=0) => lblNonpunned;
+let defaulted_nonpunned_lbl_h =
+    (~lbl as [@ATTR] (lblNonpunned: int)=0) => lblNonpunned;
+
+let defaulted_nonpunned_lbl_i =
+    (~lbl as [@ATTR] lblNonpunned: int=0) => lblNonpunned;
+let defaulted_nonpunned_lbl_i' =
+    (~lbl as [@ATTR] (lblNonpunned: int)=0) => lblNonpunned;
+
 /* Won't parse: let [@attr] x1 : int = xInt; */
 let xInt = 0;
 

--- a/formatTest/typeCheckedTests/expected_output/patternMatching.re
+++ b/formatTest/typeCheckedTests/expected_output/patternMatching.re
@@ -281,3 +281,9 @@ switch (None) {
   ()
 | _ => ()
 };
+
+type aOrB =
+  | A(int)
+  | B(int);
+let (nestedAnnotation: int): int = 0;
+let (A(i) | B(i)): aOrB = A(0);

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -562,6 +562,32 @@ let nonpunned_lbl_h = (~lbl as ([@ATTR] (lblNonpunned: int))) => lblNonpunned;
 let nonpunned_lbl_i = (~lbl as [@ATTR] lblNonpunned: int) => lblNonpunned;
 let nonpunned_lbl_i' = (~lbl as [@ATTR] (lblNonpunned: int)) => lblNonpunned;
 
+let defaulted_punnned_lbl_a = (~lbl as [@ATTR] lbl=0) => lbl;
+let defaulted_punnned_lbl_b = (~lbl as [@ATTR] (lbl: int)=0) => lbl;
+let defaulted_punnned_lbl_c = (~lbl as [@ATTR] ([@ATTR2] lbl)=0) => lbl;
+let defaulted_punnned_lbl_d = (~lbl as [@ATTR] ([@ATTR2] lbl: int)=0) => lbl;
+let defaulted_punnned_lbl_e = (~lbl as [@ATTR] ([@ATTR2] (lbl: int))=0) => lbl;
+
+let defaulted_punnned_lbl_f = (~lbl as [@ATTR] lbl: int=0) => lbl;
+let defaulted_punnned_lbl_g = (~lbl as ([@ATTR] lbl: int)=0) => lbl;
+let defaulted_punnned_lbl_h = (~lbl as ([@ATTR] (lbl: int))=0) => lbl;
+/** Attributes have lower precedence than type constraint. The following should
+ * be printed identically.  */
+let defaulted_punnned_lbl_i = (~lbl as [@ATTR] lbl: int=0) => lbl;
+let defaulted_punnned_lbl_i' = (~lbl as [@ATTR] (lbl: int)=0) => lbl;
+
+let defaulted_nonpunned_lbla = (~lbl as [@ATTR] lblNonpunned=0) => lblNonpunned;
+let defaulted_nonpunned_lbl_b = (~lbl as [@ATTR] (lblNonpunned: int)=0) => lblNonpunned;
+let defaulted_nonpunned_lbl_c = (~lbl as [@ATTR] ([@ATTR2] lblNonpunned)=0) => lblNonpunned;
+let defaulted_nonpunned_lbl_d = (~lbl as [@ATTR] ([@ATTR2] lblNonpunned: int)=0) => lblNonpunned;
+let defaulted_nonpunned_lbl_e = (~lbl as [@ATTR] ([@ATTR2] (lblNonpunned: int))=0) => lblNonpunned;
+
+let defaulted_nonpunned_lbl_f = (~lbl as [@ATTR] lblNonpunned: int=0) => lblNonpunned;
+let defaulted_nonpunned_lbl_g = (~lbl as ([@ATTR] lblNonpunned: int)=0) => lblNonpunned;
+let defaulted_nonpunned_lbl_h = (~lbl as ([@ATTR] (lblNonpunned: int))=0) => lblNonpunned;
+
+let defaulted_nonpunned_lbl_i = (~lbl as [@ATTR] lblNonpunned: int=0) => lblNonpunned;
+let defaulted_nonpunned_lbl_i' = (~lbl as [@ATTR] (lblNonpunned: int)=0) => lblNonpunned;
 
 /* Won't parse: let [@attr] x1 : int = xInt; */
 let xInt = 0;

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -562,32 +562,32 @@ let nonpunned_lbl_h = (~lbl as ([@ATTR] (lblNonpunned: int))) => lblNonpunned;
 let nonpunned_lbl_i = (~lbl as [@ATTR] lblNonpunned: int) => lblNonpunned;
 let nonpunned_lbl_i' = (~lbl as [@ATTR] (lblNonpunned: int)) => lblNonpunned;
 
-let defaulted_punnned_lbl_a = (~lbl as [@ATTR] lbl=0) => lbl;
-let defaulted_punnned_lbl_b = (~lbl as [@ATTR] (lbl: int)=0) => lbl;
-let defaulted_punnned_lbl_c = (~lbl as [@ATTR] ([@ATTR2] lbl)=0) => lbl;
-let defaulted_punnned_lbl_d = (~lbl as [@ATTR] ([@ATTR2] lbl: int)=0) => lbl;
-let defaulted_punnned_lbl_e = (~lbl as [@ATTR] ([@ATTR2] (lbl: int))=0) => lbl;
+let defaulted_punnned_lbl_a = (~lbl as [@ATTR] lbl=0, ()) => lbl;
+let defaulted_punnned_lbl_b = (~lbl as [@ATTR] (lbl: int)=0, ()) => lbl;
+let defaulted_punnned_lbl_c = (~lbl as [@ATTR] ([@ATTR2] lbl)=0, ()) => lbl;
+let defaulted_punnned_lbl_d = (~lbl as [@ATTR] ([@ATTR2] lbl: int)=0, ()) => lbl;
+let defaulted_punnned_lbl_e = (~lbl as [@ATTR] ([@ATTR2] (lbl: int))=0, ()) => lbl;
 
-let defaulted_punnned_lbl_f = (~lbl as [@ATTR] lbl: int=0) => lbl;
-let defaulted_punnned_lbl_g = (~lbl as ([@ATTR] lbl: int)=0) => lbl;
-let defaulted_punnned_lbl_h = (~lbl as ([@ATTR] (lbl: int))=0) => lbl;
+let defaulted_punnned_lbl_f = (~lbl as [@ATTR] lbl: int=0, ()) => lbl;
+let defaulted_punnned_lbl_g = (~lbl as ([@ATTR] lbl: int)=0, ()) => lbl;
+let defaulted_punnned_lbl_h = (~lbl as ([@ATTR] (lbl: int))=0, ()) => lbl;
 /** Attributes have lower precedence than type constraint. The following should
  * be printed identically.  */
-let defaulted_punnned_lbl_i = (~lbl as [@ATTR] lbl: int=0) => lbl;
-let defaulted_punnned_lbl_i' = (~lbl as [@ATTR] (lbl: int)=0) => lbl;
+let defaulted_punnned_lbl_i = (~lbl as [@ATTR] lbl: int=0, ()) => lbl;
+let defaulted_punnned_lbl_i' = (~lbl as [@ATTR] (lbl: int)=0, ()) => lbl;
 
-let defaulted_nonpunned_lbla = (~lbl as [@ATTR] lblNonpunned=0) => lblNonpunned;
-let defaulted_nonpunned_lbl_b = (~lbl as [@ATTR] (lblNonpunned: int)=0) => lblNonpunned;
-let defaulted_nonpunned_lbl_c = (~lbl as [@ATTR] ([@ATTR2] lblNonpunned)=0) => lblNonpunned;
-let defaulted_nonpunned_lbl_d = (~lbl as [@ATTR] ([@ATTR2] lblNonpunned: int)=0) => lblNonpunned;
-let defaulted_nonpunned_lbl_e = (~lbl as [@ATTR] ([@ATTR2] (lblNonpunned: int))=0) => lblNonpunned;
+let defaulted_nonpunned_lbla = (~lbl as [@ATTR] lblNonpunned=0, ()) => lblNonpunned;
+let defaulted_nonpunned_lbl_b = (~lbl as [@ATTR] (lblNonpunned: int)=0, ()) => lblNonpunned;
+let defaulted_nonpunned_lbl_c = (~lbl as [@ATTR] ([@ATTR2] lblNonpunned)=0, ()) => lblNonpunned;
+let defaulted_nonpunned_lbl_d = (~lbl as [@ATTR] ([@ATTR2] lblNonpunned: int)=0, ()) => lblNonpunned;
+let defaulted_nonpunned_lbl_e = (~lbl as [@ATTR] ([@ATTR2] (lblNonpunned: int))=0, ()) => lblNonpunned;
 
-let defaulted_nonpunned_lbl_f = (~lbl as [@ATTR] lblNonpunned: int=0) => lblNonpunned;
-let defaulted_nonpunned_lbl_g = (~lbl as ([@ATTR] lblNonpunned: int)=0) => lblNonpunned;
-let defaulted_nonpunned_lbl_h = (~lbl as ([@ATTR] (lblNonpunned: int))=0) => lblNonpunned;
+let defaulted_nonpunned_lbl_f = (~lbl as [@ATTR] lblNonpunned: int=0, ()) => lblNonpunned;
+let defaulted_nonpunned_lbl_g = (~lbl as ([@ATTR] lblNonpunned: int)=0, ()) => lblNonpunned;
+let defaulted_nonpunned_lbl_h = (~lbl as ([@ATTR] (lblNonpunned: int))=0, ()) => lblNonpunned;
 
-let defaulted_nonpunned_lbl_i = (~lbl as [@ATTR] lblNonpunned: int=0) => lblNonpunned;
-let defaulted_nonpunned_lbl_i' = (~lbl as [@ATTR] (lblNonpunned: int)=0) => lblNonpunned;
+let defaulted_nonpunned_lbl_i = (~lbl as [@ATTR] lblNonpunned: int=0, ()) => lblNonpunned;
+let defaulted_nonpunned_lbl_i' = (~lbl as [@ATTR] (lblNonpunned: int)=0, ()) => lblNonpunned;
 
 /* Won't parse: let [@attr] x1 : int = xInt; */
 let xInt = 0;

--- a/formatTest/typeCheckedTests/input/attributes.re
+++ b/formatTest/typeCheckedTests/input/attributes.re
@@ -486,10 +486,10 @@ module Callbacks = {
 };
 
 let test = {
-  let x = 1;
+  let _x = 1;
   [@attr1]
   open Callbacks;
-  let s = "hello" ++ "!";
+  let _s = "hello" ++ "!";
   [@attr2] Callbacks.("hello" ++ "!");
 };
 

--- a/formatTest/typeCheckedTests/input/patternMatching.re
+++ b/formatTest/typeCheckedTests/input/patternMatching.re
@@ -236,3 +236,9 @@ switch (None) {
 | Some([someSuperLongString, ...es6ListSugarLikeSyntaxWhichIsSuperLong]) => ()
 | _ => ()
 }
+
+
+
+type aOrB = A(int) | B(int);
+let ((nestedAnnotation: int) : int) = 0;
+let ((A(i) | B(i): aOrB)) = A(0);

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3189,7 +3189,7 @@ let printer = object(self:'self)
       ~postSpace:true
       ~preSpace:true
       [left; right]
-      
+
   (*
    * Renders level 3 or simpler patterns:
    *
@@ -3283,7 +3283,7 @@ let printer = object(self:'self)
    *        v
    * let (x : int, foo) = ..
    *
-   * 
+   *
    * Renders level 3 or simpler patterns:
    *
    * Simpler


### PR DESCRIPTION
We were not printing attributes on patterns in many cases, and we also printed attributes on named args incorrectly. This will fix the printing bug and also print attributes in many newly supported locations (patterns).
In the future, we can support a sugar for attributes on named args, but right now they require `as` aliases.
```
(~argName as [@attr] argName) => .
```

An alternative sugar syntax for punned could be:
```
(~argName [@attr]) => .
```