### PR TITLE
fix parsing of "module type of" on functors return

### DIFF
--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -639,3 +639,8 @@ module type Event = (module type of {
 });
 
 include (Version2: (module type of Version2));
+
+/* https://github.com/facebook/reason/issues/2608 */
+module Functor =
+       (())
+       : (module type of {}) => {};

--- a/formatTest/unit_tests/input/modules.re
+++ b/formatTest/unit_tests/input/modules.re
@@ -485,3 +485,6 @@ module type Event = (module type of {
 });
 
 include (Version2: (module type of Version2));
+
+/* https://github.com/facebook/reason/issues/2608 */
+module Functor = (()): (module type of {}) => {};

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -1787,6 +1787,8 @@ mark_position_mty
     { mkmty (Pmty_ident $1) }
   | extension
     { mkmty (Pmty_extension $1) }
+  | LPAREN MODULE TYPE OF module_expr RPAREN
+    { mkmty (Pmty_typeof $5) }
   ) {$1};
 
 module_type_signature:
@@ -1832,8 +1834,6 @@ mark_position_mty
     { mkmty (Pmty_with($1, $2)) }
   | simple_module_type
     {$1}
-  | LPAREN MODULE TYPE OF module_expr RPAREN
-    { mkmty (Pmty_typeof $5) }
   | attribute module_type %prec attribute_precedence
     { {$2 with pmty_attributes = $1 :: $2.pmty_attributes} }
   | functor_parameters EQUALGREATER module_type %prec below_SEMI


### PR DESCRIPTION
As there is no ambiguity and `(module type of X)` seems to fit on our definition of `simple_module_type` it seems that it should be there.

Also this is probably safe and there is only two usage of `simple_module_type`, at `module_type` itself and at at https://github.com/facebook/reason/blob/master/src/reason-parser/reason_parser.mly#L1574

This PR closes #2608 

