### PR TITLE
Fix printing of externals that happen to have newlines/quotes in them.

### DIFF
--- a/formatTest/unit_tests/expected_output/externals.re
+++ b/formatTest/unit_tests/expected_output/externals.re
@@ -4,4 +4,31 @@
 external foo: type_ = "%caml_something_or_other";
 
 external multilineStringExtern: int => int =
-  "\n Did you know you can put whatver you want inside\n of an extern? Good luck with the linker though!\n";
+  {|
+ Did you know you can put whatver you want inside
+ of an extern? Good luck with the linker though!
+|};
+
+module Nested = {
+  external multilineStringExtern: int => int =
+    {|
+   Did you know you can put whatver you want inside
+   of an extern? Good luck with the linker though!
+  |};
+  external multilineStringExternWithTag:
+    int => int =
+    {|
+   Did you know you can put whatver you want inside
+   of an extern? Good luck with the linker though!
+  |};
+  external multilineStringExtern: int => int =
+    {|
+   And this has a newline in it, so will be formatted with { | | } style string|};
+  external containsQuote: int => int =
+    {|This has a quote in it " so will be formatted as { | | } style string|};
+  external noIndentation: int => int =
+    {|
+Did you know you can put whatver you want inside
+of an extern? Good luck with the linker though!
+|};
+};

--- a/formatTest/unit_tests/input/externals.re
+++ b/formatTest/unit_tests/input/externals.re
@@ -7,3 +7,21 @@ external multilineStringExtern : int => int = {|
  Did you know you can put whatver you want inside
  of an extern? Good luck with the linker though!
 |};
+
+module Nested = {
+  external multilineStringExtern : int => int = {|
+   Did you know you can put whatver you want inside
+   of an extern? Good luck with the linker though!
+  |};
+  external multilineStringExternWithTag : int => int = {js|
+   Did you know you can put whatver you want inside
+   of an extern? Good luck with the linker though!
+  |js};
+  external multilineStringExtern : int => int = "
+   And this has a newline in it, so will be formatted with { | | } style string";
+  external containsQuote : int => int = "This has a quote in it \" so will be formatted as { | | } style string";
+  external noIndentation : int => int = {|
+Did you know you can put whatver you want inside
+of an extern? Good luck with the linker though!
+|};
+};


### PR DESCRIPTION
Summary:Before this diff, we would print these as "" strings with \n inside of them.

Test Plan:Added test cases

Reviewers:

CC: