### PR TITLE
fix(parser): prefer the arrow reading for (args): t => body in expres…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+- fix(parser): prefer the arrow-function reading for `(args): t => body` in
+  expression position, so e.g. `f((x: int): int => x)` parses as a function
+  with a return-type annotation instead of an expression constrained to the
+  arrow type `int => x`. This also makes the printer's output for functions
+  whose body carries a type constraint (e.g. first-class-module coercions like
+  `(module M: SIG) => (module M: SUB)`) re-parse as the same program instead
+  of becoming ill-typed. Constraining an expression against an arrow type is
+  still expressible by parenthesizing the type: `(e: ((a, b) => t))`.
+  (@seprov, [#2925](https://github.com/reasonml/reason/issues/2925))
+
 ## 3.18.0
 
 - build: remove unused AST migrations (@anmonteiro,

--- a/src/reason-parser/reason_multi_parser.ml
+++ b/src/reason-parser/reason_multi_parser.ml
@@ -9,11 +9,23 @@ type 'a step =
   | Success of 'a * Reason_lexer.invalid_docstrings
   | Error
 
+(* When the lexer injects ES6_FUN (its lookahead saw `(...)` followed by `=>`
+   or `:`), we fork: [x] continues without the token (e.g. the expression
+   reading) and [x'] consumes it (the arrow-function reading). Both parsers may
+   run to completion when the source is genuinely ambiguous — e.g.
+   [f((x: int): int => x)], where `int => x` is also a valid arrow *type*, so
+   the whole argument can be read as the constrained expression
+   [(x: int) : (int => x)]. Since [step]/[progress_successful] return the
+   first success in list order, the ordering here decides the winner. Put the
+   arrow-function parser first: an ES6 arrow is what such code means in
+   practice, and this matches how the same text already parses in let-binding
+   position (where the bare-constraint reading is not grammatical). See
+   reasonml/reason#2925. *)
 let rec fork token = function
   | [] -> []
   | x :: xs ->
     (match S.step x token with
-    | S.Intermediate x' -> x :: x' :: fork token xs
+    | S.Intermediate x' -> x' :: x :: fork token xs
     | _ -> x :: fork token xs)
 
 let rec progress_successful token acc = function

--- a/test/es6FunReturnAnnotation.t/input.re
+++ b/test/es6FunReturnAnnotation.t/input.re
@@ -1,0 +1,54 @@
+/* Regression test for reasonml/reason#2925.
+ *
+ * An ES6 arrow with a return-type annotation in argument position, e.g.
+ * `f((x: int): int => x)`, is ambiguous when the body is also valid *type*
+ * syntax: the same tokens can be read as the constrained expression
+ * `f((x: int) : (int => x))`. The parser must prefer the arrow-function
+ * reading (as it already does in let-binding position); the expression
+ * reading is still expressible by parenthesizing the type:
+ * `f((x: int): (int => x))` never forks in the first place, and
+ * `(e: ((a, b) => t))` disambiguates constraints against arrow types.
+ *
+ * This also matters for the printer: `(module M: SIG) => (module M: SUB)`
+ * is printed with the body's constraint hoisted into return position,
+ * `(module M: SIG): (module SUB) => (module M)`, which must re-parse as the
+ * same function. */
+module type FOO = {
+  let foo: string;
+};
+
+module type FOO_WITH_X = {
+  let foo: string;
+  let x: int;
+};
+
+/* Narrowing a first-class module to a smaller signature (the report's
+   example): the printer hoists the body constraint into return position. */
+let some_foo_with_x: option(module FOO_WITH_X) =
+  Some(
+    (module
+     {
+       let foo = "foo";
+       let x = 1;
+     }),
+  );
+
+let some_foo =
+  some_foo_with_x
+  |> Option.map((module Foo_with_x: FOO_WITH_X) =>
+       (module Foo_with_x: FOO)
+     );
+
+/* Hand-written return annotation, module-free, body is type-shaped (a plain
+   ident): used to mis-parse as `(n: int) : (int => n)`. */
+let idents = l => List.map((n: int): int => n, l);
+
+/* Hand-written return annotation whose return type is a package type, body
+   projects a module out of the parameter. */
+module type ID = {let id: int;};
+module type VIEW = {module Id: ID; let name: string;};
+
+let apply = (h, x: (module VIEW)) => h(x);
+
+let project = (x: (module VIEW)) =>
+  apply((module T: VIEW): (module ID) => (module T.Id), x);

--- a/test/es6FunReturnAnnotation.t/run.t
+++ b/test/es6FunReturnAnnotation.t/run.t
@@ -1,0 +1,85 @@
+ES6 arrows with return-type annotations in argument position (reasonml/reason#2925)
+
+Type-check the source as written
+
+  $ ocamlc -c -pp 'refmt --print binary' -intf-suffix .rei -impl input.re
+
+Format it
+
+  $ refmt ./input.re > ./formatted.re
+  $ cat ./formatted.re
+  /* Regression test for reasonml/reason#2925.
+   *
+   * An ES6 arrow with a return-type annotation in argument position, e.g.
+   * `f((x: int): int => x)`, is ambiguous when the body is also valid *type*
+   * syntax: the same tokens can be read as the constrained expression
+   * `f((x: int) : (int => x))`. The parser must prefer the arrow-function
+   * reading (as it already does in let-binding position); the expression
+   * reading is still expressible by parenthesizing the type:
+   * `f((x: int): (int => x))` never forks in the first place, and
+   * `(e: ((a, b) => t))` disambiguates constraints against arrow types.
+   *
+   * This also matters for the printer: `(module M: SIG) => (module M: SUB)`
+   * is printed with the body's constraint hoisted into return position,
+   * `(module M: SIG): (module SUB) => (module M)`, which must re-parse as the
+   * same function. */
+  module type FOO = {
+    let foo: string;
+  };
+  
+  module type FOO_WITH_X = {
+    let foo: string;
+    let x: int;
+  };
+  
+  /* Narrowing a first-class module to a smaller signature (the report's
+     example): the printer hoists the body constraint into return position. */
+  let some_foo_with_x: option(module FOO_WITH_X) =
+    Some(
+      (module
+       {
+         let foo = "foo";
+         let x = 1;
+       }),
+    );
+  
+  let some_foo =
+    some_foo_with_x
+    |> Option.map(
+         (module Foo_with_x: FOO_WITH_X): (module FOO) =>
+         (module Foo_with_x)
+       );
+  
+  /* Hand-written return annotation, module-free, body is type-shaped (a plain
+     ident): used to mis-parse as `(n: int) : (int => n)`. */
+  let idents = l =>
+    List.map((n: int): int => n, l);
+  
+  /* Hand-written return annotation whose return type is a package type, body
+     projects a module out of the parameter. */
+  module type ID = {
+    let id: int;
+  };
+  module type VIEW = {
+    module Id: ID;
+    let name: string;
+  };
+  
+  let apply = (h, x: (module VIEW)) => h(x);
+  
+  let project = (x: (module VIEW)) =>
+    apply(
+      (module T: VIEW): (module ID) =>
+        (module T.Id),
+      x,
+    );
+
+Formatting must preserve well-typedness (the formatted output re-parses as
+the same program)
+
+  $ ocamlc -c -pp 'refmt --print binary' -intf-suffix .rei -impl formatted.re
+
+Formatting is idempotent
+
+  $ refmt ./formatted.re > ./formatted_back.re
+  $ diff formatted.re formatted_back.re

--- a/test/wrapping-re.t/input.re
+++ b/test/wrapping-re.t/input.re
@@ -1382,6 +1382,11 @@ let df_locallyAbstractFuncAnnotated: type a b. (a, b) => (inputEchoRecord(a), in
  * is not so trivial. We have to take the last Pexp_constraint type, varify the
  * constructors, then check if the result is equal to the first
  * Ppat_constraint. In this case, they're not equal!
+ *
+ * The constraint's arrow type is parenthesized: a bare
+ * `expr: (a, b) => ...` where the body of `expr` is itself valid type syntax
+ * is read as an ES6 arrow with a return-type annotation (see #2925), which is
+ * not what this fixture is about.
  */
 let df_locallyAbstractFuncAnnotated:
   'figureMeOut
@@ -1391,7 +1396,7 @@ let df_locallyAbstractFuncAnnotated:
       {inputIs: input},
       {inputIs: input2}
     ):
-    (a, b) => (inputEchoRecord(a), inputEchoRecord(b))
+    ((a, b) => (inputEchoRecord(a), inputEchoRecord(b)))
   );
 
 

--- a/test/wrapping-re.t/run.t
+++ b/test/wrapping-re.t/run.t
@@ -2193,6 +2193,11 @@ Format wrapping in .re files
    * is not so trivial. We have to take the last Pexp_constraint type, varify the
    * constructors, then check if the result is equal to the first
    * Ppat_constraint. In this case, they're not equal!
+   *
+   * The constraint's arrow type is parenthesized: a bare
+   * `expr: (a, b) => ...` where the body of `expr` is itself valid type syntax
+   * is read as an ES6 arrow with a return-type annotation (see #2925), which is
+   * not what this fixture is about.
    */
   let df_locallyAbstractFuncAnnotated
       : 'figureMeOut =


### PR DESCRIPTION
…sion position

The lexer injects ES6_FUN when a parenthesized group is followed by => or :, and the multi-parser forks: one parser consumes the token (the arrow-function reading) and one ignores it (e.g. the expression reading). When the return annotation's type is followed by => and the arrow body is itself valid type syntax -- e.g. f((x: int): int => x), where int => x is also an arrow *type* -- both parsers run to completion, and the winner was whichever came first in the fork list: the expression reading, f((x: int) : (int => x)).

That preference also breaks the printer round-trip: printing hoists a function body's type constraint into return-annotation position ((module M: SIG) => (module M: SUB) prints as
(module M: SIG): (module SUB) => (module M)), and re-parsing that output under the expression preference yields an ill-typed constraint instead of the original function -- refmt could turn a compiling program into a non-compiling one.

Put the forked (arrow) parser first instead. This matches how the same text already parses in let-binding position, where the bare-constraint reading is not grammatical. Constraining an expression against an arrow type remains expressible with a parenthesized type: (e: ((a, b) => t)); the one fixture relying on the bare form (wrapping-re.t, df_locallyAbstractFuncAnnotated: 'figureMeOut) is updated to that spelling and formats back to byte-identical output.

Fixes #2925