### PR TITLE
ocaml-migrate-parsetree 2.0

### DIFF
--- a/reason.json
+++ b/reason.json
@@ -14,7 +14,7 @@
     "@opam/menhir": " >= 20170418.0.0",
     "@opam/merlin-extend": " >= 0.3",
     "@opam/result": "*",
-    "@opam/ocaml-migrate-parsetree": "*",
+    "@opam/ocaml-migrate-parsetree": "< 2.0.0",
     "@opam/dune": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
OMP 2.0 was launched and we got some breaking changes, so if you try it now it's not working with esy, also we probably need a release, maybe as 3.6.1

```json
{
  "dependencies": {
    "@opam/dune": "2.6.2",
    "ocaml": "4.10.0",
    "@esy-ocaml/reason": "3.6.0"
  }
}
```

@jordwalke @anmonteiro 