### PR TITLE
Put upper bound of 2.0.0 for Ocaml migrate parsetree.

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -2,7 +2,7 @@
   "name": "reason-cli",
   "notes": "This is just the dev package config (also built as globally installable reason-cli). See ./refmt.json ./rtop.json for individual release package configs.",
   "license": "MIT",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "dependencies": {
     "ocaml": " >= 4.2.0 < 4.11.0",
     "@opam/fix": "*",
@@ -11,7 +11,7 @@
     "@opam/utop": " >= 1.17.0 < 2.5.0",
     "@opam/merlin-extend": " >= 0.6",
     "@opam/result": "*",
-    "@opam/ocaml-migrate-parsetree": "*",
+    "@opam/ocaml-migrate-parsetree": " < 2.0.0",
     "@opam/dune": "< 2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "reason",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"description": "Simple, fast & type safe code that leverages the JavaScript & OCaml ecosystems",
 	"repository": {
 		"type": "git",

--- a/reason.json
+++ b/reason.json
@@ -1,6 +1,6 @@
 {
   "name": "@esy-ocaml/reason",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "license": "MIT",
   "description": "Native Compiler Support for Reason: Simple, fast & type safe code that leverages the JavaScript & OCaml ecosystems",
   "repository": {
@@ -14,7 +14,7 @@
     "@opam/menhir": " >= 20170418.0.0",
     "@opam/merlin-extend": " >= 0.3",
     "@opam/result": "*",
-    "@opam/ocaml-migrate-parsetree": "*",
+    "@opam/ocaml-migrate-parsetree": " < 2.0.0",
     "@opam/dune": "*"
   },
   "devDependencies": {

--- a/reason.opam
+++ b/reason.opam
@@ -19,7 +19,7 @@ depends: [
   "merlin-extend" {>= "0.6"}
   "fix"
   "result"
-  "ocaml-migrate-parsetree"
+  "ocaml-migrate-parsetree" {< "2.0.0"}
 ]
 synopsis: "Reason: Syntax & Toolchain for OCaml"
 description: """

--- a/src/refmt/package.ml
+++ b/src/refmt/package.ml
@@ -1,4 +1,4 @@
 
-let version = "3.6.0"
+let version = "3.6.1"
 let git_version = "59339f6fde0ea2cd4822d32bb99a7ec5b6865e3a"
 let git_short_version = "59339f6"


### PR DESCRIPTION
This is a more complete version of [this PR](https://github.com/facebook/reason/pull/2621)

Questions:
I think that this won't be enough to fix package installs because we might need
to deprecated the old version of Reason packages, or at least edit the esy opam
overrides repo to make sure earlier versions of Reason don't get solved
assuming it is compatible with omp 2.0.0