### PR TITLE
Reason Syntax v4: Angle Brackets Type Parameters (PARSING)

### DIFF
--- a/docs/GETTING_STARTED_CONTRIBUTING.md
+++ b/docs/GETTING_STARTED_CONTRIBUTING.md
@@ -177,13 +177,17 @@ Run the main parser through Menhir with the `--explain` flag to have it print
 out details about the conflict. `esy menhir --explain src/reason-parser/reason_parser.mly`.
 The debug information can be found at `src/reason-parser/reason_parser.conflicts`.
 
-### Debugging the Parser State at Runtime
+Use the `--dump` flag to have Menhir print the state transitions for debugging the parser rules
+that are applied `esy  menhir --dump  src/reason-parser/reason_parser.mly`
+It will generate `src/reason-parser/reason_parser.automaton` which you can inspect. It will also
+drop a `reason_parser.ml` and `reason_parser.mli` in that directory which you need to remove before
+building again.
 
-If you set the environment variable as follows, the parser state will be printed out as it parses files.
+### Debugging the Lexer/Parser State at Runtime
 
-```sh
-export OCAMLRUNPARAM='p'
-```
+Add the `--trace` flag to the _end_ of the `menhir` `(flags..)` section in the
+`dune` file for the `reason-parser`, and it will print out tokens that are
+lexed along with parser state transitions.
 
 ### Add a Menhir Error Message
 

--- a/docs/TYPE_PARAMETERS_PARSING.md
+++ b/docs/TYPE_PARAMETERS_PARSING.md
@@ -1,0 +1,47 @@
+Contributors: Lexing and Parsing Type Parameters:
+===================================================
+
+Lexing and Parsing type parameters with angle brackets such as the following:
+
+```reason
+type t<'x> = list<'x>;
+```
+
+is difficult because type parameter angle brackets can "stack" at the end of a
+nested parameterized type, resulting in something that looks a lot like an
+infix operator beginning with greater-than symbol `>`.
+
+```reason
+type t<'x> = something<list<'x>>;
+```
+
+In the original implementation of the Reason lexer
+`reason_declarative_lexer.mll`, it would tokenize what appears to be infix
+operators as a single token so in that case will tokenize `>>` at the end of
+the type definition. But in order to correctly parse parameterized types, we
+nee to be able to "balance" the opening and closing angle brackets.
+
+Another potential lexing conflict with infix operators is in the parsing of
+default values in named arguments with type annotations.
+
+```reason
+let f = (~name: list<thing>=[myThing]) => {..};
+```
+
+In that example, the `>=` could be parsed as an infix operator if we are not
+careful.
+
+Any workable solution will need to maintain multiple `GREATER` tokens when
+lexing `>>>` so they can be used for balancing type parameters. There are a few
+options:
+
+**Solution:**
+
+In `Reason_single_parser.ml`, we use the same token splitting technique, where
+upon a failure to parse on a token, we examine the token and determine if we
+can split it into several tokens. We already did this for when we lexed the
+token `=?` and failed to parse with it (we split it into `=`, `?'`).  When we
+fail to parse with a lexed token beginning with `>`, we split all of the
+leading `>` characters into a stream of `GREATER` tokens, and split the
+remaining as best as possible.
+

--- a/formatTest/typeCheckedTests/expected_output/typeParameters.re
+++ b/formatTest/typeCheckedTests/expected_output/typeParameters.re
@@ -1,0 +1,87 @@
+/**
+ * Testing type parameters.
+ */
+
+type threeThings('t) = ('t, 't, 't);
+type listOf('t) = list('t);
+
+type underscoreParam(_) =
+  | Underscored;
+type underscoreParamCovariance(+_) =
+  | Underscored;
+type underscoreParamContravariance(-_) =
+  | Underscored;
+
+type tickParamCovariance(+'a) =
+  | Underscored;
+type tickParamContravariance(-'a) =
+  | Underscored;
+
+let x: option(list('a)) = None;
+type myFunctionType('a) = (
+  list(('a, 'a)),
+  int => option(list('a)),
+);
+let funcAnnoted = (~a: list(int)=[0, 1], ()) => a;
+
+/**
+ * Syntax that would be likely to conflict with lexing parsing of < > syntax.
+ */
+
+let zero = 0;
+let isGreaterThanNegFive = zero > (-5);
+let isGreaterThanNegFive2 = zero > (-5);
+let isGreaterThanNegFive3 = zero > (-5);
+
+let isGreaterThanEqNegFive = zero >= (-5);
+let isGreaterThanEqNegFive2 = zero >= (-5);
+let isGreaterThanEqNegFive3 = zero >= (-5);
+
+let (>>=) = (a, b) => a >= b;
+
+let isSuperGreaterThanEqNegFive = zero >>= (-5);
+let isSuperGreaterThanEqNegFive2 = zero >>= (-5);
+let isSuperGreaterThanEqNegFive3 = zero >>= (-5);
+
+let jsx = (~children, ()) => 0;
+
+type t('a) = 'a;
+let optionArg = (~arg: option(t(int))=?, ()) => arg;
+let optionArgList =
+    (~arg: list(list(int))=?, ()) => arg;
+let defaultJsxArg = (~arg: t(int)=<jsx />, ()) => arg;
+let defaultFalse = (~arg: t(bool)=!true, ()) => arg;
+/* Doesn't work on master either let defaultTrue = (~arg:t<bool>= !!true) => arg; */
+
+/**
+ * Things likely to conflict or impact precedence.
+ */
+let neg = (-1);
+let tru = !false;
+let x =
+  "arbitrary" === "example"
+  && "how long" >= "can you get"
+  && "seriously" <= "what is the line length";
+
+let z = 0;
+module Conss = {
+  let (>-) = (a, b) => a + b;
+  let four = 3 >- 1;
+  let two = 3 >- (-1);
+  let four' = 3 >- 1;
+
+  let tr = 3 > (-1);
+  let tr' = 3 > 1;
+  let tr'' = 3 > (-1);
+};
+
+module Idents = {
+  let (>-) = (a, b) => a + b;
+  let four = z >- z;
+  let two = z >- - z;
+  let four' = z >- - (- z);
+
+  let tr = z > - z;
+  let tr' = z > - (- z);
+  let tr'' = z > - (- (- z));
+};

--- a/formatTest/typeCheckedTests/expected_output/typeParameters.re
+++ b/formatTest/typeCheckedTests/expected_output/typeParameters.re
@@ -48,7 +48,7 @@ let jsx = (~children, ()) => 0;
 type t('a) = 'a;
 let optionArg = (~arg: option(t(int))=?, ()) => arg;
 let optionArgList =
-    (~arg: list(list(int))=?, ()) => arg;
+    (~arg: option(list(list(int)))=?, ()) => arg;
 let defaultJsxArg = (~arg: t(int)=<jsx />, ()) => arg;
 let defaultFalse = (~arg: t(bool)=!true, ()) => arg;
 /* Doesn't work on master either let defaultTrue = (~arg:t<bool>= !!true) => arg; */

--- a/formatTest/typeCheckedTests/input/typeParameters.re
+++ b/formatTest/typeCheckedTests/input/typeParameters.re
@@ -5,16 +5,16 @@
 type threeThings<'t> = ('t, 't, 't);
 type listOf<'t> = list<'t>;
 
-type underscoreParam< _> = Underscored;
-type underscoreParamCovariance< +_> = Underscored;
-type underscoreParamContravariance< -_> = Underscored;
+type underscoreParam<_> = Underscored;
+type underscoreParamCovariance<+_> = Underscored;
+type underscoreParamContravariance<-_> = Underscored;
 
-type tickParamCovariance< +'a> = Underscored;
-type tickParamContravariance< -'a> = Underscored;
+type tickParamCovariance<+'a> = Underscored;
+type tickParamContravariance<-'a> = Underscored;
 
 let x : option<list<'a> > = None;
 type myFunctionType<'a> = (list<('a, 'a)>, int => option<list<'a> >);
-let funcAnnoted = (~a: list<int> =[0, 1, ], ()) => a;
+let funcAnnoted = (~a: list<int>=[0, 1, ], ()) => a;
 
 
 
@@ -41,7 +41,7 @@ let jsx= (~children, ()) => 0;
 
 type t<'a> = 'a;
 let optionArg = (~arg:option<t<int>>=?, ()) => arg;
-let optionArgList = (~arg:list<list<int>>=?, ()) => arg;
+let optionArgList = (~arg:option<list<list<int>>>=?, ()) => arg;
 let defaultJsxArg = (~arg:t(int)=<jsx/>, ()) => arg;
 let defaultFalse = (~arg:t<bool>=!true, ()) => arg;
 /* Doesn't work on master either let defaultTrue = (~arg:t<bool>= !!true) => arg; */

--- a/formatTest/typeCheckedTests/input/typeParameters.re
+++ b/formatTest/typeCheckedTests/input/typeParameters.re
@@ -1,0 +1,80 @@
+/**
+ * Testing type parameters.
+ */
+
+type threeThings<'t> = ('t, 't, 't);
+type listOf<'t> = list<'t>;
+
+type underscoreParam< _> = Underscored;
+type underscoreParamCovariance< +_> = Underscored;
+type underscoreParamContravariance< -_> = Underscored;
+
+type tickParamCovariance< +'a> = Underscored;
+type tickParamContravariance< -'a> = Underscored;
+
+let x : option<list<'a> > = None;
+type myFunctionType<'a> = (list<('a, 'a)>, int => option<list<'a> >);
+let funcAnnoted = (~a: list<int> =[0, 1, ], ()) => a;
+
+
+
+/**
+ * Syntax that would be likely to conflict with lexing parsing of < > syntax.
+ */
+
+let zero = 0;
+let isGreaterThanNegFive = zero > - 5;
+let isGreaterThanNegFive2 = zero > -5;
+let isGreaterThanNegFive3 = zero >(-5);
+
+let isGreaterThanEqNegFive = zero >= -5;
+let isGreaterThanEqNegFive2 = zero >= -5;
+let isGreaterThanEqNegFive3 = zero >=(-5);
+
+let (>>=) = (a, b) => a >= b;
+
+let isSuperGreaterThanEqNegFive = zero >>= - 5;
+let isSuperGreaterThanEqNegFive2 = zero >>= -5;
+let isSuperGreaterThanEqNegFive3 = zero >>= (-5);
+
+let jsx= (~children, ()) => 0;
+
+type t<'a> = 'a;
+let optionArg = (~arg:option<t<int>>=?, ()) => arg;
+let optionArgList = (~arg:list<list<int>>=?, ()) => arg;
+let defaultJsxArg = (~arg:t(int)=<jsx/>, ()) => arg;
+let defaultFalse = (~arg:t<bool>=!true, ()) => arg;
+/* Doesn't work on master either let defaultTrue = (~arg:t<bool>= !!true) => arg; */
+
+/**
+ * Things likely to conflict or impact precedence.
+ */
+let neg=-1;
+let tru=!false;
+let x =
+ "arbitrary" === "example"
+ && "how long" >= "can you get"
+ && "seriously" <= "what is the line length";
+
+let z = 0;
+module Conss = {
+  let (>-) = (a, b) => a + b;
+  let four = 3 >- 1;
+  let two = 3 >- -1;
+  let four' = 3 >- - - 1;
+
+  let tr = 3 > - 1;
+  let tr' = 3 > - -1;
+  let tr'' = 3 > - - - 1;
+}
+
+module Idents = {
+  let (>-) = (a, b) => a + b;
+  let four = z >- z;
+  let two = z >- -z;
+  let four' = z >- - - z;
+
+  let tr = z > - z;
+  let tr' = z > - -z;
+  let tr'' = z > - - - z;
+}

--- a/src/reason-parser/reason_declarative_lexer.mll
+++ b/src/reason-parser/reason_declarative_lexer.mll
@@ -319,7 +319,6 @@ let identchar_latin1 =
 let operator_chars =
   ['!' '$' '%' '&' '+' '-' ':' '<' '=' '>' '?' '@' '^' '|' '~' '#' '.'] |
   ( '\\'? ['/' '*'] )
-
 let dotsymbolchar =
   ['!' '$' '%' '&' '*' '+' '-' '/' ':' '=' '>' '?' '@' '^' '|' '\\' 'a'-'z' 'A'-'Z' '_' '0'-'9']
 let kwdopchar = ['$' '&' '*' '+' '-' '/' '<' '=' '>' '@' '^' '|' '.' '!']
@@ -490,6 +489,8 @@ rule token state = parse
   | "[>" { LBRACKETGREATER }
   | "<" (((uppercase identchar* '.')* lowercase identchar*) as tag)
     { LESSIDENT tag }
+  | "<" ((uppercase identchar*) as tag)
+    { LESSUIDENT tag }
   | ">..." { GREATERDOTDOTDOT }
   (* Allow parsing of Pexp_override:
    * let z = {<state: 0, x: y>};
@@ -583,7 +584,11 @@ rule token state = parse
   | '\\'? ['~' '?' '!'] operator_chars+
     { PREFIXOP (lexeme_operator lexbuf) }
   | '\\'? ['=' '<' '>' '|' '&' '$'] operator_chars*
-    { INFIXOP0 (lexeme_operator lexbuf) }
+    {
+      (* See decompose_token in Reason_single_parser.ml for how let `x=-1` is lexed
+       * and broken up into multiple tokens when necessary. *)
+      INFIXOP0 (lexeme_operator lexbuf)
+    }
   | '\\'? '@' operator_chars*
     { INFIXOP1 (lexeme_operator lexbuf) }
   | '\\'? '^' ('\\' '.')? operator_chars*

--- a/src/reason-parser/reason_declarative_lexer.mll
+++ b/src/reason-parser/reason_declarative_lexer.mll
@@ -308,6 +308,7 @@ let update_loc lexbuf file line absolute chars =
 let newline = ('\013'* '\010')
 let blank = [' ' '\009' '\012']
 let lowercase = ['a'-'z' '_']
+let lowercase_no_under = ['a'-'z']
 let uppercase = ['A'-'Z']
 let uppercase_or_lowercase = lowercase | uppercase
 let identchar = ['A'-'Z' 'a'-'z' '_' '\'' '0'-'9']
@@ -487,7 +488,11 @@ rule token state = parse
   | "[|" { LBRACKETBAR }
   | "[<" { LBRACKETLESS }
   | "[>" { LBRACKETGREATER }
-  | "<" (((uppercase identchar* '.')* lowercase identchar*) as tag)
+  | "<" (((uppercase identchar* '.')*
+         (lowercase_no_under | lowercase identchar identchar*)) as tag)
+    (* Parsing <_ helps resolve no conflicts in the parser and creates other
+     * challenges with splitting up INFIXOP0 tokens (in Reason_parser_single)
+     * so we don't do it. *)
     { LESSIDENT tag }
   | "<" ((uppercase identchar*) as tag)
     { LESSUIDENT tag }

--- a/src/reason-parser/reason_parser.conflicts
+++ b/src/reason-parser/reason_parser.conflicts
@@ -1,0 +1,38 @@
+
+** Conflict (shift/reduce) in state 1219.
+** Tokens involved: SLASHGREATER QUESTION LPAREN INFIXOP3 GREATERDOTDOTDOT GREATER DOT
+** The following explanations concentrate on token LPAREN.
+** This state is reached from implementation after reading:
+
+unattributed_expr GREATER LESS UIDENT 
+
+** The derivations that appear below have the following common factor:
+** (The question mark symbol (?) represents the spot where the derivations begin to differ.)
+
+implementation 
+structure EOF 
+structure_item 
+unattributed_expr 
+(?)
+
+** In state 1219, looking ahead at LPAREN, shifting is permitted
+** because of the following sub-derivation:
+
+unattributed_expr GREATER expr 
+                          simple_expr_call 
+                          jsx 
+                          jsx_start_tag_and_args SLASHGREATER 
+                          LESS mod_ext_longident jsx_arguments 
+                               mod_ext_apply 
+                               UIDENT . LPAREN lseparated_nonempty_list_aux(COMMA,mod_ext_longident) RPAREN 
+
+** In state 1219, looking ahead at LPAREN, reducing production
+** mod_longident -> UIDENT 
+** is permitted because of the following sub-derivation:
+
+unattributed_expr GREATER LESS expr 
+                               simple_expr_call 
+                               simple_expr_call labeled_arguments // lookahead token appears because labeled_arguments can begin with LPAREN
+                               constr_longident // lookahead token is inherited
+                               mod_longident // lookahead token is inherited
+                               UIDENT . 

--- a/src/reason-parser/reason_single_parser.ml
+++ b/src/reason-parser/reason_single_parser.ml
@@ -226,7 +226,14 @@ let rec decompose_token pos0 split =
         | Some(r) -> Some(List.rev gt_tokens @ r))
   | _ -> None
 
-let explode s = List.init (String.length s) (String.get s)
+
+let rec init_tailrec_aux acc i n f =
+  if i >= n then acc
+  else init_tailrec_aux (f i :: acc) (i+1) n f
+
+let list_init len f = List.rev (init_tailrec_aux [] 0 len f)
+
+let explode s = list_init (String.length s) (String.get s)
 
 let rec try_split_label (tok_kind, pos0, posn) =
   match tok_kind with


### PR DESCRIPTION
This is a non-breaking change to Reason parser to implement Reason Syntax v4 Angle Brackets type parameters.
This diff only implements the parsing, and they will be reprinted as parenthesis. In a follow up diff I can implement the printing.
With this change, all existing Reason code will continue to be parsed, it just adds a new way to express type parameters.

```javascript
type t<'a> = option<list<'a>>;
```