### PR TITLE
Floating doc comments /** */ should become ocaml.text for odoc

### DIFF
--- a/src/reason-parser/reason_attributes.ml
+++ b/src/reason-parser/reason_attributes.ml
@@ -33,7 +33,7 @@ let rec partitionAttributes ?(partDoc=false) ?(allowUncurry=true) attrs : attrib
   | ({ attr_name = {txt="ocaml.text"}; _} as doc)::atTl when partDoc = true ->
     let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
     {partition with docAttrs=doc::partition.docAttrs}
-  | ({ attr_name = {txt="ocaml.doc"}; _} as doc)::atTl when partDoc = true ->
+  | ({ attr_name = {txt="ocaml.doc" | "ocaml.text"}; _} as doc)::atTl when partDoc = true ->
     let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
     {partition with docAttrs=doc::partition.docAttrs}
   | ({ attr_name = {txt="reason.raw_literal"}; _} as attr) :: atTl ->

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -140,6 +140,11 @@ module Clflags = Reason_syntax_util.Clflags
 
 *)
 
+let make_floating_doc = function
+  | {attr_name = {txt = "ocaml.doc"; _} as attr_name; _} as attr ->
+      {attr with attr_name = {attr_name with txt = "ocaml.text"}}
+  | attr -> attr
+
 let uncurry_payload ?(name="bs") loc =
   { attr_name = {loc; txt = name};
     attr_payload = PStr [];
@@ -987,6 +992,7 @@ let mkBsObjTypeSugar ~loc ~closed rows =
 let doc_loc loc = {txt = "ocaml.doc"; loc = loc}
 
 let doc_attr text loc =
+  (* Here is where we will convert from markdown to odoc - transform the "text" *)
   let open Parsetree in
   let exp =
     { pexp_desc = Pexp_constant (Pconst_string(text, None));
@@ -1728,8 +1734,12 @@ structure_item:
     | let_bindings
       { val_of_let_bindings $1 }
     ) { [$1] }
- | located_attributes
-   { List.map (fun x -> mkstr ~loc:x.loc (Pstr_attribute x.txt)) $1 }
+   | located_attributes
+     {
+       List.map
+        (fun x -> mkstr ~loc:x.loc (Pstr_attribute (make_floating_doc x.txt)))
+        $1
+     }
 ;
 
 module_binding_body:
@@ -1949,7 +1959,9 @@ signature_item:
 signature_items:
   | as_loc(signature_item) { [mksig ~loc:$1.loc $1.txt] }
   | located_attributes
-    { List.map (fun x -> mksig ~loc:x.loc (Psig_attribute x.txt)) $1 }
+    { List.map
+      (fun x -> mksig ~loc:x.loc (Psig_attribute (make_floating_doc x.txt)))
+      $1 }
 ;
 
 open_declaration:
@@ -2109,7 +2121,9 @@ class_field:
       { mkcf_attrs (Pcf_extension $2) $1 }
     ) { [$1] }
   | located_attributes
-    { List.map (fun x -> mkcf ~loc:x.loc (Pcf_attribute x.txt)) $1 }
+    { List.map
+      (fun x -> mkcf ~loc:x.loc (Pcf_attribute (make_floating_doc x.txt)))
+      $1 }
 ;
 
 value:
@@ -2373,7 +2387,9 @@ class_sig_field:
       { mkctf_attrs (Pctf_extension $2) $1 }
     ) { [$1] }
   | located_attributes
-    { List.map (fun x -> mkctf ~loc:x.loc (Pctf_attribute x.txt)) $1 }
+    { List.map
+      (fun x -> mkctf ~loc:x.loc (Pctf_attribute (make_floating_doc x.txt)))
+      $1 }
 ;
 
 value_type:
@@ -4916,7 +4932,13 @@ attribute:
         attr_loc = mklocation $symbolstartpos $endpos
       }
     }
-  | DOCSTRING { doc_attr $1 (mklocation $symbolstartpos $endpos) }
+  | DOCSTRING {
+    (* Here is where we will make another copy of doc_attr but with
+     * reason.doc/text instead of ocaml.doc/text and _that_ is the one that the
+     * printer should pay attention to, completely ignoring the ocaml.doc/text
+     * ones.  The ocaml.doc/text ones would only be received by odoc. *)
+    doc_attr $1 (mklocation $symbolstartpos $endpos)
+  }
 ;
 
 (* Inlined to avoid having to deal with buggy $symbolstartpos *)


### PR DESCRIPTION
This allows Reason to be used with odoc such that floating doc comments become the main odoc documentation header for a module.

```reason
/**
 * This is a floating doc comment because it has a semicolon. That means it doesn't attach to the binding below it.
 */;

let x = "hello";
```
This is missing a test case, which is a little hard to test since it prints the same as it parses, without guarantee that it actually becomes ocaml.text in the AST.

